### PR TITLE
feat: add Pax8 MCP token validation to doctor (#102)

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
 import { runCliExpectSuccess } from "./test-utils.js";
+import { checkMcp } from "../commands/doctor.js";
 
 describe("pax8 doctor", () => {
   it("runs diagnostics in demo mode", async () => {
@@ -35,5 +39,30 @@ describe("pax8 doctor", () => {
     const result = await runCliExpectSuccess(["doctor", "--help"]);
     expect(result.stdout).toContain("diagnostic");
     expect(result.stdout).toContain("Examples:");
+  });
+});
+
+describe("checkMcp", () => {
+  it("passes with skip detail when .mcp.json is not found anywhere up the tree", async () => {
+    // Create an isolated temp dir whose root has no .mcp.json by walking up
+    // (mkdtemp uses os.tmpdir() so the walk hits / without finding one).
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-doctor-mcp-"));
+    try {
+      // Force non-demo so the demo-mode early-return doesn't mask the file lookup.
+      const prev = process.env.PAX8_DEMO;
+      delete process.env.PAX8_DEMO;
+      try {
+        const fetchImpl = (() => {
+          throw new Error("fetch should not be called when .mcp.json is missing");
+        }) as unknown as typeof fetch;
+        const result = await checkMcp({ cwd: tmp, fetchImpl });
+        expect(result.passed).toBe(true);
+        expect(result.detail).toContain(".mcp.json not found");
+      } finally {
+        if (prev !== undefined) process.env.PAX8_DEMO = prev;
+      }
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -145,6 +145,116 @@ async function checkApiHealth(): Promise<CheckResult[]> {
   return results;
 }
 
+interface McpJson {
+  mcpServers?: {
+    pax8?: {
+      url?: string;
+      headers?: Record<string, string>;
+    };
+  };
+}
+
+async function findMcpJson(startDir: string): Promise<string | null> {
+  let dir = startDir;
+  // Walk up at most 8 levels to avoid pathological traversal
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, ".mcp.json");
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // not here, walk up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export async function checkMcp(opts?: {
+  cwd?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<CheckResult> {
+  const name = "MCP server";
+  const isDemo = await isDemoMode();
+  if (isDemo) {
+    return { name, passed: true, detail: "Demo mode — MCP check skipped." };
+  }
+
+  const startDir = opts?.cwd ?? process.cwd();
+  const mcpPath = await findMcpJson(startDir);
+  if (!mcpPath) {
+    return {
+      name,
+      passed: true,
+      detail:
+        ".mcp.json not found — MCP not configured (skip if you don't use Claude/Cursor/Copilot)",
+    };
+  }
+
+  let parsed: McpJson;
+  try {
+    const raw = await fs.readFile(mcpPath, "utf8");
+    parsed = JSON.parse(raw) as McpJson;
+  } catch (err) {
+    return {
+      name,
+      passed: false,
+      detail: `Failed to parse ${mcpPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const server = parsed.mcpServers?.pax8;
+  const url = server?.url;
+  const token = server?.headers?.["x-pax8-mcp-token"];
+  if (!url || !token) {
+    return {
+      name,
+      passed: false,
+      detail: ".mcp.json found but missing pax8 server url or x-pax8-mcp-token header.",
+    };
+  }
+
+  const doFetch = opts?.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await doFetch(url, {
+      method: "GET",
+      headers: { "x-pax8-mcp-token": token, accept: "application/json, text/event-stream" },
+      signal: controller.signal,
+    });
+    if (res.status >= 200 && res.status < 300) {
+      return { name, passed: true, detail: "MCP server reachable, token valid" };
+    }
+    if (res.status === 401 || res.status === 403) {
+      return {
+        name,
+        passed: false,
+        detail:
+          "MCP token invalid or revoked. Regenerate at https://app.pax8.com/integrations/mcp",
+      };
+    }
+    // Other 4xx (e.g. 405 from a streamable-HTTP MCP that rejects bare GET) means
+    // we reached the server — token shape unverified, but no point failing doctor.
+    return {
+      name,
+      passed: true,
+      detail: `MCP server reachable (HTTP ${res.status}); token shape unverified`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      name,
+      passed: false,
+      detail: `MCP server unreachable. Check network/firewall. (${msg})`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function checkCredentialPermissions(): Promise<CheckResult> {
   const store = new CredentialStore();
   const result = await store.checkPermissions();
@@ -205,7 +315,7 @@ Examples:
     process.stdout.write(chalk.bold("\n  Pax8 CLI — Diagnostics\n\n"));
 
     // Run all checks in parallel for speed
-    const [nodeV, configF, authC, credPerms, tokenC, apiCs, cacheC, telC] = await Promise.all([
+    const [nodeV, configF, authC, credPerms, tokenC, apiCs, cacheC, telC, mcpC] = await Promise.all([
       checkNodeVersion(),
       checkConfigFile(),
       checkAuth(),
@@ -214,8 +324,9 @@ Examples:
       checkApiHealth(),
       checkCacheDir(),
       checkTelemetry(),
+      checkMcp(),
     ]);
-    const checks: CheckResult[] = [nodeV, configF, authC, credPerms, tokenC, ...apiCs, cacheC, telC];
+    const checks: CheckResult[] = [nodeV, configF, authC, credPerms, tokenC, ...apiCs, cacheC, telC, mcpC];
 
     let allPassed = true;
     for (const check of checks) {


### PR DESCRIPTION
## Summary

Adds an MCP-server reachability/token check to \`pax8 doctor\`. The repo's \`.mcp.json\` (when present) gets read, the configured server URL is hit with the token in the \`x-pax8-mcp-token\` header, and the result is mapped to the existing \`CheckResult\` shape.

## Implementation notes

- \`GET https://mcp.pax8.com/v1/mcp\` with a 5s \`AbortController\` timeout. Built-in \`fetch\` — no new deps.
- **2xx → pass** (\"reachable, token valid\")
- **401/403 → fail** with regenerate-token pointer
- **Other 4xx (e.g. 405) → soft pass** with a \"reachable, token shape unverified\" detail. The live MCP returns 405 to bare GET — confirmed via curl. A full validation would require an MCP \`initialize\` POST, which is out of scope for a low-cost diagnostic.
- **Network/timeout → fail**
- **\`.mcp.json\` missing → skip-pass** (it's optional config)
- **Demo mode → skip** (matches existing \`isDemoMode()\` short-circuit pattern)

## Surprises

- \`.mcp.json\` is not committed to the repo — it's a per-developer dotfile. The check handles this cleanly (skip-pass), but the issue body implied otherwise.

## Follow-ups

- Optional \`pax8 doctor --mcp-deep\` flag that does a real \`initialize\` POST for full token validation when the soft-pass path masks a revoked token.
- Consider committing \`.mcp.json\` as a template (with a placeholder token).

## Test plan

- [x] \`pnpm build\` passes
- [x] \`pnpm test\` — 828 passed (+1 new test for the missing-file case)
- [ ] Manual: \`pax8 doctor\` from a directory with a valid \`.mcp.json\`
- [ ] Manual: \`pax8 doctor\` from a directory without one

Closes #102