### PR TITLE
chore(dependabot): ignore known-breaking npm major bumps until v0.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,19 @@ updates:
       production-dependencies:
         dependency-type: "production"
         update-types: ["minor", "patch"]
+    # Defer known-breaking npm major bumps until a deliberate v0.2.x
+    # upgrade plan. Each requires source updates / migration work that
+    # shouldn't ride alongside an unrelated PR. Revisit per-package
+    # post-v0.1.0.
+    ignore:
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ora"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "commander"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Adds explicit `ignore` rules for the four npm/TS major bumps that have been sitting open with red CI (#47 zod 3→4, #48 ora 8→9, #49 commander 12→14, #89 typescript 5→6). Each requires source-update / migration work that shouldn't ride alongside an unrelated PR.

Closing #47, #48, #49, #89 in tandem with this PR; we'll revisit each as part of a deliberate v0.2.x upgrade.

GitHub Actions ecosystem majors are intentionally **not** ignored — those are workflow-only changes that can be handled inline as the dependabot PRs come through (and the existing 5 are getting rebased + try-merged separately).

## Test plan
- [x] yaml parses
- [x] no other PR conflict expected (single 13-line addition to .github/dependabot.yml)