### PR TITLE
fix: clean up lint violations and add Lint step to CI (closes #117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Typecheck
         run: pnpm -r exec tsc --noEmit
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Test
         run: pnpm test
         env:

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runCli, runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess } from "./test-utils.js";
 
 describe("pax8 auth", () => {
   describe("auth login", () => {

--- a/packages/cli/src/__tests__/companies.test.ts
+++ b/packages/cli/src/__tests__/companies.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runCli, runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess } from "./test-utils.js";
 
 describe("pax8 companies", () => {
   describe("companies list", () => {

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runCli, runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess } from "./test-utils.js";
 import * as os from "node:os";
 import * as path from "node:path";
 

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runCli, runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess } from "./test-utils.js";
 
 describe("pax8 invoices", () => {
   describe("invoices list", () => {

--- a/packages/cli/src/__tests__/orders.test.ts
+++ b/packages/cli/src/__tests__/orders.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 
 describe("pax8 orders", () => {
   describe("orders list", () => {

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runCli, runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess } from "./test-utils.js";
 
 describe("pax8 recommendations", () => {
   describe("recommendations list", () => {

--- a/packages/cli/src/__tests__/table-output.test.ts
+++ b/packages/cli/src/__tests__/table-output.test.ts
@@ -62,7 +62,7 @@ function parseTableRows(
 
   // Filter to lines containing column separators (│ or |)
   const dataLines = lines.filter(
-    (line) => line.includes("│") || (line.includes("|") && !line.match(/^[\s─┼+\-]+$/))
+    (line) => line.includes("│") || (line.includes("|") && !line.match(/^[\s─┼+-]+$/))
   );
 
   if (dataLines.length === 0) {
@@ -107,7 +107,7 @@ describe("table output — TTY-aware rendering", () => {
       const result = await runTable(["companies", "list", "--csv"]);
       expect(result.exitCode).toBe(0);
       // CSV should never contain ANSI escape sequences
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       const lines = result.stdout.trim().split("\n");
       // Header + data rows
       expect(lines.length).toBeGreaterThan(1);
@@ -124,7 +124,7 @@ describe("table output — TTY-aware rendering", () => {
     it("JSON output has no ANSI codes", async () => {
       const result = await runTable(["companies", "list", "--json"]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       // Should be valid JSON
       expect(() => JSON.parse(result.stdout)).not.toThrow();
     });
@@ -134,7 +134,7 @@ describe("table output — TTY-aware rendering", () => {
     it("CSV output has consistent columns and no ANSI", async () => {
       const result = await runTable(["subscriptions", "list", "--csv"]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       const lines = result.stdout.trim().split("\n");
       expect(lines.length).toBeGreaterThan(1);
       expect(lines[0]).toContain("Company");
@@ -145,7 +145,7 @@ describe("table output — TTY-aware rendering", () => {
     it("JSON output is clean", async () => {
       const result = await runTable(["subscriptions", "list", "--json"]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       const data = JSON.parse(result.stdout);
       expect(Array.isArray(data)).toBe(true);
     });
@@ -161,7 +161,7 @@ describe("table output — TTY-aware rendering", () => {
         "90d",
       ]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       const data = JSON.parse(result.stdout);
       expect(Array.isArray(data)).toBe(true);
     });
@@ -175,7 +175,7 @@ describe("table output — TTY-aware rendering", () => {
         "90d",
       ]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
     });
   });
 
@@ -183,7 +183,7 @@ describe("table output — TTY-aware rendering", () => {
     it("JSON output is clean", async () => {
       const result = await runTable(["recommendations", "list", "--json"]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       const data = JSON.parse(result.stdout);
       expect(Array.isArray(data)).toBe(true);
     });
@@ -191,7 +191,7 @@ describe("table output — TTY-aware rendering", () => {
     it("CSV output has no ANSI codes", async () => {
       const result = await runTable(["recommendations", "list", "--csv"]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
     });
   });
 
@@ -199,7 +199,7 @@ describe("table output — TTY-aware rendering", () => {
     it("CSV output has consistent columns and no ANSI", async () => {
       const result = await runTable(["invoices", "list", "--csv"]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       const lines = result.stdout.trim().split("\n");
       expect(lines.length).toBeGreaterThan(1);
       expect(lines[0]).toContain("Company");
@@ -209,7 +209,7 @@ describe("table output — TTY-aware rendering", () => {
     it("JSON output is clean", async () => {
       const result = await runTable(["invoices", "list", "--json"]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain("\x1b[");
       const data = JSON.parse(result.stdout);
       expect(Array.isArray(data)).toBe(true);
     });
@@ -266,7 +266,7 @@ describe("table rendering — unit tests", () => {
             trimmed.endsWith("┘") ||
             trimmed.endsWith("┐") ||
             trimmed.endsWith("┤") ||
-            trimmed.match(/[─┼+\-]$/)
+            trimmed.match(/[─┼+-]$/)
         ).toBeTruthy();
       }
     } finally {
@@ -348,7 +348,7 @@ describe("table rendering — unit tests", () => {
 
       const written = stdoutWrite.mock.calls.map((c) => c[0]).join("");
       // CSV should NOT contain ANSI codes — it uses raw values, not formatters
-      expect(written).not.toMatch(/\x1b\[/);
+      expect(written).not.toContain("\x1b[");
       expect(written).toContain("Active");
     } finally {
       stdoutWrite.mockRestore();
@@ -368,7 +368,7 @@ describe("table rendering — unit tests", () => {
       output(data, { format: "json" });
 
       const written = stdoutWrite.mock.calls.map((c) => c[0]).join("");
-      expect(written).not.toMatch(/\x1b\[/);
+      expect(written).not.toContain("\x1b[");
       expect(() => JSON.parse(written)).not.toThrow();
     } finally {
       stdoutWrite.mockRestore();

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { runCli, runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess } from "./test-utils.js";
 
 describe("pax8 telemetry", () => {
   describe("telemetry --help", () => {

--- a/packages/cli/src/__tests__/test-utils.ts
+++ b/packages/cli/src/__tests__/test-utils.ts
@@ -2,7 +2,6 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect } from "vitest";
 
 const exec = promisify(execFile);
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -122,7 +122,7 @@ async function checkApiHealth(): Promise<CheckResult[]> {
 
   const results: CheckResult[] = [];
   let passed = 0;
-  let total = endpoints.length;
+  const total = endpoints.length;
 
   // Run all endpoint checks in parallel
   const start = Date.now();

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -7,7 +7,7 @@ import { formatCurrency, calculateMrr, formatTimeAgo } from "../lib/formatters.j
 import { enrichProductNames, enrichCompanyNames } from "../lib/enrich-subscriptions.js";
 import { ALL_SUBS_PAGE_SIZE, getUpcomingRenewals } from "@pax8/core";
 import { getRecommendations } from "@pax8/core";
-import type { Subscription } from "@pax8/core";
+import type { Subscription, Company, Product, Order } from "@pax8/core";
 import { replCmd } from "../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../lib/next-step.js";
 
@@ -114,10 +114,10 @@ Examples:
       ]);
 
       const emptyPage = { number: 0, totalPages: 0, totalElements: 0 };
-      const companiesResult = companiesSettled.status === 'fulfilled' ? companiesSettled.value : { content: [] as any[], page: { ...emptyPage } };
-      const subsResult = subsSettled.status === 'fulfilled' ? subsSettled.value : { content: [] as any[], page: { ...emptyPage } };
-      const productsResult = productsSettled.status === 'fulfilled' ? productsSettled.value : { content: [] as any[], page: { ...emptyPage } };
-      const ordersResult = ordersSettled.status === 'fulfilled' ? ordersSettled.value : { content: [] as any[], page: { ...emptyPage } };
+      const companiesResult = companiesSettled.status === 'fulfilled' ? companiesSettled.value : { content: [] as Company[], page: { ...emptyPage } };
+      const subsResult = subsSettled.status === 'fulfilled' ? subsSettled.value : { content: [] as Subscription[], page: { ...emptyPage } };
+      const productsResult = productsSettled.status === 'fulfilled' ? productsSettled.value : { content: [] as Product[], page: { ...emptyPage } };
+      const ordersResult = ordersSettled.status === 'fulfilled' ? ordersSettled.value : { content: [] as Order[], page: { ...emptyPage } };
 
       if (companiesSettled.status === 'rejected') {
         process.stderr.write(chalk.yellow("  ⚠ Could not load companies\n"));

--- a/packages/cli/src/lib/confirm.test.ts
+++ b/packages/cli/src/lib/confirm.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { confirm, confirmDestructive } from "./confirm.js";
 
 describe("confirm", () => {

--- a/packages/cli/src/lib/context.test.ts
+++ b/packages/cli/src/lib/context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getOutputFormat, buildContext, warnIfTruncated, type GlobalOptions } from "./context.js";
+import { getOutputFormat, buildContext, warnIfTruncated } from "./context.js";
 
 describe("getOutputFormat", () => {
   const originalIsTTY = process.stdout.isTTY;

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -62,7 +62,7 @@ export interface GlobalOptions {
   verbose?: boolean;
   noColor?: boolean;
   config?: string;
-  parent?: any;
+  parent?: unknown;
 }
 
 export function getOutputFormat(

--- a/packages/cli/src/lib/enrich-subscriptions.test.ts
+++ b/packages/cli/src/lib/enrich-subscriptions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { enrichProductNames } from "./enrich-subscriptions.js";
+import type { CommandContext } from "./context.js";
+
+type MockSub = { productId: string; productName?: string };
 
 function mockCtx(catalogProducts: Array<{ id: string; name: string }>, individualLookups: Record<string, string>) {
   return {
@@ -13,58 +16,60 @@ function mockCtx(catalogProducts: Array<{ id: string; name: string }>, individua
         }),
       },
     },
-  } as any;
+  } as unknown as CommandContext & {
+    api: { products: { list: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> } };
+  };
 }
 
 describe("enrichProductNames", () => {
   it("resolves names from bulk catalog", async () => {
-    const subs = [{ productId: "p1", productName: undefined }];
+    const subs: MockSub[] = [{ productId: "p1", productName: undefined }];
     const ctx = mockCtx([{ id: "p1", name: "Microsoft 365" }], {});
-    await enrichProductNames(ctx, subs as any);
+    await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("Microsoft 365");
     expect(ctx.api.products.get).not.toHaveBeenCalled();
   });
 
   it("falls back to individual lookup when not in catalog", async () => {
-    const subs = [{ productId: "p1", productName: undefined }];
+    const subs: MockSub[] = [{ productId: "p1", productName: undefined }];
     const ctx = mockCtx([], { p1: "Defender for Business" });
-    await enrichProductNames(ctx, subs as any);
+    await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("Defender for Business");
     expect(ctx.api.products.get).toHaveBeenCalledWith("p1");
   });
 
   it("uses catalog for some and individual for others", async () => {
-    const subs = [
+    const subs: MockSub[] = [
       { productId: "p1", productName: undefined },
       { productId: "p2", productName: undefined },
     ];
     const ctx = mockCtx([{ id: "p1", name: "M365" }], { p2: "Acronis Backup" });
-    await enrichProductNames(ctx, subs as any);
+    await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("M365");
     expect(subs[1].productName).toBe("Acronis Backup");
   });
 
   it("skips subs that already have names", async () => {
-    const subs = [{ productId: "p1", productName: "Already Named" }];
+    const subs: MockSub[] = [{ productId: "p1", productName: "Already Named" }];
     const ctx = mockCtx([], {});
-    await enrichProductNames(ctx, subs as any);
+    await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("Already Named");
     expect(ctx.api.products.list).not.toHaveBeenCalled();
   });
 
   it("handles individual lookup 404 gracefully", async () => {
-    const subs = [
+    const subs: MockSub[] = [
       { productId: "good", productName: undefined },
       { productId: "gone", productName: undefined },
     ];
     const ctx = mockCtx([], { good: "Good Product" });
-    await enrichProductNames(ctx, subs as any);
+    await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("Good Product");
     expect(subs[1].productName).toBeUndefined();
   });
 
   it("handles bulk fetch failure and falls back entirely", async () => {
-    const subs = [{ productId: "p1", productName: undefined }];
+    const subs: MockSub[] = [{ productId: "p1", productName: undefined }];
     const ctx = {
       api: {
         products: {
@@ -72,8 +77,8 @@ describe("enrichProductNames", () => {
           get: vi.fn().mockResolvedValue({ id: "p1", name: "Fallback Product" }),
         },
       },
-    } as any;
-    await enrichProductNames(ctx, subs as any);
+    } as unknown as CommandContext;
+    await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("Fallback Product");
   });
 });

--- a/packages/cli/src/lib/instrumented-action.ts
+++ b/packages/cli/src/lib/instrumented-action.ts
@@ -1,6 +1,5 @@
 import {
   getTelemetry,
-  type TelemetryEvent,
   AuthError,
   RateLimitError,
   ValidationError,

--- a/packages/cli/src/lib/next-step.ts
+++ b/packages/cli/src/lib/next-step.ts
@@ -38,7 +38,7 @@ export async function promptNextSteps(steps: NextStep[]): Promise<void> {
 
   process.stderr.write("\n");
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<void>((resolve, _reject) => {
     const child = spawn("pax8", picked.command, {
       stdio: "inherit",
       env: process.env,

--- a/packages/cli/src/lib/resolve-company.test.ts
+++ b/packages/cli/src/lib/resolve-company.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { resolveCompany, resolveCompanyId } from "./resolve-company.js";
 import type { CommandContext } from "./context.js";
 

--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -285,6 +285,8 @@ describe("OrderSchema", () => {
   });
 
   it("validates without lineItems", () => {
+    // Strip lineItems via destructure; the unused name is the rest-sibling idiom.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { lineItems, ...rest } = valid;
     expect(OrderSchema.parse(rest)).toEqual(rest);
   });
@@ -437,6 +439,8 @@ describe("SubscriptionHistorySchema", () => {
   });
 
   it("validates without previousQuantity", () => {
+    // Strip previousQuantity via destructure; rest-sibling idiom.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { previousQuantity, ...rest } = valid;
     expect(SubscriptionHistorySchema.parse(rest)).toEqual(rest);
   });
@@ -469,6 +473,8 @@ describe("InvoiceSchema", () => {
   });
 
   it("rejects missing total", () => {
+    // Strip total via destructure; rest-sibling idiom.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { total, ...rest } = valid;
     expect(() => InvoiceSchema.parse(rest)).toThrow();
   });
@@ -571,6 +577,8 @@ describe("UsageLineSchema", () => {
   });
 
   it("rejects missing date", () => {
+    // Strip date via destructure; rest-sibling idiom.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { date, ...rest } = valid;
     expect(() => UsageLineSchema.parse(rest)).toThrow();
   });
@@ -595,6 +603,8 @@ describe("QuoteSchema", () => {
   });
 
   it("validates without lineItems", () => {
+    // Strip lineItems via destructure; rest-sibling idiom.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { lineItems, ...rest } = valid;
     expect(QuoteSchema.parse(rest)).toEqual(rest);
   });
@@ -631,6 +641,8 @@ describe("WebhookSchema", () => {
   });
 
   it("rejects missing topics", () => {
+    // Strip topics via destructure; rest-sibling idiom.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { topics, ...rest } = valid;
     expect(() => WebhookSchema.parse(rest)).toThrow();
   });
@@ -690,6 +702,8 @@ describe("WebhookLogSchema", () => {
   });
 
   it("rejects missing responseCode", () => {
+    // Strip responseCode via destructure; rest-sibling idiom.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { responseCode, ...rest } = valid;
     expect(() => WebhookLogSchema.parse(rest)).toThrow();
   });

--- a/packages/core/src/auth/credential-store.test.ts
+++ b/packages/core/src/auth/credential-store.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CredentialStore } from "./credential-store.js";
 import * as fs from "node:fs/promises";
-import { constants } from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -40,12 +40,13 @@ export async function loadConfig(configPath?: string): Promise<Config> {
     const content = await fs.readFile(filePath, "utf-8");
     const raw = YAML.parse(content);
     return ConfigSchema.parse(raw);
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
+  } catch (err: unknown) {
+    const e = err as { code?: string; name?: string };
+    if (e?.code === "ENOENT") {
       return getDefaultConfig();
     }
     // If it's a Zod validation error, re-throw as-is
-    if (err?.name === "ZodError") {
+    if (e?.name === "ZodError") {
       throw err;
     }
     throw err;

--- a/packages/core/src/services/bulk-executor.test.ts
+++ b/packages/core/src/services/bulk-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { executeBulk, type BulkOp } from "./bulk-executor.js";
 
 describe("executeBulk", () => {

--- a/packages/core/src/telemetry/telemetry-extended.test.ts
+++ b/packages/core/src/telemetry/telemetry-extended.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- accessing private members for testing */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- accessing private members for testing */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -71,11 +71,6 @@ describe("Telemetry", () => {
     await fs.mkdir(tmpDir, { recursive: true });
     const configPath = path.join(tmpDir, "config.yaml");
     await fs.writeFile(configPath, 'version: "1.0"\ntelemetry:\n  enabled: false\n', "utf-8");
-
-    // Monkey-patch the loader to use our temp config
-    const loader = await import("../config/loader.js");
-    const origLoad = loader.loadConfig;
-    const origSave = loader.saveConfig;
 
     // We can't easily mock ESM, so we test the public interface with real config.
     // Instead, test the state toggle:


### PR DESCRIPTION
## Summary
Closes #117. Fixes 29 errors + 27 warnings surfaced by `pnpm lint`, and adds the `Lint` step to `ci.yml`.

## Approach
- Replaced `any` with precise types (no widening to `unknown` and re-narrowing where the shape was clear)
- Removed truly unused vars; underscore-prefixed only where the position matters
- No inline disables added except where genuinely necessary (with comments)

## Test plan
- [x] `pnpm lint` exits 0 (no errors, no warnings)
- [x] `pnpm test` still green
- [x] Lint step added to CI

## Note for reviewer
Likely conflicts with the parallel #93 (typecheck) and #118 (telemetry flake) PRs touching the same files. Will rebase.