### PR TITLE
test: fill cli/lib coverage gaps + PAX8_API_BASE tests

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -40,6 +40,33 @@ describe("pax8 doctor", () => {
     expect(result.stdout).toContain("diagnostic");
     expect(result.stdout).toContain("Examples:");
   });
+
+  it("reports the default API base URL when PAX8_API_BASE is unset", async () => {
+    const result = await runCliExpectSuccess(["doctor"], { PAX8_API_BASE: "" });
+    expect(result.stdout).toMatch(/✓.*API base URL/);
+    expect(result.stdout).toContain("https://api.pax8.com/v1");
+    expect(result.stdout).toContain("default");
+  });
+
+  it("reports the overridden API base URL when PAX8_API_BASE is set", async () => {
+    const result = await runCliExpectSuccess(["doctor"], {
+      PAX8_API_BASE: "https://api-staging.pax8.com/v1",
+    });
+    expect(result.stdout).toMatch(/✓.*API base URL/);
+    expect(result.stdout).toContain("https://api-staging.pax8.com/v1");
+    expect(result.stdout).toContain("overridden via PAX8_API_BASE");
+    // staging != prod, so it should also flag "non-prod"
+    expect(result.stdout).toContain("non-prod");
+  });
+
+  it("does not flag non-prod when PAX8_API_BASE is explicitly set to the prod URL", async () => {
+    const result = await runCliExpectSuccess(["doctor"], {
+      PAX8_API_BASE: "https://api.pax8.com/v1",
+    });
+    expect(result.stdout).toMatch(/✓.*API base URL/);
+    expect(result.stdout).toContain("overridden via PAX8_API_BASE");
+    expect(result.stdout).not.toContain("non-prod");
+  });
 });
 
 describe("checkMcp", () => {

--- a/packages/cli/src/lib/confirm.test.ts
+++ b/packages/cli/src/lib/confirm.test.ts
@@ -1,5 +1,27 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { confirm, confirmDestructive } from "./confirm.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Queue of answers the next `prompt()` call should hand back. Tests push
+// onto this array in order. We can't `vi.spyOn(readline, "createInterface")`
+// because the readline module namespace is non-configurable in ESM.
+const answerQueue: string[] = [];
+
+vi.mock("readline", () => ({
+  createInterface: () => ({
+    question: (_q: string, cb: (answer: string) => void) => {
+      const next = answerQueue.shift() ?? "";
+      cb(next);
+    },
+    close: () => {},
+  }),
+}));
+
+import {
+  confirm,
+  confirmDestructive,
+  confirmWithChange,
+  isReplMode,
+  replCmd,
+} from "./confirm.js";
 
 describe("confirm", () => {
   const originalEnv = { ...process.env };
@@ -58,5 +80,194 @@ describe("confirmDestructive", () => {
     process.argv = ["node", "test", "--yes"];
     const result = await confirmDestructive("Delete?", "DELETE");
     expect(result).toBe(true);
+  });
+});
+
+describe("isReplMode and replCmd", () => {
+  const originalRepl = process.env.PAX8_REPL;
+
+  afterEach(() => {
+    if (originalRepl === undefined) delete process.env.PAX8_REPL;
+    else process.env.PAX8_REPL = originalRepl;
+  });
+
+  it("isReplMode is false when PAX8_REPL is unset", () => {
+    delete process.env.PAX8_REPL;
+    expect(isReplMode()).toBe(false);
+  });
+
+  it("isReplMode is true when PAX8_REPL=1", () => {
+    process.env.PAX8_REPL = "1";
+    expect(isReplMode()).toBe(true);
+  });
+
+  it("isReplMode is false for any non-1 value", () => {
+    process.env.PAX8_REPL = "true";
+    expect(isReplMode()).toBe(false);
+    process.env.PAX8_REPL = "0";
+    expect(isReplMode()).toBe(false);
+  });
+
+  it("replCmd strips the leading 'pax8 ' when in REPL mode", () => {
+    process.env.PAX8_REPL = "1";
+    expect(replCmd("pax8 auth login")).toBe("auth login");
+    expect(replCmd("pax8 doctor")).toBe("doctor");
+  });
+
+  it("replCmd is a no-op when not in REPL mode", () => {
+    delete process.env.PAX8_REPL;
+    expect(replCmd("pax8 auth login")).toBe("pax8 auth login");
+  });
+
+  it("replCmd does not strip if string does not start with 'pax8 '", () => {
+    process.env.PAX8_REPL = "1";
+    expect(replCmd("auth login")).toBe("auth login");
+    expect(replCmd("notpax8 thing")).toBe("notpax8 thing");
+  });
+});
+
+describe("confirmWithChange", () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    delete process.env.PAX8_YES;
+    process.argv = ["node", "test"];
+    answerQueue.length = 0;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = originalArgv;
+    answerQueue.length = 0;
+  });
+
+  it("returns the current value when PAX8_YES=1", async () => {
+    process.env.PAX8_YES = "1";
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBe(5);
+  });
+
+  it("returns the current value when --yes is set", async () => {
+    process.argv = ["node", "test", "--yes"];
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBe(5);
+  });
+
+  it("returns null when answered with 'n'", async () => {
+    answerQueue.push("n");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBeNull();
+  });
+
+  it("returns the current value when answered with empty string", async () => {
+    answerQueue.push("");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBe(5);
+  });
+
+  it("prompts for change when 'c' picked, then accepts new value", async () => {
+    // Three sequential prompts: 'c', '7', '' (empty re-confirm = accept).
+    answerQueue.push("c", "7", "");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBe(7);
+  });
+
+  it("returns null when 'change' answer is invalid", async () => {
+    answerQueue.push("c", "not-a-number");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when re-confirmation rejects the new value", async () => {
+    answerQueue.push("c", "8", "n");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when 'change' answer is zero or negative", async () => {
+    answerQueue.push("c", "0");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBeNull();
+  });
+
+  it("returns the existing value when 'change' answer is empty", async () => {
+    answerQueue.push("c", "");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBe(5);
+  });
+});
+
+describe("confirm interactive prompt", () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    delete process.env.PAX8_YES;
+    process.argv = ["node", "test"];
+    answerQueue.length = 0;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = originalArgv;
+    answerQueue.length = 0;
+  });
+
+  it("returns true on 'y' answer", async () => {
+    answerQueue.push("y");
+    expect(await confirm("Continue?")).toBe(true);
+  });
+
+  it("returns false on 'n' answer", async () => {
+    answerQueue.push("n");
+    expect(await confirm("Continue?")).toBe(false);
+  });
+
+  it("uses options.default true when answer is empty", async () => {
+    answerQueue.push("");
+    expect(await confirm("Continue?", { default: true })).toBe(true);
+  });
+
+  it("uses options.default false when answer is empty", async () => {
+    answerQueue.push("");
+    expect(await confirm("Continue?", { default: false })).toBe(false);
+  });
+
+  it("falls back to default=false when no options passed", async () => {
+    answerQueue.push("");
+    expect(await confirm("Continue?")).toBe(false);
+  });
+});
+
+describe("confirmDestructive interactive prompt", () => {
+  const originalEnv = { ...process.env };
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    delete process.env.PAX8_YES;
+    process.argv = ["node", "test"];
+    answerQueue.length = 0;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    process.argv = originalArgv;
+    answerQueue.length = 0;
+  });
+
+  it("returns true only when the typed answer matches the keyword exactly", async () => {
+    answerQueue.push("DELETE");
+    expect(await confirmDestructive("Delete?", "DELETE")).toBe(true);
+  });
+
+  it("returns false on a case-mismatch", async () => {
+    answerQueue.push("delete");
+    expect(await confirmDestructive("Delete?", "DELETE")).toBe(false);
+  });
+
+  it("returns false on a different answer", async () => {
+    answerQueue.push("yes");
+    expect(await confirmDestructive("Delete?", "DELETE")).toBe(false);
   });
 });

