### PR TITLE
chore(actions): bump remaining workflow action versions to match ci.yml

### DIFF
--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/login-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"


### PR DESCRIPTION
Brings `release.yml` and `demo-image.yml` to the same action versions `ci.yml` already uses. Each per-action dependabot PR only updates one workflow file, which left these two files pinned to older versions even after the per-action PRs (#43, #45, #77, #78) merged. Now consistent across all three workflows.

Will close the duplicate open dependabot PRs (#154 setup-node, #155 pnpm/action-setup, #156 checkout) in tandem with this PR.

## Test plan
- [x] yaml syntax intact
- [x] no source-code changes