### PR TITLE
fix(telemetry): drop unemitted company_count and rec_count from schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ The CLI also honors two ambient environment variables (no opt-in required) and s
 | `node_version` | always | `process.version` |
 | `os` | always | `process.platform` |
 | `demo_mode` | always | Whether `PAX8_DEMO=1` was set |
-| `company_count` | optional segment marker | Bucket of how many companies the partner has — never a list of names or IDs |
-| `rec_count`, `recs_presented`, `recs_ordered`, `recs_skipped`, `recs_mrr_captured` | recommendations commands | Aggregate counts only |
+| `recs_presented`, `recs_ordered`, `recs_skipped`, `recs_mrr_captured` | `recommendations act` | Aggregate counts only |
 | `order_success`, `order_total_dollars`, `order_mrr_impact`, `order_seats` | `orders create` | Aggregate transaction outcome only |
 
 The anonymous `distinct_id` is `sha256(hostname + ":" + username)` truncated to 16 hex chars — computed locally, never reversible to its inputs.

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -22,10 +22,6 @@ export interface TelemetryEvent {
   demo_mode: boolean;
   /** Full subcommand path, e.g. "recommendations.list" */
   subcommand?: string;
-  /** Number of companies the user has (segment size) */
-  company_count?: number;
-  /** For recommendations commands, how many recs were found */
-  rec_count?: number;
   /** For order create, did the order actually succeed */
   order_success?: boolean;
   /** Revenue: order total in dollars (unit_price × quantity) */
@@ -183,8 +179,6 @@ export class Telemetry {
             os: event.os,
             demo_mode: event.demo_mode,
             ...(event.subcommand !== undefined && { subcommand: event.subcommand }),
-            ...(event.company_count !== undefined && { company_count: event.company_count }),
-            ...(event.rec_count !== undefined && { rec_count: event.rec_count }),
             ...(event.order_success !== undefined && { order_success: event.order_success }),
             ...(event.order_total_dollars !== undefined && { order_total_dollars: event.order_total_dollars }),
             ...(event.order_mrr_impact !== undefined && { order_mrr_impact: event.order_mrr_impact }),


### PR DESCRIPTION
## Summary

- Removes `company_count` and `rec_count` from the `TelemetryEvent` interface and the `flush()` serializer — neither field was ever populated by any command handler, but the README's Telemetry table claimed both would be sent.
- Tightens the README §Telemetry table to reflect what's actually emitted: `recs_*` only fire on `recommendations act`, no general `rec_count`.

Spotted as part of the v0.1.0 telemetry review — see #144 for the full audit and other follow-ups (#145, #146, #147). This is the smallest of the must-fixes; the others touch more code and are filed for separate PRs.

Re-introducing `company_count` and `rec_count` is intentional v0.2.x work — we want to bucket them properly (e.g., `< 10`, `10-49`, `50-199`, `200+`) before sending, rather than ship raw counts that could re-identify small partners.

Closes #148. Refs #144.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` — all 838 tests pass (1 unrelated skip)
- [x] `pnpm lint` clean
- [x] `grep -rn "company_count\|rec_count" packages/` returns no matches after change