--- a/packages/cli/src/lib/context.test.ts
+++ b/packages/cli/src/lib/context.test.ts
@@ -1,4 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Track spawn calls so we can assert on cache-warmer invocations without
+// actually spawning detached child processes during tests.
+const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+
+vi.mock("node:child_process", async (importActual) => {
+  const actual = await importActual<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (cmd: string, args: string[], _opts?: unknown) => {
+      spawnCalls.push({ cmd, args });
+      const obj = {
+        on: () => obj,
+        unref: () => {},
+      };
+      return obj;
+    },
+  };
+});
+
 import { getOutputFormat, buildContext, warnIfTruncated } from "./context.js";
 
 describe("getOutputFormat", () => {
@@ -107,6 +127,146 @@ describe("buildContext", () => {
       await expect(buildContext({ json: true })).rejects.toThrow("Not authenticated");
     } finally {
       getCredSpy.mockRestore();
+    }
+  });
+
+  it("returns the ERROR_AUTH_MISSING code on the missing-credentials CliError", async () => {
+    process.env.PAX8_DEMO = undefined;
+    delete process.env.PAX8_CLIENT_ID;
+    delete process.env.PAX8_CLIENT_SECRET;
+
+    const core = await import("@pax8/core");
+    const getCredSpy = vi
+      .spyOn(core.CredentialStore.prototype, "getCredentials")
+      .mockResolvedValue(null);
+
+    try {
+      const error = await buildContext({ json: true }).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(Error);
+      const err = error as Error & {
+        code?: string;
+        causes?: string[];
+        recoverySteps?: string[];
+        docsUrl?: string;
+      };
+      expect(err.code).toBe(core.ERROR_AUTH_MISSING);
+      expect(err.causes).toEqual(["No Pax8 API credentials found"]);
+      expect(err.recoverySteps?.length).toBeGreaterThan(0);
+      expect(err.docsUrl).toBe("https://devx.pax8.com/");
+    } finally {
+      getCredSpy.mockRestore();
+    }
+  });
+
+  it("propagates verbose=true through to the demo-mode context", async () => {
+    process.env.PAX8_DEMO = "1";
+    const ctx = await buildContext({ verbose: true, json: true });
+    expect(ctx.verbose).toBe(true);
+  });
+
+  it("defaults verbose to false when not provided", async () => {
+    process.env.PAX8_DEMO = "1";
+    const ctx = await buildContext({ json: true });
+    expect(ctx.verbose).toBe(false);
+  });
+
+  it("config 'demo: true' enables demo mode even without PAX8_DEMO env", async () => {
+    delete process.env.PAX8_DEMO;
+    const core = await import("@pax8/core");
+    const cfg = {
+      version: "1.0" as const,
+      demo: true,
+      defaults: {
+        output_format: "table" as const,
+        page_size: 50,
+        confirm_destructive: true,
+      },
+      cache: { enabled: true, ttl_hours: 24 },
+      telemetry: { enabled: false },
+    };
+    const loadSpy = vi
+      .spyOn(core, "loadConfig")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial config for tests
+      .mockResolvedValue(cfg as any);
+    try {
+      const ctx = await buildContext({ json: true });
+      expect(ctx.isDemo).toBe(true);
+    } finally {
+      loadSpy.mockRestore();
+    }
+  });
+
+  it("non-demo path constructs a real api client when credentials are present", async () => {
+    delete process.env.PAX8_DEMO;
+    // Skip the cache warmer so the test doesn't spawn detached child procs.
+    process.env.PAX8_CACHE_WARMING = "1";
+
+    const core = await import("@pax8/core");
+    const getCredSpy = vi
+      .spyOn(core.CredentialStore.prototype, "getCredentials")
+      .mockResolvedValue({ clientId: "id-x", clientSecret: "secret-y" });
+
+    try {
+      const ctx = await buildContext({ json: true, verbose: true });
+      expect(ctx.isDemo).toBe(false);
+      expect(ctx.verbose).toBe(true);
+      expect(ctx.outputFormat).toBe("json");
+      // Should expose the full ApiClient surface
+      expect(ctx.api).toBeDefined();
+      expect("companies" in ctx.api).toBe(true);
+      expect("subscriptions" in ctx.api).toBe(true);
+      expect("orders" in ctx.api).toBe(true);
+      expect("invoices" in ctx.api).toBe(true);
+      expect("contacts" in ctx.api).toBe(true);
+      expect("products" in ctx.api).toBe(true);
+      expect("usage" in ctx.api).toBe(true);
+      expect("quotes" in ctx.api).toBe(true);
+      expect("webhooks" in ctx.api).toBe(true);
+    } finally {
+      getCredSpy.mockRestore();
+      delete process.env.PAX8_CACHE_WARMING;
+    }
+  });
+
+  it("non-demo path spawns three cache warmers when not already warming", async () => {
+    delete process.env.PAX8_DEMO;
+    delete process.env.PAX8_CACHE_WARMING;
+    spawnCalls.length = 0;
+
+    const core = await import("@pax8/core");
+    const getCredSpy = vi
+      .spyOn(core.CredentialStore.prototype, "getCredentials")
+      .mockResolvedValue({ clientId: "id-x", clientSecret: "secret-y" });
+
+    try {
+      await buildContext({ json: true });
+      expect(spawnCalls).toHaveLength(3);
+      // The warmers list companies, subscriptions, products in parallel.
+      const resources = spawnCalls.map((c) => c.args[0]).sort();
+      expect(resources).toEqual(["companies", "products", "subscriptions"]);
+      // Each should pass --quiet --json so they never write to a real terminal.
+      for (const c of spawnCalls) {
+        expect(c.args).toContain("--json");
+        expect(c.args).toContain("--quiet");
+      }
+    } finally {
+      getCredSpy.mockRestore();
+    }
+  });
+
+  it("loadConfig failure is recovered with sane defaults", async () => {
+    process.env.PAX8_DEMO = "1";
+    const core = await import("@pax8/core");
+    const loadSpy = vi
+      .spyOn(core, "loadConfig")
+      .mockRejectedValue(new Error("config corrupt"));
+    try {
+      const ctx = await buildContext({});
+      expect(ctx.config.version).toBe("1.0");
+      expect(ctx.config.defaults?.page_size).toBe(50);
+      expect(ctx.isDemo).toBe(true);
+    } finally {
+      loadSpy.mockRestore();
     }
   });
 });

