### PR TITLE
feat: machine-readable error codes (#90)

### DIFF
--- a/packages/cli/src/__tests__/error-codes.test.ts
+++ b/packages/cli/src/__tests__/error-codes.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { runCliExpectFailure } from "./test-utils.js";
+
+/**
+ * The CLI must emit a structured JSON envelope on stderr when a command fails
+ * under `--json`. Agents rely on the `code` field to decide whether to retry,
+ * re-auth, or escalate — see docs/UX_GUIDE.md §12 and packages/core/src/errors/codes.ts.
+ */
+describe("error codes (JSON envelope)", () => {
+  it("emits a parseable JSON object with a registry code on company-not-found", async () => {
+    const result = await runCliExpectFailure([
+      "companies",
+      "show",
+      "definitely-does-not-exist-at-all",
+      "--json",
+    ]);
+
+    // The JSON envelope is the last well-formed JSON object on stderr —
+    // strip any preamble lines (banners, demo notice) before parsing.
+    const start = result.stderr.indexOf("{");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const json = JSON.parse(result.stderr.slice(start));
+
+    expect(json).toHaveProperty("code");
+    expect(typeof json.code).toBe("string");
+    expect(json.code).toMatch(/^ERROR_[A-Z_]+$/);
+    // The specific failure here is a company lookup miss
+    expect(json.code).toBe("ERROR_COMPANY_NOT_FOUND");
+    expect(json).toHaveProperty("message");
+    expect(typeof json.message).toBe("string");
+  });
+});

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { CredentialStore, TokenManager } from "@pax8/core";
+import { CredentialStore, ERROR_AUTH_MISSING, TokenManager } from "@pax8/core";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
 import { replCmd } from "../../lib/confirm.js";
@@ -44,7 +44,8 @@ Examples:
           `Provide credentials via flags: ${replCmd("pax8 auth login")} --client-id <id> --client-secret <secret>`,
           "Or set environment variables: PAX8_CLIENT_ID and PAX8_CLIENT_SECRET",
         ],
-        "https://devx.pax8.com/"
+        "https://devx.pax8.com/",
+        ERROR_AUTH_MISSING,
       );
     }
 

--- a/packages/cli/src/commands/companies/update.ts
+++ b/packages/cli/src/commands/companies/update.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
 import { buildContext } from "../../lib/context.js";
@@ -37,7 +38,9 @@ Examples:
         throw new CliError(
           "No updates provided",
           ["At least one update flag is required"],
-          ["Use --name, --phone, or --website to specify what to update"]
+          ["Use --name, --phone, or --website to specify what to update"],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 

--- a/packages/cli/src/commands/contacts/create.ts
+++ b/packages/cli/src/commands/contacts/create.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
@@ -38,6 +39,8 @@ Examples:
           `Invalid --type "${options.type}"`,
           [`Allowed values: ${VALID_TYPES.join(", ")}`],
           [`Try: ${replCmd("pax8 contacts create")} --type Admin ...`],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 

--- a/packages/cli/src/commands/contacts/list.ts
+++ b/packages/cli/src/commands/contacts/list.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output, type Column } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
@@ -37,6 +38,8 @@ Examples:
             `Pick a company first: ${replCmd("pax8 companies list")}`,
             `Then: ${replCmd("pax8 contacts list")} --company <id|name>`,
           ],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 

--- a/packages/cli/src/commands/contacts/update.ts
+++ b/packages/cli/src/commands/contacts/update.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
@@ -43,6 +44,9 @@ Examples:
           throw new CliError(
             `Invalid --type "${options.type}"`,
             [`Allowed values: ${VALID_TYPES.join(", ")}`],
+            undefined,
+            undefined,
+            ERROR_INVALID_INPUT,
           );
         }
         data.types = [type];
@@ -53,6 +57,8 @@ Examples:
           "No fields to update",
           ["At least one of --first-name, --last-name, --email, --phone, or --type is required"],
           [`Try: ${replCmd("pax8 contacts update")} ${id} --email <new-email>`],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { loadConfig, saveConfig } from "@pax8/core";
