### PR TITLE
refactor: tighten @pax8/core public surface (follow-up from #100)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,7 +59,7 @@ The durable asset — questions this package answers without you having to assem
 - **API client** (`Pax8Client`) — typed wrapper over Pax8 v1 with auth, retry, and rate-limit awareness. Sub-clients: `companies`, `contacts`, `subscriptions`, `orders`, `invoices`, `products`, `usage`, `quotes`, `webhooks`.
 - **Mock client** (`MockPax8Client`) — drop-in replacement backed by an in-memory fixture. Same interface as `Pax8Client`. Used by the CLI for `PAX8_DEMO=1`.
 - **Bulk executor** (`executeBulk`) — concurrency-bounded batch runner with progress callbacks, used to apply a list of operations (e.g. ordering across many companies) without overwhelming the API rate limit.
-- **Types and Zod schemas** — `Subscription`, `Company`, `Invoice`, `Product`, `Order`, etc., plus typed errors (`Pax8ApiError`) and machine-readable error codes.
+- **Types and Zod schemas** — `Subscription`, `Company`, `Invoice`, `Product`, `Order`, etc., plus typed errors (`ApiError`, `AuthError`, `RateLimitError`, `NotFoundError`, `ValidationError`) and machine-readable error codes (`ERROR_AUTH_EXPIRED`, `ERROR_COMPANY_NOT_FOUND`, etc., as a `Pax8ErrorCode` union).
 
 ## Versioning
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,18 @@
-// API types, schemas, client, and resource modules
-export * from "./api/types.js";
-export * from "./api/errors.js";
-export * from "./api/constants.js";
+// Public entrypoint for `@pax8/core`.
+//
+// This file is the single source of truth for what `@pax8/core` exposes to
+// external consumers. Re-exports are explicit (no `export *`) so that adding
+// a new file under `src/` does not silently grow the public surface.
+//
+// Anything intentionally kept exported but not part of the documented public
+// API (because the CLI in this repo depends on it) is marked with `@internal`
+// JSDoc on its declaration. With `stripInternal: true` enabled in tsconfig,
+// those symbols still exist at runtime for the CLI but are stripped from the
+// generated `dist/index.d.ts` so external TypeScript consumers don't see them
+// in IDE autocomplete.
 
-// Error codes — machine-readable identifiers for agent consumers
-export * from "./errors/codes.js";
+// ─── API client + per-resource sub-clients ──────────────────────────────────
+
 export { Pax8Client } from "./api/client.js";
 export type { Pax8ClientOptions } from "./api/client.js";
 export { CompaniesApi } from "./api/companies.js";
@@ -17,19 +25,224 @@ export { UsageApi } from "./api/usage.js";
 export { QuotesApi } from "./api/quotes.js";
 export { WebhooksApi } from "./api/webhooks.js";
 
-// Auth
-export * from "./auth/index.js";
+// ─── API constants ──────────────────────────────────────────────────────────
 
-// Services
-export * from "./services/index.js";
+export { ALL_SUBS_PAGE_SIZE } from "./api/constants.js";
 
-// Config
-export * from "./config/index.js";
+// ─── API error classes ──────────────────────────────────────────────────────
 
-// Telemetry
-export * from "./telemetry/index.js";
+export {
+  ApiError,
+  AuthError,
+  RateLimitError,
+  NotFoundError,
+  ValidationError,
+} from "./api/errors.js";
+export type { FieldError } from "./api/errors.js";
 
-// Mock/demo - data arrays and mock client (types come from api/types.ts)
+// ─── Machine-readable error codes ───────────────────────────────────────────
+
+export {
+  ERROR_AUTH_EXPIRED,
+  ERROR_AUTH_MISSING,
+  ERROR_COMPANY_NOT_FOUND,
+  ERROR_PRODUCT_NOT_FOUND,
+  ERROR_SUBSCRIPTION_NOT_FOUND,
+  ERROR_RATE_LIMITED,
+  ERROR_API_TIMEOUT,
+  ERROR_API_VALIDATION,
+  ERROR_INVALID_INPUT,
+  ERROR_NOT_AUTHORIZED,
+  ERROR_INTERNAL,
+} from "./errors/codes.js";
+export type { Pax8ErrorCode } from "./errors/codes.js";
+
+// ─── Domain types & Zod schemas ─────────────────────────────────────────────
+//
+// Schemas are runtime values (zod objects) so they must use a value re-export.
+// Pure type aliases use `export type` so consumers that only need types don't
+// pull in the runtime.
+
+export {
+  // Schemas
+  AddressSchema,
+  CompanySchema,
+  CreateCompanyInputSchema,
+  UpdateCompanyInputSchema,
+  ContactSchema,
+  CreateContactInputSchema,
+  UpdateContactInputSchema,
+  ProductSchema,
+  ProductPricingPlanSchema,
+  ProductPricingRateSchema,
+  ProductPricingResponseSchema,
+  ProvisioningDetailSchema,
+  ProvisioningFieldSchema,
+  ProductDependencySchema,
+  OrderSchema,
+  OrderLineItemSchema,
+  OrderLineItemInputSchema,
+  OrderLineItemProvisioningSchema,
+  CreateOrderInputSchema,
+  CommitmentSchema,
+  CommitmentTermSchema,
+  SubscriptionSchema,
+  UpdateSubscriptionInputSchema,
+  SubscriptionHistorySchema,
+  InvoiceSchema,
+  InvoiceItemSchema,
+  UsageSummarySchema,
+  UsageLineSchema,
+  QuoteSchema,
+  QuoteLineItemSchema,
+  CreateQuoteInputSchema,
+  UpdateQuoteInputSchema,
+  WebhookSchema,
+  WebhookLogSchema,
+  CreateWebhookInputSchema,
+  UpdateWebhookInputSchema,
+  PageInfoSchema,
+  PageSchema,
+  PaginatedResponseSchema,
+  // Enum schemas (also have inferred types below)
+  ContactTypeSchema,
+  SubscriptionStatusSchema,
+  BillingTermSchema,
+  InvoiceStatusSchema,
+  WebhookStatusSchema,
+  CompanyStatusSchema,
+} from "./api/types.js";
+export type {
+  Address,
+  Company,
+  CreateCompanyInput,
+  UpdateCompanyInput,
+  Contact,
+  CreateContactInput,
+  UpdateContactInput,
+  Product,
+  ProductPricing,
+  ProductPricingPlan,
+  ProductPricingRate,
+  ProvisioningDetail,
+  ProvisioningField,
+  ProductDependency,
+  Order,
+  OrderLineItem,
+  OrderLineItemInput,
+  CreateOrderInput,
+  Commitment,
+  CommitmentTerm,
+  Subscription,
+  UpdateSubscriptionInput,
+  SubscriptionHistory,
+  Invoice,
+  InvoiceItem,
+  UsageSummary,
+  UsageLine,
+  Quote,
+  QuoteLineItem,
+  CreateQuoteInput,
+  UpdateQuoteInput,
+  Webhook,
+  WebhookLog,
+  CreateWebhookInput,
+  UpdateWebhookInput,
+  PageInfo,
+  PaginatedResponse,
+  // Enum types
+  ContactType,
+  SubscriptionStatus,
+  BillingTerm,
+  InvoiceStatus,
+  WebhookStatus,
+  CompanyStatus,
+} from "./api/types.js";
+
+// ─── Auth ───────────────────────────────────────────────────────────────────
+
+export { TokenManager } from "./auth/token-manager.js";
+export { CredentialStore } from "./auth/credential-store.js";
+export type { Credentials, PermissionCheckResult } from "./auth/credential-store.js";
+
+// ─── Services: computed business logic over the API ─────────────────────────
+
+export {
+  getUpcomingRenewals,
+} from "./services/renewal-tracker.js";
+export type { RenewalItem, RenewalReport } from "./services/renewal-tracker.js";
+
+export {
+  auditInvoices,
+} from "./services/invoice-auditor.js";
+export type { AuditDiscrepancy, AuditReport } from "./services/invoice-auditor.js";
+
+export {
+  subscriptionMrr,
+  computeMrr,
+  computeGrowth,
+} from "./services/analytics.js";
+export type { MrrReport, GrowthReport } from "./services/analytics.js";
+
+export {
+  executeBulk,
+} from "./services/bulk-executor.js";
+export type { BulkOp, BulkResult } from "./services/bulk-executor.js";
+
+export {
+  getRecommendations,
+  getPortfolioCoverage,
+  categorizeProduct,
+  ALL_CATEGORIES,
+} from "./services/recommendations.js";
+export type {
+  Recommendation,
+  RecommendationReport,
+  CompanyCoverage,
+  ProductCategory,
+} from "./services/recommendations.js";
+
+/**
+ * On-disk cache for API responses, keyed by request path + params.
+ *
+ * @internal Used by the bundled `@pax8/cli` for cache invalidation after
+ * write operations. Not part of the documented public API — external
+ * consumers should rely on the cache being managed transparently by
+ * `Pax8Client` and not depend on this class directly.
+ */
+export { FileCache } from "./services/cache.js";
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+
+export {
+  loadConfig,
+  saveConfig,
+  getConfigDir,
+  ensureConfigDir,
+} from "./config/loader.js";
+export { ConfigSchema } from "./config/schema.js";
+export type { Config } from "./config/schema.js";
+
+// ─── Telemetry ──────────────────────────────────────────────────────────────
+
+export {
+  Telemetry,
+  getTelemetry,
+  TELEMETRY_NOTICE,
+} from "./telemetry/telemetry.js";
+export type { TelemetryEvent } from "./telemetry/telemetry.js";
+
+/**
+ * Reset the singleton `Telemetry` instance. Used by the test suite to ensure
+ * isolation between tests.
+ *
+ * @internal
+ */
+export { resetTelemetry } from "./telemetry/telemetry.js";
+
+// ─── Mock / demo data ───────────────────────────────────────────────────────
+
+export { MockPax8Client } from "./mock/mock-client.js";
 export {
   companies as demoCompanies,
   subscriptions as demoSubscriptions,
@@ -44,5 +257,4 @@ export {
   webhooks as demoWebhooks,
   webhookLogs as demoWebhookLogs,
   webhookTopics as demoWebhookTopics,
-  MockPax8Client,
-} from "./mock/index.js";
+} from "./mock/demo-data.js";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "stripInternal": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
## Summary

\`@pax8/core\` was promoted as a standalone library in #104, but its public API was still accidentally wide — wildcard re-exports leaked \`FileCache\` and \`resetTelemetry\` as public when they're internals. This PR tightens the public surface without breaking \`@pax8/cli\`.

## What changed

1. **Replaced wildcard \`export *\` re-exports with explicit named re-exports** in \`packages/core/src/index.ts\`. Every CLI import already resolves to a now-explicitly-exported symbol.
2. **Tagged \`FileCache\` and \`resetTelemetry\` as \`/** @internal */\`.** Both still ship in \`dist/index.js\` so \`@pax8/cli\` can use them, but they no longer appear in \`dist/index.d.ts\`.
3. **Enabled \`stripInternal: true\`** in \`packages/core/tsconfig.json\` so future \`@internal\` tags are honored automatically.
4. Updated \`packages/core/README.md\` to match what's actually exported.

## Diff size

\`packages/core/src/index.ts\`: +229 / −17 (mostly explicit re-exports).
\`dist/index.d.ts\`: 2196 → 2185 lines (the \`FileCache\` class declaration + \`resetTelemetry\` function declaration are now hidden).

## Public API now consists of

API client + sub-clients · errors + machine-readable codes · domain types and zod schemas · auth (TokenManager, CredentialStore) · config (load/save) · services (renewals, audit, MRR, recommendations, growth, bulk) · telemetry (Telemetry, getTelemetry, TelemetryEvent) · MockPax8Client + demo data · ALL_SUBS_PAGE_SIZE.

## CLI dependency flagged for follow-up

\`packages/cli/src/lib/invalidate-cache.ts\` instantiates \`FileCache\` directly. Kept exporting at runtime to avoid breakage; the cleaner fix is adding an \`invalidateCache()\` method to \`Pax8Client\` so neither \`@pax8/cli\` nor any external consumer needs the internal class. Worth filing as a follow-up.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 838 passed, 8 pre-existing skipped (unchanged from baseline)
- [x] Verified \`FileCache\` and \`resetTelemetry\` no longer appear in \`dist/index.d.ts\`
- [x] All \`@pax8/cli\` imports from \`@pax8/core\` still resolve

Refs #100 (follow-up flagged in that PR's description).