--- a/packages/cli/src/lib/errors.test.ts
+++ b/packages/cli/src/lib/errors.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { CliError, handleCommandError } from "./errors.js";
+import { z } from "zod";
+import {
+  ApiError,
+  ERROR_AUTH_EXPIRED,
+  ERROR_API_TIMEOUT,
+  ERROR_API_VALIDATION,
+  ERROR_COMPANY_NOT_FOUND,
+  ERROR_INTERNAL,
+  ERROR_NOT_AUTHORIZED,
+  ERROR_PRODUCT_NOT_FOUND,
+  ERROR_RATE_LIMITED,
+  ERROR_SUBSCRIPTION_NOT_FOUND,
+} from "@pax8/core";
+import { CliError, handleCommandError, extractErrorDetail } from "./errors.js";
 
 describe("CliError", () => {
   it("constructs with message only", () => {
@@ -132,5 +145,255 @@ describe("handleCommandError", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial mock for testing
     expect(() => handleCommandError(new Error("test"), spinner as any)).toThrow("process.exit intercepted");
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("formats ApiError 401 with re-auth recovery hint", () => {
+    expect(() =>
+      handleCommandError(
+        new ApiError("Unauthorized", 401, "/companies", "GET", { message: "bad token" })
+      )
+    ).toThrow("process.exit intercepted");
+
+    const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
+    expect(written).toContain("Unauthorized");
+    expect(written).toContain("auth login");
+  });
+
+  it("formats ApiError 404 with extracted detail message", () => {
+    expect(() =>
+      handleCommandError(
+        new ApiError("Not Found", 404, "/companies/123", "GET", { message: "company missing" })
+      )
+    ).toThrow("process.exit intercepted");
+
+    const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
+    expect(written).toContain("company missing");
+  });
+
+  it("formats ApiError 404 without responseBody falls back to generic hint", () => {
+    expect(() =>
+      handleCommandError(
+        new ApiError("Not Found", 404, "/companies/123", "GET")
+      )
+    ).toThrow("process.exit intercepted");
+
+    const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
+    expect(written).toContain("Check the ID or name");
+  });
+
+  it("formats ZodError with parse-failure message and a doctor hint", () => {
+    const schema = z.object({ id: z.string() });
+    const parsed = schema.safeParse({ id: 42 });
+    if (parsed.success) throw new Error("expected parse to fail");
+
+    expect(() => handleCommandError(parsed.error)).toThrow("process.exit intercepted");
+
+    const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
+    expect(written).toContain("unexpected response");
+    expect(written).toContain("doctor");
+  });
+});
+
+describe("handleCommandError JSON envelope", () => {
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    process.argv = [...originalArgv, "--json"];
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+    exitSpy.mockRestore();
+    process.argv = originalArgv;
+  });
+
+  function captured(): string {
+    return stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+  }
+
+  it("emits a JSON envelope with code, message, causes, recoverySteps, docsUrl for CliError", () => {
+    expect(() =>
+      handleCommandError(
+        new CliError(
+          "Auth failed",
+          ["Token expired"],
+          ["Run pax8 auth login", "Or check your client ID"],
+          "https://docs.pax8.com/auth",
+          ERROR_AUTH_EXPIRED
+        )
+      )
+    ).toThrow("process.exit intercepted");
+
+    const env = JSON.parse(captured());
+    expect(env).toEqual({
+      code: ERROR_AUTH_EXPIRED,
+      message: "Auth failed",
+      causes: ["Token expired"],
+      recoverySteps: ["Run pax8 auth login", "Or check your client ID"],
+      docsUrl: "https://docs.pax8.com/auth",
+    });
+  });
+
+  it("omits unset optional fields from the JSON envelope", () => {
+    expect(() =>
+      handleCommandError(new CliError("simple error"))
+    ).toThrow("process.exit intercepted");
+
+    const env = JSON.parse(captured());
+    expect(env).toEqual({ message: "simple error" });
+    expect(env.code).toBeUndefined();
+    expect(env.causes).toBeUndefined();
+    expect(env.recoverySteps).toBeUndefined();
+    expect(env.docsUrl).toBeUndefined();
+  });
+
+  it("prepends the context to the JSON envelope message", () => {
+    expect(() =>
+      handleCommandError(new CliError("nope"), undefined, "Failed to list companies")
+    ).toThrow("process.exit intercepted");
+    const env = JSON.parse(captured());
+    expect(env.message).toBe("Failed to list companies: nope");
+  });
+
+  it("maps ApiError 401 -> ERROR_AUTH_EXPIRED", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Unauthorized", 401, "/x", "GET"))
+    ).toThrow("process.exit intercepted");
+    const env = JSON.parse(captured());
+    expect(env.code).toBe(ERROR_AUTH_EXPIRED);
+    expect(env.recoverySteps?.[0]).toContain("auth login");
+  });
+
+  it("maps ApiError 408 -> ERROR_API_TIMEOUT", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Timeout", 408, "/x", "GET"))
+    ).toThrow("process.exit intercepted");
+    expect(JSON.parse(captured()).code).toBe(ERROR_API_TIMEOUT);
+  });
+
+  it("maps ApiError 429 -> ERROR_RATE_LIMITED", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Rate limited", 429, "/x", "GET"))
+    ).toThrow("process.exit intercepted");
+    expect(JSON.parse(captured()).code).toBe(ERROR_RATE_LIMITED);
+  });
+
+  it("maps ApiError 5xx -> ERROR_INTERNAL", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Server boom", 503, "/x", "GET"))
+    ).toThrow("process.exit intercepted");
+    expect(JSON.parse(captured()).code).toBe(ERROR_INTERNAL);
+  });
+
+  it("maps ApiError 404 on /companies -> ERROR_COMPANY_NOT_FOUND", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Not Found", 404, "/companies/abc", "GET"))
+    ).toThrow("process.exit intercepted");
+    expect(JSON.parse(captured()).code).toBe(ERROR_COMPANY_NOT_FOUND);
+  });
+
+  it("maps ApiError 404 on /products -> ERROR_PRODUCT_NOT_FOUND", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Not Found", 404, "/products/abc", "GET"))
+    ).toThrow("process.exit intercepted");
+    expect(JSON.parse(captured()).code).toBe(ERROR_PRODUCT_NOT_FOUND);
+  });
+
+  it("maps ApiError 404 on /subscriptions -> ERROR_SUBSCRIPTION_NOT_FOUND", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Not Found", 404, "/subscriptions/abc", "GET"))
+    ).toThrow("process.exit intercepted");
+    expect(JSON.parse(captured()).code).toBe(ERROR_SUBSCRIPTION_NOT_FOUND);
+  });
+
+  it("falls back to ERROR_NOT_AUTHORIZED on a generic 404", () => {
+    expect(() =>
+      handleCommandError(new ApiError("Not Found", 404, "/totallyrandom", "GET"))
+    ).toThrow("process.exit intercepted");
+    expect(JSON.parse(captured()).code).toBe(ERROR_NOT_AUTHORIZED);
+  });
+
+  it("emits ERROR_API_VALIDATION envelope for ZodError", () => {
+    const schema = z.object({ id: z.string() });
+    const parsed = schema.safeParse({ id: 42 });
+    if (parsed.success) throw new Error("expected parse to fail");
+
+    expect(() => handleCommandError(parsed.error)).toThrow("process.exit intercepted");
+
+    const env = JSON.parse(captured());
+    expect(env.code).toBe(ERROR_API_VALIDATION);
+    expect(env.causes).toBeDefined();
+    expect(env.recoverySteps).toBeDefined();
+  });
+
+  it("emits ERROR_INTERNAL for a plain Error", () => {
+    expect(() => handleCommandError(new Error("oops"))).toThrow(
+      "process.exit intercepted"
+    );
+    const env = JSON.parse(captured());
+    expect(env.code).toBe(ERROR_INTERNAL);
+    expect(env.message).toBe("oops");
+  });
+
+  it("emits ERROR_INTERNAL for an unknown thrown value", () => {
+    expect(() => handleCommandError("nope")).toThrow("process.exit intercepted");
+    const env = JSON.parse(captured());
+    expect(env.code).toBe(ERROR_INTERNAL);
+    expect(env.message).toContain("unexpected error");
+  });
+
+  it("includes API error responseBody detail as causes when present", () => {
+    expect(() =>
+      handleCommandError(
+        new ApiError("Bad Request", 400, "/x", "POST", { detail: "missing field foo" })
+      )
+    ).toThrow("process.exit intercepted");
+    const env = JSON.parse(captured());
+    expect(env.causes).toEqual(["missing field foo"]);
+  });
+});
+
+describe("extractErrorDetail", () => {
+  it("returns undefined for non-objects", () => {
+    expect(extractErrorDetail(null)).toBeUndefined();
+    expect(extractErrorDetail("string")).toBeUndefined();
+    expect(extractErrorDetail(42)).toBeUndefined();
+  });
+
+  it("extracts from message/error/detail/error_description in priority order", () => {
+    expect(extractErrorDetail({ message: "m" })).toBe("m");
+    expect(extractErrorDetail({ error: "e" })).toBe("e");
+    expect(extractErrorDetail({ detail: "d" })).toBe("d");
+    expect(extractErrorDetail({ error_description: "ed" })).toBe("ed");
+  });
+
+  it("extracts message from a nested error object", () => {
+    expect(extractErrorDetail({ error: { message: "nested" } })).toBe("nested");
+  });
+
+  it("returns undefined when no recognized key holds a string", () => {
+    expect(extractErrorDetail({ unrelated: "x" })).toBeUndefined();
+    expect(extractErrorDetail({ message: 42 })).toBeUndefined();
+  });
+});
+
+describe("CliError with code", () => {
+  it("preserves the code property", () => {
+    const err = new CliError(
+      "msg",
+      undefined,
+      undefined,
+      undefined,
+      ERROR_AUTH_EXPIRED
+    );
+    expect(err.code).toBe(ERROR_AUTH_EXPIRED);
   });
 });

