### PR TITLE
feat: add invoices dispute closed-loop workflow (#101)

### DIFF
--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -7,6 +7,8 @@ import { handleCommandError } from "../../lib/errors.js";
 import { formatCurrency, formatQuantity } from "../../lib/formatters.js";
 import { ALL_SUBS_PAGE_SIZE, auditInvoices } from "@pax8/core";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
+import { discrepancyId } from "./dispute.js";
+import { replCmd } from "../../lib/confirm.js";
 
 export const invoicesAuditCommand = new Command("audit")
   .description("Audit invoices against active subscriptions")
@@ -81,15 +83,31 @@ Examples:
       // Run audit
       const report = auditInvoices(itemsResult.content, normalizedSubs);
 
+      // Stamp each discrepancy with a stable ID so `pax8 invoices dispute
+      // --discrepancy <id>` can locate it without re-auditing under the user's
+      // exact filters.
+      const stampedDiscrepancies = report.discrepancies.map((d) => ({
+        ...d,
+        discrepancyId: discrepancyId({
+          companyId: d.companyId,
+          productName: d.productName,
+          type: d.type,
+          month: options.month,
+        }),
+      }));
+
       // JSON output
       if (ctx.outputFormat === "json") {
-        const nextActions = report.discrepancies
+        const nextActions = stampedDiscrepancies
           .slice(0, 5)
           .map((d) => ({
-            command: `pax8 subscriptions list --company "${d.companyName}" --json`,
-            description: `Investigate ${d.type} for ${d.companyName} — ${d.productName} (Δ${d.delta > 0 ? "+" : ""}${d.delta})`,
+            command: `pax8 invoices dispute --discrepancy ${d.discrepancyId}${options.month ? ` --month ${options.month}` : ""}`,
+            description: `File a dispute for ${d.companyName} — ${d.productName} (${d.type}, Δ${d.delta > 0 ? "+" : ""}${d.delta})`,
           }));
-        output([{ ...report, nextActions }], { format: "json" });
+        output(
+          [{ ...report, discrepancies: stampedDiscrepancies, nextActions }],
+          { format: "json" },
+        );
         return;
       }
 
@@ -126,9 +144,9 @@ Examples:
         `\n  ${chalk.yellow("⚠")} ${report.discrepancies.length} discrepancies found in ${monthLabel} invoices:\n\n`
       );
 
-      for (const d of report.discrepancies) {
+      for (const d of stampedDiscrepancies) {
         process.stdout.write(
-          `  ${chalk.bold(d.companyName)} — ${d.productName}\n`
+          `  ${chalk.bold(d.companyName)} — ${d.productName}  ${chalk.dim(`[${d.discrepancyId}]`)}\n`
         );
 
         const deltaSign = d.delta > 0 ? "+" : "";
@@ -159,6 +177,17 @@ Examples:
         `  ${chalk.bold("Net impact:")}   ${formatCurrency(report.netImpact)}\n`
       );
       process.stdout.write("\n");
+
+      // Closed-loop hint: surface the dispute command so the partner can act
+      // on what the audit just found, without leaving the terminal.
+      if (stampedDiscrepancies.length > 0) {
+        process.stderr.write(chalk.dim("  Try next:\n"));
+        const first = stampedDiscrepancies[0];
+        process.stderr.write(
+          `    ${chalk.cyan(replCmd(`pax8 invoices dispute --discrepancy ${first.discrepancyId}`))}  ${chalk.dim("file a dispute draft")}\n`,
+        );
+        process.stderr.write("\n");
+      }
     } catch (error) {
       handleCommandError(error, spinner, "Failed to audit invoices");
     }

