### PR TITLE
feat: pax8 report-bug — sanitized GitHub issue from the last error

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,40 @@ The anonymous `distinct_id` is `sha256(hostname + ":" + username)` truncated to 
 
 **On the embedded PostHog key:** the project key shipped in the bundle is the public, write-only PostHog *project ingestion* key — this is the standard pattern for OSS analytics, and [PostHog's own guidance](https://posthog.com/docs/api#public-posthog-api) recommends embedding it. It cannot read events back, only append.
 
+### Reporting bugs
+
+When a command fails, the CLI prints recovery hints and a one-line nudge:
+
+```
+✗ ERROR_AUTH_EXPIRED  Authentication failed.
+
+  Recovery steps:
+    → Your credentials may have expired. Run pax8 auth login to re-authenticate.
+
+  → Help us fix this: run pax8 report-bug to file a sanitized report
+```
+
+`pax8 report-bug` files a GitHub issue against [`pax8labs/pax8-cli`](https://github.com/pax8labs/pax8-cli) prefilled with the *redacted* envelope of the most recent failure. It runs through a redactor (see [`packages/cli/src/lib/redactor.ts`](packages/cli/src/lib/redactor.ts)) that strips:
+
+- UUIDs (replaced with `<REDACTED:UUID>`)
+- Email addresses (`<REDACTED:EMAIL>`)
+- `$HOME` paths on macOS / Linux / Windows / `~/...` form (`<REDACTED:PATH>` — the suffix after the username is preserved so the tail of the path is still useful for debugging)
+- JWTs and `Bearer` tokens (`<REDACTED:JWT>` / `<REDACTED:TOKEN>`)
+- Long opaque hex / base64-shaped strings (`>=32` chars; covers Pax8 client secrets and similar) (`<REDACTED:TOKEN>`)
+
+The reporter is **opt-in per invocation**, not via a config setting. Nothing leaves your machine without explicit `[y/N]` confirmation — the command always prints the body to stdout *first*, so you can see exactly what would be submitted.
+
+```bash
+pax8 report-bug             # interactive: review the body, then [y/N]
+pax8 report-bug --print     # print the redacted Markdown body and exit
+pax8 report-bug --json      # print the redacted envelope as JSON (for piping)
+pax8 report-bug -y          # submit without prompting (for scripts)
+```
+
+If you have [`gh`](https://cli.github.com) installed and authenticated, the command shells out to `gh issue create`. Otherwise it falls back to opening a prefilled issue URL via your platform's default browser (`open` on macOS, `xdg-open` on Linux, `start` on Windows). No new npm dependencies — only Node's built-in `child_process`.
+
+The error envelope persisted to `~/.pax8/last-error.json` (mode 0600) is what `pax8 report-bug` reads. It contains the same fields as the `--json` error output (`code`, `message`, `causes`, `recoverySteps`, `docsUrl`), plus the command name, flag *names* (no values), CLI / Node / OS versions, and an ISO timestamp. The redactor runs over this envelope on every invocation — so even though the file on disk is your own data, the report you submit cannot leak the content of an argument or a path under your home directory.
+
 ### Network egress
 
 For partners on restricted networks, this is the complete allowlist of hosts the CLI may contact:
@@ -319,8 +353,9 @@ For partners on restricted networks, this is the complete allowlist of hosts the
 | `https://api.pax8.com` | Every API call | Always |
 | `https://api.pax8.com/v1/token` | OAuth client-credentials token exchange | Always (during auth) |
 | `https://us.i.posthog.com` | Telemetry capture | Only when `pax8 telemetry enable` has been set AND no opt-out env var is present |
+| `https://github.com/pax8labs/pax8-cli/issues/new` | Bug-report submission | Only when you run `pax8 report-bug` AND confirm `[y/N]` (or pass `-y`). When `gh` is installed, the upload happens via `gh`; otherwise the URL is opened in your default browser |
 
-No other network egress. The CLI does not contact npm, GitHub, the Pax8 portal, the marketing site, or any auto-update service at runtime.
+No other network egress. The CLI does not contact npm, the Pax8 portal, the marketing site, or any auto-update service at runtime.
 
 ### Using @pax8/core as a standalone library
 

--- a/packages/cli/src/__tests__/report-bug.test.ts
+++ b/packages/cli/src/__tests__/report-bug.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { runCli, runCliExpectFailure, runCliExpectSuccess } from "./test-utils.js";
+
+// Each test gets a unique config-dir so they can run in any order and pollute
+// nothing on the host machine. We rely on the `PAX8_CONFIG_DIR` seam from
+// #128, which `getConfigDir()` honors.
+async function makeTmpConfigDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "pax8-report-bug-"));
+}
+
+const SAMPLE_ENVELOPE = {
+  code: "ERROR_AUTH_EXPIRED",
+  message: "Authentication failed for client_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  causes: [
+    "Token expired",
+    "Cached at /Users/jdulberger/.pax8/cache/auth-token.json",
+  ],
+  recoverySteps: ["Run pax8 auth login to re-authenticate."],
+  docsUrl: "https://docs.pax8.com/auth",
+  command: "companies list",
+  flags: ["--json"],
+  cli_version: "0.1.0",
+  node_version: "v22.5.1",
+  os: "darwin",
+  timestamp: "2026-05-05T12:00:00.000Z",
+};
+
+describe("pax8 report-bug", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTmpConfigDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exits 1 when no last-error.json exists", async () => {
+    const result = await runCliExpectFailure(["report-bug", "--print"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    expect(result.stderr).toContain("No recent error found");
+  });
+
+  it("--print outputs a redacted Markdown body and does not submit", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "last-error.json"),
+      JSON.stringify(SAMPLE_ENVELOPE)
+    );
+    const result = await runCliExpectSuccess(["report-bug", "--print"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    // PII is gone…
+    expect(result.stdout).not.toContain("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    expect(result.stdout).not.toContain("jdulberger");
+    // …but the markers prove the redactor ran.
+    expect(result.stdout).toContain("<REDACTED:UUID>");
+    expect(result.stdout).toContain("<REDACTED:PATH>");
+    // The body has the expected sections.
+    expect(result.stdout).toContain("[ERROR_AUTH_EXPIRED]");
+    expect(result.stdout).toContain("**Error code:**");
+    expect(result.stdout).toContain("### Message");
+    expect(result.stdout).toContain("Sanitized by `pax8 report-bug`");
+    // No submission attempted (we never reach the gh fork without -y).
+    expect(result.stdout).not.toContain("https://github.com/pax8labs");
+  });
+
+  it("--json outputs the redacted envelope as JSON", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "last-error.json"),
+      JSON.stringify(SAMPLE_ENVELOPE)
+    );
+    const result = await runCliExpectSuccess(["report-bug", "--json"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.code).toBe("ERROR_AUTH_EXPIRED");
+    expect(parsed.message).toContain("<REDACTED:UUID>");
+    // Pre-redaction PII must not survive.
+    const all = JSON.stringify(parsed);
+    expect(all).not.toContain("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    expect(all).not.toContain("jdulberger");
+  });
+
+  it("the [y/N] prompt is bypassed under PAX8_YES=1 with --print so no submission attempt is made", async () => {
+    // We can't actually exercise the submission path in CI (would call `gh`
+    // or open a browser). What we can verify is that --print short-circuits
+    // before any prompt, and that PAX8_YES=1 plumbing is wired.
+    await fs.writeFile(
+      path.join(tmpDir, "last-error.json"),
+      JSON.stringify(SAMPLE_ENVELOPE)
+    );
+    const result = await runCliExpectSuccess(["report-bug", "--print"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_YES: "1",
+    });
+    expect(result.stdout).toContain("[ERROR_AUTH_EXPIRED]");
+  });
+
+  it("rejects malformed last-error.json gracefully", async () => {
+    await fs.writeFile(path.join(tmpDir, "last-error.json"), "not json");
+    const result = await runCli(["report-bug", "--print"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("No recent error found");
+  });
+
+  it("shows help text", async () => {
+    const result = await runCliExpectSuccess(["report-bug", "--help"]);
+    expect(result.stdout).toContain("File a sanitized GitHub issue");
+    expect(result.stdout).toContain("--print");
+    expect(result.stdout).toContain("--yes");
+    expect(result.stdout).toContain("--json");
+  });
+});
+
+describe("handleCommandError last-error.json side effect", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTmpConfigDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes a structured envelope on a CliError and is mode 0600", async () => {
+    // Force a CliError by asking for a company that doesn't exist in demo data.
+    const result = await runCliExpectFailure(
+      ["companies", "show", "definitely-does-not-exist", "--json"],
+      { PAX8_CONFIG_DIR: tmpDir }
+    );
+    expect(result.exitCode).toBe(1);
+
+    const envPath = path.join(tmpDir, "last-error.json");
+    const stat = await fs.stat(envPath);
+    // Mode check (skip on Windows where chmod is a no-op).
+    if (process.platform !== "win32") {
+      // Lower 9 bits represent rwxrwxrwx; we want owner-only rw (0o600).
+      const perms = stat.mode & 0o777;
+      expect(perms).toBe(0o600);
+    }
+    const raw = await fs.readFile(envPath, "utf-8");
+    const env = JSON.parse(raw);
+    expect(typeof env.message).toBe("string");
+    expect(env.code).toBe("ERROR_COMPANY_NOT_FOUND");
+    expect(typeof env.cli_version).toBe("string");
+    expect(typeof env.node_version).toBe("string");
+    expect(typeof env.os).toBe("string");
+    expect(typeof env.timestamp).toBe("string");
+    expect(env.command).toContain("companies");
+    expect(Array.isArray(env.flags)).toBe(true);
+    expect(env.flags).toContain("--json");
+  });
+
+  it("end-to-end: failed command → report-bug --print produces a redacted body", async () => {
+    // Cause a failure that populates last-error.json.
+    await runCliExpectFailure(
+      ["companies", "show", "definitely-does-not-exist", "--json"],
+      { PAX8_CONFIG_DIR: tmpDir }
+    );
+
+    // Now report-bug should pick it up.
+    const result = await runCliExpectSuccess(["report-bug", "--print"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    expect(result.stdout).toContain("[ERROR_COMPANY_NOT_FOUND]");
+    expect(result.stdout).toContain("Sanitized by `pax8 report-bug`");
+  });
+});

