### PR TITLE
chore: release-prep quick wins (#116, #123, #124)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Pax8 Labs
+   Copyright 2026 Pax8, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ git clone https://github.com/pax8labs/pax8-cli.git
 cd pax8-cli
 pnpm install
 pnpm build
-pnpm test              # 700+ tests (739 and counting)
+pnpm test              # full test suite (~840 tests)
 pnpm test:coverage
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "private": true,
   "version": "0.1.0",
   "description": "Pax8 open source CLI for MSPs to manage cloud marketplace operations",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pax8labs/pax8-cli.git"
+  },
+  "homepage": "https://github.com/pax8labs/pax8-cli#readme",
+  "bugs": "https://github.com/pax8labs/pax8-cli/issues",
   "scripts": {
     "build": "pnpm -r build",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- LICENSE: fill in Copyright 2026 Pax8, Inc. (closes #116)
- package.json: add repository/homepage/bugs to root (closes #123)
- README: update stale test count claim (closes #124)

## Test plan
- [x] LICENSE copyright line filled in
- [x] Root package.json has repository field
- [x] README test-count line is current