+import { ERROR_INTERNAL, loadConfig, saveConfig } from "@pax8/core";
 import { replCmd } from "../lib/confirm.js";
 import { CliError } from "../lib/errors.js";
 
@@ -71,7 +71,8 @@ Examples:
           `Overwrite a corrupt config with defaults: ${chalk.cyan(replCmd("pax8 init --force"))}`,
           `Skip credential setup and try sample data: ${chalk.cyan(replCmd("pax8 init --demo"))}`,
         ],
-        "https://devx.pax8.com/"
+        "https://devx.pax8.com/",
+        ERROR_INTERNAL,
       );
     }
   });

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -6,7 +6,13 @@ import { buildContext } from "../../lib/context.js";
 import { confirmWithChange, replCmd } from "../../lib/confirm.js";
 import { formatStatus, formatDate, formatCurrency, formatQuantity, calculateMrr } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
-import { ApiError, getTelemetry } from "@pax8/core";
+import {
+  ApiError,
+  ERROR_API_VALIDATION,
+  ERROR_INVALID_INPUT,
+  ERROR_PRODUCT_NOT_FOUND,
+  getTelemetry,
+} from "@pax8/core";
 import type { CreateOrderInput, OrderLineItemInput, BillingTerm } from "@pax8/core";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
@@ -44,6 +50,8 @@ Examples:
           `Invalid quantity: "${allOpts.quantity}"`,
           ["Quantity must be a positive integer (1 or greater)"],
           [`Example: ${replCmd("pax8 orders create")} --company <id> --product <id> --quantity 5`],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 
@@ -75,6 +83,8 @@ Examples:
             `Search the catalog: ${replCmd("pax8 products search")} "${allOpts.product}"`,
             `Then use the product ID: ${replCmd("pax8 orders create")} --product <product-id> ...`,
           ],
+          undefined,
+          ERROR_PRODUCT_NOT_FOUND,
         );
       }
 
@@ -284,6 +294,8 @@ Examples:
                 `Search for alternatives: ${replCmd("pax8 products search")} "${shortName}"`,
                 `View ${displayCompany}'s current subscriptions: ${replCmd("pax8 companies more")} "${displayCompany}"`,
               ],
+              undefined,
+              ERROR_PRODUCT_NOT_FOUND,
             ),
           );
         }
@@ -310,6 +322,8 @@ Examples:
               `Can't order "${displayProduct}" for ${displayCompany}`,
               causes,
               steps,
+              undefined,
+              ERROR_API_VALIDATION,
             ),
           );
         }
@@ -331,7 +345,13 @@ Examples:
           steps.push(`View product details: ${replCmd("pax8 products show")} ${allOpts.product}`);
 
           handleCommandError(
-            new CliError(`Can't order "${displayProduct}" for ${displayCompany}`, causes, steps),
+            new CliError(
+              `Can't order "${displayProduct}" for ${displayCompany}`,
+              causes,
+              steps,
+              undefined,
+              ERROR_API_VALIDATION,
+            ),
           );
         }
       }

--- a/packages/cli/src/commands/quotes/create.ts
+++ b/packages/cli/src/commands/quotes/create.ts
@@ -9,6 +9,7 @@ import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { formatQuantity } from "../../lib/formatters.js";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import type { CreateQuoteInput, BillingTerm } from "@pax8/core";
 
 export const quotesCreateCommand = new Command("create")
@@ -36,6 +37,9 @@ Examples:
         throw new CliError(
           `Invalid quantity: "${options.quantity}"`,
           ["Quantity must be a positive integer"],
+          undefined,
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 

--- a/packages/cli/src/commands/quotes/update.ts
+++ b/packages/cli/src/commands/quotes/update.ts
@@ -7,6 +7,7 @@ import { handleCommandError, CliError } from "../../lib/errors.js";
 import { confirm, replCmd } from "../../lib/confirm.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import type { UpdateQuoteInput, BillingTerm } from "@pax8/core";
 
 export const quotesUpdateCommand = new Command("update")
@@ -37,6 +38,9 @@ Examples:
           throw new CliError(
             `Invalid quantity: "${options.quantity}"`,
             ["Quantity must be a positive integer"],
+            undefined,
+            undefined,
+            ERROR_INVALID_INPUT,
           );
         }
         const product = await resolveProduct(ctx, options.product);
