### PR TITLE
docs: README framing and elevate @pax8/core (#99 #100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 An open-source CLI for managing Pax8 cloud marketplace operations. Built for MSPs who want to manage subscriptions, billing, customers, and growth opportunities from the terminal.
 
+## Status
+
+This is an early-stage open-source experiment. We're using engagement signals (installs, issues, command usage) to learn which capabilities are worth investing in further. Feedback, issues, and PRs are welcome.
+
 ## Highlights
 
-- **Business dashboard** — `pax8 status` shows MRR, renewals, growth opportunities, and expiring trials in one command
-- **Recommendation engine** — analyzes customer portfolios, flags missing products (backup, security, identity), and estimates MRR uplift
-- **Act on recommendations** — `pax8 recommendations act` walks through opportunities one by one and places orders
-- **Full Pax8 API coverage** — companies, subscriptions, orders, invoices, products
-- **Claude AI integration** — agents get structured access to renewals, audits, recommendations, and MRR via the Claude Code skill
-- **Smart UX** — interactive drill-downs, copy-paste order commands, actionable error messages
+- **Answers the API doesn't** — renewals, invoice audit, upsell recommendations, MRR analytics computed locally from raw Pax8 data
+- **Closes the loop** — `pax8 recommendations act` walks portfolio gaps and places the orders, so insight and action live in the same tool
+- **Works for humans and agents identically** — every command emits structured JSON, so a Claude Code skill, a shell pipeline, or a person at a terminal all use the same surface
+- **Demo mode** — `PAX8_DEMO=1` runs every command against an in-memory fixture, no credentials required
 
 ## Why This Exists
 
@@ -23,6 +25,10 @@ This CLI computes what the API doesn't:
 - **MRR analytics** — aggregation by company/product/vendor with annual-to-monthly amortization
 
 Every command supports `--json`, so humans and AI agents use the same tool.
+
+## When to use this CLI vs the Pax8 MCP
+
+Pax8 publishes a hosted MCP server at `mcp.pax8.com` for AI assistants — see the [Pax8 MCP docs](https://devx.pax8.com/docs/mcp-server). Use this CLI when you want a richer command surface (recommendations, invoice audit, MRR analytics, demo mode) or when you're scripting against a stable, versioned interface. Use the Pax8 MCP when you want zero-install access via Claude, Cursor, Copilot, or VS Code and you don't need the CLI-specific capabilities.
 
 ## Quick Start
 
@@ -44,10 +50,10 @@ PAX8_DEMO=1 pax8 status
 
 ```bash
 pax8 status                              # MRR, renewals, growth opportunities
-pax8 companies list                      # Browse customers (type # to drill in)
-pax8 companies more "Acme Corp"          # Full customer summary
 pax8 recommendations list                # Cross-sell and seat gap opportunities
 pax8 recommendations act                 # Walk through and place orders (y/s/q)
+pax8 companies list                      # Browse customers (type # to drill in)
+pax8 companies more "Acme Corp"          # Full customer summary
 ```
 
 ## Commands
@@ -207,6 +213,10 @@ Claude: runs pax8 recommendations list --json, returns prioritized gaps
 ```
 
 Works with Claude Code, Cursor, Copilot, and any agent framework that can run shell commands.
+
+## Core library
+
+All business logic lives in [`@pax8/core`](packages/core) with zero CLI dependencies — the renewal tracker, invoice auditor, recommendation engine, and MRR analytics are all importable from a portal feature, a Lambda, a dashboard, or your own tool. The CLI is one consumer; the durable asset is the domain knowledge in `core`. See [`packages/core/README.md`](packages/core/README.md) for the install, import example, and capability list.
 
 ## Performance
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,72 @@
+# @pax8/core
+
+Computed business logic for Pax8 marketplace operations — renewal tracking, invoice audit, upsell recommendations, and MRR analytics. Interface-agnostic: the same package powers [`pax8-cli`](https://github.com/pax8labs/pax8-cli), and is usable from a portal feature, a web dashboard, a Lambda, or any Node.js context. The Pax8 API is a CRUD layer; this package is what turns raw subscriptions, invoices, and products into the answers MSPs actually ask for.
+
+## Install
+
+```bash
+pnpm add @pax8/core
+# or: npm install @pax8/core
+# or: yarn add @pax8/core
+```
+
+Requires Node.js 20+. ESM only.
+
+## Quick example
+
+Compute upcoming renewals and total MRR at risk for the next 30 days:
+
+```ts
+import { Pax8Client, getUpcomingRenewals } from "@pax8/core";
+
+const client = new Pax8Client({
+  clientId: process.env.PAX8_CLIENT_ID!,
+  clientSecret: process.env.PAX8_CLIENT_SECRET!,
+});
+
+const subscriptions = await client.subscriptions.listAll({ status: "Active" });
+const companies = await client.companies.listAll();
+const companyNameById = new Map(companies.map((c) => [c.id, c.name]));
+
+const report = getUpcomingRenewals(subscriptions, companyNameById, {
+  withinDays: 30,
+});
+
+console.log(`${report.items.length} renewals, $${report.totalMrrAtRisk.toFixed(2)} MRR at risk`);
+for (const item of report.items.slice(0, 5)) {
+  console.log(`  ${item.companyName} — ${item.productName} in ${item.daysUntilRenewal}d`);
+}
+```
+
+Demo mode (no credentials):
+
+```ts
+import { MockPax8Client, getUpcomingRenewals } from "@pax8/core";
+
+const client = new MockPax8Client();
+const subscriptions = await client.subscriptions.listAll();
+// ...same shape as above
+```
+
+## What's in here
+
+The durable asset — questions this package answers without you having to assemble them from raw API calls:
+
+- **Renewal tracker** (`getUpcomingRenewals`) — which subscriptions renew within N days, how much MRR is at risk, sorted by urgency. The Pax8 API has no renewals endpoint; this parses commitment dates and computes the report.
+- **Invoice auditor** (`auditInvoices`) — cross-references invoice line items against active subscriptions to flag overcharges, undercharges, and orphan line items with dollar impact.
+- **Recommendation engine** (`getRecommendations`, `getPortfolioCoverage`) — analyzes each customer's stack against backup / security / identity / productivity categories, identifies gaps, estimates MRR uplift, and emits ready-to-execute order parameters.
+- **MRR analytics** (`subscriptionMrr`, `computeMrr`, `computeGrowth`) — per-subscription MRR with annual-to-monthly amortization; aggregation by company/product/vendor; growth deltas across snapshots.
+- **API client** (`Pax8Client`) — typed wrapper over Pax8 v1 with auth, retry, and rate-limit awareness. Sub-clients: `companies`, `contacts`, `subscriptions`, `orders`, `invoices`, `products`, `usage`, `quotes`, `webhooks`.
+- **Mock client** (`MockPax8Client`) — drop-in replacement backed by an in-memory fixture. Same interface as `Pax8Client`. Used by the CLI for `PAX8_DEMO=1`.
+- **Bulk executor** (`executeBulk`) — concurrency-bounded batch runner with progress callbacks, used to apply a list of operations (e.g. ordering across many companies) without overwhelming the API rate limit.
+- **Types and Zod schemas** — `Subscription`, `Company`, `Invoice`, `Product`, `Order`, etc., plus typed errors (`Pax8ApiError`) and machine-readable error codes.
+
+## Versioning
+
+**Experimental.** This package is currently `0.x` and the public surface may change between minor versions. Pin a specific version (`"@pax8/core": "0.1.0"`, not `"^0.1.0"`) until the package reaches `1.0`. Breaking changes will be called out in release notes.
+
+The CLI in this repo is the reference consumer — if you're unsure how to assemble a workflow, look at how [`packages/cli`](https://github.com/pax8labs/pax8-cli/tree/main/packages/cli/src/commands) uses these services.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
## Summary

Two related framing updates from the strategy-doc review:

### Main README (#99)
- New **\"Status\"** section near the top — sets expectations that this is an early-stage open-source experiment.
- New **\"When to use this CLI vs the Pax8 MCP\"** section after \"Why This Exists.\"
- **Reordered Highlights** to lead with the closed-loop differentiator.
- **Reordered demo flow** so \`recommendations act\` appears within the first 3 commands.
- New **\"Core library\"** section pointing at \`packages/core\`.

### packages/core/README.md (#100, new)
72 lines. Elevator pitch, install, import example with both the real client and \`MockPax8Client\`, capability list, experimental versioning posture, pointer to the CLI as the reference consumer.

## Verification

\`@pax8/core\` is publishable today: not marked private, has \`exports\`/\`main\`/\`types\` set, and \`pnpm publish --dry-run -F @pax8/core\` succeeds (39.7 kB packed). No publish in this PR.

## Follow-up worth filing

\`packages/core/src/index.ts\` re-exports via wildcards — \`FileCache\`, telemetry helpers, and internal config bits leak as public API by accident. Worth an audit before \`1.0\`.

Closes #99
Closes #100