### PR TITLE
feat: --idempotency-key on write commands (#91)

### DIFF
--- a/packages/cli/src/__tests__/idempotency.test.ts
+++ b/packages/cli/src/__tests__/idempotency.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+
+const COMPANY_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const PRODUCT_ID = "prod-m365-biz-prem-0001";
+
+describe("--idempotency-key", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-idem-it-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("first call hits the API; second call replays from cache", async () => {
+    const key = "9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d";
+
+    const first = await runCliExpectSuccess(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--quantity", "5",
+        "--billing-term", "Monthly",
+        "--yes",
+        "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_IDEMPOTENCY_DIR: tmpDir },
+    );
+
+    expect(first.stderr).not.toContain("idempotent replay");
+    const firstJson = JSON.parse(first.stdout);
+    expect(firstJson).toHaveProperty("id");
+
+    // Cache file should exist
+    const files = await fs.readdir(tmpDir);
+    expect(files.filter((f) => f.endsWith(".json")).length).toBe(1);
+
+    const second = await runCliExpectSuccess(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--quantity", "5",
+        "--billing-term", "Monthly",
+        "--yes",
+        "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_IDEMPOTENCY_DIR: tmpDir },
+    );
+
+    expect(second.stderr).toContain("idempotent replay");
+    // Replay should produce byte-for-byte identical stdout (the cached payload).
+    expect(second.stdout).toBe(first.stdout);
+  });
+
+  it("rejects same key with different args", async () => {
+    const key = "abc12345-1234-4abc-8def-0123456789ab";
+
+    await runCliExpectSuccess(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--quantity", "5",
+        "--yes", "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_IDEMPOTENCY_DIR: tmpDir },
+    );
+
+    const second = await runCliExpectFailure(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--quantity", "10",         // different quantity
+        "--yes", "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_IDEMPOTENCY_DIR: tmpDir },
+    );
+
+    expect(second.stderr).toMatch(/[Ii]dempotency key reused with different arguments/);
+  });
+
+  it("rejects an invalid key", async () => {
+    const result = await runCliExpectFailure(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--yes", "--json",
+        "--idempotency-key", "bad key!", // contains space and bang
+      ],
+      { PAX8_IDEMPOTENCY_DIR: tmpDir },
+    );
+    expect(result.stderr).toMatch(/[Ii]nvalid idempotency key/);
+  });
+
+  it("works in demo mode (caches locally)", async () => {
+    // Default test env already has PAX8_DEMO=1; this asserts the flag is honored
+    // even with the mock client.
+    const key = "demomode-1234-4abc-8def-0123456789ab";
+    const first = await runCliExpectSuccess(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--quantity", "3",
+        "--yes", "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_IDEMPOTENCY_DIR: tmpDir, PAX8_DEMO: "1" },
+    );
+    const second = await runCliExpectSuccess(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--quantity", "3",
+        "--yes", "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_IDEMPOTENCY_DIR: tmpDir, PAX8_DEMO: "1" },
+    );
+    expect(second.stderr).toContain("idempotent replay");
+    expect(second.stdout).toBe(first.stdout);
+  });
+
+  it("read commands do not accept --idempotency-key", async () => {
+    const result = await runCli(
+      ["companies", "list", "--idempotency-key", "abc12345-1234-4abc-8def-0123456789ab"],
+    );
+    // Commander prints "unknown option" to stderr and exits non-zero.
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/unknown option|--idempotency-key/);
+  });
+
+  it("--help mentions --idempotency-key on writes", async () => {
+    const result = await runCliExpectSuccess(["orders", "create", "--help"]);
+    expect(result.stdout).toContain("--idempotency-key");
+    expect(result.stdout).toContain("24h TTL");
+  });
+
+  it("--help on a read command does not mention --idempotency-key", async () => {
+    const result = await runCliExpectSuccess(["companies", "list", "--help"]);
+    expect(result.stdout).not.toContain("--idempotency-key");
+  });
+});

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -16,6 +16,7 @@ import {
 import type { CreateOrderInput, OrderLineItemInput, BillingTerm } from "@pax8/core";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
+import { hashArgs, isValidKey, loadEntry, saveEntry } from "../../lib/idempotency.js";
 
 export const ordersCreateCommand = new Command("create")
   .description("Create a new order")
@@ -26,13 +27,18 @@ export const ordersCreateCommand = new Command("create")
   .option("--commitment-term <term>", "Commitment term (Monthly, 1-Year, or 3-Year) — auto-resolves to UUID from existing subscription")
   .option("--commitment-term-id <uuid>", "Commitment term UUID (from subscription commitment.id)")
   .option("-y, --yes", "Skip confirmation prompt")
+  .option(
+    "--idempotency-key <uuid>",
+    "Replay-safe key for retries (24h TTL). Accepts UUIDs or 8–128 char identifiers (letters, digits, '-', '_', '.')",
+  )
   .addHelpText(
     "after",
     `
 Examples:
   pax8 orders create --company a1b2c3d4-e5f6-7890-abcd-ef1234567890 --product prod-m365-biz-prem-0001 --quantity 5
   pax8 orders create --company a1b2c3d4 --product prod-123 --quantity 10 --billing-term Annual
-  pax8 orders create --company a1b2c3d4 --product prod-123 --yes`
+  pax8 orders create --company a1b2c3d4 --product prod-123 --yes
+  pax8 orders create --company a1b2c3d4 --product prod-123 --idempotency-key 9f3b2c1e-...-e1`
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -40,6 +46,109 @@ Examples:
     // Hoist names so they're available in catch block for error messages
     let productName: string = allOpts.product;
     let companyName: string = allOpts.company;
+
+    // --- Idempotency handling ---
+    // The "args hash" deliberately excludes `yes` (cosmetic) and the key itself,
+    // so retrying with the same key under -y or interactive confirm is allowed.
+    const idempotencyKey: string | undefined = allOpts.idempotencyKey;
+    const commandName = "orders.create";
+    let argsHash: string | null = null;
+    if (idempotencyKey !== undefined) {
+      if (!isValidKey(idempotencyKey)) {
+        handleCommandError(
+          new CliError(
+            `Invalid idempotency key: "${idempotencyKey}"`,
+            [
+              "Idempotency keys must be 8–128 characters of letters, digits, '-', '_', or '.'",
+              "UUID v4 is recommended.",
+            ],
+            [
+              "Generate one with: uuidgen",
+              `Example: ${replCmd("pax8 orders create")} ... --idempotency-key 9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d`,
+            ],
+          ),
+        );
+      }
+      argsHash = hashArgs({
+        company: allOpts.company,
+        product: allOpts.product,
+        quantity: allOpts.quantity,
+        billingTerm: allOpts.billingTerm,
+        commitmentTerm: allOpts.commitmentTerm,
+        commitmentTermId: allOpts.commitmentTermId,
+      });
+
+      try {
+        const cached = await loadEntry(commandName, idempotencyKey);
+        if (cached) {
+          if (cached.argsHash !== argsHash) {
+            handleCommandError(
+              new CliError(
+                "Idempotency key reused with different arguments — refusing to retry.",
+                [
+                  `The key "${idempotencyKey}" was previously used for ${cached.command} with a different argument set.`,
+                  "Replaying with new arguments would risk a double-write or a misleading 'cached' response.",
+                ],
+                [
+                  "Generate a new idempotency key for the new request.",
+                  `Or wait 24h for the old entry to expire (cached at ${cached.createdAt}).`,
+                ],
+              ),
+            );
+          }
+          process.stderr.write(chalk.dim("  (idempotent replay)\n"));
+          if (cached.output) process.stdout.write(cached.output);
+          process.exit(cached.exitCode);
+          return;
+        }
+      } catch (err) {
+        // Re-throw CliError thrown via handleCommandError; for other read errors,
+        // log in debug mode and proceed (fail-open: if cache is broken, the user
+        // still gets to make the call).
+        if (err instanceof CliError) throw err;
+        if (process.env.PAX8_DEBUG) {
+          process.stderr.write(`[debug] idempotency cache read failed: ${err}\n`);
+        }
+      }
+    }
+
+    // Capture stdout so we can replay it on a future invocation with the
+    // same idempotency key. We only install the proxy when a key is present.
+    let captured = "";
+    let succeeded = false;
+    const realStdoutWrite = process.stdout.write.bind(process.stdout);
+    if (idempotencyKey) {
+      // Cast to satisfy the multi-overload signature of process.stdout.write.
+      (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) = (
+        chunk: string | Uint8Array,
+      ): boolean => {
+        const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+        captured += text;
+        return realStdoutWrite(chunk as string);
+      };
+    }
+    const restoreStdout = (): void => {
+      if (idempotencyKey) {
+        process.stdout.write = realStdoutWrite as typeof process.stdout.write;
+      }
+    };
+    const persistEntry = async (): Promise<void> => {
+      if (!idempotencyKey || !succeeded || argsHash === null) return;
+      try {
+        await saveEntry({
+          key: idempotencyKey,
+          command: commandName,
+          argsHash,
+          output: captured,
+          exitCode: 0,
+          createdAt: new Date().toISOString(),
+        });
+      } catch (err) {
+        if (process.env.PAX8_DEBUG) {
+          process.stderr.write(`[debug] idempotency cache write failed: ${err}\n`);
+        }
+      }
+    };
 
     try {
       const ctx = await buildContext(allOpts);
@@ -204,6 +313,11 @@ Examples:
         companyId: resolvedCompanyId,
         lineItems: [lineItem],
       };
+      // TODO: When the Pax8 API adds support for an `Idempotency-Key` request
+      // header on POST /orders (not currently documented in the existing
+      // `OrdersApi.create` shape — see packages/core/src/api/orders.ts), pass
+      // `idempotencyKey` through here so the server dedupes natively. Until
+      // then, deduplication is purely local via the file cache below.
       const order = await ctx.api.orders.create(orderInput);
       await invalidateCacheAfterWrite();
 
@@ -241,6 +355,9 @@ Examples:
           annualCost: annualCost ?? null,
         };
         process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
+        succeeded = true;
+        await persistEntry();
+        restoreStdout();
         return;
       }
 
@@ -275,7 +392,14 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders show ${order.id}`))}  ${chalk.dim("check order status")}\n`);
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions list --company "${companyName}"`))}  ${chalk.dim("view subscriptions")}\n`);
       process.stderr.write("\n");
+      succeeded = true;
+      await persistEntry();
+      restoreStdout();
     } catch (error) {
+      // Restore stdout before delegating to handleCommandError (which prints
+      // formatted error to stderr and calls process.exit). We don't persist the
+      // idempotency entry on error — the agent can retry.
+      restoreStdout();
       // Provide order-specific error messages with actionable guidance
       if (error instanceof ApiError) {
         const displayProduct = productName || allOpts.product;

--- a/packages/cli/src/lib/idempotency.test.ts
+++ b/packages/cli/src/lib/idempotency.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  IDEMPOTENCY_TTL_MS,
+  gc,
+  hashArgs,
+  isValidKey,
+  loadEntry,
+  saveEntry,
+  type IdempotencyEntry,
+} from "./idempotency.js";
+
+describe("idempotency", () => {
+  let tmpDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-idempotency-"));
+    originalEnv = process.env.PAX8_IDEMPOTENCY_DIR;
+    process.env.PAX8_IDEMPOTENCY_DIR = tmpDir;
+  });
+
+  afterEach(async () => {
+    if (originalEnv === undefined) delete process.env.PAX8_IDEMPOTENCY_DIR;
+    else process.env.PAX8_IDEMPOTENCY_DIR = originalEnv;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("isValidKey", () => {
+    it("accepts UUID v4", () => {
+      expect(isValidKey("9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d")).toBe(true);
+    });
+
+    it("accepts 8+ char alphanumeric identifiers", () => {
+      expect(isValidKey("abc12345")).toBe(true);
+      expect(isValidKey("order_2026-04-30.001")).toBe(true);
+    });
+
+    it("rejects too-short keys", () => {
+      expect(isValidKey("short")).toBe(false);
+      expect(isValidKey("")).toBe(false);
+    });
+
+    it("rejects too-long keys", () => {
+      expect(isValidKey("a".repeat(129))).toBe(false);
+    });
+
+    it("rejects invalid characters", () => {
+      expect(isValidKey("has spaces hello")).toBe(false);
+      expect(isValidKey("has/slashes/foo")).toBe(false);
+      expect(isValidKey("has@symbols!yes")).toBe(false);
+    });
+
+    it("rejects non-string input", () => {
+      // @ts-expect-error testing runtime validation
+      expect(isValidKey(undefined)).toBe(false);
+      // @ts-expect-error testing runtime validation
+      expect(isValidKey(null)).toBe(false);
+      // @ts-expect-error testing runtime validation
+      expect(isValidKey(12345678)).toBe(false);
+    });
+  });
+
+  describe("hashArgs", () => {
+    it("is deterministic", () => {
+      const a = hashArgs({ foo: "bar", n: 1 });
+      const b = hashArgs({ foo: "bar", n: 1 });
+      expect(a).toBe(b);
+    });
+
+    it("is order-independent", () => {
+      const a = hashArgs({ a: 1, b: 2, c: 3 });
+      const b = hashArgs({ c: 3, a: 1, b: 2 });
+      expect(a).toBe(b);
+    });
+
+    it("differs when values differ", () => {
+      const a = hashArgs({ qty: 5 });
+      const b = hashArgs({ qty: 6 });
+      expect(a).not.toBe(b);
+    });
+
+    it("ignores undefined values", () => {
+      const a = hashArgs({ x: 1, y: undefined });
+      const b = hashArgs({ x: 1 });
+      expect(a).toBe(b);
+    });
+
+    it("normalizes nested objects (key order)", () => {
+      const a = hashArgs({ obj: { a: 1, b: 2 } });
+      const b = hashArgs({ obj: { b: 2, a: 1 } });
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("save / load", () => {
+    it("returns null when no entry exists", async () => {
+      expect(await loadEntry("orders.create", "abc12345")).toBeNull();
+    });
+
+    it("round-trips an entry", async () => {
+      const entry: IdempotencyEntry = {
+        key: "abc12345",
+        command: "orders.create",
+        argsHash: "deadbeef",
+        output: "hello\n",
+        exitCode: 0,
+        createdAt: new Date().toISOString(),
+      };
+      await saveEntry(entry);
+      const loaded = await loadEntry("orders.create", "abc12345");
+      expect(loaded).toEqual(entry);
+    });
+
+    it("isolates entries by command", async () => {
+      const baseEntry = {
+        key: "abc12345",
+        argsHash: "h1",
+        output: "x",
+        exitCode: 0,
+        createdAt: new Date().toISOString(),
+      };
+      await saveEntry({ ...baseEntry, command: "orders.create" });
+      await saveEntry({ ...baseEntry, command: "subscriptions.update" });
+      const a = await loadEntry("orders.create", "abc12345");
+      const b = await loadEntry("subscriptions.update", "abc12345");
+      expect(a?.command).toBe("orders.create");
+      expect(b?.command).toBe("subscriptions.update");
+    });
+  });
+
+  describe("garbage collection", () => {
+    it("evicts entries older than 24h", async () => {
+      const old = new Date(Date.now() - IDEMPOTENCY_TTL_MS - 60_000).toISOString();
+      const fresh = new Date().toISOString();
+
+      await saveEntry({
+        key: "oldkey12",
+        command: "orders.create",
+        argsHash: "h",
+        output: "stale",
+        exitCode: 0,
+        createdAt: old,
+      });
+      await saveEntry({
+        key: "freshkey",
+        command: "orders.create",
+        argsHash: "h",
+        output: "fresh",
+        exitCode: 0,
+        createdAt: fresh,
+      });
+
+      // gc is invoked implicitly by loadEntry, but we also call it directly.
+      await gc();
+
+      expect(await loadEntry("orders.create", "oldkey12")).toBeNull();
+      expect(await loadEntry("orders.create", "freshkey")).not.toBeNull();
+    });
+
+    it("loadEntry refuses to return a stale entry", async () => {
+      const old = new Date(Date.now() - IDEMPOTENCY_TTL_MS - 1_000).toISOString();
+      await saveEntry({
+        key: "stalekey",
+        command: "orders.create",
+        argsHash: "h",
+        output: "x",
+        exitCode: 0,
+        createdAt: old,
+      });
+      // Even before background gc, loadEntry filters based on createdAt.
+      expect(await loadEntry("orders.create", "stalekey")).toBeNull();
+    });
+
+    it("removes corrupt files", async () => {
+      const dir = process.env.PAX8_IDEMPOTENCY_DIR!;
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, "garbage.json"), "{ not json");
+      await gc();
+      const remaining = await fs.readdir(dir);
+      expect(remaining.filter((f) => f.endsWith(".json"))).toHaveLength(0);
+    });
+
+    it("does not throw when the dir does not exist", async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      await expect(gc()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/lib/idempotency.ts
+++ b/packages/cli/src/lib/idempotency.ts
@@ -1,0 +1,146 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { homedir } from "node:os";
+import { createHash } from "node:crypto";
+
+/**
+ * Idempotency cache for write commands.
+ *
+ * Storage: one JSON file per entry under `~/.pax8/idempotency/`.
+ * Filename is `<sha1(command + ":" + key)>.json`. One-file-per-entry was chosen
+ * over a JSON-lines file because:
+ *   1. Concurrent writes from different commands don't need locking.
+ *   2. GC is a simple stat + unlink loop — no rewrite of an entire file.
+ *   3. Atomic writes via tmp+rename are trivial per file.
+ *
+ * TTL: 24 hours. GC runs on every read and write.
+ *
+ * The directory can be overridden with `PAX8_IDEMPOTENCY_DIR` (used in tests).
+ */
+
+export interface IdempotencyEntry {
+  key: string;
+  command: string;
+  argsHash: string;       // sha256 of normalized args
+  output: string;         // captured stdout (or response body)
+  exitCode: number;
+  createdAt: string;      // ISO8601
+}
+
+export const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+function dirPath(): string {
+  return process.env.PAX8_IDEMPOTENCY_DIR
+    ?? path.join(homedir(), ".pax8", "idempotency");
+}
+
+function entryFilePath(command: string, key: string): string {
+  const hash = createHash("sha1").update(`${command}:${key}`).digest("hex");
+  return path.join(dirPath(), `${hash}.json`);
+}
+
+/**
+ * Validate an idempotency key.
+ *
+ * Accepts:
+ *   - UUID v4 (preferred — lowercase hex with hyphens)
+ *   - Other "reasonable identifiers": 8–128 chars of letters, digits,
+ *     `-`, `_`, `.` (so agents that mint shorter ULIDs / nanoids work).
+ *
+ * Rejects empty strings, whitespace, and anything outside the charset.
+ */
+export function isValidKey(key: string): boolean {
+  if (typeof key !== "string") return false;
+  if (key.length < 8 || key.length > 128) return false;
+  return /^[A-Za-z0-9._-]+$/.test(key);
+}
+
+/**
+ * Hash a normalized record of arguments.
+ * Keys are sorted for stability; values are stringified.
+ */
+export function hashArgs(args: Record<string, unknown>): string {
+  const entries = Object.entries(args)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => [k, normalizeValue(v)]);
+  return createHash("sha256").update(JSON.stringify(entries)).digest("hex");
+}
+
+function normalizeValue(v: unknown): unknown {
+  if (v === null || v === undefined) return null;
+  if (Array.isArray(v)) return v.map(normalizeValue);
+  if (typeof v === "object") {
+    const obj = v as Record<string, unknown>;
+    return Object.keys(obj)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, k) => {
+        acc[k] = normalizeValue(obj[k]);
+        return acc;
+      }, {});
+  }
+  return v;
+}
+
+/**
+ * Garbage-collect entries older than the TTL. Best-effort — failures are
+ * swallowed so cache problems never break the user's command.
+ */
+export async function gc(now: number = Date.now()): Promise<void> {
+  const dir = dirPath();
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return; // dir doesn't exist
+  }
+
+  await Promise.all(
+    files
+      .filter((f) => f.endsWith(".json"))
+      .map(async (f) => {
+        const fp = path.join(dir, f);
+        try {
+          const raw = await fs.readFile(fp, "utf-8");
+          const entry = JSON.parse(raw) as IdempotencyEntry;
+          const ts = Date.parse(entry.createdAt);
+          if (Number.isNaN(ts) || now - ts > IDEMPOTENCY_TTL_MS) {
+            await fs.unlink(fp).catch(() => {});
+          }
+        } catch {
+          // Corrupt file — remove it.
+          await fs.unlink(fp).catch(() => {});
+        }
+      }),
+  );
+}
+
+export async function loadEntry(
+  command: string,
+  key: string,
+): Promise<IdempotencyEntry | null> {
+  await gc();
+  try {
+    const raw = await fs.readFile(entryFilePath(command, key), "utf-8");
+    const entry = JSON.parse(raw) as IdempotencyEntry;
+    const ts = Date.parse(entry.createdAt);
+    if (Number.isNaN(ts) || Date.now() - ts > IDEMPOTENCY_TTL_MS) {
+      // Stale — remove and return null.
+      await fs.unlink(entryFilePath(command, key)).catch(() => {});
+      return null;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveEntry(entry: IdempotencyEntry): Promise<void> {
+  await gc();
+  const dir = dirPath();
+  await fs.mkdir(dir, { recursive: true });
+  const fp = entryFilePath(entry.command, entry.key);
+  const tmp = fp + ".tmp";
+  await fs.writeFile(tmp, JSON.stringify(entry), { encoding: "utf-8", mode: 0o600 });
+  await fs.rename(tmp, fp);
+}


### PR DESCRIPTION
## Summary

Implements the **idempotency keys** contract from \`docs/UX_GUIDE.md\` §12. Agents passing \`--idempotency-key <uuid>\` can retry safely — the second call with a matching key+args replays the cached output without re-hitting the API.

## What changed

- **New** \`packages/cli/src/lib/idempotency.ts\` (146 lines) — \`isValidKey\`, \`hashArgs\`, \`loadEntry\`, \`saveEntry\`, \`gc\`. Storage at \`~/.pax8/idempotency/<sha1(command+key)>.json\`, 24h TTL, GC on every read/write. \`PAX8_IDEMPOTENCY_DIR\` env override for tests.
- **\`packages/cli/src/commands/orders/create.ts\`** — adds \`--idempotency-key <uuid>\` option, validates it, checks the cache before the API call, persists captured stdout on success.
- **Tests**: 191 lines of unit tests + 158 lines of subprocess integration tests covering replay, args mismatch rejection, invalid key rejection, demo mode caching, read-command rejection of the flag, and help-text presence.

## Decisions

- **Storage:** one JSON file per entry (atomic writes, per-entry GC) over a JSON-lines log.
- **Args hash** excludes \`--yes\` and the key itself, so \`-y\` and interactive runs with the same key are interchangeable.
- **Server-side** \`Idempotency-Key\` **header:** Pax8 API doesn't appear to accept one (\`packages/core/src/api/orders.ts\` does a plain POST). Defaulted to local-only with a TODO; if the API adds support later, plumb the header through and skip the local cache.
- **Cache-read failures fail open** (debug-logged), so a broken cache never blocks a write.

## Notes

- The two new \`CliError\` throws (invalid key, key reused with different args) are plain \`CliError\` for now — once #90 lands, attach \`ERROR_INVALID_INPUT\` and a new \`ERROR_IDEMPOTENCY_KEY_REUSED\` code.
- Touches \`orders/create.ts\` so will conflict with #92.

## Test plan

- [x] \`pnpm build\` passes
- [x] \`pnpm test\` — 816 passed / 8 pre-existing skipped
- [ ] Manual: \`pax8 orders create ... --idempotency-key <uuid>\` twice → second call shows \`(idempotent replay)\` on stderr
- [ ] Manual: same key with different args → \`CliError\`

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)