--- a/packages/cli/src/commands/invoices/dispute.test.ts
+++ b/packages/cli/src/commands/invoices/dispute.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runCli, runCliExpectSuccess, runCliExpectFailure } from "../../__tests__/test-utils.js";
+
+describe("invoices dispute (closed-loop counterpart to audit)", () => {
+  let disputesDir: string;
+  let idemDir: string;
+
+  beforeEach(async () => {
+    disputesDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-dispute-"));
+    idemDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-dispute-idem-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(disputesDir, { recursive: true, force: true });
+    await fs.rm(idemDir, { recursive: true, force: true });
+  });
+
+  it("happy path: files a dispute draft from a discrepancy ID in demo mode", async () => {
+    // First run audit to grab a real discrepancy ID
+    const auditResult = await runCliExpectSuccess(["invoices", "audit", "--json"]);
+    const audit = JSON.parse(auditResult.stdout);
+    const report = Array.isArray(audit) ? audit[0] : audit;
+    expect(report.discrepancies.length).toBeGreaterThan(0);
+    const discId = report.discrepancies[0].discrepancyId;
+    expect(discId).toMatch(/^disc-[a-f0-9]{12}$/);
+
+    // Audit's nextActions should now point at the dispute command
+    expect(report.nextActions[0].command).toContain("invoices dispute --discrepancy");
+
+    // File the dispute
+    const result = await runCliExpectSuccess(
+      ["invoices", "dispute", "--discrepancy", discId, "--yes", "--json"],
+      { PAX8_DISPUTES_DIR: disputesDir },
+    );
+    const draft = JSON.parse(result.stdout);
+    expect(draft.id).toMatch(/^disp-/);
+    expect(draft.status).toBe("draft");
+    expect(draft.discrepancyId).toBe(discId);
+    expect(draft.portalTemplate).toContain("Billing discrepancy");
+    expect(draft.portalTemplate).toContain("Pax8 billing team");
+    expect(draft.filePath).toContain(disputesDir);
+
+    // Draft persisted to disk
+    const files = await fs.readdir(disputesDir);
+    expect(files.filter((f) => f.endsWith(".json"))).toHaveLength(1);
+  });
+
+  it("--yes skips the confirmation prompt", async () => {
+    // Without -y the command would block on stdin in non-TTY tests, hanging the
+    // process. The fact that --yes makes this finish proves the prompt is
+    // skipped (the test runner's 15s timeout would catch a regression).
+    const auditResult = await runCliExpectSuccess(["invoices", "audit", "--json"]);
+    const report = JSON.parse(auditResult.stdout);
+    const discId = (Array.isArray(report) ? report[0] : report).discrepancies[0].discrepancyId;
+
+    const result = await runCliExpectSuccess(
+      ["invoices", "dispute", "--discrepancy", discId, "--yes", "--json"],
+      { PAX8_DISPUTES_DIR: disputesDir },
+    );
+    expect(result.stderr).not.toContain("File this dispute draft?");
+    const draft = JSON.parse(result.stdout);
+    expect(draft.status).toBe("draft");
+  });
+
+  it("--idempotency-key replays a prior dispute byte-for-byte", async () => {
+    const auditResult = await runCliExpectSuccess(["invoices", "audit", "--json"]);
+    const report = JSON.parse(auditResult.stdout);
+    const discId = (Array.isArray(report) ? report[0] : report).discrepancies[0].discrepancyId;
+
+    const key = "dispute-idem-1234-4abc-8def-0123456789ab";
+
+    const first = await runCliExpectSuccess(
+      [
+        "invoices", "dispute",
+        "--discrepancy", discId,
+        "--yes", "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_DISPUTES_DIR: disputesDir, PAX8_IDEMPOTENCY_DIR: idemDir },
+    );
+    expect(first.stderr).not.toContain("idempotent replay");
+
+    const second = await runCliExpectSuccess(
+      [
+        "invoices", "dispute",
+        "--discrepancy", discId,
+        "--yes", "--json",
+        "--idempotency-key", key,
+      ],
+      { PAX8_DISPUTES_DIR: disputesDir, PAX8_IDEMPOTENCY_DIR: idemDir },
+    );
+    expect(second.stderr).toContain("idempotent replay");
+    expect(second.stdout).toBe(first.stdout);
+
+    // Replay must NOT create a second file on disk.
+    const files = await fs.readdir(disputesDir);
+    expect(files.filter((f) => f.endsWith(".json"))).toHaveLength(1);
+  });
+
+  it("rejects when no discrepancy or company is provided", async () => {
+    const result = await runCliExpectFailure(
+      ["invoices", "dispute", "--yes", "--json"],
+      { PAX8_DISPUTES_DIR: disputesDir },
+    );
+    expect(result.stderr).toMatch(/--discrepancy|--company/);
+  });
+
+  it("rejects an unknown discrepancy ID", async () => {
+    const result = await runCli(
+      [
+        "invoices", "dispute",
+        "--discrepancy", "disc-deadbeef0000",
+        "--yes", "--json",
+      ],
+      { PAX8_DISPUTES_DIR: disputesDir },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/No discrepancy matches/);
+  });
+
+  it("--help mentions --idempotency-key (write command)", async () => {
+    const result = await runCliExpectSuccess(["invoices", "dispute", "--help"]);
+    expect(result.stdout).toContain("--idempotency-key");
+    expect(result.stdout).toContain("24h TTL");
+  });
+
+  it("audit --json surfaces the dispute command in nextActions", async () => {
+    const result = await runCliExpectSuccess(["invoices", "audit", "--json"]);
+    const audit = JSON.parse(result.stdout);
+    const report = Array.isArray(audit) ? audit[0] : audit;
+    expect(report.nextActions).toBeDefined();
+    for (const action of report.nextActions) {
+      expect(action.command).toMatch(/^pax8 invoices dispute --discrepancy disc-[a-f0-9]{12}/);
+    }
+  });
+});

--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -1,0 +1,513 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { homedir } from "node:os";
+import { createHash, randomUUID } from "node:crypto";
+import { ALL_SUBS_PAGE_SIZE, auditInvoices, ERROR_INVALID_INPUT, ERROR_INTERNAL, type Pax8ErrorCode } from "@pax8/core";
+import { buildContext } from "../../lib/context.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError, CliError } from "../../lib/errors.js";
+import { formatCurrency, formatQuantity } from "../../lib/formatters.js";
+import { resolveCompanyId } from "../../lib/resolve-company.js";
+import { confirm, replCmd } from "../../lib/confirm.js";
+import { markWriteInFlight } from "../../lib/signals.js";
+import { hashArgs, isValidKey, loadEntry, saveEntry } from "../../lib/idempotency.js";
+
+/**
+ * NOTE: The Pax8 v1 API does not expose a public dispute / write-off / credit
+ * endpoint for invoice line items (verified against
+ * `packages/core/src/api/invoices.ts` — only GET endpoints exist). Pax8
+ * billing disputes are handled out-of-band via the partner portal and support.
+ *
+ * Rather than fake an API call, this command closes the loop locally:
+ *   1. Materializes a dispute draft as a JSON record under ~/.pax8/disputes/.
+ *   2. Renders a portal-ready support ticket (markdown) the partner can paste
+ *      into the Pax8 portal or email to billing support.
+ *
+ * If/when Pax8 ships a real endpoint, the local-storage path can be replaced
+ * with `ctx.api.invoices.dispute(...)` without changing the CLI surface.
+ */
+
+const DISPUTES_DIR_ENV = "PAX8_DISPUTES_DIR";
+
+function disputesDir(): string {
+  return process.env[DISPUTES_DIR_ENV] ?? path.join(homedir(), ".pax8", "disputes");
+}
+
+/**
+ * Compute a stable discrepancy ID from the audit fields so `pax8 invoices audit`
+ * and `pax8 invoices dispute --discrepancy <id>` speak the same language.
+ */
+export function discrepancyId(parts: {
+  companyId: string;
+  productName: string;
+  type: string;
+  month?: string;
+}): string {
+  const key = `${parts.companyId}|${parts.productName}|${parts.type}|${parts.month ?? ""}`;
+  return "disc-" + createHash("sha1").update(key).digest("hex").slice(0, 12);
+}
+
+interface DisputeDraft {
+  id: string;
+  discrepancyId: string;
+  status: "draft";
+  createdAt: string;
+  month?: string;
+  companyId: string;
+  companyName: string;
+  productName: string;
+  type: "overcharge" | "undercharge" | "missing" | "unexpected";
+  invoicedQuantity: number;
+  activeQuantity: number;
+  delta: number;
+  dollarImpact: number;
+  reason?: string;
+  portalTemplate: string;
+}
+
+function buildPortalTemplate(d: Omit<DisputeDraft, "id" | "portalTemplate" | "status" | "createdAt">): string {
+  const sign = d.delta > 0 ? "+" : "";
+  const impactLabel =
+    d.dollarImpact > 0
+      ? `${formatCurrency(d.dollarImpact)} overcharge`
+      : `${formatCurrency(Math.abs(d.dollarImpact))} undercharge`;
+  const period = d.month ? d.month : "current period";
+  const lines = [
+    `Subject: Billing discrepancy — ${d.companyName} — ${d.productName} (${period})`,
+    "",
+    `Hi Pax8 billing team,`,
+    "",
+    `I'd like to dispute a billing discrepancy detected by automated reconciliation.`,
+    "",
+    `  Company:           ${d.companyName} (${d.companyId})`,
+    `  Product:           ${d.productName}`,
+    `  Period:            ${period}`,
+    `  Discrepancy type:  ${d.type}`,
+    `  Invoiced quantity: ${d.invoicedQuantity}`,
+    `  Active quantity:   ${d.activeQuantity}`,
+    `  Delta:             ${sign}${d.delta} seat(s)`,
+    `  Impact:            ${impactLabel}`,
+    `  Discrepancy ID:    ${d.discrepancyId}`,
+    "",
+  ];
+  if (d.reason) {
+    lines.push(`Notes from partner:`);
+    lines.push(`  ${d.reason}`);
+    lines.push("");
+  }
+  lines.push(`Please review and adjust the invoice or issue a credit memo.`);
+  lines.push("");
+  lines.push(`— Filed via pax8-cli`);
+  return lines.join("\n");
+}
+
+async function writeDraft(draft: DisputeDraft): Promise<string> {
+  const dir = disputesDir();
+  await fs.mkdir(dir, { recursive: true });
+  const fp = path.join(dir, `${draft.id}.json`);
+  const tmp = fp + ".tmp";
+  await fs.writeFile(tmp, JSON.stringify(draft, null, 2), { encoding: "utf-8", mode: 0o600 });
+  await fs.rename(tmp, fp);
+  return fp;
+}
+
+interface DiscrepancyShape {
+  companyId: string;
+  companyName: string;
+  productName: string;
+  type: "overcharge" | "undercharge" | "missing" | "unexpected";
+  invoicedQuantity: number;
+  activeQuantity: number;
+  delta: number;
+  dollarImpact: number;
+}
+
+async function findDiscrepancy(
+  opts: { discrepancy?: string; company?: string; product?: string; month?: string },
+  ctx: Awaited<ReturnType<typeof buildContext>>,
+): Promise<DiscrepancyShape> {
+  // Audit the relevant slice
+  const companyId = opts.company ? await resolveCompanyId(ctx, opts.company) : undefined;
+  const [invoicesResult, subsResult] = await Promise.all([
+    ctx.api.invoices.list({ month: opts.month, companyId, size: 200 }),
+    ctx.api.subscriptions.list({ companyId, size: ALL_SUBS_PAGE_SIZE }),
+  ]);
+  const allItems = (
+    await Promise.all(
+      invoicesResult.content.map((inv) =>
+        ctx.api.invoices.listItems(inv.id, { size: 500 }).catch(() => ({ content: [] })),
+      ),
+    )
+  ).flatMap((r) => r.content);
+
+  const normalizedSubs = subsResult.content.map((s) => {
+    const { id: _id, ...rest } = s;
+    return { ...rest, subscriptionId: undefined, unitPrice: s.price };
+  });
+  const report = auditInvoices(allItems, normalizedSubs);
+
+  if (report.discrepancies.length === 0) {
+    throw new CliError(
+      "No discrepancies found to dispute.",
+      ["The audit returned a clean bill of health for the requested scope."],
+      [`Run ${replCmd("pax8 invoices audit")} to refresh.`],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+
+  // Match by discrepancy ID first
+  if (opts.discrepancy) {
+    const target = report.discrepancies.find(
+      (d) => discrepancyId({ companyId: d.companyId, productName: d.productName, type: d.type, month: opts.month }) === opts.discrepancy,
+    );
+    if (!target) {
+      throw new CliError(
+        `No discrepancy matches ID "${opts.discrepancy}"`,
+        ["The discrepancy ID couldn't be located in the current audit."],
+        [
+          `Re-run ${replCmd("pax8 invoices audit --json")} to get fresh discrepancy IDs.`,
+          `Or pass --company and --product instead.`,
+        ],
+        undefined,
+        ERROR_INVALID_INPUT,
+      );
+    }
+    return target;
+  }
+
+  // Match by company + product
+  if (opts.product) {
+    const wanted = opts.product.toLowerCase();
+    const matches = report.discrepancies.filter((d) =>
+      d.productName.toLowerCase().includes(wanted),
+    );
+    if (matches.length === 0) {
+      throw new CliError(
+        `No discrepancy for product "${opts.product}"${opts.company ? ` at ${opts.company}` : ""}.`,
+        undefined,
+        [`Run ${replCmd("pax8 invoices audit")} to see what's open.`],
+        undefined,
+        ERROR_INVALID_INPUT,
+      );
+    }
+    if (matches.length > 1) {
+      throw new CliError(
+        `Multiple discrepancies match "${opts.product}".`,
+        matches.slice(0, 5).map((m) => `${m.companyName} — ${m.productName} (${m.type})`),
+        [`Pass --discrepancy <id> from ${replCmd("pax8 invoices audit --json")} to disambiguate.`],
+        undefined,
+        ERROR_INVALID_INPUT,
+      );
+    }
+    return matches[0];
+  }
+
+  // Last resort: if exactly one discrepancy in scope, use it
+  if (report.discrepancies.length === 1) return report.discrepancies[0];
+
+  throw new CliError(
+    "Ambiguous dispute target.",
+    [`The audit returned ${report.discrepancies.length} discrepancies.`],
+    [
+      `Pass --discrepancy <id> from ${replCmd("pax8 invoices audit --json")},`,
+      `or narrow with --company and --product.`,
+    ],
+    undefined,
+    ERROR_INVALID_INPUT,
+  );
+}
+
+export const invoicesDisputeCommand = new Command("dispute")
+  .description("File a dispute draft for an invoice discrepancy surfaced by 'pax8 invoices audit'")
+  .option("--discrepancy <id>", "Discrepancy ID from `pax8 invoices audit --json`")
+  .option("--company <id|name>", "Company filter — required if --discrepancy isn't given")
+  .option("--product <name>", "Product name (substring) — narrows when multiple match")
+  .option("--month <YYYY-MM>", "Period the discrepancy applies to")
+  .option("--reason <text>", "Free-form note included in the support template")
+  .option("-y, --yes", "Skip the confirmation prompt")
+  .option(
+    "--idempotency-key <uuid>",
+    "Replay-safe key for retries (24h TTL). Accepts UUIDs or 8–128 char identifiers (letters, digits, '-', '_', '.')",
+  )
+  .addHelpText(
+    "after",
+    `
+Closed loop with 'pax8 invoices audit':
+  audit identifies the discrepancy → dispute records the draft and renders a
+  portal-ready support template. Drafts are stored under ~/.pax8/disputes/.
+
+Examples:
+  pax8 invoices audit                                              # find discrepancies first
+  pax8 invoices dispute --company "Summit Healthcare" --product "Microsoft 365"
+  pax8 invoices dispute --discrepancy disc-a1b2c3d4e5f6 --reason "Customer downgraded mid-cycle"
+  pax8 invoices dispute --company "Summit Healthcare" --product "M365" --yes
+  pax8 invoices dispute --discrepancy disc-a1b2c3d4e5f6 --json
+
+Note: The Pax8 v1 API does not expose a public dispute endpoint, so this
+command files a local draft and produces a support ticket template you can
+paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
+  )
+  .action(async (_options, command: Command) => {
+    const allOpts = command.optsWithGlobals();
+
+    // ── Idempotency handling ────────────────────────────────────────────────
+    const idempotencyKey: string | undefined = allOpts.idempotencyKey;
+    const commandName = "invoices.dispute";
+    let argsHash: string | null = null;
+    if (idempotencyKey !== undefined) {
+      if (!isValidKey(idempotencyKey)) {
+        handleCommandError(
+          new CliError(
+            `Invalid idempotency key: "${idempotencyKey}"`,
+            [
+              "Idempotency keys must be 8–128 characters of letters, digits, '-', '_', or '.'",
+              "UUID v4 is recommended.",
+            ],
+            [
+              "Generate one with: uuidgen",
+              `Example: ${replCmd("pax8 invoices dispute")} ... --idempotency-key 9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d`,
+            ],
+            undefined,
+            ERROR_INVALID_INPUT satisfies Pax8ErrorCode,
+          ),
+        );
+      }
+      argsHash = hashArgs({
+        discrepancy: allOpts.discrepancy,
+        company: allOpts.company,
+        product: allOpts.product,
+        month: allOpts.month,
+        reason: allOpts.reason,
+      });
+      try {
+        const cached = await loadEntry(commandName, idempotencyKey);
+        if (cached) {
+          if (cached.argsHash !== argsHash) {
+            handleCommandError(
+              new CliError(
+                "Idempotency key reused with different arguments — refusing to retry.",
+                [
+                  `The key "${idempotencyKey}" was previously used for ${cached.command} with a different argument set.`,
+                  "Replaying with new arguments would risk a double-write or a misleading 'cached' response.",
+                ],
+                [
+                  "Generate a new idempotency key for the new request.",
+                  `Or wait 24h for the old entry to expire (cached at ${cached.createdAt}).`,
+                ],
+              ),
+            );
+          }
+          process.stderr.write(chalk.dim("  (idempotent replay)\n"));
+          if (cached.output) process.stdout.write(cached.output);
+          process.exit(cached.exitCode);
+          return;
+        }
+      } catch (err) {
+        if (err instanceof CliError) throw err;
+        if (process.env.PAX8_DEBUG) {
+          process.stderr.write(`[debug] idempotency cache read failed: ${err}\n`);
+        }
+      }
+    }
+
+    // Capture stdout for idempotent replay
+    let captured = "";
+    let succeeded = false;
+    const realStdoutWrite = process.stdout.write.bind(process.stdout);
+    if (idempotencyKey) {
+      (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) = (
+        chunk: string | Uint8Array,
+      ): boolean => {
+        const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+        captured += text;
+        return realStdoutWrite(chunk as string);
+      };
+    }
+    const restoreStdout = (): void => {
+      if (idempotencyKey) {
+        process.stdout.write = realStdoutWrite as typeof process.stdout.write;
+      }
+    };
+    const persistEntry = async (): Promise<void> => {
+      if (!idempotencyKey || !succeeded || argsHash === null) return;
+      try {
+        await saveEntry({
+          key: idempotencyKey,
+          command: commandName,
+          argsHash,
+          output: captured,
+          exitCode: 0,
+          createdAt: new Date().toISOString(),
+        });
+      } catch (err) {
+        if (process.env.PAX8_DEBUG) {
+          process.stderr.write(`[debug] idempotency cache write failed: ${err}\n`);
+        }
+      }
+    };
+
+    const ctx = await buildContext(allOpts);
+    const spinner = createSpinner("Locating discrepancy...");
+
+    try {
+      // Validate that we have something to look up
+      if (!allOpts.discrepancy && !allOpts.company) {
+        throw new CliError(
+          "Provide --discrepancy <id> or --company <name>.",
+          ["Without one of these flags there's no way to identify the discrepancy to dispute."],
+          [
+            `Run ${replCmd("pax8 invoices audit --json")} and pass the discrepancy ID.`,
+            `Or: ${replCmd("pax8 invoices dispute")} --company "Acme Corp" --product "M365"`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT satisfies Pax8ErrorCode,
+        );
+      }
+
+      spinner.start();
+      const target = await findDiscrepancy(allOpts, ctx);
+      spinner.stop();
+
+      const month: string | undefined = allOpts.month;
+      const discId = discrepancyId({
+        companyId: target.companyId,
+        productName: target.productName,
+        type: target.type,
+        month,
+      });
+
+      const draftBase = {
+        discrepancyId: discId,
+        month,
+        companyId: target.companyId,
+        companyName: target.companyName,
+        productName: target.productName,
+        type: target.type,
+        invoicedQuantity: target.invoicedQuantity,
+        activeQuantity: target.activeQuantity,
+        delta: target.delta,
+        dollarImpact: target.dollarImpact,
+        reason: allOpts.reason,
+      };
+      const portalTemplate = buildPortalTemplate(draftBase);
+
+      // ── Preview ──────────────────────────────────────────────────────────
+      const sign = target.delta > 0 ? "+" : "";
+      const impactLabel =
+        target.dollarImpact > 0
+          ? `${formatCurrency(target.dollarImpact)} overcharge`
+          : `${formatCurrency(Math.abs(target.dollarImpact))} undercharge`;
+
+      if (ctx.outputFormat !== "json" && ctx.outputFormat !== "quiet") {
+        process.stderr.write(chalk.bold("\n  📝 Dispute Draft:\n\n"));
+        process.stderr.write(`  ${chalk.dim("Company:".padEnd(18))}${target.companyName}\n`);
+        process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${target.productName}\n`);
+        if (month) process.stderr.write(`  ${chalk.dim("Period:".padEnd(18))}${month}\n`);
+        process.stderr.write(`  ${chalk.dim("Type:".padEnd(18))}${target.type}\n`);
+        process.stderr.write(`  ${chalk.dim("Invoiced:".padEnd(18))}${formatQuantity(target.invoicedQuantity)}\n`);
+        process.stderr.write(`  ${chalk.dim("Active:".padEnd(18))}${formatQuantity(target.activeQuantity)}\n`);
+        process.stderr.write(`  ${chalk.dim("Delta:".padEnd(18))}${sign}${target.delta}\n`);
+        process.stderr.write(`  ${chalk.dim("Impact:".padEnd(18))}${chalk.yellow(impactLabel)}\n`);
+        if (allOpts.reason) {
+          process.stderr.write(`  ${chalk.dim("Note:".padEnd(18))}${allOpts.reason}\n`);
+        }
+        process.stderr.write(`  ${chalk.dim("Discrepancy ID:".padEnd(18))}${discId}\n\n`);
+      }
+
+      const ok = await confirm("File this dispute draft?", { default: true });
+      if (!ok) {
+        if (ctx.outputFormat !== "json" && ctx.outputFormat !== "quiet") {
+          process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        }
+        restoreStdout();
+        return;
+      }
+
+      // ── Persist the draft (the "write" half of the closed loop) ─────────
+      const id = "disp-" + randomUUID().slice(0, 8);
+      const draft: DisputeDraft = {
+        id,
+        status: "draft",
+        createdAt: new Date().toISOString(),
+        portalTemplate,
+        ...draftBase,
+      };
+
+      const writeSpinner = createSpinner("Filing dispute...").start();
+      const done = markWriteInFlight("invoices");
+      let filePath: string;
+      try {
+        filePath = await writeDraft(draft);
+      } finally {
+        done();
+      }
+      writeSpinner.succeed("Dispute draft filed");
+
+      // ── Output ───────────────────────────────────────────────────────────
+      if (ctx.outputFormat === "json") {
+        const enriched = {
+          ...draft,
+          filePath,
+          nextActions: [
+            {
+              command: `cat "${filePath}"`,
+              description: "View the full dispute draft (incl. portal template)",
+            },
+            {
+              command: `pax8 invoices audit --month ${month ?? new Date().toISOString().slice(0, 7)} --json`,
+              description: "Re-audit to confirm the discrepancy is still open",
+            },
+          ],
+        };
+        process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
+        succeeded = true;
+        await persistEntry();
+        restoreStdout();
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") {
+        succeeded = true;
+        await persistEntry();
+        restoreStdout();
+        return;
+      }
+
+      process.stdout.write("\n");
+      process.stdout.write(`  ${chalk.dim("Draft ID:".padEnd(18))}${draft.id}\n`);
+      process.stdout.write(`  ${chalk.dim("Saved to:".padEnd(18))}${filePath}\n`);
+      process.stdout.write("\n");
+      process.stdout.write(chalk.dim("  ── Portal-ready support ticket ──\n"));
+      for (const line of portalTemplate.split("\n")) {
+        process.stdout.write(`  ${line}\n`);
+      }
+      process.stdout.write("\n");
+      process.stderr.write(chalk.dim("  Next steps:\n"));
+      process.stderr.write(`    ${chalk.cyan(`Paste the template above into the Pax8 portal billing support form.`)}\n`);
+      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 invoices audit`))} ${chalk.dim("re-audit later to confirm resolution")}\n\n`);
+
+      succeeded = true;
+      await persistEntry();
+      restoreStdout();
+    } catch (error) {
+      restoreStdout();
+      if (error instanceof CliError) {
+        handleCommandError(error, spinner);
+      }
+      handleCommandError(
+        error instanceof Error
+          ? new CliError(
+              `Failed to file dispute: ${error.message}`,
+              undefined,
+              undefined,
+              undefined,
+              ERROR_INTERNAL satisfies Pax8ErrorCode,
+            )
+          : error,
+        spinner,
+      );
+    }
+  });