--- a/packages/cli/src/lib/invalidate-cache.test.ts
+++ b/packages/cli/src/lib/invalidate-cache.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { invalidateCacheAfterWrite } from "./invalidate-cache.js";
+
+describe("invalidateCacheAfterWrite", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls FileCache.clear() to wipe cached entries", async () => {
+    const core = await import("@pax8/core");
+    const clearSpy = vi
+      .spyOn(core.FileCache.prototype, "clear")
+      .mockResolvedValue();
+
+    await invalidateCacheAfterWrite();
+
+    expect(clearSpy).toHaveBeenCalledOnce();
+  });
+
+  it("swallows errors thrown by FileCache.clear()", async () => {
+    const core = await import("@pax8/core");
+    vi.spyOn(core.FileCache.prototype, "clear").mockRejectedValueOnce(
+      new Error("disk full")
+    );
+
+    // Must not reject — we don't want a write command to fail just because
+    // the post-write cache wipe couldn't run.
+    await expect(invalidateCacheAfterWrite()).resolves.toBeUndefined();
+  });
+
+  it("does not propagate sync errors to callers", async () => {
+    // Even if `clear()` throws synchronously instead of rejecting, the
+    // wrapper must still resolve cleanly — callers rely on this contract.
+    const core = await import("@pax8/core");
+    vi.spyOn(core.FileCache.prototype, "clear").mockImplementationOnce(() => {
+      throw new Error("sync boom");
+    });
+
+    await expect(invalidateCacheAfterWrite()).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/last-list.test.ts
+++ b/packages/cli/src/lib/last-list.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { saveLastList, resolveFromLastList } from "./last-list.js";
+
+describe("last-list", () => {
+  let tmpDir: string;
+  const originalConfigDir = process.env.PAX8_CONFIG_DIR;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-last-list-"));
+    process.env.PAX8_CONFIG_DIR = tmpDir;
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) delete process.env.PAX8_CONFIG_DIR;
+    else process.env.PAX8_CONFIG_DIR = originalConfigDir;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("saves and resolves a numbered entry", async () => {
+    await saveLastList([
+      { index: 1, id: "abc-123", name: "Acme Corp" },
+      { index: 2, id: "def-456", name: "Beta Inc" },
+    ]);
+
+    const found = await resolveFromLastList("1");
+    expect(found).toEqual({ id: "abc-123", name: "Acme Corp" });
+
+    const found2 = await resolveFromLastList("2");
+    expect(found2).toEqual({ id: "def-456", name: "Beta Inc" });
+  });
+
+  it("returns null for non-numeric input", async () => {
+    await saveLastList([{ index: 1, id: "abc", name: "Acme" }]);
+    expect(await resolveFromLastList("abc-123")).toBeNull();
+    expect(await resolveFromLastList("not-a-number")).toBeNull();
+  });
+
+  it("returns null for a UUID-like string even if it begins with digits", async () => {
+    await saveLastList([{ index: 1, id: "abc", name: "Acme" }]);
+    // parseInt("123abc") would be 123 — guard rejects via String(num) !== input.trim()
+    expect(await resolveFromLastList("123abc")).toBeNull();
+  });
+
+  it("returns null when the index is out of range", async () => {
+    await saveLastList([{ index: 1, id: "abc", name: "Acme" }]);
+    expect(await resolveFromLastList("99")).toBeNull();
+  });
+
+  it("returns null when no last list has been saved", async () => {
+    expect(await resolveFromLastList("1")).toBeNull();
+  });
+
+  it("trims whitespace before matching", async () => {
+    await saveLastList([{ index: 5, id: "x", name: "X" }]);
+    const found = await resolveFromLastList("5");
+    expect(found).toEqual({ id: "x", name: "X" });
+  });
+
+  it("overwrites a previously-saved list", async () => {
+    await saveLastList([{ index: 1, id: "old", name: "Old" }]);
+    await saveLastList([{ index: 1, id: "new", name: "New" }]);
+    const found = await resolveFromLastList("1");
+    expect(found).toEqual({ id: "new", name: "New" });
+  });
+
+  it("returns null when the cache file is corrupt", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "last-list.json"), "{ not json", "utf-8");
+    expect(await resolveFromLastList("1")).toBeNull();
+  });
+
+  it("does not throw when the config dir cannot be created", async () => {
+    // Point at a path that exists as a file, so mkdir fails — saveLastList must swallow.
+    const blockerFile = path.join(tmpDir, "blocker");
+    await fs.writeFile(blockerFile, "block");
+    process.env.PAX8_CONFIG_DIR = path.join(blockerFile, "nested");
+    // Should not throw
+    await expect(
+      saveLastList([{ index: 1, id: "x", name: "y" }])
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/next-step.test.ts
+++ b/packages/cli/src/lib/next-step.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const answerQueue: string[] = [];
+
+vi.mock("readline", () => ({
+  createInterface: () => ({
+    question: (_q: string, cb: (a: string) => void) => {
+      cb(answerQueue.shift() ?? "");
+    },
+    close: () => {},
+  }),
+}));
+
+// Mock spawn so we don't actually launch a child process in tests where
+// the user "selects" a step.
+const spawnedCommands: Array<{ args: string[] }> = [];
+vi.mock("child_process", async (importActual) => {
+  const actual = await importActual<typeof import("child_process")>();
+  return {
+    ...actual,
+    spawn: (_cmd: string, args: string[]) => {
+      spawnedCommands.push({ args });
+      const handlers: Record<string, () => void> = {};
+      // Synchronously invoke the close handler on next tick.
+      const obj = {
+        on: (event: string, cb: () => void) => {
+          handlers[event] = cb;
+          if (event === "close") {
+            // schedule close in a microtask
+            queueMicrotask(() => cb());
+          }
+          return obj;
+        },
+      };
+      return obj;
+    },
+  };
+});
+
+import { promptNextSteps, type NextStep } from "./next-step.js";
+
+describe("promptNextSteps", () => {
+  const originalIsTTY = process.stdin.isTTY;
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    answerQueue.length = 0;
+    spawnedCommands.length = 0;
+    stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("returns silently when stdin is not a TTY (piped invocation)", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+
+    const steps: NextStep[] = [
+      { key: "1", label: "List subscriptions", command: ["subscriptions", "list"] },
+    ];
+    await promptNextSteps(steps);
+    expect(stderrWrite).not.toHaveBeenCalled();
+    expect(spawnedCommands).toHaveLength(0);
+  });
+
+  it("returns silently when there are no steps to suggest", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    await promptNextSteps([]);
+    expect(stderrWrite).not.toHaveBeenCalled();
+    expect(spawnedCommands).toHaveLength(0);
+  });
+
+  it("renders each step's key, label, and command preview to stderr", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    answerQueue.push(""); // user just hits Enter
+
+    const steps: NextStep[] = [
+      { key: "1", label: "List subscriptions", command: ["subscriptions", "list"] },
+      { key: "2", label: "Show renewals", command: ["subscriptions", "renewals"] },
+    ];
+
+    await promptNextSteps(steps);
+
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("[1]");
+    expect(written).toContain("List subscriptions");
+    expect(written).toContain("subscriptions list");
+    expect(written).toContain("[2]");
+    expect(written).toContain("Show renewals");
+    expect(written).toContain("subscriptions renewals");
+    // No spawn since user skipped.
+    expect(spawnedCommands).toHaveLength(0);
+  });
+
+  it("returns without spawning when the user picks an unknown key", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    answerQueue.push("99");
+
+    const steps: NextStep[] = [
+      { key: "1", label: "x", command: ["a"] },
+    ];
+    await promptNextSteps(steps);
+    expect(spawnedCommands).toHaveLength(0);
+  });
+
+  it("returns without spawning when the user just hits Enter", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    answerQueue.push("   "); // whitespace-only -> trim() empty -> skip
+
+    const steps: NextStep[] = [
+      { key: "1", label: "x", command: ["a"] },
+    ];
+    await promptNextSteps(steps);
+    expect(spawnedCommands).toHaveLength(0);
+  });
+
+  it("spawns the picked step's command when the user enters a valid key", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    answerQueue.push("1");
+
+    const steps: NextStep[] = [
+      { key: "1", label: "List subs", command: ["subscriptions", "list"] },
+      { key: "2", label: "Renewals", command: ["subscriptions", "renewals"] },
+    ];
+
+    await promptNextSteps(steps);
+
+    expect(spawnedCommands).toHaveLength(1);
+    expect(spawnedCommands[0].args).toEqual(["subscriptions", "list"]);
+  });
+});

