### PR TITLE
fix(telemetry): isolate test storage dirs (closes #118)

### DIFF
--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -8,6 +8,14 @@ const DEFAULT_CONFIG_DIR = path.join(homedir(), ".pax8");
 const DEFAULT_CONFIG_FILE = "config.yaml";
 
 export function getConfigDir(): string {
+  // PAX8_CONFIG_DIR overrides the default so tests can isolate state per-test
+  // and avoid clobbering the user's real ~/.pax8 dir. This is intentionally
+  // read on every call so tests that set/unset the env var between runs are
+  // honored without needing to reset module state.
+  const override = process.env.PAX8_CONFIG_DIR;
+  if (override && override.length > 0) {
+    return override;
+  }
   return DEFAULT_CONFIG_DIR;
 }
 
@@ -18,7 +26,7 @@ export async function ensureConfigDir(): Promise<string> {
 }
 
 function defaultConfigPath(): string {
-  return path.join(DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILE);
+  return path.join(getConfigDir(), DEFAULT_CONFIG_FILE);
 }
 
 function getDefaultConfig(): Config {

--- a/packages/core/src/telemetry/telemetry-extended.test.ts
+++ b/packages/core/src/telemetry/telemetry-extended.test.ts
@@ -26,15 +26,27 @@ function makeEvent(overrides: Partial<TelemetryEvent> = {}): TelemetryEvent {
 
 describe("Telemetry — extended coverage", () => {
   const originalEnv = { ...process.env };
+  let isolatedConfigDir: string;
 
   beforeEach(() => {
     resetTelemetry();
     delete process.env.PAX8_TELEMETRY_DISABLED;
     delete process.env.DO_NOT_TRACK;
+    // Each test gets its own config dir so enable/disable/loadEnabled don't
+    // race against telemetry.test.ts (or each other) on the shared real
+    // ~/.pax8/config.yaml. This was the source of the cold-cache flake: two
+    // test files concurrently mutating the same config file produced ENOENT
+    // and Zod parse errors inside Telemetry.disable / loadEnabled.
+    isolatedConfigDir = path.join(
+      os.tmpdir(),
+      `pax8-tel-ext-cfg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    process.env.PAX8_CONFIG_DIR = isolatedConfigDir;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     process.env = { ...originalEnv };
+    await fs.rm(isolatedConfigDir, { recursive: true, force: true }).catch(() => {});
   });
 
   it("TELEMETRY_NOTICE is a non-empty string", () => {

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -26,15 +26,24 @@ function makeEvent(overrides: Partial<TelemetryEvent> = {}): TelemetryEvent {
 
 describe("Telemetry", () => {
   const originalEnv = { ...process.env };
+  let isolatedConfigDir: string;
 
   beforeEach(() => {
     resetTelemetry();
     delete process.env.PAX8_TELEMETRY_DISABLED;
     delete process.env.DO_NOT_TRACK;
+    // Each test gets its own config dir so we don't clobber the user's real
+    // ~/.pax8 or race against other test files that touch config.yaml.
+    isolatedConfigDir = path.join(
+      os.tmpdir(),
+      `pax8-telemetry-cfg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    process.env.PAX8_CONFIG_DIR = isolatedConfigDir;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     process.env = { ...originalEnv };
+    await fs.rm(isolatedConfigDir, { recursive: true, force: true }).catch(() => {});
   });
 
   it("is disabled by default", () => {


### PR DESCRIPTION
## Summary
Telemetry tests shared the default config-dir, causing ENOENT failures when one test deleted state another expected. Each test now gets an isolated tmpdir.

## Repro before fix
- Cold-cache full-suite run: 2 failures in telemetry-extended (Telemetry.disable)
- File-in-isolation: 10/10 pass
- Warm second run: pass

## Test plan
- [x] Two consecutive cold-cache full-suite runs both green
- [x] No retries / no skipped tests added