--- a/packages/cli/src/commands/report-bug.ts
+++ b/packages/cli/src/commands/report-bug.ts
@@ -1,0 +1,266 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { getConfigDir } from "@pax8/core";
+import { confirm } from "../lib/confirm.js";
+import { redactEnvelope, type BugReportEnvelope } from "../lib/redactor.js";
+
+const execFileP = promisify(execFile);
+
+const REPO = "pax8labs/pax8-cli";
+const ISSUE_NEW_URL = `https://github.com/${REPO}/issues/new`;
+
+/**
+ * Path on disk where `handleCommandError` parks the most recent failure
+ * envelope. Honors `PAX8_CONFIG_DIR` via `getConfigDir()` for test isolation.
+ */
+export function lastErrorPath(): string {
+  return path.join(getConfigDir(), "last-error.json");
+}
+
+/**
+ * Build the Markdown body of the GitHub issue from a redacted envelope.
+ * Pure function so it's easy to test and reuse from the `--print` path.
+ */
+export function buildIssueBody(env: BugReportEnvelope): string {
+  const sections: string[] = [];
+
+  sections.push(`**Error code:** \`${env.code ?? "ERROR"}\``);
+  const versions = [
+    env.cli_version ? `CLI ${env.cli_version}` : null,
+    env.node_version ? `Node ${env.node_version}` : null,
+    env.os ? `OS ${env.os}` : null,
+  ].filter(Boolean);
+  if (versions.length > 0) {
+    sections.push(`**Environment:** ${versions.join(" · ")}`);
+  }
+  if (env.timestamp) {
+    sections.push(`**When:** ${env.timestamp}`);
+  }
+
+  const flagPart =
+    env.flags && env.flags.length > 0 ? env.flags.join(", ") : "none";
+  sections.push(
+    `**Command:** \`${env.command ?? "unknown"}\` (flags: ${flagPart})`
+  );
+
+  sections.push("");
+  sections.push("### Message");
+  sections.push(env.message);
+
+  if (env.causes && env.causes.length > 0) {
+    sections.push("");
+    sections.push("### Causes");
+    for (const c of env.causes) sections.push(`- ${c}`);
+  }
+
+  if (env.recoverySteps && env.recoverySteps.length > 0) {
+    sections.push("");
+    sections.push("### Recovery steps suggested by the CLI");
+    for (const r of env.recoverySteps) sections.push(`- ${r}`);
+  }
+
+  if (env.docsUrl) {
+    sections.push("");
+    sections.push(`**Docs:** ${env.docsUrl}`);
+  }
+
+  sections.push("");
+  sections.push("---");
+  sections.push(
+    "_Sanitized by `pax8 report-bug`. No IDs, names, paths, or credentials included._"
+  );
+
+  return sections.join("\n");
+}
+
+/**
+ * Build the title from a redacted envelope. Truncates the message so the
+ * title stays under GitHub's 256-char limit and looks reasonable in lists.
+ */
+export function buildIssueTitle(env: BugReportEnvelope): string {
+  const code = env.code ?? "ERROR";
+  const msg = (env.message ?? "").trim().split("\n")[0] ?? "";
+  const truncated = msg.length > 60 ? msg.slice(0, 60).trimEnd() + "…" : msg;
+  return `[${code}] ${truncated}`.trim();
+}
+
+/**
+ * Cross-platform "open this URL in the user's default browser" using only
+ * Node's built-in `child_process` — deliberately avoids the `open` npm
+ * package since this is the only call site and the platform commands are
+ * stable.
+ */
+async function openUrl(url: string): Promise<void> {
+  const platform = process.platform;
+  let cmd: string;
+  let args: string[];
+  if (platform === "darwin") {
+    cmd = "open";
+    args = [url];
+  } else if (platform === "win32") {
+    // `start` is a cmd.exe builtin; `""` is the empty title arg required when
+    // the URL contains characters cmd would otherwise treat as a title.
+    cmd = "cmd";
+    args = ["/c", "start", "", url];
+  } else {
+    cmd = "xdg-open";
+    args = [url];
+  }
+  await new Promise<void>((resolve) => {
+    const child = spawn(cmd, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => resolve());
+    child.unref();
+    // Don't await — detached. Resolve next tick so the caller can return.
+    setImmediate(resolve);
+  });
+}
+
+/**
+ * Returns true if `gh` is on PATH AND authenticated. We treat
+ * "installed but not authenticated" as a fall-back-to-URL signal rather than
+ * a hard failure so first-time reporters aren't blocked.
+ */
+async function ghReady(): Promise<boolean> {
+  try {
+    await execFileP("gh", ["--version"]);
+  } catch {
+    return false;
+  }
+  try {
+    await execFileP("gh", ["auth", "status"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface ReportBugOptions {
+  yes?: boolean;
+  print?: boolean;
+  json?: boolean;
+}
+
+/**
+ * `--json` is also defined as a global program option, which means Commander
+ * consumes it before subcommand-level handlers see it. Read directly from
+ * argv so `pax8 report-bug --json` reliably hits the JSON-envelope path.
+ */
+function jsonFlagInArgv(): boolean {
+  return process.argv.includes("--json");
+}
+
+async function readEnvelope(): Promise<BugReportEnvelope | null> {
+  const filePath = lastErrorPath();
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as BugReportEnvelope;
+    if (typeof parsed.message !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function runReportBug(opts: ReportBugOptions): Promise<number> {
+  const raw = await readEnvelope();
+  if (!raw) {
+    process.stderr.write(
+      "No recent error found. Run a command that fails and try again.\n"
+    );
+    return 1;
+  }
+
+  const env = redactEnvelope(raw);
+
+  if (opts.json || jsonFlagInArgv()) {
+    process.stdout.write(JSON.stringify(env, null, 2) + "\n");
+    return 0;
+  }
+
+  const title = buildIssueTitle(env);
+  const body = buildIssueBody(env);
+
+  if (opts.print) {
+    process.stdout.write(`Title: ${title}\n\n`);
+    process.stdout.write(body + "\n");
+    return 0;
+  }
+
+  // Show what would be submitted before asking.
+  process.stdout.write(chalk.bold("\n  Title: ") + title + "\n\n");
+  process.stdout.write(body + "\n\n");
+
+  const ok = opts.yes
+    ? true
+    : await confirm("Submit this issue?", { default: false });
+  if (!ok) {
+    process.stderr.write(chalk.dim("  Aborted. Nothing was sent.\n"));
+    return 0;
+  }
+
+  if (await ghReady()) {
+    try {
+      const { stdout } = await execFileP("gh", [
+        "issue",
+        "create",
+        "-R",
+        REPO,
+        "--title",
+        title,
+        "--body",
+        body,
+      ]);
+      const trimmed = stdout.trim();
+      if (trimmed) process.stdout.write(trimmed + "\n");
+      return 0;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        chalk.yellow(`  gh issue create failed (${msg}); falling back to browser.\n`)
+      );
+      // fall through to URL flow
+    }
+  }
+
+  const url = `${ISSUE_NEW_URL}?title=${encodeURIComponent(
+    title
+  )}&body=${encodeURIComponent(body)}`;
+  process.stdout.write(
+    chalk.dim("  Opening a prefilled GitHub issue in your browser…\n")
+  );
+  process.stdout.write(chalk.dim(`  If nothing opens, paste this URL:\n  ${url}\n`));
+  await openUrl(url);
+  return 0;
+}
+
+export function reportBugCommand(): Command {
+  return new Command("report-bug")
+    .description(
+      "File a sanitized GitHub issue for the most recent error (opt-in, per-invocation)"
+    )
+    .option("-y, --yes", "skip the interactive [y/N] confirmation")
+    .option("--print", "print the redacted Markdown body and exit (no submission)")
+    .addHelpText(
+      "after",
+      `
+Output:
+  --json                         # print the structured (redacted) envelope as JSON and exit
+
+Examples:
+  pax8 report-bug                # interactive: review then confirm
+  pax8 report-bug --print        # see exactly what would be submitted
+  pax8 report-bug --json         # pipe the redacted envelope to jq / etc.
+  pax8 report-bug -y             # submit without prompting`
+    )
+    .action(async (opts: ReportBugOptions) => {
+      const exitCode = await runReportBug(opts);
+      if (exitCode !== 0) process.exit(exitCode);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { doctorCommand } from "./commands/doctor.js";
 import { completionsCommand } from "./commands/completions.js";
 import { versionCommand } from "./commands/version.js";
 import { initCommand } from "./commands/init.js";
+import { reportBugCommand } from "./commands/report-bug.js";
 import { handleCommandError } from "./lib/errors.js";
 import { installSigintHandler } from "./lib/signals.js";
 import { consumeTelemetryFields } from "./lib/telemetry-context.js";
@@ -104,6 +105,7 @@ export function createProgram(): Command {
   program.addCommand(doctorCommand);
   program.addCommand(completionsCommand);
   program.addCommand(versionCommand);
+  program.addCommand(reportBugCommand());
 
   // Easter egg commands (hidden from main help)
   program.addCommand(mooCommand, { hidden: true });

--- a/packages/cli/src/lib/errors.test.ts
+++ b/packages/cli/src/lib/errors.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { z } from "zod";
 import {
   ApiError,
@@ -13,6 +16,29 @@ import {
   ERROR_SUBSCRIPTION_NOT_FOUND,
 } from "@pax8/core";
 import { CliError, handleCommandError, extractErrorDetail } from "./errors.js";
+
+// handleCommandError persists the structured envelope to
+// `getConfigDir() + "/last-error.json"` so `pax8 report-bug` has something to
+// report. Isolate the config dir for the whole file so this test suite
+// doesn't clobber the developer's real ~/.pax8/last-error.json.
+let tmpConfigDir: string;
+let originalConfigDir: string | undefined;
+
+beforeAll(() => {
+  originalConfigDir = process.env.PAX8_CONFIG_DIR;
+  tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "pax8-errors-test-"));
+  process.env.PAX8_CONFIG_DIR = tmpConfigDir;
+});
+
+afterAll(() => {
+  if (originalConfigDir === undefined) delete process.env.PAX8_CONFIG_DIR;
+  else process.env.PAX8_CONFIG_DIR = originalConfigDir;
+  try {
+    fs.rmSync(tmpConfigDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
 
 describe("CliError", () => {
   it("constructs with message only", async () => {
@@ -471,5 +497,61 @@ describe("handleCommandError flushes telemetry before exit (#145)", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     flushSpy.mockRestore();
+  });
+});
+
+describe("handleCommandError last-error.json side effect (in-process)", () => {
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    // Clean any prior envelope so our assertion sees a fresh write.
+    const p = path.join(tmpConfigDir, "last-error.json");
+    try { fs.unlinkSync(p); } catch { /* not present */ }
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("persists the envelope to <configDir>/last-error.json with mode 0600", async () => {
+    await expect(
+      handleCommandError(
+        new CliError(
+          "Auth failed",
+          ["Token expired"],
+          ["Run pax8 auth login"],
+          "https://docs.pax8.com/auth",
+          ERROR_AUTH_EXPIRED
+        )
+      )
+    ).rejects.toThrow("process.exit intercepted");
+
+    const filePath = path.join(tmpConfigDir, "last-error.json");
+    const stat = fs.statSync(filePath);
+    if (process.platform !== "win32") {
+      expect(stat.mode & 0o777).toBe(0o600);
+    }
+
+    const env = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    expect(env.code).toBe(ERROR_AUTH_EXPIRED);
+    expect(env.message).toBe("Auth failed");
+    expect(env.causes).toEqual(["Token expired"]);
+    expect(env.recoverySteps).toEqual(["Run pax8 auth login"]);
+    expect(typeof env.cli_version).toBe("string");
+    expect(typeof env.node_version).toBe("string");
+    expect(typeof env.os).toBe("string");
+    expect(typeof env.timestamp).toBe("string");
+    // command/flags fields are present (string + array), even if empty when
+    // the test runner has odd argv shape.
+    expect(typeof env.command).toBe("string");
+    expect(Array.isArray(env.flags)).toBe(true);
   });
 });

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -1,6 +1,8 @@
 import chalk from "chalk";
 import { ZodError, ZodIssueCode } from "zod";
 import type { Ora } from "ora";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import {
   ApiError,
   ERROR_API_TIMEOUT,
@@ -12,10 +14,13 @@ import {
   ERROR_PRODUCT_NOT_FOUND,
   ERROR_RATE_LIMITED,
   ERROR_SUBSCRIPTION_NOT_FOUND,
+  getConfigDir,
   getTelemetry,
   type Pax8ErrorCode,
 } from "@pax8/core";
 import { replCmd } from "./confirm.js";
+
+declare const __CLI_VERSION__: string;
 
 /**
  * Flush buffered telemetry and shut down the PostHog client before the CLI
@@ -139,6 +144,79 @@ interface ErrorEnvelope {
 }
 
 /**
+ * Persist a richer copy of the error envelope to `~/.pax8/last-error.json`
+ * (mode 0600) so `pax8 report-bug` has something to report. Includes
+ * command/flag *names* (no values) and runtime metadata. Failures here are
+ * intentionally swallowed — we never want a config-dir issue (read-only fs,
+ * full disk, sandboxed env) to hide the actual error from the user.
+ */
+function getCliVersion(): string {
+  return typeof __CLI_VERSION__ !== "undefined" ? __CLI_VERSION__ : "0.0.0";
+}
+
+/**
+ * Best-effort extraction of the command name (e.g. "companies list") and the
+ * flag *names* (e.g. ["--json", "--page"]) from `process.argv`. We do not
+ * include flag values — those frequently contain customer names or IDs.
+ */
+function extractCommandAndFlags(): { command: string; flags: string[] } {
+  const args = process.argv.slice(2);
+  const cmdParts: string[] = [];
+  const flags: string[] = [];
+  for (const a of args) {
+    if (a.startsWith("--")) {
+      // Strip "--flag=value" form down to "--flag".
+      const eq = a.indexOf("=");
+      flags.push(eq >= 0 ? a.slice(0, eq) : a);
+    } else if (a.startsWith("-")) {
+      flags.push(a);
+    } else if (cmdParts.length < 3 && /^[a-z][\w-]*$/i.test(a)) {
+      // Conservative: only keep tokens that look like Commander subcommand
+      // names. This filters out positional values like company names or IDs.
+      cmdParts.push(a);
+    } else {
+      // Stop accumulating once we hit something that isn't a subcommand.
+      break;
+    }
+  }
+  return {
+    command: cmdParts.join(" ") || "unknown",
+    flags: [...new Set(flags)].sort(),
+  };
+}
+
+function writeLastErrorEnvelope(envelope: ErrorEnvelope): void {
+  try {
+    const dir = getConfigDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const { command, flags } = extractCommandAndFlags();
+    const payload = {
+      ...envelope,
+      command,
+      flags,
+      cli_version: getCliVersion(),
+      node_version: process.version,
+      os: process.platform,
+      timestamp: new Date().toISOString(),
+    };
+    const filePath = path.join(dir, "last-error.json");
+    // writeFileSync with mode applies the mode on creation; if the file
+    // already exists it keeps existing perms — chmod after to be safe.
+    fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), {
+      mode: 0o600,
+    });
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // Some filesystems (e.g. fat32 / windows) don't support chmod; ignore.
+    }
+  } catch {
+    // Persisting the envelope is a nice-to-have for `pax8 report-bug`. Never
+    // let it interfere with the user-facing error path.
+  }
+}
+
+/**
  * Build the JSON envelope for a thrown error. Omits fields that aren't set so
  * consumers don't have to special-case `null`.
  */
@@ -211,9 +289,17 @@ export async function handleCommandError(
     }
   }
 
+  // Persist the structured envelope so `pax8 report-bug` has something to
+  // report. Write happens *before* any exit logic. This is decoupled from the
+  // telemetry pipeline by design (works with telemetry off).
+  // Coordination: another agent is rewriting handleCommandError to be async
+  // and to flush before exit (#145/#146). This call is logically independent —
+  // resolve any rebase by keeping both the envelope-write and the flush.
+  const envelope = buildErrorEnvelope(error, context);
+  writeLastErrorEnvelope(envelope);
+
   // Machine-readable JSON envelope when --json is set
   if (isJsonOutputRequested()) {
-    const envelope = buildErrorEnvelope(error, context);
     process.stderr.write(JSON.stringify(envelope, null, 2) + "\n");
     // Flush telemetry before exit (#145) so failure events actually reach
     // PostHog. Bounded by a 2s timeout in flushAndShutdown.
@@ -248,6 +334,14 @@ export async function handleCommandError(
     if (error.docsUrl) {
       process.stderr.write(
         chalk.dim(`\n  Docs: ${error.docsUrl}\n`)
+      );
+    }
+
+    if (error.code) {
+      process.stderr.write(
+        chalk.dim(
+          `\n  → Help us fix this: run ${chalk.cyan(replCmd("pax8 report-bug"))} to file a sanitized report\n`
+        )
       );
     }
 

--- a/packages/cli/src/lib/redactor.test.ts
+++ b/packages/cli/src/lib/redactor.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import { redactString, redactEnvelope, type BugReportEnvelope } from "./redactor.js";
+
+describe("redactString", () => {
+  describe("UUIDs", () => {
+    it("redacts a Pax8-style client_id UUID", () => {
+      const out = redactString("client_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890 failed");
+      expect(out).toBe("client_id=<REDACTED:UUID> failed");
+    });
+
+    it("redacts uppercase UUIDs", () => {
+      const out = redactString("ID: A1B2C3D4-E5F6-7890-ABCD-EF1234567890");
+      expect(out).toBe("ID: <REDACTED:UUID>");
+    });
+
+    it("redacts multiple UUIDs in one string", () => {
+      const out = redactString(
+        "from a1b2c3d4-e5f6-7890-abcd-ef1234567890 to f9e8d7c6-b5a4-3210-fedc-ba0987654321"
+      );
+      expect(out).toBe("from <REDACTED:UUID> to <REDACTED:UUID>");
+    });
+
+    it("does not redact short hex strings that look UUID-ish but aren't", () => {
+      // 12345678-1234-1234 (no fourth segment) — not a UUID
+      const out = redactString("partial 12345678-1234-1234 abc");
+      expect(out).toContain("12345678-1234-1234");
+    });
+  });
+
+  describe("emails", () => {
+    it("redacts a plain email", () => {
+      expect(redactString("contact admin@example.com please")).toBe(
+        "contact <REDACTED:EMAIL> please"
+      );
+    });
+
+    it("redacts emails with plus-aliases", () => {
+      expect(redactString("from user.name+tag@example.co.uk")).toBe(
+        "from <REDACTED:EMAIL>"
+      );
+    });
+  });
+
+  describe("home paths", () => {
+    it("redacts macOS user paths and preserves the suffix", () => {
+      const out = redactString("config at /Users/jdoe/.pax8/config.yaml");
+      expect(out).toBe("config at <REDACTED:PATH>/.pax8/config.yaml");
+    });
+
+    it("redacts Linux user paths and preserves the suffix", () => {
+      const out = redactString("/home/alice/.pax8/last-error.json missing");
+      expect(out).toBe("<REDACTED:PATH>/.pax8/last-error.json missing");
+    });
+
+    it("redacts Windows user paths and preserves the suffix", () => {
+      const out = redactString(
+        "wrote C:\\Users\\Bob\\.pax8\\config.yaml ok"
+      );
+      expect(out).toContain("<REDACTED:PATH>");
+      expect(out).toContain(".pax8");
+      expect(out).not.toContain("Bob");
+    });
+
+    it("redacts tilde paths", () => {
+      expect(redactString("see ~/.pax8/last-error.json")).toBe(
+        "see <REDACTED:PATH>/.pax8/last-error.json"
+      );
+    });
+
+    it("does not eat tilde when not followed by a path", () => {
+      expect(redactString("about ~10 minutes ago")).toContain("~10 minutes");
+    });
+
+    it("redacts a bare home dir with no suffix", () => {
+      expect(redactString("at /Users/jdoe/")).toBe("at <REDACTED:PATH>/");
+    });
+  });
+
+  describe("JWTs and bearer tokens", () => {
+    it("redacts a JWT", () => {
+      const jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV";
+      const out = redactString(`Authorization: ${jwt}`);
+      expect(out).toBe("Authorization: <REDACTED:JWT>");
+    });
+
+    it("redacts Bearer prefix tokens", () => {
+      const out = redactString(
+        "Authorization: Bearer abcdef1234567890ABCDEF==/+_-.xyz"
+      );
+      expect(out).toBe("Authorization: Bearer <REDACTED:TOKEN>");
+    });
+  });
+
+  describe("opaque token blobs", () => {
+    it("redacts long mixed-case+digit base64-shaped strings (>=32 chars)", () => {
+      // 48 chars, mixed case + digits — looks like a Pax8 client_secret.
+      const out = redactString(
+        "secret=AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh done"
+      );
+      expect(out).toBe("secret=<REDACTED:TOKEN> done");
+    });
+
+    it("redacts a long hex blob", () => {
+      // 40 chars hex (sha1-shaped).
+      const out = redactString("hash=a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 ok");
+      expect(out).toBe("hash=<REDACTED:TOKEN> ok");
+    });
+
+    it("does not over-redact normal English words", () => {
+      const out = redactString(
+        "The Pax8 API returned an unexpected response. Try a different query."
+      );
+      expect(out).toBe(
+        "The Pax8 API returned an unexpected response. Try a different query."
+      );
+    });
+
+    it("does not redact short alphanumeric values like flag names", () => {
+      const out = redactString("flag --json was set, page=0, size=2");
+      expect(out).toBe("flag --json was set, page=0, size=2");
+    });
+
+    it("does not redact a 31-character mixed string (under floor)", () => {
+      const s = "Ab1Ab1Ab1Ab1Ab1Ab1Ab1Ab1Ab1Ab1A"; // 31 chars
+      expect(s.length).toBe(31);
+      expect(redactString(`x=${s} y`)).toBe(`x=${s} y`);
+    });
+  });
+
+  describe("idempotency", () => {
+    it("running redactString twice yields the same output", () => {
+      const first = redactString(
+        "client_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890 at /Users/x/.pax8"
+      );
+      expect(redactString(first)).toBe(first);
+    });
+  });
+
+  describe("non-string inputs", () => {
+    it("returns empty input unchanged", () => {
+      expect(redactString("")).toBe("");
+    });
+  });
+});
+
+describe("redactEnvelope", () => {
+  it("redacts the message, causes, and recoverySteps fields", () => {
+    const env: BugReportEnvelope = {
+      code: "ERROR_AUTH_EXPIRED",
+      message:
+        "Auth failed for client_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      causes: [
+        "Token rejected: bearer Bearer abcdef1234567890ABCDEF==/+_-.xyz",
+        "Email user@example.com on file",
+      ],
+      recoverySteps: ["Edit /Users/jdoe/.pax8/credentials.json"],
+      docsUrl: "https://docs.pax8.com/auth",
+      command: "auth login",
+      flags: ["--json"],
+      cli_version: "0.1.0",
+      node_version: "v22.5.1",
+      os: "darwin",
+      timestamp: "2026-05-05T12:00:00.000Z",
+    };
+    const out = redactEnvelope(env);
+
+    expect(out.code).toBe("ERROR_AUTH_EXPIRED");
+    expect(out.message).not.toContain("a1b2c3d4");
+    expect(out.message).toContain("<REDACTED:UUID>");
+
+    expect(out.causes?.[0]).toContain("<REDACTED:TOKEN>");
+    expect(out.causes?.[0]).not.toContain("abcdef1234567890");
+    expect(out.causes?.[1]).toContain("<REDACTED:EMAIL>");
+    expect(out.causes?.[1]).not.toContain("user@example.com");
+
+    expect(out.recoverySteps?.[0]).toContain("<REDACTED:PATH>");
+    expect(out.recoverySteps?.[0]).not.toContain("jdoe");
+
+    // Pass-throughs.
+    expect(out.docsUrl).toBe("https://docs.pax8.com/auth");
+    expect(out.command).toBe("auth login");
+    expect(out.flags).toEqual(["--json"]);
+    expect(out.cli_version).toBe("0.1.0");
+    expect(out.os).toBe("darwin");
+  });
+
+  it("regression: a realistic Pax8 401 envelope leaks no PII", () => {
+    const env: BugReportEnvelope = {
+      code: "ERROR_AUTH_EXPIRED",
+      message:
+        "Pax8 API returned 401 Unauthorized for client_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      causes: [
+        'Body: {"error":"invalid_token","error_description":"Token expired at 2026-05-05T11:59:59Z"}',
+        "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhMWIyYzNkNCJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV",
+        "Cached at /Users/jdulberger/.pax8/cache/auth-token.json",
+      ],
+      recoverySteps: ["Run pax8 auth login to refresh"],
+      docsUrl: "https://docs.pax8.com/auth",
+      command: "companies.list",
+      flags: ["--company", "--json"],
+      cli_version: "0.1.0",
+      node_version: "v22.5.1",
+      os: "darwin",
+      timestamp: "2026-05-05T12:00:00.000Z",
+    };
+    const out = redactEnvelope(env);
+    const all = JSON.stringify(out);
+    // No raw UUID, no JWT, no home username, no email.
+    expect(all).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+    expect(all).not.toMatch(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/);
+    expect(all).not.toContain("jdulberger");
+    expect(all).not.toMatch(/\b[\w.+-]+@[\w-]+\.[\w.-]+\b/);
+    // But the markers should appear so reviewers see what was stripped.
+    expect(all).toContain("<REDACTED:UUID>");
+    expect(all).toContain("<REDACTED:JWT>");
+    expect(all).toContain("<REDACTED:PATH>");
+  });
+
+  it("regression: a Zod issue path containing a company name is redacted", () => {
+    const env: BugReportEnvelope = {
+      code: "ERROR_API_VALIDATION",
+      message: "The Pax8 API returned an unexpected response.",
+      causes: [
+        '"data.companies[0].id": expected string, got null at /Users/jdoe/.pax8/cache/companies.json',
+      ],
+      cli_version: "0.1.0",
+      os: "darwin",
+    };
+    const out = redactEnvelope(env);
+    const all = JSON.stringify(out);
+    expect(all).not.toContain("jdoe");
+    expect(all).toContain("<REDACTED:PATH>");
+  });
+
+  it("preserves the structural shape (no extra fields, omits unset ones)", () => {
+    const env: BugReportEnvelope = { message: "hi" };
+    const out = redactEnvelope(env);
+    expect(out).toEqual({ message: "hi" });
+  });
+
+  it("handles undefined optional arrays safely", () => {
+    const env: BugReportEnvelope = { message: "x" };
+    const out = redactEnvelope(env);
+    expect(out.causes).toBeUndefined();
+    expect(out.recoverySteps).toBeUndefined();
+    expect(out.flags).toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/redactor.ts
+++ b/packages/cli/src/lib/redactor.ts
@@ -1,0 +1,138 @@
+/**
+ * Redactor for the `pax8 report-bug` command. Takes a structured error
+ * envelope and returns a sanitized copy with anything that smells like PII,
+ * a secret, or a path under `$HOME` replaced with a `<REDACTED:KIND>` marker.
+ *
+ * Markers (instead of empty strings) are deliberate — they let a reviewer of
+ * the resulting GitHub issue see *what* was stripped, which doubles as a
+ * sanity check against over-redaction.
+ *
+ * The README's "Never sent" section is the load-bearing privacy contract this
+ * module enforces. When in doubt, redact more aggressively.
+ */
+export interface BugReportEnvelope {
+  code?: string;
+  message: string;
+  causes?: string[];
+  recoverySteps?: string[];
+  docsUrl?: string;
+  command?: string;
+  flags?: string[];
+  cli_version?: string;
+  node_version?: string;
+  os?: string;
+  timestamp?: string;
+}
+
+// UUIDs (covers Pax8 client_id and most resource IDs).
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+// Email addresses.
+const EMAIL_RE = /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g;
+
+// JWTs (eyJ... three dot-separated base64url segments).
+const JWT_RE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+
+// Bearer prefix attached to a token-shaped string (any non-whitespace run).
+// Replace the whole `Bearer xxx` so the token alone can't slip through later
+// when an opaque-token rule has a length floor.
+const BEARER_RE = /Bearer\s+[A-Za-z0-9._\-+/=]+/g;
+
+// Character class for opaque-token bodies. `=` is excluded (it's a separator
+// like `key=value`); base64 padding `==` at the tail is rare in token output
+// and we'd rather under-match than collapse `key=long_word_here`.
+const TOKEN_CHARS = "A-Za-z0-9_\\-+/";
+
+// macOS / Linux home paths. The capture preserves the suffix so the tail
+// (e.g. `/.pax8/config.yaml`) remains useful for debugging.
+const POSIX_HOME_RE = /\/(?:Users|home)\/[^/\s"'`]+(\/[^\s"'`]*)?/g;
+
+// Windows home paths. Both backslash and forward-slash forms appear in
+// stringified paths; handle both.
+const WIN_HOME_RE = /[Cc]:[\\/]Users[\\/][^\\/\s"'`]+([\\/][^\s"'`]*)?/g;
+
+// Tilde-style home references — only when followed by a path separator so we
+// don't match e.g. "~10 minutes".
+const TILDE_HOME_RE = /~(\/[^\s"'`]*)/g;
+
+// Long opaque hex strings (>=32 chars) — likely tokens, hashes, or secrets.
+// Word boundaries keep it from chopping up sentences. UUIDs would already be
+// caught above, but we still match here to cover non-hyphenated hex blobs.
+const HEX_TOKEN_RE = /\b[0-9a-fA-F]{32,}\b/g;
+
+// Long base64-ish opaque strings that look like API tokens / client_secrets.
+// Pax8 client secrets are roughly 40–60 chars of base64; we use a 32+ floor
+// with required mixed character classes to avoid eating English words.
+// Excluded: pure-alpha words, pure-digit numbers, hex (covered above).
+const OPAQUE_TOKEN_RE = new RegExp(
+  `(?<![${TOKEN_CHARS}])` +
+    `(?=[${TOKEN_CHARS}]{32,}(?![${TOKEN_CHARS}]))` +
+    `(?=[${TOKEN_CHARS}]*[A-Z])` +
+    `(?=[${TOKEN_CHARS}]*[a-z])` +
+    `(?=[${TOKEN_CHARS}]*[0-9])` +
+    `[${TOKEN_CHARS}]{32,}`,
+  "g",
+);
+
+/**
+ * Redact a single string value. Order matters: longer/more-specific patterns
+ * (JWT, Bearer, paths) run before shorter ones (UUID, hex tokens) so a JWT
+ * isn't partially eaten by the hex-token rule.
+ */
+export function redactString(input: string): string {
+  if (typeof input !== "string" || input.length === 0) return input;
+
+  let out = input;
+
+  // JWTs first (most specific, includes dots).
+  out = out.replace(JWT_RE, "<REDACTED:JWT>");
+  // Bearer-prefixed tokens.
+  out = out.replace(BEARER_RE, "Bearer <REDACTED:TOKEN>");
+  // Path-shaped values before UUID/email so a username inside a path is
+  // collapsed into the path marker rather than emerging as a bare word.
+  out = out.replace(WIN_HOME_RE, (_m, suffix) => `<REDACTED:PATH>${suffix ?? ""}`);
+  out = out.replace(POSIX_HOME_RE, (_m, suffix) => `<REDACTED:PATH>${suffix ?? ""}`);
+  out = out.replace(TILDE_HOME_RE, (_m, suffix) => `<REDACTED:PATH>${suffix ?? ""}`);
+  // Emails before UUIDs (an email's local part can contain dots and digits
+  // but isn't UUID-shaped, so order is mostly defensive).
+  out = out.replace(EMAIL_RE, "<REDACTED:EMAIL>");
+  // UUIDs (covers Pax8 client_id, resource IDs).
+  out = out.replace(UUID_RE, "<REDACTED:UUID>");
+  // Opaque tokens (mixed-class long base64) — must run before HEX so a hex
+  // string with mixed case doesn't prematurely match the hex rule.
+  out = out.replace(OPAQUE_TOKEN_RE, "<REDACTED:TOKEN>");
+  // Long hex blobs.
+  out = out.replace(HEX_TOKEN_RE, "<REDACTED:TOKEN>");
+
+  return out;
+}
+
+function redactStringArray(arr: string[] | undefined): string[] | undefined {
+  if (!arr) return arr;
+  return arr.map(redactString);
+}
+
+/**
+ * Redact every string-typed field of an envelope. Numeric / structural fields
+ * pass through untouched.
+ */
+export function redactEnvelope(env: BugReportEnvelope): BugReportEnvelope {
+  const out: BugReportEnvelope = { ...env };
+  out.message = redactString(env.message ?? "");
+  if (env.code !== undefined) out.code = env.code; // codes are a closed registry — safe.
+  if (env.causes !== undefined) out.causes = redactStringArray(env.causes);
+  if (env.recoverySteps !== undefined) {
+    out.recoverySteps = redactStringArray(env.recoverySteps);
+  }
+  if (env.docsUrl !== undefined) out.docsUrl = redactString(env.docsUrl);
+  if (env.command !== undefined) out.command = redactString(env.command);
+  // Flags are flag *names* only by construction; redact defensively in case
+  // a future code path puts a value here.
+  if (env.flags !== undefined) out.flags = redactStringArray(env.flags);
+  // Versions and OS are non-PII metadata; pass through.
+  if (env.cli_version !== undefined) out.cli_version = env.cli_version;
+  if (env.node_version !== undefined) out.node_version = env.node_version;
+  if (env.os !== undefined) out.os = env.os;
+  if (env.timestamp !== undefined) out.timestamp = env.timestamp;
+  return out;
+}


### PR DESCRIPTION
## Summary

Implements the recommendation from the spike at #142: a user-invoked `pax8 report-bug` command that opens a prefilled, sanitized GitHub issue with the context of the most recent failure. Honors the README's public "never sent" commitment — nothing leaves the user's machine without explicit `[y/N]` confirmation, and the redactor strips UUIDs, emails, `$HOME` paths, JWTs, and long token-shaped strings.

## What ships

- New command `pax8 report-bug` (`-y`, `--print`, `--json`)
- New module `packages/cli/src/lib/redactor.ts` with comprehensive PII rules + tests
- `handleCommandError` writes `~/.pax8/last-error.json` (mode 0600) on every CliError so the command has something to report
- Error renderer prints a one-line hint pointing at `pax8 report-bug` (the spike's "5-line free win")
- README "Reporting bugs" section
- `gh` if installed + authenticated; falls back to opening a prefilled GitHub issue URL via the platform open command (no new npm dep)

## Redactor rules implemented

| Rule | Pattern | Marker |
|------|---------|--------|
| UUIDs | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `<REDACTED:UUID>` |
| Emails | `\b[\w.+-]+@[\w-]+\.[\w.-]+\b` | `<REDACTED:EMAIL>` |
| Home paths (POSIX) | `/Users/<x>/...`, `/home/<x>/...` (suffix preserved) | `<REDACTED:PATH>/...` |
| Home paths (Windows) | `C:\Users\<x>\...` (suffix preserved) | `<REDACTED:PATH>/...` |
| Tilde paths | `~/...` (only when followed by a path separator) | `<REDACTED:PATH>/...` |
| JWTs | `eyJ[...].[...].[...]` | `<REDACTED:JWT>` |
| Bearer tokens | `Bearer <opaque>` | `Bearer <REDACTED:TOKEN>` |
| Long opaque tokens | base64-shaped, ≥32 chars, mixed upper+lower+digit | `<REDACTED:TOKEN>` |
| Long hex tokens | `[0-9a-fA-F]{32,}` | `<REDACTED:TOKEN>` |

Markers (vs empty strings) are intentional — they let a reviewer of the resulting GitHub issue see *what* was stripped, which doubles as a sanity check against over-redaction.

## Closes / refs

- Closes #142 (spike) — implements the recommended Approach 1
- Layered v0.2.x extension (Approach 2 PostHog → GH Action watcher) deferred to a separate issue post public-repo migration

## Coordination

Touches `packages/cli/src/lib/errors.ts` — the in-flight #145/#146 PR also rewrites `handleCommandError`. Logically independent additions; expect a small rebase conflict resolved by keeping both the envelope-write and the flush.

## Test plan

- [x] Redactor unit tests covering every rule + a real-world Pax8 envelope regression test (no PII survives end-to-end)
- [x] Subprocess tests for the command (`--print`, `--json`, missing `last-error.json`, malformed JSON, `--help`)
- [x] Integration test for the envelope-write side using `PAX8_CONFIG_DIR` tmpdir; asserts mode 0600 and full payload shape
- [x] End-to-end test: failed command → `report-bug --print` produces a redacted body
- [x] Build, lint, typecheck, full suite all green (971 passing)
- [x] Coverage threshold gate green