@@ -58,6 +62,8 @@ Examples:
           "No fields to update",
           ["Use --product (with --quantity) to replace line items, or --expiration-date"],
           [`Try: ${replCmd("pax8 quotes update")} ${id} --expiration-date 2026-05-15`],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
@@ -53,6 +54,8 @@ Examples:
           [
             `Example: ${replCmd("pax8 webhooks create")} --url https://example.com/hook --events subscription.created`,
           ],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 
@@ -63,6 +66,8 @@ Examples:
           [
             `Example: ${replCmd("pax8 webhooks create")} --url ${url} --events subscription.created,invoice.paid`,
           ],
+          undefined,
+          ERROR_INVALID_INPUT,
         );
       }
 

--- a/packages/cli/src/commands/webhooks/logs.ts
+++ b/packages/cli/src/commands/webhooks/logs.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
@@ -15,6 +16,8 @@ function parseSinceMs(input: string): number {
       `Invalid --since value: "${input}"`,
       ['Use format like "7d", "24h", or "30m"'],
       ['Example: pax8 webhooks logs --since 7d'],
+      undefined,
+      ERROR_INVALID_INPUT,
     );
   }
   const n = parseInt(match[1], 10);

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -13,6 +13,7 @@ import {
   TokenManager,
   CredentialStore,
   loadConfig,
+  ERROR_AUTH_MISSING,
 } from "@pax8/core";
 import type { Config } from "@pax8/core";
 import { spawn } from "node:child_process";
@@ -118,6 +119,7 @@ export async function buildContext(
           `Or use demo mode: PAX8_DEMO=1 ${replCmd("pax8")} <command> (macOS/Linux) or $env:PAX8_DEMO="1"; ${replCmd("pax8")} <command> (PowerShell)`,
         ],
         "https://devx.pax8.com/",
+        ERROR_AUTH_MISSING,
       );
     }
 

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -1,7 +1,19 @@
 import chalk from "chalk";
 import { ZodError, ZodIssueCode } from "zod";
 import type { Ora } from "ora";
