### PR TITLE
docs: refresh CLAUDE.md with UX guide reference and shipped contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ When the user asks ANYTHING about Pax8 data (companies, subscriptions, MRR, reco
 | invoice audit | `pax8 invoices audit --json 2>/dev/null` |
 | products / catalog | `pax8 products search "query" --json 2>/dev/null` |
 | place an order | `pax8 orders create --company <id> --product <id> --quantity <n>` (confirm first) |
-| act on a recommendation | Extract orderCommand from recommendations JSON and run it. Always confirm with the user first. |
+| act on a recommendation | Extract `orderCommand` from `pax8 recommendations list --json` and run it (confirm with user first), or use `pax8 recommendations act` for the interactive flow. |
+| invoice dispute | `pax8 invoices dispute --discrepancy <id>` (after `invoices audit` returns the id) |
+| diagnostics / health | `pax8 doctor --json 2>/dev/null` |
 
 MRR math: monthly subs = price × qty. Annual subs = price × qty ÷ 12. Group by companyId, resolve names from companies list.
 
@@ -26,9 +28,13 @@ Rules: No clarifying questions. Parallel calls when possible. Lead with the key 
 
 ## What is this project?
 
-An open-source CLI tool for MSPs to manage Pax8 cloud marketplace operations (subscriptions, billing, customers, products) from the terminal. See `docs/PRD.md` for full product requirements.
+An open-source CLI for MSPs that turns the Pax8 marketplace API (raw CRUD) into computed answers — renewals, invoice audits, MRR analytics, upsell recommendations, closed-loop order placement. The durable asset lives in `packages/core` and is interface-agnostic.
+
+Pax8 also runs a hosted MCP server at `mcp.pax8.com` (see `.mcp.json`). The two are complementary: this CLI has the richer command surface and demo mode; the Pax8 MCP has zero-install access from Claude/Cursor/Copilot/VSCode. See `README.md` for the user-facing comparison and `docs/UX_GUIDE.md` §12 for how the CLI is designed for both human and agent consumers.
 
 ## Autonomous Build Mode
+
+This mode applies only when explicitly following `docs/BUILD.md`. Default behavior is conservative — confirm before destructive or shared-state actions.
 
 When following `docs/BUILD.md`, operate fully autonomously with ZERO human interaction:
 - NEVER ask questions, for permission, or for confirmation.
@@ -41,12 +47,14 @@ When following `docs/BUILD.md`, operate fully autonomously with ZERO human inter
 ## Key commands
 
 ```bash
-pnpm install          # Install all dependencies
-pnpm build            # Build all packages
-pnpm test             # Run all tests
-pnpm test:coverage    # Run tests with coverage report
-pnpm lint             # Lint all packages
-pnpm dev              # Run CLI in dev mode
+pnpm install                                            # Install all dependencies
+pnpm build                                              # Build all packages
+pnpm test                                               # Run all tests
+pnpm test packages/cli/src/__tests__/invoices.test.ts   # Run one test file
+pnpm test --run -t "should audit"                       # Run by name pattern
+pnpm test:coverage                                      # Run tests with coverage report
+pnpm lint                                               # Lint all packages
+pnpm dev                                                # Run CLI in dev mode
 ```
 
 ## Architecture
@@ -58,11 +66,16 @@ pnpm dev              # Run CLI in dev mode
 
 ## Conventions
 
+`docs/UX_GUIDE.md` is the source of truth for command patterns, output formatting, error handling, and the agent-facing contracts. **Read it before adding or modifying any command.** Highlights:
+
 - TypeScript strict mode, Zod for validation
-- Every command supports `--json`, `--csv`, `--quiet` output flags
-- Demo mode (`PAX8_DEMO=1`) works for every command
-- Tests: Vitest with subprocess integration tests
-- Spinners on stderr, data on stdout (never mix)
+- Every command supports `--json`, `--csv`, `--quiet`. List/summary commands also support `--with-actions` to wrap output in `{ data, nextActions }` for tool chaining.
+- Errors throw `CliError` with a `code` (one of the `ERROR_*` constants from `@pax8/core`). `--json` mode serializes errors as structured objects on stderr.
+- Writes accept `--idempotency-key <uuid>`, wrap their API call with `markWriteInFlight()`, and prompt unless `-y` / `PAX8_YES=1` is set.
+- SIGINT exits 130; active spinners stop cleanly without `✗`.
+- Stdout for data, stderr for everything else (spinners, hints, banners).
+- Demo mode (`PAX8_DEMO=1`) works for every command and is what the test suite runs under.
+- Tests: Vitest with subprocess integration tests in `packages/cli/src/__tests__/`.
 
 ## Pax8 API Reference
 
@@ -70,3 +83,11 @@ pnpm dev              # Run CLI in dev mode
 - Auth: OAuth 2.0 client credentials → `POST /v1/token`
 - Rate limit: 1,000 calls/minute
 - Docs: https://devx.pax8.com/
+
+## References
+
+- `docs/UX_GUIDE.md` — command patterns and agent contracts (read before adding commands)
+- `docs/PRD.md` — product requirements
+- `docs/BUILD.md` — autonomous build mode (mode-specific instructions)
+- `packages/core/README.md` — `@pax8/core` as a standalone embeddable library
+- `.mcp.json` — Pax8 hosted MCP server config (separate AI surface, complementary to this CLI)


### PR DESCRIPTION
## Summary

CLAUDE.md was missing references to most of what shipped this cycle (UX guide, error codes, idempotency keys, SIGINT, \`nextActions\`, the Pax8 hosted MCP, \`pax8 doctor\`, \`invoices dispute\`). This PR refreshes it.

## What changed

- **Points at \`docs/UX_GUIDE.md\`** as the source of truth for command patterns. *Highest-value addition* — without it, future Claude instances reinvent patterns we've already standardized.
- **Adds \`invoice dispute\` and \`pax8 doctor\` rows** to the data-queries quick-reference.
- **Updates "What is this project?"** to the strategy framing — computed answers vs raw CRUD, complementary to \`mcp.pax8.com\`.
- **Adds single-test commands** to Key commands (one file + pattern match).
- **Replaces Conventions** with the shipped contracts (\`--with-actions\` / \`nextActions\`, \`CliError\` codes, \`--idempotency-key\`, \`markWriteInFlight\`, SIGINT exit 130).
- **Scopes Autonomous Build Mode** so it only applies when following \`BUILD.md\` (the prior wording could be misread as default).
- **New References section** pointing at UX_GUIDE, PRD, BUILD, \`packages/core/README\`, and \`.mcp.json\`.

## What's preserved

- "ACT FIRST, THINK LATER" rule (it works, prescriptive tone is right)
- Architecture section
- Pax8 API Reference
- MRR math hint

## Test plan

- [x] No code changes; build / tests unaffected
- [x] Read-through confirms all new claims map to landed PRs (#94 / #95 / #96 / #97 / #102 / #108)