--- a/packages/cli/src/lib/signals.test.ts
+++ b/packages/cli/src/lib/signals.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  installSigintHandler,
   markWriteInFlight,
   _getWriteInFlight,
   _resetWriteInFlight,
@@ -37,5 +38,128 @@ describe("markWriteInFlight", () => {
   it("preserves the optional hint", () => {
     markWriteInFlight("orders", "id=abc");
     expect(_getWriteInFlight()).toEqual({ resource: "orders", hint: "id=abc" });
+  });
+});
+
+describe("installSigintHandler — capture and invoke", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+  let sigintHandler: ((...args: unknown[]) => void) | null = null;
+  let onSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    sigintHandler = null;
+    _resetWriteInFlight();
+
+    // Force the module to re-run by resetting the module registry. After this,
+    // the next `import("./signals.js")` will execute the file fresh — meaning
+    // the `handlerInstalled` flag is reset to false and `installSigintHandler`
+    // will actually wire a fresh listener via the spied `process.on`.
+    vi.resetModules();
+
+    onSpy = vi
+      .spyOn(process, "on")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock signature
+      .mockImplementation((event: string | symbol, listener: any) => {
+        if (event === "SIGINT") {
+          sigintHandler = listener;
+        }
+        return process;
+      });
+
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+
+    stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    const fresh = await import("./signals.js");
+    fresh._resetWriteInFlight();
+    fresh.installSigintHandler();
+  });
+
+  afterEach(() => {
+    onSpy.mockRestore();
+    exitSpy.mockRestore();
+    stderrWrite.mockRestore();
+  });
+
+  it("captures exactly one SIGINT handler on first install", () => {
+    expect(sigintHandler).not.toBeNull();
+  });
+
+  it("on first SIGINT exits with code 130", () => {
+    expect(sigintHandler).not.toBeNull();
+    sigintHandler!();
+    expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+
+  it("on second SIGINT also exits with 130 (Node default takes over)", () => {
+    expect(sigintHandler).not.toBeNull();
+    sigintHandler!();
+    sigintHandler!();
+    expect(exitSpy).toHaveBeenCalledTimes(2);
+    expect(exitSpy).toHaveBeenLastCalledWith(130);
+  });
+
+  it("on first SIGINT with an in-flight write writes a (cancelled) hint to stderr", async () => {
+    expect(sigintHandler).not.toBeNull();
+    const fresh = await import("./signals.js");
+    fresh.markWriteInFlight("orders", "(idempotency-key=xyz)");
+
+    sigintHandler!();
+
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("(cancelled)");
+    expect(written).toContain("orders");
+    expect(written).toContain("idempotency-key=xyz");
+    expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+
+  it("on first SIGINT without an in-flight write skips the (cancelled) hint", () => {
+    expect(sigintHandler).not.toBeNull();
+    sigintHandler!();
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).not.toContain("(cancelled)");
+    expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+});
+
+describe("installSigintHandler — idempotent", () => {
+  beforeEach(() => {
+    _resetWriteInFlight();
+  });
+
+  it("calling installSigintHandler() twice does not register a second listener", async () => {
+    vi.resetModules();
+    const calls: string[] = [];
+    const onSpy = vi
+      .spyOn(process, "on")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock signature
+      .mockImplementation((event: string | symbol, _listener: any) => {
+        calls.push(String(event));
+        return process;
+      });
+
+    try {
+      const fresh = await import("./signals.js");
+      fresh.installSigintHandler();
+      fresh.installSigintHandler();
+      fresh.installSigintHandler();
+
+      const sigintCount = calls.filter((c) => c === "SIGINT").length;
+      expect(sigintCount).toBe(1);
+    } finally {
+      onSpy.mockRestore();
+    }
+  });
+});
+
+// installSigintHandler is exported but the import alone shouldn't trigger it.
+describe("installSigintHandler — exported", () => {
+  it("is a function", () => {
+    expect(typeof installSigintHandler).toBe("function");
   });
 });

--- a/packages/core/src/api/client.test.ts
+++ b/packages/core/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Pax8Client } from "./client.js";
+import { Pax8Client, getDefaultBaseUrl } from "./client.js";
 import { ApiError, RateLimitError } from "./errors.js";
 
 const mockTokenManager = { getToken: vi.fn().mockResolvedValue("test-token") };
@@ -255,5 +255,105 @@ describe("Pax8Client", () => {
     const output = stderrSpy.mock.calls.map((c) => c[0]).join("");
     expect(output).toContain("GET");
     expect(output).toContain("/test");
+  });
+});
+
+describe("getDefaultBaseUrl", () => {
+  const originalApiBase = process.env.PAX8_API_BASE;
+
+  afterEach(() => {
+    if (originalApiBase === undefined) delete process.env.PAX8_API_BASE;
+    else process.env.PAX8_API_BASE = originalApiBase;
+  });
+
+  it("falls back to the production URL when PAX8_API_BASE is unset", () => {
+    delete process.env.PAX8_API_BASE;
+    expect(getDefaultBaseUrl()).toBe("https://api.pax8.com/v1");
+  });
+
+  it("falls back to the production URL when PAX8_API_BASE is empty string", () => {
+    process.env.PAX8_API_BASE = "";
+    expect(getDefaultBaseUrl()).toBe("https://api.pax8.com/v1");
+  });
+
+  it("honors PAX8_API_BASE when set", () => {
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1";
+    expect(getDefaultBaseUrl()).toBe("https://api-staging.pax8.com/v1");
+  });
+
+  it("re-reads the env on every call (lazy lookup, not cached)", () => {
+    delete process.env.PAX8_API_BASE;
+    expect(getDefaultBaseUrl()).toBe("https://api.pax8.com/v1");
+
+    process.env.PAX8_API_BASE = "https://example.test/v1";
+    expect(getDefaultBaseUrl()).toBe("https://example.test/v1");
+
+    process.env.PAX8_API_BASE = "https://other.test/v2";
+    expect(getDefaultBaseUrl()).toBe("https://other.test/v2");
+
+    delete process.env.PAX8_API_BASE;
+    expect(getDefaultBaseUrl()).toBe("https://api.pax8.com/v1");
+  });
+});
+
+describe("Pax8Client + PAX8_API_BASE", () => {
+  let originalFetch: typeof globalThis.fetch;
+  const originalApiBase = process.env.PAX8_API_BASE;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockTokenManager.getToken.mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    if (originalApiBase === undefined) delete process.env.PAX8_API_BASE;
+    else process.env.PAX8_API_BASE = originalApiBase;
+  });
+
+  it("uses PAX8_API_BASE for the request URL when no explicit baseUrl is passed", async () => {
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1";
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/companies");
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toContain("https://api-staging.pax8.com/v1/companies");
+  });
+
+  it("strips trailing slashes from PAX8_API_BASE before composing the URL", async () => {
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1//";
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/companies");
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    // Should not double up slashes between base and path
+    expect(url.toString()).toBe("https://api-staging.pax8.com/v1/companies");
+  });
+
+  it("explicit baseUrl option overrides PAX8_API_BASE", async () => {
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1";
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.example.com/v1",
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/companies");
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toContain("https://api.example.com/v1/companies");
+    expect(url.toString()).not.toContain("staging");
   });
 });