--- a/packages/cli/src/commands/invoices/index.ts
+++ b/packages/cli/src/commands/invoices/index.ts
@@ -3,6 +3,7 @@ import { invoicesListCommand } from "./list.js";
 import { invoicesShowCommand } from "./show.js";
 import { invoicesItemsCommand } from "./items.js";
 import { invoicesAuditCommand } from "./audit.js";
+import { invoicesDisputeCommand } from "./dispute.js";
 
 export function registerInvoicesCommands(program: Command): void {
   const invoices = new Command("invoices").description("Manage invoices");
@@ -11,6 +12,7 @@ export function registerInvoicesCommands(program: Command): void {
   invoices.addCommand(invoicesShowCommand);
   invoices.addCommand(invoicesItemsCommand);
   invoices.addCommand(invoicesAuditCommand);
+  invoices.addCommand(invoicesDisputeCommand);
 
   program.addCommand(invoices);
 }


### PR DESCRIPTION
## Summary

Adds a second instance of the closed-loop pattern: \`pax8 invoices audit → pax8 invoices dispute\`. Hardens the strategy-doc claim that the CLI is an \"operating surface, not a dashboard.\"

## Implementation note: local drafts (no API endpoint exists)

The Pax8 v1 API exposes only \`list/get/listItems/listDraftItems\` on invoices — **no dispute / write-off / credit / adjustment endpoint**. Confirmed via \`packages/core/src/api/invoices.ts\` and devx.pax8.com/docs.pax8.com.

Rather than fake an API call, \`pax8 invoices dispute\`:
1. Files a local draft to \`~/.pax8/disputes/disp-<8>.json\` (override via \`PAX8_DISPUTES_DIR\`)
2. Renders a portal-ready Markdown template the partner can paste into the Pax8 support flow
3. Returns the draft, file path, template, and \`nextActions\` over \`--json\` for chaining

When Pax8 ships a dispute endpoint, only the \`writeDraft()\` step needs to change.

## Audit → dispute handshake

Each discrepancy gets a stable \`discrepancyId = disc-{12-hex of sha1(companyId|productName|type|month)}\`:
- \`pax8 invoices audit\`'s JSON \`nextActions\` already point at \`pax8 invoices dispute --discrepancy <id>\`
- Human-mode table now prints \`[disc-xxxxx]\` next to each row
- Footer adds a \"Try next\" hint

## Conventions followed

Idempotency-key support, \`markWriteInFlight(\"invoices\")\`, \`CliError\` with \`Pax8ErrorCode\`, \`-y/--yes\`, \`--json/--csv/--quiet\`, \`replCmd\` for next-step hints, 5-example help text.

## Limitations / follow-ups

- No real Pax8 dispute endpoint — drafts are partner-local. Worth a Pax8 DevX request.
- \`discrepancyId\` is recomputed by hashing audit fields; if the audit logic changes (e.g., month bucketing), old IDs stop matching.
- No \`pax8 disputes list\` subcommand yet — natural follow-up.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 834 passed / 8 skipped (+7 new dispute tests)
- [ ] Manual: \`pax8 invoices audit\` + \`pax8 invoices dispute --discrepancy <id>\` chain
- [ ] Manual: idempotency-key replay

Closes #101