-import { ApiError } from "@pax8/core";
+import {
+  ApiError,
+  ERROR_API_TIMEOUT,
+  ERROR_API_VALIDATION,
+  ERROR_AUTH_EXPIRED,
+  ERROR_COMPANY_NOT_FOUND,
+  ERROR_INTERNAL,
+  ERROR_NOT_AUTHORIZED,
+  ERROR_PRODUCT_NOT_FOUND,
+  ERROR_RATE_LIMITED,
+  ERROR_SUBSCRIPTION_NOT_FOUND,
+  type Pax8ErrorCode,
+} from "@pax8/core";
 import { replCmd } from "./confirm.js";
 
 export class CliError extends Error {
@@ -9,7 +21,8 @@ export class CliError extends Error {
     message: string,
     public causes?: string[],
     public recoverySteps?: string[],
-    public docsUrl?: string
+    public docsUrl?: string,
+    public code?: Pax8ErrorCode,
   ) {
     super(message);
     this.name = "CliError";
@@ -55,10 +68,116 @@ export function extractErrorDetail(body: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * Detect whether the global `--json` flag is set. We check argv directly
+ * because handleCommandError is often invoked from a `catch` block where the
+ * Commander context isn't available, and because we want JSON envelope output
+ * even for errors that fire before `buildContext()` succeeds.
+ */
+function isJsonOutputRequested(): boolean {
+  return process.argv.includes("--json");
+}
+
+/**
+ * Map an ApiError to a stable error code based on status + message hints.
+ */
+function codeForApiError(error: ApiError): Pax8ErrorCode {
+  const status = error.statusCode;
+  if (status === 401 || status === 403) return ERROR_AUTH_EXPIRED;
+  if (status === 408) return ERROR_API_TIMEOUT;
+  if (status === 429) return ERROR_RATE_LIMITED;
+  if (status >= 500) return ERROR_INTERNAL;
+  if (status === 404) {
+    const haystack = (
+      error.message +
+      " " +
+      (typeof error.requestPath === "string" ? error.requestPath : "")
+    ).toLowerCase();
+    if (haystack.includes("company") || haystack.includes("companies")) {
+      return ERROR_COMPANY_NOT_FOUND;
+    }
+    if (haystack.includes("product")) {
+      return ERROR_PRODUCT_NOT_FOUND;
+    }
+    if (haystack.includes("subscription")) {
+      return ERROR_SUBSCRIPTION_NOT_FOUND;
+    }
+    return ERROR_NOT_AUTHORIZED;
+  }
+  return ERROR_INTERNAL;
+}
+
+interface ErrorEnvelope {
+  code?: Pax8ErrorCode;
+  message: string;
+  causes?: string[];
+  recoverySteps?: string[];
+  docsUrl?: string;
+}
+
+/**
+ * Build the JSON envelope for a thrown error. Omits fields that aren't set so
+ * consumers don't have to special-case `null`.
+ */
+function buildErrorEnvelope(error: unknown, context?: string): ErrorEnvelope {
+  const prefix = context ? `${context}: ` : "";
+
+  if (error instanceof CliError) {
+    const env: ErrorEnvelope = { message: prefix + error.message };
+    if (error.code) env.code = error.code;
+    if (error.causes && error.causes.length > 0) env.causes = error.causes;
+    if (error.recoverySteps && error.recoverySteps.length > 0) {
+      env.recoverySteps = error.recoverySteps;
+    }
+    if (error.docsUrl) env.docsUrl = error.docsUrl;
+    return env;
+  }
+
+  if (error instanceof ZodError) {
+    return {
+      code: ERROR_API_VALIDATION,
+      message:
+        prefix +
+        "The Pax8 API returned an unexpected response.",
+      causes: [formatZodError(error)],
+      recoverySteps: [
+        "Try a different query, or run pax8 doctor to check your setup.",
+      ],
+    };
+  }
+
+  if (error instanceof ApiError) {
+    const env: ErrorEnvelope = {
+      code: codeForApiError(error),
+      message: prefix + error.message,
+    };
+    const detail = extractErrorDetail(error.responseBody);
+    if (detail) env.causes = [detail];
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      env.recoverySteps = [
+        "Your credentials may have expired. Run pax8 auth login to re-authenticate.",
+      ];
+    }
+    return env;
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: ERROR_INTERNAL,
+      message: prefix + error.message,
+    };
+  }
+
+  return {
+    code: ERROR_INTERNAL,
+    message: prefix + "An unexpected error occurred",
+  };
+}
+
 export function handleCommandError(
   error: unknown,
   spinner?: Ora,
-  context?: string
+  context?: string,
 ): never {
   // Stop spinner if active
   if (spinner) {
@@ -67,6 +186,16 @@ export function handleCommandError(
     } catch {
       // Spinner may already be stopped
     }
+  }
+
+  // Machine-readable JSON envelope when --json is set
+  if (isJsonOutputRequested()) {
+    const envelope = buildErrorEnvelope(error, context);
+    process.stderr.write(JSON.stringify(envelope, null, 2) + "\n");
+    process.exit(1);
+
+    // Honor never return contract when process.exit is mocked
+    throw new Error("process.exit intercepted");
   }
 
   const prefix = context ? `${context}\n` : "";

--- a/packages/cli/src/lib/resolve-company.ts
+++ b/packages/cli/src/lib/resolve-company.ts
@@ -1,5 +1,6 @@
-import type { Company } from "@pax8/core";
+import { ERROR_COMPANY_NOT_FOUND, type Company } from "@pax8/core";
 import type { CommandContext } from "./context.js";
+import { CliError } from "./errors.js";
 import { resolveFromLastList } from "./last-list.js";
 import { replCmd } from "./confirm.js";
 
@@ -37,12 +38,22 @@ export async function resolveCompany(ctx: CommandContext, input: string): Promis
   const fuzzy = result.content.filter((c) => c.name.toLowerCase().includes(lower));
   if (fuzzy.length === 1) return fuzzy[0];
   if (fuzzy.length > 1) {
-    throw new Error(
-      `Multiple companies match "${input}": ${fuzzy.map((c) => c.name).join(", ")}. Use an exact name or ID.`,
+    throw new CliError(
+      `Multiple companies match "${input}"`,
+      [`Matches: ${fuzzy.map((c) => c.name).join(", ")}`],
+      [`Use an exact name or ID. Run ${replCmd("pax8 companies list")} to see all companies.`],
+      undefined,
+      ERROR_COMPANY_NOT_FOUND,
     );
   }
 
-  throw new Error(`Company not found: "${input}". Run '${replCmd("pax8 companies list")}' to see available companies.`);
+  throw new CliError(
+    `Company not found: "${input}"`,
+    ["No active company matched the supplied name or ID."],
+    [`Run ${replCmd("pax8 companies list")} to see available companies.`],
+    undefined,
+    ERROR_COMPANY_NOT_FOUND,
+  );
 }
 
 /**

--- a/packages/cli/src/lib/resolve-product.ts
+++ b/packages/cli/src/lib/resolve-product.ts
@@ -1,5 +1,6 @@
-import type { Product } from "@pax8/core";
+import { ERROR_PRODUCT_NOT_FOUND, type Product } from "@pax8/core";
 import type { CommandContext } from "./context.js";
+import { CliError } from "./errors.js";
 import { replCmd } from "./confirm.js";
 
 // Vendors common in the Pax8 catalog. Used to detect a vendor prefix in
@@ -97,8 +98,12 @@ export async function resolveProduct(ctx: CommandContext, input: string): Promis
       .slice(0, 5)
       .map((p) => p.name)
       .join(", ");
-    throw new Error(
-      `Multiple products match "${input}": ${names}. Use an exact name or product ID.`,
+    throw new CliError(
+      `Multiple products match "${input}"`,
+      [`Matches: ${names}`],
+      ["Use an exact name or product ID."],
+      undefined,
+      ERROR_PRODUCT_NOT_FOUND,
     );
   }
 
@@ -116,12 +121,20 @@ export async function resolveProduct(ctx: CommandContext, input: string): Promis
       .slice(0, 5)
       .map((p) => p.name)
       .join(", ");
-    throw new Error(
-      `Multiple products match "${input}": ${names}. Use an exact name or product ID.`,
+    throw new CliError(
+      `Multiple products match "${input}"`,
+      [`Matches: ${names}`],
+      ["Use an exact name or product ID."],
+      undefined,
+      ERROR_PRODUCT_NOT_FOUND,
     );
   }
 
-  throw new Error(
-    `Product not found: "${input}". Try '${replCmd("pax8 products search")} "${input}"' to browse the catalog.`,
+  throw new CliError(
+    `Product not found: "${input}"`,
+    ["No product in the catalog matched the supplied name or ID."],
+    [`Try ${replCmd("pax8 products search")} "${input}" to browse the catalog.`],
+    undefined,
+    ERROR_PRODUCT_NOT_FOUND,
   );
 }

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -1,0 +1,40 @@
+/**
+ * Machine-readable error codes for pax8-cli.
+ *
+ * Codes are stable identifiers carried on `CliError` instances and surfaced in
+ * the structured `--json` error envelope. They let agents (and humans writing
+ * scripts) decide whether to retry, re-auth, or escalate without regex-matching
+ * English error strings.
+ *
+ * **Append-only.** Never repurpose an existing code, even for a "near-match"
+ * failure mode. If you need a new code, add a new constant.
+ */
+
+export const ERROR_AUTH_EXPIRED = "ERROR_AUTH_EXPIRED";
+export const ERROR_AUTH_MISSING = "ERROR_AUTH_MISSING";
+export const ERROR_COMPANY_NOT_FOUND = "ERROR_COMPANY_NOT_FOUND";
+export const ERROR_PRODUCT_NOT_FOUND = "ERROR_PRODUCT_NOT_FOUND";
+export const ERROR_SUBSCRIPTION_NOT_FOUND = "ERROR_SUBSCRIPTION_NOT_FOUND";
+export const ERROR_RATE_LIMITED = "ERROR_RATE_LIMITED";
+export const ERROR_API_TIMEOUT = "ERROR_API_TIMEOUT";
+export const ERROR_API_VALIDATION = "ERROR_API_VALIDATION";
+export const ERROR_INVALID_INPUT = "ERROR_INVALID_INPUT";
+export const ERROR_NOT_AUTHORIZED = "ERROR_NOT_AUTHORIZED";
+export const ERROR_INTERNAL = "ERROR_INTERNAL";
+
+/**
+ * Union of all known Pax8 CLI error codes. Use this for exhaustive switch
+ * statements in agent-facing consumers.
+ */
+export type Pax8ErrorCode =
+  | typeof ERROR_AUTH_EXPIRED
+  | typeof ERROR_AUTH_MISSING
+  | typeof ERROR_COMPANY_NOT_FOUND
+  | typeof ERROR_PRODUCT_NOT_FOUND
+  | typeof ERROR_SUBSCRIPTION_NOT_FOUND
+  | typeof ERROR_RATE_LIMITED
+  | typeof ERROR_API_TIMEOUT
+  | typeof ERROR_API_VALIDATION
+  | typeof ERROR_INVALID_INPUT
+  | typeof ERROR_NOT_AUTHORIZED
+  | typeof ERROR_INTERNAL;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,9 @@
 export * from "./api/types.js";
 export * from "./api/errors.js";
 export * from "./api/constants.js";
+
+// Error codes — machine-readable identifiers for agent consumers
+export * from "./errors/codes.js";
 export { Pax8Client } from "./api/client.js";
 export type { Pax8ClientOptions } from "./api/client.js";
 export { CompaniesApi } from "./api/companies.js";


### PR DESCRIPTION
## Summary

Implements the **machine-readable error codes** contract from \`docs/UX_GUIDE.md\` §12. Adds a stable \`code\` field to \`CliError\`, a registry of 11 codes in \`@pax8/core\`, and a JSON-envelope error output mode triggered by \`--json\`. ApiError, ZodError, and plain \`Error\` are mapped to codes inside \`handleCommandError\`.

## What changed

- **New** \`packages/core/src/errors/codes.ts\` — 11 \`Pax8ErrorCode\` constants + union type, exported from \`@pax8/core\`.
- **\`packages/cli/src/lib/errors.ts\`** — 5th constructor arg on \`CliError\`; JSON envelope branch when \`--json\` is set; ApiError/ZodError → code mapping.
- **Backfilled codes** on every existing \`new CliError\` (\`lib/context.ts\`, \`lib/resolve-company.ts\`, \`lib/resolve-product.ts\`, plus 11 command files). \`resolve-company.ts\` and \`resolve-product.ts\` had \`new Error(...)\` previously — promoted to \`CliError\`.
- **New** test \`packages/cli/src/__tests__/error-codes.test.ts\` validates the JSON envelope shape on a known failure path.

## Notes

- \`--json\` detection reads \`process.argv\` directly so the envelope is emitted even when an error fires before \`buildContext()\` (e.g. auth failures).
- 404 mapping: tries to match the resource keyword in the API message (\`company\` → \`ERROR_COMPANY_NOT_FOUND\`, etc.) and falls back to \`ERROR_NOT_AUTHORIZED\`. The fallback semantically wants a generic \`ERROR_NOT_FOUND\` — worth a small follow-up.
- May conflict with #91 / #92 once those land (they touch some of the same command files).

## Test plan

- [x] \`pnpm build\` passes
- [x] \`pnpm test\` — 792 passing (+1 new test)
- [ ] Manual: \`pax8 companies show bad-id --json\` emits JSON with \`code\` field on stderr
- [ ] Manual: \`pax8 companies show bad-id\` (no --json) still renders human-formatted error

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)