--- a/packages/core/src/auth/token-manager.test.ts
+++ b/packages/core/src/auth/token-manager.test.ts
@@ -183,3 +183,71 @@ describe("TokenManager", () => {
     expect(fetchSpy).toHaveBeenCalledOnce();
   });
 });
+
+describe("TokenManager + PAX8_API_BASE", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  const originalApiBase = process.env.PAX8_API_BASE;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalApiBase === undefined) delete process.env.PAX8_API_BASE;
+    else process.env.PAX8_API_BASE = originalApiBase;
+  });
+
+  it("derives the token URL from PAX8_API_BASE when set", async () => {
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1";
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN }), { status: 200 })
+    );
+
+    const manager = createManager();
+    await manager.getToken();
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api-staging.pax8.com/v1/token");
+  });
+
+  it("uses the production token URL when PAX8_API_BASE is unset", async () => {
+    delete process.env.PAX8_API_BASE;
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN }), { status: 200 })
+    );
+
+    const manager = createManager();
+    await manager.getToken();
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.pax8.com/v1/token");
+  });
+
+  it("normalizes a trailing slash on PAX8_API_BASE before appending /token", async () => {
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1/";
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN }), { status: 200 })
+    );
+
+    const manager = createManager();
+    await manager.getToken();
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    // The trailing slash must NOT result in `//token`.
+    expect(url).toBe("https://api-staging.pax8.com/v1/token");
+  });
+
+  it("normalizes multiple trailing slashes on PAX8_API_BASE", async () => {
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1///";
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN }), { status: 200 })
+    );
+
+    const manager = createManager();
+    await manager.getToken();
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api-staging.pax8.com/v1/token");
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for the `cli/src/lib/*` files that were at 0% (or low) coverage, plus dedicated tests for the `PAX8_API_BASE` env-var behavior shipped in #135.

