### PR TITLE
docs: README + SECURITY + CONTRIBUTING polish for v0.1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to pax8-cli
 
-Thanks for your interest in contributing! This guide covers the basics.
+Thanks for your interest in contributing! Outside contributions are welcome — issues, discussion, bug fixes, and features are all fair game. There is no CLA. We use a [Developer Certificate of Origin](https://developercertificate.org) sign-off instead (`git commit -s`); see below.
 
 ## Development Setup
 
@@ -8,8 +8,10 @@ Thanks for your interest in contributing! This guide covers the basics.
 git clone https://github.com/pax8labs/pax8-cli.git
 cd pax8-cli
 pnpm install
-pnpm build
-pnpm test
+
+# Recommended dev workflow runs entirely against demo data — no API credentials
+# required, no network egress beyond local filesystem.
+PAX8_DEMO=1 NO_COLOR=1 pnpm test
 ```
 
 ### Demo Mode
@@ -63,11 +65,12 @@ pnpm test:coverage     # With coverage report
 2. Write tests for new functionality
 3. Run `pnpm build && pnpm test` before submitting
 4. Keep PRs focused — one feature or fix per PR
-5. Use descriptive commit messages
+5. Sign off every commit with the DCO (see below) and use [Conventional Commits](https://www.conventionalcommits.org) for the subject line
+6. The repo ships [issue templates](.github/ISSUE_TEMPLATE/) and a [PR template](.github/pull_request_template.md) — please use them so reviewers have what they need
 
 ## Commit Messages
 
-Follow conventional commits:
+Follow [Conventional Commits](https://www.conventionalcommits.org):
 
 ```
 feat: add subscription scheduling
@@ -75,6 +78,16 @@ fix: correct invoice audit overcharge calculation
 docs: update README with demo mode examples
 chore: upgrade vitest to v4
 ```
+
+## Developer Certificate of Origin (DCO)
+
+We use the [Developer Certificate of Origin](https://developercertificate.org) instead of a CLA. Every commit must be signed off, which certifies that you authored the change (or have the right to submit it under the project's Apache-2.0 license).
+
+```bash
+git commit -s -m "feat: add subscription scheduling"
+```
+
+The `-s` flag appends a `Signed-off-by: Your Name <your@email>` trailer using your `user.name` / `user.email` git config. PRs without sign-off on every commit will be asked to amend before merge. There is no CLA.
 
 ## Releases
 
@@ -93,6 +106,10 @@ On merge to `main`, the release workflow opens (or updates) a `chore: release` P
 ### Maintainer note: npm trusted publishing
 
 The release workflow publishes via [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — no `NPM_TOKEN` secret. For this to work, the `@pax8` scope must have the `pax8labs/pax8-cli` repository and the `Release` workflow registered as a trusted publisher at <https://www.npmjs.com/settings/pax8/packages> for every package the workflow publishes (`@pax8/cli`, `@pax8/core`). The workflow already declares `permissions.id-token: write` and `setup-node`'s `registry-url`; once the npm side is configured, `npm publish` exchanges the OIDC token for an ephemeral publish token automatically.
+
+## Security Reports
+
+Do **not** open a GitHub Issue for security vulnerabilities. Report them via the process in [SECURITY.md](SECURITY.md) (email to `security@pax8.com`).
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ git clone https://github.com/pax8labs/pax8-cli.git
 cd pax8-cli
 pnpm install
 pnpm build
-pnpm test              # full test suite (~840 tests)
+pnpm test              # comprehensive test suite (800+ tests across unit, CLI integration, and e2e flows; see CI for current count)
 pnpm test:coverage
 ```
 
@@ -255,12 +255,85 @@ pnpm test:coverage
 
 ### Telemetry
 
-Anonymous, opt-in usage telemetry via PostHog. Tracks command names, duration, and revenue processed — never credentials, company data, or PII.
+Anonymous, **opt-in** usage telemetry via PostHog. Off by default — `telemetry.enabled` defaults to `false` in config and the CLI sends nothing until you explicitly opt in.
 
 ```bash
-pax8 telemetry enable    # Opt in
-pax8 telemetry disable   # Opt out
+pax8 telemetry enable     # Opt in
+pax8 telemetry disable    # Opt out
+pax8 telemetry status     # Check current state
 ```
+
+The CLI also honors two ambient environment variables (no opt-in required) and short-circuits before constructing the PostHog client:
+
+- `PAX8_TELEMETRY_DISABLED=1`
+- `DO_NOT_TRACK=1` (the [Console Do Not Track](https://consoledonottrack.com) standard)
+
+**Single event:** `command_executed`
+
+| Property | Sent | Notes |
+|---|---|---|
+| `command` | always | The top-level command, e.g. `companies` |
+| `subcommand` | when present | Dotted path, e.g. `recommendations.list` |
+| `flags` | always | The flag *names* the user passed (no values) |
+| `duration_ms` | always | Wall-clock duration in ms |
+| `success` | always | Boolean |
+| `error_code` | on error | One of the `ERROR_*` constants from `@pax8/core` |
+| `cli_version` | always | From package.json |
+| `node_version` | always | `process.version` |
+| `os` | always | `process.platform` |
+| `demo_mode` | always | Whether `PAX8_DEMO=1` was set |
+| `company_count` | optional segment marker | Bucket of how many companies the partner has — never a list of names or IDs |
+| `rec_count`, `recs_presented`, `recs_ordered`, `recs_skipped`, `recs_mrr_captured` | recommendations commands | Aggregate counts only |
+| `order_success`, `order_total_dollars`, `order_mrr_impact`, `order_seats` | `orders create` | Aggregate transaction outcome only |
+
+The anonymous `distinct_id` is `sha256(hostname + ":" + username)` truncated to 16 hex chars — computed locally, never reversible to its inputs.
+
+**Never sent:**
+
+- API client_id, client_secret, OAuth tokens
+- Customer / company / subscription / order IDs
+- Customer or company names
+- Command argument values (only flag *names* — `--company`, never `--company "Acme Corp"`)
+- Partner identifiers, account names, billing data
+- Stack traces, file paths, environment variables
+- Any PII
+
+**On the embedded PostHog key:** the project key shipped in the bundle is the public, write-only PostHog *project ingestion* key — this is the standard pattern for OSS analytics, and [PostHog's own guidance](https://posthog.com/docs/api#public-posthog-api) recommends embedding it. It cannot read events back, only append.
+
+### Network egress
+
+For partners on restricted networks, this is the complete allowlist of hosts the CLI may contact:
+
+| Host | When | Required? |
+|---|---|---|
+| `https://api.pax8.com` | Every API call | Always |
+| `https://api.pax8.com/v1/token` | OAuth client-credentials token exchange | Always (during auth) |
+| `https://us.i.posthog.com` | Telemetry capture | Only when `pax8 telemetry enable` has been set AND no opt-out env var is present |
+
+No other network egress. The CLI does not contact npm, GitHub, the Pax8 portal, the marketing site, or any auto-update service at runtime.
+
+### Using @pax8/core as a standalone library
+
+All business logic lives in [`@pax8/core`](packages/core) with zero CLI dependencies — the renewal tracker, invoice auditor, recommendation engine, and MRR analytics are all importable. See [`packages/core/README.md`](packages/core/README.md) for the full API; here is a minimal end-to-end example:
+
+```ts
+import { Pax8Client, getUpcomingRenewals, ALL_SUBS_PAGE_SIZE } from "@pax8/core";
+
+const client = new Pax8Client({
+  clientId: process.env.PAX8_CLIENT_ID!,
+  clientSecret: process.env.PAX8_CLIENT_SECRET!,
+});
+
+const { content: subs } = await client.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE });
+const report = getUpcomingRenewals(subs, 30);
+
+console.log(`${report.items.length} renewals in 30 days, $${report.totalMrrAtRisk}/mo at risk`);
+for (const r of report.items.slice(0, 5)) {
+  console.log(`  ${r.daysUntil}d  ${r.companyName}  ${r.productName}  $${r.mrr}/mo`);
+}
+```
+
+The same pattern works for `auditInvoices(...)`, `computeMrr(...)`, `computeGrowth(...)`, and `getRecommendations(...)` — see [`packages/core/README.md`](packages/core/README.md) for the full surface.
 
 ## Documentation
 
@@ -277,3 +350,7 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE)
+
+---
+
+Pax8 and the Pax8 logo are trademarks of Pax8, Inc.

--- a/README.md
+++ b/README.md
@@ -317,19 +317,28 @@ No other network egress. The CLI does not contact npm, GitHub, the Pax8 portal, 
 All business logic lives in [`@pax8/core`](packages/core) with zero CLI dependencies — the renewal tracker, invoice auditor, recommendation engine, and MRR analytics are all importable. See [`packages/core/README.md`](packages/core/README.md) for the full API; here is a minimal end-to-end example:
 
 ```ts
-import { Pax8Client, getUpcomingRenewals, ALL_SUBS_PAGE_SIZE } from "@pax8/core";
+import {
+  Pax8Client,
+  TokenManager,
+  SubscriptionsApi,
+  getUpcomingRenewals,
+  ALL_SUBS_PAGE_SIZE,
+} from "@pax8/core";
 
-const client = new Pax8Client({
+const tokenManager = new TokenManager({
   clientId: process.env.PAX8_CLIENT_ID!,
   clientSecret: process.env.PAX8_CLIENT_SECRET!,
 });
 
-const { content: subs } = await client.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE });
-const report = getUpcomingRenewals(subs, 30);
+const client = new Pax8Client({ tokenManager });
+const subscriptions = new SubscriptionsApi(client);
+
+const { content } = await subscriptions.list({ size: ALL_SUBS_PAGE_SIZE });
+const report = getUpcomingRenewals(content, 30);
 
 console.log(`${report.items.length} renewals in 30 days, $${report.totalMrrAtRisk}/mo at risk`);
 for (const r of report.items.slice(0, 5)) {
-  console.log(`  ${r.daysUntil}d  ${r.companyName}  ${r.productName}  $${r.mrr}/mo`);
+  console.log(`  ${r.daysUntilRenewal}d  ${r.companyName}  ${r.productName}  $${r.mrrAtRisk}/mo`);
 }
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,3 +33,11 @@ Vulnerabilities in the Pax8 API itself should be reported to Pax8 directly at ht
 - Credentials are never logged, displayed in output, or included in telemetry
 - Tokens are cached in memory only and never written to disk
 - The `--verbose` flag logs API request URLs and status codes but never request/response bodies
+
+## OAuth scope
+
+Pax8 API credentials carry the full set of permissions associated with the issuing partner account — there is currently no per-scope or read-only credential type at the API level. Treat them as account-equivalent and store them only on machines you trust. To revoke credentials, see <https://app.pax8.com> (Integrations Hub → API Credentials).
+
+## Claude skill data flow
+
+When a partner uses [`@pax8/claude-skill`](packages/claude-skill) via Claude Code, command output flows to Anthropic via Claude Code as part of the agent loop — i.e. whatever the CLI prints in response to a tool invocation becomes part of the model's context for that turn. This is the normal Claude Code data flow and is governed by Anthropic's policies. Pax8 does not receive or store skill conversations and is not involved in that data path.


### PR DESCRIPTION
## Summary
Pre-release polish across the three top-level docs files.

### README.md
- Test count phrasing made forward-compatible (`800+ tests across unit, CLI integration, and e2e flows; see CI for current count`) so it doesn't need a PR every time the suite grows
- New **Telemetry** section: opt-in default, env var overrides (`PAX8_TELEMETRY_DISABLED`, `DO_NOT_TRACK`), full event/property table sourced from `packages/core/src/telemetry/telemetry.ts`, explicit list of what is never sent, note on the embedded public PostHog key
- New **Network egress** section: complete allowlist of hosts the CLI reaches (api.pax8.com always, posthog only when telemetry enabled, nothing else) — useful for partners on restricted networks
- New **Using @pax8/core as a standalone library** section with a 10-line TS example (instantiate client → list subs → run `getUpcomingRenewals`)
- Trademark notice in the footer

### SECURITY.md
- Added **OAuth scope** paragraph: Pax8 API credentials are account-equivalent; how to revoke
- Added **Claude skill data flow** paragraph: clarifies that command output flows to Anthropic via Claude Code, Pax8 is not in that data path

### CONTRIBUTING.md
- Explicit "outside contributions welcome, no CLA"
- DCO sign-off (`git commit -s`) requirement with example
- Conventional Commits link
- References to issue / PR templates already in repo
- Security reports route through SECURITY.md, not Issues
- Demo-mode dev workflow (`PAX8_DEMO=1 NO_COLOR=1 pnpm test`) added to the setup block

## Test plan
- [x] Reviewed README rendering for the new tables / fences
- [x] Verified telemetry properties listed in README match `telemetry.ts` (`command_executed` event)
- [x] Verified egress hosts match grep across `packages/{core,cli}/src/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KynZASgsB5mf61ERym7KKv)_