### PR TITLE
feat: standardize and backfill nextActions across commands (#97)

### DIFF
--- a/packages/cli/src/__tests__/companies.test.ts
+++ b/packages/cli/src/__tests__/companies.test.ts
@@ -51,6 +51,27 @@ describe("pax8 companies", () => {
       const result = await runCliExpectSuccess(["companies", "list"]);
       expect(result.stderr).toContain("companies");
     });
+
+    it("--with-actions wraps in { companies, nextActions }", async () => {
+      const result = await runCliExpectSuccess([
+        "companies",
+        "list",
+        "--json",
+        "--with-actions",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("companies");
+      expect(data).toHaveProperty("nextActions");
+      expect(Array.isArray(data.companies)).toBe(true);
+      expect(Array.isArray(data.nextActions)).toBe(true);
+      expect(data.nextActions.length).toBeGreaterThan(0);
+      for (const action of data.nextActions) {
+        expect(action).toHaveProperty("command");
+        expect(action).toHaveProperty("description");
+        expect(typeof action.command).toBe("string");
+        expect(typeof action.description).toBe("string");
+      }
+    });
   });
 
   describe("companies show", () => {

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -47,6 +47,25 @@ describe("pax8 invoices", () => {
         expect(inv.companyId).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
       }
     });
+
+    it("--with-actions wraps in { invoices, nextActions }", async () => {
+      const result = await runCliExpectSuccess([
+        "invoices",
+        "list",
+        "--json",
+        "--with-actions",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("invoices");
+      expect(data).toHaveProperty("nextActions");
+      expect(Array.isArray(data.invoices)).toBe(true);
+      expect(Array.isArray(data.nextActions)).toBe(true);
+      expect(data.nextActions.length).toBeGreaterThan(0);
+      for (const action of data.nextActions) {
+        expect(action).toHaveProperty("command");
+        expect(action).toHaveProperty("description");
+      }
+    });
   });
 
   describe("invoices show", () => {

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -49,6 +49,25 @@ describe("pax8 subscriptions list", () => {
     expect(result.stdout).toContain("--company");
     expect(result.stdout).toContain("Examples:");
   });
+
+  it("--with-actions wraps in { subscriptions, nextActions }", async () => {
+    const result = await runCliExpectSuccess([
+      "subscriptions",
+      "list",
+      "--json",
+      "--with-actions",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data).toHaveProperty("subscriptions");
+    expect(data).toHaveProperty("nextActions");
+    expect(Array.isArray(data.subscriptions)).toBe(true);
+    expect(Array.isArray(data.nextActions)).toBe(true);
+    expect(data.nextActions.length).toBeGreaterThan(0);
+    for (const action of data.nextActions) {
+      expect(action).toHaveProperty("command");
+      expect(action).toHaveProperty("description");
+    }
+  });
 });
 
 describe("pax8 subscriptions show", () => {

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -40,6 +40,7 @@ export const companiesListCommand = new Command("list")
   .option("--size <number>", "Page size", "25")
   .option("--ids-only", "Output only resource IDs, one per line")
   .option("--coverage", "Include portfolio coverage analysis")
+  .option("--with-actions", "Wrap JSON output as { companies, nextActions } instead of a flat array")
   .addHelpText(
     "after",
     `
@@ -49,6 +50,7 @@ Examples:
   pax8 companies list --page 1 --size 25
   pax8 companies list --coverage
   pax8 companies list --json
+  pax8 companies list --json --with-actions
   pax8 companies list --csv
   pax8 companies list --ids-only
   pax8 companies list --ids-only | xargs -I{} pax8 subscriptions list --company {}`
@@ -179,6 +181,41 @@ Examples:
       } catch { /* best effort */ }
 
       const columns = coverageMap ? coverageColumns : baseColumns;
+
+      if (ctx.outputFormat === "json" && allOpts.withActions) {
+        const nextActions: { command: string; description: string }[] = [];
+        // Companies with the largest coverage gaps first if available
+        const ranked = coverageMap
+          ? [...result.content].sort((a, b) => {
+              const aGap = coverageMap!.get(String(a.id))?.estimatedUplift ?? 0;
+              const bGap = coverageMap!.get(String(b.id))?.estimatedUplift ?? 0;
+              return bGap - aGap;
+            })
+          : result.content;
+        for (const c of ranked.slice(0, 3)) {
+          nextActions.push({
+            command: `pax8 companies more "${c.name}"`,
+            description: `Drill into ${c.name}`,
+          });
+        }
+        if (coverageMap) {
+          const top = ranked.find((c) => (coverageMap!.get(String(c.id))?.estimatedUplift ?? 0) > 0);
+          if (top) {
+            nextActions.push({
+              command: `pax8 recommendations list --company "${top.name}" --json`,
+              description: `Review growth opportunities for ${top.name}`,
+            });
+          }
+        } else {
+          nextActions.push({
+            command: "pax8 companies list --coverage --json",
+            description: "Re-run with portfolio coverage analysis to surface gaps",
+          });
+        }
+        process.stdout.write(JSON.stringify({ companies: numbered, nextActions }, null, 2) + "\n");
+        return;
+      }
+
       output(numbered, { format: ctx.outputFormat, columns });
 
       if (ctx.outputFormat === "table") {

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -15,6 +15,7 @@ export const invoicesListCommand = new Command("list")
   .option("--page <number>", "Page number", "1")
   .option("--size <number>", "Page size", "25")
   .option("--ids-only", "Output only resource IDs, one per line")
+  .option("--with-actions", "Wrap JSON output as { invoices, nextActions } instead of a flat array")
   .addHelpText(
     "after",
     `
@@ -24,6 +25,7 @@ Examples:
   pax8 invoices list --company "Summit Healthcare"
   pax8 invoices list --status Unpaid
   pax8 invoices list --json
+  pax8 invoices list --json --with-actions
   pax8 invoices list --csv
   pax8 invoices list --ids-only | xargs -I{} pax8 invoices show {}`
   )
@@ -87,6 +89,33 @@ Examples:
           format: (v) => formatCurrency(Number(v)),
         },
       ];
+
+      if (ctx.outputFormat === "json" && options.withActions) {
+        const nextActions: { command: string; description: string }[] = [];
+        const invoices = result.content;
+        const unpaid = invoices.filter((inv) =>
+          ["unpaid", "overdue"].includes(String((inv as Record<string, unknown>).status ?? "").toLowerCase())
+        );
+        if (unpaid.length > 0) {
+          nextActions.push({
+            command: `pax8 invoices show ${unpaid[0].id}`,
+            description: `Review the first unpaid invoice (${unpaid.length} unpaid total)`,
+          });
+        } else if (invoices.length > 0) {
+          nextActions.push({
+            command: `pax8 invoices show ${invoices[0].id}`,
+            description: "Drill into the most recent invoice",
+          });
+        }
+        nextActions.push({
+          command: "pax8 invoices audit --json",
+          description: "Audit invoices against active subscriptions for billing discrepancies",
+        });
+        process.stdout.write(
+          JSON.stringify({ invoices: result.content, nextActions }, null, 2) + "\n"
+        );
+        return;
+      }
 
       output(result.content, { format: ctx.outputFormat, columns });
 

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -41,6 +41,7 @@ export const subscriptionsListCommand = new Command("list")
   .option("--page <number>", "Page number", "1")
   .option("--size <number>", "Page size", "25")
   .option("--ids-only", "Output only resource IDs, one per line")
+  .option("--with-actions", "Wrap JSON output as { subscriptions, nextActions } instead of a flat array")
   .addHelpText(
     "after",
     `
@@ -50,6 +51,7 @@ Examples:
   pax8 subscriptions list --status Active
   pax8 subscriptions list --size 10 --page 2
   pax8 subscriptions list --json
+  pax8 subscriptions list --json --with-actions
   pax8 subscriptions list --csv
   pax8 subscriptions list --ids-only | xargs -I{} pax8 subscriptions show {}`
   )
@@ -86,6 +88,33 @@ Examples:
         for (const item of result.content) {
           process.stdout.write(item.id + "\n");
         }
+        return;
+      }
+
+      if (ctx.outputFormat === "json" && options.withActions) {
+        const nextActions: { command: string; description: string }[] = [];
+        const subsList = result.content;
+        const trials = subsList.filter((s) => (s.status ?? "").toLowerCase() === "trial");
+        const top = subsList[0];
+        if (top) {
+          nextActions.push({
+            command: `pax8 subscriptions show ${top.id}`,
+            description: `View details for the first subscription (${(top as Record<string, unknown>).productName ?? "subscription"})`,
+          });
+        }
+        if (trials.length > 0) {
+          nextActions.push({
+            command: "pax8 subscriptions list --status Trial --json",
+            description: `Review ${trials.length} trial subscription${trials.length > 1 ? "s" : ""} to convert or cancel`,
+          });
+        }
+        nextActions.push({
+          command: "pax8 subscriptions renewals --json --with-actions",
+          description: "Check upcoming renewals before they auto-renew",
+        });
+        process.stdout.write(
+          JSON.stringify({ subscriptions: result.content, nextActions }, null, 2) + "\n"
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary

Closes the credibility gap between the strategy doc's claim that \"every command emits \`nextActions\`\" and the actual code. Uses the existing \`--with-actions\` flag (precedent from commit \`b6be979\`) so default JSON output stays a flat array; the envelope is opt-in.

## What changed

### Audit findings
- **Inline (single-object responses):** \`status\`, \`report mrr\`, \`report growth\`, \`invoices audit\`, \`webhooks {create,delete,test}\` already emit \`nextActions\`.
- **Opt-in \`--with-actions\` envelope (list responses):** \`webhooks list\`, \`webhooks logs\`, \`recommendations list\`, \`subscriptions renewals\` already use the envelope.
- **Shape consistency:** \`{ command: string, description: string }\` was already uniform. No normalization needed.

### Backfilled
- \`pax8 companies list --with-actions\` — drill-into-top-N + recs pointer (uses coverage ranking when \`--coverage\` set)
- \`pax8 subscriptions list --with-actions\` — show-first + trial-review + renewals
- \`pax8 invoices list --with-actions\` — show-unpaid + audit pointer

### Documentation
- New \"Next-action hints — (implementing)\" subsection in \`docs/UX_GUIDE.md\` §12 documenting the shape, flag, and rule
- New checklist item in §13: list/summary commands must populate \`nextActions\` under \`--with-actions\`

### Out of scope
\`show\` commands (UX_GUIDE explicitly carves them out — detail views don't chain). Inline-only commands left as-is.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 830 passed / 8 skipped (+3 new \`--with-actions\` tests)
- [ ] Manual: \`pax8 companies list --json --with-actions\` returns envelope with populated \`nextActions\`

Closes #97