## Files covered

| File | Before | After |
|---|---|---|
| `last-list.ts` | 0% | 100% |
| `next-step.ts` | 0% | 96.15% |
| `invalidate-cache.ts` | 0% | 100% |
| `confirm.ts` | 24% | 100% |
| `errors.ts` | 29% | 93.69% |
| `signals.ts` | 32% | 100% |
| `context.ts` | 52% | 86.36% |

## PAX8_API_BASE coverage
- `getDefaultBaseUrl()` env-var precedence + prod fallback + lazy lookup (re-reads env on every call, not cached)
- `Pax8Client` uses the env-derived base URL and strips trailing slashes; explicit `baseUrl` option still wins
- `TokenManager` derives `/token` URL from `PAX8_API_BASE` with single + multi trailing-slash normalization
- `pax8 doctor` surfaces the active base — default vs. overridden vs. overridden-but-still-prod

## Notes
- For `confirm.ts` and `next-step.ts`, used `vi.mock("readline")` with a controlled answer queue (rather than `vi.spyOn`, which fails in ESM with "Module namespace is not configurable").
- `signals.ts` SIGINT handler is exercised by capturing the registered listener via a spied `process.on` and invoking it directly with mocked `process.exit` and `process.stderr.write`. Used `vi.resetModules()` to reset the module-level `handlerInstalled` guard between tests.
- `context.ts` cache-warmer path mocks `node:child_process` so the test doesn't actually spawn detached `pax8` children.
- All env-var tests save and restore `process.env.PAX8_API_BASE` / `PAX8_REPL` / `PAX8_YES` / `PAX8_DEMO` / `PAX8_CACHE_WARMING` in `afterEach`.

## Test plan
- [x] `PAX8_DEMO=1 NO_COLOR=1 pnpm test` — 838 -> 931 passing (+93), 8 skipped (unchanged)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r exec tsc --noEmit` — 0 errors
- [x] No flakes (env vars saved/restored in `afterEach`)
- [x] No existing tests disabled or modified semantically