### PR TITLE
fix(telemetry): flush before exit + dedup write-command events (closes #145, #146)

### DIFF
--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -70,6 +70,6 @@ Examples:
         chalk.green(`\n  ✓ Credentials saved for ${masked}\n\n`)
       );
     } catch (error) {
-      handleCommandError(error, spinner, "Authentication failed");
+      await handleCommandError(error, spinner, "Authentication failed");
     }
   });

--- a/packages/cli/src/commands/companies/create.ts
+++ b/packages/cli/src/commands/companies/create.ts
@@ -83,6 +83,6 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Status:")}   ${company.status}\n`);
       process.stdout.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to create company");
+      await handleCommandError(error, undefined, "Failed to create company");
     }
   });

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -252,6 +252,6 @@ Examples:
         await promptNextSteps(steps);
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list companies");
+      await handleCommandError(error, spinner, "Failed to list companies");
     }
   });

--- a/packages/cli/src/commands/companies/more.ts
+++ b/packages/cli/src/commands/companies/more.ts
@@ -309,6 +309,6 @@ Examples:
         process.exit(1);
         throw new Error("process.exit intercepted");
       }
-      handleCommandError(error, spinner, "Failed to load company summary");
+      await handleCommandError(error, spinner, "Failed to load company summary");
     }
   });

--- a/packages/cli/src/commands/companies/show.ts
+++ b/packages/cli/src/commands/companies/show.ts
@@ -110,6 +110,6 @@ Examples:
         }
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show company");
+      await handleCommandError(error, spinner, "Failed to show company");
     }
   });

--- a/packages/cli/src/commands/companies/update.ts
+++ b/packages/cli/src/commands/companies/update.ts
@@ -86,6 +86,6 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Website:")}  ${company.website || chalk.dim("—")}\n`);
       process.stdout.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to update company");
+      await handleCommandError(error, undefined, "Failed to update company");
     }
   });

--- a/packages/cli/src/commands/contacts/create.ts
+++ b/packages/cli/src/commands/contacts/create.ts
@@ -101,6 +101,6 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts list --company "${company.name}"`))}  ${chalk.dim("view all contacts at this company")}\n`);
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to create contact");
+      await handleCommandError(error, undefined, "Failed to create contact");
     }
   });

--- a/packages/cli/src/commands/contacts/delete.ts
+++ b/packages/cli/src/commands/contacts/delete.ts
@@ -60,6 +60,6 @@ Examples:
         output([{ id: contact.id, status: "Deleted" }], { format: "json" });
       }
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to delete contact");
+      await handleCommandError(error, undefined, "Failed to delete contact");
     }
   });

--- a/packages/cli/src/commands/contacts/list.ts
+++ b/packages/cli/src/commands/contacts/list.ts
@@ -83,7 +83,7 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list contacts");
+      await handleCommandError(error, spinner, "Failed to list contacts");
     }
   });
 

--- a/packages/cli/src/commands/contacts/show.ts
+++ b/packages/cli/src/commands/contacts/show.ts
@@ -64,6 +64,6 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts delete ${contact.id}`))}  ${chalk.dim("delete this contact")}\n`);
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show contact");
+      await handleCommandError(error, spinner, "Failed to show contact");
     }
   });

--- a/packages/cli/src/commands/contacts/update.ts
+++ b/packages/cli/src/commands/contacts/update.ts
@@ -111,6 +111,6 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Types:".padEnd(14))}${(updated.types ?? []).join(", ")}\n`);
       process.stdout.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to update contact");
+      await handleCommandError(error, undefined, "Failed to update contact");
     }
   });

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -189,7 +189,7 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to audit invoices");
+      await handleCommandError(error, spinner, "Failed to audit invoices");
     }
   });
 

--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -259,7 +259,7 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
     let argsHash: string | null = null;
     if (idempotencyKey !== undefined) {
       if (!isValidKey(idempotencyKey)) {
-        handleCommandError(
+        await handleCommandError(
           new CliError(
             `Invalid idempotency key: "${idempotencyKey}"`,
             [
@@ -286,7 +286,7 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
         const cached = await loadEntry(commandName, idempotencyKey);
         if (cached) {
           if (cached.argsHash !== argsHash) {
-            handleCommandError(
+            await handleCommandError(
               new CliError(
                 "Idempotency key reused with different arguments — refusing to retry.",
                 [
@@ -495,9 +495,9 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
     } catch (error) {
       restoreStdout();
       if (error instanceof CliError) {
-        handleCommandError(error, spinner);
+        await handleCommandError(error, spinner);
       }
-      handleCommandError(
+      await handleCommandError(
         error instanceof Error
           ? new CliError(
               `Failed to file dispute: ${error.message}`,

--- a/packages/cli/src/commands/invoices/items.ts
+++ b/packages/cli/src/commands/invoices/items.ts
@@ -69,6 +69,6 @@ Examples:
         );
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list invoice items");
+      await handleCommandError(error, spinner, "Failed to list invoice items");
     }
   });

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -125,6 +125,6 @@ Examples:
         );
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list invoices");
+      await handleCommandError(error, spinner, "Failed to list invoices");
     }
   });

--- a/packages/cli/src/commands/invoices/show.ts
+++ b/packages/cli/src/commands/invoices/show.ts
@@ -67,6 +67,6 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show invoice");
+      await handleCommandError(error, spinner, "Failed to show invoice");
     }
   });

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -12,12 +12,12 @@ import {
   ERROR_API_VALIDATION,
   ERROR_INVALID_INPUT,
   ERROR_PRODUCT_NOT_FOUND,
-  getTelemetry,
 } from "@pax8/core";
 import type { CreateOrderInput, OrderLineItemInput, BillingTerm } from "@pax8/core";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 import { hashArgs, isValidKey, loadEntry, saveEntry } from "../../lib/idempotency.js";
+import { setTelemetryFields } from "../../lib/telemetry-context.js";
 
 export const ordersCreateCommand = new Command("create")
   .description("Create a new order")
@@ -330,26 +330,15 @@ Examples:
 
       spinner.succeed("Order created 🎉");
 
-      // Track revenue
-      try {
-        const tel = getTelemetry();
-        const orderMrr = unitPrice ? calculateMrr(unitPrice, confirmedQty, allOpts.billingTerm) : undefined;
-        tel.track({
-          event: "command_executed",
-          command: "orders.create",
-          flags: [],
-          duration_ms: 0,
-          success: true,
-          cli_version: "0.1.0",
-          node_version: process.version,
-          os: process.platform,
-          demo_mode: process.env.PAX8_DEMO === "1",
-          order_success: true,
-          order_total_dollars: unitPrice ? unitPrice * confirmedQty : undefined,
-          order_mrr_impact: orderMrr ?? undefined,
-          order_seats: confirmedQty,
-        });
-      } catch { /* telemetry never breaks the CLI */ }
+      // Contribute revenue counters to the single command_executed event
+      // emitted by the postAction hook (#146 — was double-firing).
+      const orderMrr = unitPrice ? calculateMrr(unitPrice, confirmedQty, allOpts.billingTerm) : undefined;
+      setTelemetryFields({
+        order_success: true,
+        order_total_dollars: unitPrice ? unitPrice * confirmedQty : undefined,
+        order_mrr_impact: orderMrr,
+        order_seats: confirmedQty,
+      });
 
       if (ctx.outputFormat === "json") {
         const jsonMrr = unitPrice ? calculateMrr(unitPrice, confirmedQty, allOpts.billingTerm) : null;

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -56,7 +56,7 @@ Examples:
     let argsHash: string | null = null;
     if (idempotencyKey !== undefined) {
       if (!isValidKey(idempotencyKey)) {
-        handleCommandError(
+        await handleCommandError(
           new CliError(
             `Invalid idempotency key: "${idempotencyKey}"`,
             [
@@ -83,7 +83,7 @@ Examples:
         const cached = await loadEntry(commandName, idempotencyKey);
         if (cached) {
           if (cached.argsHash !== argsHash) {
-            handleCommandError(
+            await handleCommandError(
               new CliError(
                 "Idempotency key reused with different arguments — refusing to retry.",
                 [
@@ -415,7 +415,7 @@ Examples:
         if (error.statusCode === 404) {
           // Extract a short searchable name from the full product name
           const shortName = displayProduct.replace(/\s*\[.*?\]\s*/g, "").replace(/\s*\(.*?\)\s*/g, "").trim().split(" ").slice(0, 4).join(" ");
-          handleCommandError(
+          await handleCommandError(
             new CliError(
               `"${displayProduct}" can't be ordered for ${displayCompany}`,
               [
@@ -448,7 +448,7 @@ Examples:
           }
           steps.push(`View product details: ${replCmd("pax8 products show")} ${allOpts.product}`);
 
-          handleCommandError(
+          await handleCommandError(
             new CliError(
               `Can't order "${displayProduct}" for ${displayCompany}`,
               causes,
@@ -475,7 +475,7 @@ Examples:
           }
           steps.push(`View product details: ${replCmd("pax8 products show")} ${allOpts.product}`);
 
-          handleCommandError(
+          await handleCommandError(
             new CliError(
               `Can't order "${displayProduct}" for ${displayCompany}`,
               causes,
@@ -487,6 +487,6 @@ Examples:
         }
       }
 
-      handleCommandError(error, undefined, "Failed to create order");
+      await handleCommandError(error, undefined, "Failed to create order");
     }
   });

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -80,6 +80,6 @@ Examples:
         );
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list orders");
+      await handleCommandError(error, spinner, "Failed to list orders");
     }
   });

--- a/packages/cli/src/commands/orders/show.ts
+++ b/packages/cli/src/commands/orders/show.ts
@@ -67,6 +67,6 @@ Examples:
         process.stdout.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show order");
+      await handleCommandError(error, spinner, "Failed to show order");
     }
   });

--- a/packages/cli/src/commands/products/list.ts
+++ b/packages/cli/src/commands/products/list.ts
@@ -59,6 +59,6 @@ Examples:
         );
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list products");
+      await handleCommandError(error, spinner, "Failed to list products");
     }
   });

--- a/packages/cli/src/commands/products/search.ts
+++ b/packages/cli/src/commands/products/search.ts
@@ -79,6 +79,6 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to search products");
+      await handleCommandError(error, spinner, "Failed to search products");
     }
   });

--- a/packages/cli/src/commands/products/show.ts
+++ b/packages/cli/src/commands/products/show.ts
@@ -141,6 +141,6 @@ Examples:
 
       process.stdout.write("\n");
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show product");
+      await handleCommandError(error, spinner, "Failed to show product");
     }
   });

--- a/packages/cli/src/commands/quotes/create.ts
+++ b/packages/cli/src/commands/quotes/create.ts
@@ -104,6 +104,6 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes show ${quote.id}`))}  ${chalk.dim("view quote details")}\n`);
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to create quote");
+      await handleCommandError(error, undefined, "Failed to create quote");
     }
   });

--- a/packages/cli/src/commands/quotes/delete.ts
+++ b/packages/cli/src/commands/quotes/delete.ts
@@ -59,6 +59,6 @@ Examples:
         output([{ id: quote.id, status: "Deleted" }], { format: "json" });
       }
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to delete quote");
+      await handleCommandError(error, undefined, "Failed to delete quote");
     }
   });

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -95,6 +95,6 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list quotes");
+      await handleCommandError(error, spinner, "Failed to list quotes");
     }
   });

--- a/packages/cli/src/commands/quotes/show.ts
+++ b/packages/cli/src/commands/quotes/show.ts
@@ -85,6 +85,6 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes delete ${quote.id}`))}  ${chalk.dim("delete this quote")}\n`);
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show quote");
+      await handleCommandError(error, spinner, "Failed to show quote");
     }
   });

--- a/packages/cli/src/commands/quotes/update.ts
+++ b/packages/cli/src/commands/quotes/update.ts
@@ -116,6 +116,6 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Items:".padEnd(14))}${updated.lineItems?.length ?? 0}\n`);
       process.stdout.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to update quote");
+      await handleCommandError(error, undefined, "Failed to update quote");
     }
   });

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { createInterface } from "readline";
-import { ALL_SUBS_PAGE_SIZE, getRecommendations, getTelemetry, type Recommendation } from "@pax8/core";
+import { ALL_SUBS_PAGE_SIZE, getRecommendations, type Recommendation } from "@pax8/core";
 import { buildContext, type CommandContext } from "../../lib/context.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
@@ -9,6 +9,7 @@ import { formatCurrency, formatCompanyName, formatQuantity, calculateMrr } from 
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 import { filterRecommendations } from "./filter.js";
 import { markWriteInFlight } from "../../lib/signals.js";
+import { setTelemetryFields } from "../../lib/telemetry-context.js";
 
 async function prompt(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
@@ -239,25 +240,14 @@ Examples:
       if (mrrCaptured > 0) process.stderr.write(chalk.green(` · ${formatCurrency(mrrCaptured)}/mo MRR captured`));
       process.stderr.write("\n\n");
 
-      // Track recommendation flow
-      try {
-        const tel = getTelemetry();
-        tel.track({
-          event: "command_executed",
-          command: "recommendations.act",
-          flags: [],
-          duration_ms: 0,
-          success: true,
-          cli_version: "0.1.0",
-          node_version: process.version,
-          os: process.platform,
-          demo_mode: process.env.PAX8_DEMO === "1",
-          recs_presented: recs.length,
-          recs_ordered: ordered,
-          recs_skipped: skipped,
-          recs_mrr_captured: mrrCaptured > 0 ? mrrCaptured : undefined,
-        });
-      } catch { /* telemetry never breaks the CLI */ }
+      // Contribute aggregate counts to the single command_executed event
+      // emitted by the postAction hook (#146 — was double-firing).
+      setTelemetryFields({
+        recs_presented: recs.length,
+        recs_ordered: ordered,
+        recs_skipped: skipped,
+        recs_mrr_captured: mrrCaptured > 0 ? mrrCaptured : undefined,
+      });
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to process recommendations");
     }

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -259,6 +259,6 @@ Examples:
         });
       } catch { /* telemetry never breaks the CLI */ }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to process recommendations");
+      await handleCommandError(error, spinner, "Failed to process recommendations");
     }
   });

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -437,6 +437,6 @@ Examples:
       });
       await promptNextSteps(steps);
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to generate recommendations");
+      await handleCommandError(error, spinner, "Failed to generate recommendations");
     }
   });

--- a/packages/cli/src/commands/report/growth.ts
+++ b/packages/cli/src/commands/report/growth.ts
@@ -130,6 +130,6 @@ Examples:
 
       out.write("\n");
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to analyze growth");
+      await handleCommandError(error, spinner, "Failed to analyze growth");
     }
   });

--- a/packages/cli/src/commands/report/mrr.ts
+++ b/packages/cli/src/commands/report/mrr.ts
@@ -127,6 +127,6 @@ Examples:
       out.write(`  ${"Projected ARR".padEnd(nameWidth)}  ${"".padEnd(11)}  ${chalk.bold(formatCurrency(projectedArr).padStart(12))}\n`);
       out.write("\n");
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to calculate MRR");
+      await handleCommandError(error, spinner, "Failed to calculate MRR");
     }
   });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -467,6 +467,6 @@ Examples:
 
       out.write("\n");
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to load status");
+      await handleCommandError(error, spinner, "Failed to load status");
     }
   });

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -75,6 +75,6 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders create --company "${coName}" --product <name>`))}  ${chalk.dim("order a replacement")}\n`);
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to cancel subscription");
+      await handleCommandError(error, undefined, "Failed to cancel subscription");
     }
   });

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -126,6 +126,6 @@ Examples:
         );
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list subscriptions");
+      await handleCommandError(error, spinner, "Failed to list subscriptions");
     }
   });

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -168,6 +168,6 @@ Examples:
 
       process.stdout.write("\n");
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to fetch renewals");
+      await handleCommandError(error, spinner, "Failed to fetch renewals");
     }
   });

--- a/packages/cli/src/commands/subscriptions/show.ts
+++ b/packages/cli/src/commands/subscriptions/show.ts
@@ -122,6 +122,6 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show subscription");
+      await handleCommandError(error, spinner, "Failed to show subscription");
     }
   });

--- a/packages/cli/src/commands/subscriptions/update.ts
+++ b/packages/cli/src/commands/subscriptions/update.ts
@@ -93,6 +93,6 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Price:".padEnd(18))}${formatCurrency(updated.price ?? 0)}\n`);
       process.stdout.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to update subscription");
+      await handleCommandError(error, undefined, "Failed to update subscription");
     }
   });

--- a/packages/cli/src/commands/usage/list.ts
+++ b/packages/cli/src/commands/usage/list.ts
@@ -80,6 +80,6 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list usage summaries");
+      await handleCommandError(error, spinner, "Failed to list usage summaries");
     }
   });

--- a/packages/cli/src/commands/usage/show.ts
+++ b/packages/cli/src/commands/usage/show.ts
@@ -107,6 +107,6 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to show usage summary");
+      await handleCommandError(error, spinner, "Failed to show usage summary");
     }
   });

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -131,6 +131,6 @@ Examples:
       );
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to create webhook");
+      await handleCommandError(error, undefined, "Failed to create webhook");
     }
   });

--- a/packages/cli/src/commands/webhooks/delete.ts
+++ b/packages/cli/src/commands/webhooks/delete.ts
@@ -78,6 +78,6 @@ Examples:
       );
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to delete webhook");
+      await handleCommandError(error, undefined, "Failed to delete webhook");
     }
   });

--- a/packages/cli/src/commands/webhooks/list.ts
+++ b/packages/cli/src/commands/webhooks/list.ts
@@ -120,6 +120,6 @@ Examples:
         process.stderr.write("\n");
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to list webhooks");
+      await handleCommandError(error, spinner, "Failed to list webhooks");
     }
   });

--- a/packages/cli/src/commands/webhooks/logs.ts
+++ b/packages/cli/src/commands/webhooks/logs.ts
@@ -162,6 +162,6 @@ Examples:
         }
       }
     } catch (error) {
-      handleCommandError(error, spinner, "Failed to fetch webhook logs");
+      await handleCommandError(error, spinner, "Failed to fetch webhook logs");
     }
   });

--- a/packages/cli/src/commands/webhooks/test.ts
+++ b/packages/cli/src/commands/webhooks/test.ts
@@ -56,6 +56,6 @@ Examples:
       );
       process.stderr.write("\n");
     } catch (error) {
-      handleCommandError(error, undefined, "Failed to send test delivery");
+      await handleCommandError(error, undefined, "Failed to send test delivery");
     }
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { versionCommand } from "./commands/version.js";
 import { initCommand } from "./commands/init.js";
 import { handleCommandError } from "./lib/errors.js";
 import { installSigintHandler } from "./lib/signals.js";
+import { consumeTelemetryFields } from "./lib/telemetry-context.js";
 import { mooCommand } from "./commands/easter-eggs/moo.js";
 import { coffeeCommand } from "./commands/easter-eggs/coffee.js";
 import { getTimeQuip } from "./commands/easter-eggs/time-quip.js";
@@ -146,6 +147,9 @@ export function createProgram(): Command {
   program.hook("postAction", async (_thisCommand, actionCommand) => {
     try {
       const telemetry = getTelemetry();
+      // Always consume so a leftover from a (rare) early-returning handler
+      // doesn't leak into a later command run in the same process (REPL).
+      const handlerProps = consumeTelemetryFields();
       if (!telemetry.isEnabled()) return;
 
       const startTime = commandStartTimes.get(actionCommand) ?? Date.now();
@@ -153,6 +157,9 @@ export function createProgram(): Command {
       const flags = extractCommandFlags(actionCommand);
       const isDemo = process.env.PAX8_DEMO === "1" || false;
 
+      // Single canonical event for every command run (#146). Handlers
+      // contribute aggregate counters via setTelemetryFields(); they no
+      // longer call telemetry.track() directly.
       telemetry.track({
         event: "command_executed",
         command: subcommand.split(".")[0] ?? subcommand,
@@ -164,6 +171,7 @@ export function createProgram(): Command {
         node_version: process.version,
         os: process.platform,
         demo_mode: isDemo,
+        ...handlerProps,
       });
 
       // Fire-and-forget flush

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -364,6 +364,17 @@ async function main(): Promise<void> {
   // the clean cleanup path rather than Node's default `1` exit.
   installSigintHandler();
 
+  // Last-resort handlers for crashes that escape `parseAsync.catch`. Without
+  // these the process would exit before the PostHog buffer flushed, so the
+  // failure event would be lost (#145). We delegate to `handleCommandError`
+  // which now awaits the bounded telemetry shutdown before exit.
+  process.on("uncaughtException", (err) => {
+    void handleCommandError(err).catch(() => process.exit(1));
+  });
+  process.on("unhandledRejection", (reason) => {
+    void handleCommandError(reason).catch(() => process.exit(1));
+  });
+
   if (process.argv.length <= 2) {
     if (process.stdin.isTTY) {
       await startRepl();
@@ -402,7 +413,7 @@ async function main(): Promise<void> {
         // Telemetry must never interfere with error handling
       }
 
-      handleCommandError(err);
+      await handleCommandError(err);
     });
   }
 }

--- a/packages/cli/src/lib/errors.test.ts
+++ b/packages/cli/src/lib/errors.test.ts
@@ -15,7 +15,7 @@ import {
 import { CliError, handleCommandError, extractErrorDetail } from "./errors.js";
 
 describe("CliError", () => {
-  it("constructs with message only", () => {
+  it("constructs with message only", async () => {
     const err = new CliError("Something went wrong");
     expect(err.message).toBe("Something went wrong");
     expect(err.name).toBe("CliError");
@@ -24,7 +24,7 @@ describe("CliError", () => {
     expect(err.docsUrl).toBeUndefined();
   });
 
-  it("constructs with all options", () => {
+  it("constructs with all options", async () => {
     const err = new CliError(
       "Auth failed",
       ["Invalid credentials", "Token expired"],
@@ -40,7 +40,7 @@ describe("CliError", () => {
     expect(err.docsUrl).toBe("https://docs.pax8.com/auth");
   });
 
-  it("is an instance of Error", () => {
+  it("is an instance of Error", async () => {
     const err = new CliError("test");
     expect(err instanceof Error).toBe(true);
     expect(err instanceof CliError).toBe(true);
@@ -68,22 +68,22 @@ describe("handleCommandError", () => {
   // handleCommandError calls process.exit(1) then throws "process.exit intercepted"
   // We need to catch the throw to inspect stderr output and exit spy
 
-  it("formats CliError with message", () => {
-    expect(() => handleCommandError(new CliError("Something broke"))).toThrow("process.exit intercepted");
+  it("formats CliError with message", async () => {
+    await expect(handleCommandError(new CliError("Something broke"))).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("Something broke");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("formats CliError with causes and recovery steps", () => {
-    expect(() => handleCommandError(
+  it("formats CliError with causes and recovery steps", async () => {
+    await expect(handleCommandError(
       new CliError(
         "Auth failed",
         ["Token expired"],
         ["Run pax8 auth login"]
       )
-    )).toThrow("process.exit intercepted");
+    )).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("Auth failed");
@@ -91,51 +91,51 @@ describe("handleCommandError", () => {
     expect(written).toContain("Run pax8 auth login");
   });
 
-  it("formats CliError with docs URL", () => {
-    expect(() => handleCommandError(
+  it("formats CliError with docs URL", async () => {
+    await expect(handleCommandError(
       new CliError("Error", undefined, undefined, "https://example.com/docs")
-    )).toThrow("process.exit intercepted");
+    )).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("https://example.com/docs");
   });
 
-  it("formats generic Error", () => {
-    expect(() => handleCommandError(new Error("Generic problem"))).toThrow("process.exit intercepted");
+  it("formats generic Error", async () => {
+    await expect(handleCommandError(new Error("Generic problem"))).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("Generic problem");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("formats unknown error", () => {
-    expect(() => handleCommandError("a string error")).toThrow("process.exit intercepted");
+  it("formats unknown error", async () => {
+    await expect(handleCommandError("a string error")).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("unexpected error");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("prepends context if provided", () => {
-    expect(() => handleCommandError(
+  it("prepends context if provided", async () => {
+    await expect(handleCommandError(
       new CliError("broken"),
       undefined,
       "Failed to list companies"
-    )).toThrow("process.exit intercepted");
+    )).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("Failed to list companies");
   });
 
-  it("stops spinner if provided", () => {
+  it("stops spinner if provided", async () => {
     const spinner = { fail: vi.fn() };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial mock for testing
-    expect(() => handleCommandError(new Error("test"), spinner as any)).toThrow("process.exit intercepted");
+    await expect(handleCommandError(new Error("test"), spinner as any)).rejects.toThrow("process.exit intercepted");
 
     expect(spinner.fail).toHaveBeenCalled();
   });
 
-  it("handles spinner.fail throwing", () => {
+  it("handles spinner.fail throwing", async () => {
     const spinner = {
       fail: vi.fn().mockImplementation(() => {
         throw new Error("spinner error");
@@ -143,50 +143,50 @@ describe("handleCommandError", () => {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial mock for testing
-    expect(() => handleCommandError(new Error("test"), spinner as any)).toThrow("process.exit intercepted");
+    await expect(handleCommandError(new Error("test"), spinner as any)).rejects.toThrow("process.exit intercepted");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("formats ApiError 401 with re-auth recovery hint", () => {
-    expect(() =>
+  it("formats ApiError 401 with re-auth recovery hint", async () => {
+    await expect(
       handleCommandError(
         new ApiError("Unauthorized", 401, "/companies", "GET", { message: "bad token" })
       )
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("Unauthorized");
     expect(written).toContain("auth login");
   });
 
-  it("formats ApiError 404 with extracted detail message", () => {
-    expect(() =>
+  it("formats ApiError 404 with extracted detail message", async () => {
+    await expect(
       handleCommandError(
         new ApiError("Not Found", 404, "/companies/123", "GET", { message: "company missing" })
       )
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("company missing");
   });
 
-  it("formats ApiError 404 without responseBody falls back to generic hint", () => {
-    expect(() =>
+  it("formats ApiError 404 without responseBody falls back to generic hint", async () => {
+    await expect(
       handleCommandError(
         new ApiError("Not Found", 404, "/companies/123", "GET")
       )
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("Check the ID or name");
   });
 
-  it("formats ZodError with parse-failure message and a doctor hint", () => {
+  it("formats ZodError with parse-failure message and a doctor hint", async () => {
     const schema = z.object({ id: z.string() });
     const parsed = schema.safeParse({ id: 42 });
     if (parsed.success) throw new Error("expected parse to fail");
 
-    expect(() => handleCommandError(parsed.error)).toThrow("process.exit intercepted");
+    await expect(handleCommandError(parsed.error)).rejects.toThrow("process.exit intercepted");
 
     const written = stderrWrite.mock.calls.map((c) => c[0]).join("");
     expect(written).toContain("unexpected response");
@@ -219,8 +219,8 @@ describe("handleCommandError JSON envelope", () => {
     return stderrWrite.mock.calls.map((c) => String(c[0])).join("");
   }
 
-  it("emits a JSON envelope with code, message, causes, recoverySteps, docsUrl for CliError", () => {
-    expect(() =>
+  it("emits a JSON envelope with code, message, causes, recoverySteps, docsUrl for CliError", async () => {
+    await expect(
       handleCommandError(
         new CliError(
           "Auth failed",
@@ -230,7 +230,7 @@ describe("handleCommandError JSON envelope", () => {
           ERROR_AUTH_EXPIRED
         )
       )
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
 
     const env = JSON.parse(captured());
     expect(env).toEqual({
@@ -242,10 +242,10 @@ describe("handleCommandError JSON envelope", () => {
     });
   });
 
-  it("omits unset optional fields from the JSON envelope", () => {
-    expect(() =>
+  it("omits unset optional fields from the JSON envelope", async () => {
+    await expect(
       handleCommandError(new CliError("simple error"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
 
     const env = JSON.parse(captured());
     expect(env).toEqual({ message: "simple error" });
@@ -255,78 +255,78 @@ describe("handleCommandError JSON envelope", () => {
     expect(env.docsUrl).toBeUndefined();
   });
 
-  it("prepends the context to the JSON envelope message", () => {
-    expect(() =>
+  it("prepends the context to the JSON envelope message", async () => {
+    await expect(
       handleCommandError(new CliError("nope"), undefined, "Failed to list companies")
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     const env = JSON.parse(captured());
     expect(env.message).toBe("Failed to list companies: nope");
   });
 
-  it("maps ApiError 401 -> ERROR_AUTH_EXPIRED", () => {
-    expect(() =>
+  it("maps ApiError 401 -> ERROR_AUTH_EXPIRED", async () => {
+    await expect(
       handleCommandError(new ApiError("Unauthorized", 401, "/x", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     const env = JSON.parse(captured());
     expect(env.code).toBe(ERROR_AUTH_EXPIRED);
     expect(env.recoverySteps?.[0]).toContain("auth login");
   });
 
-  it("maps ApiError 408 -> ERROR_API_TIMEOUT", () => {
-    expect(() =>
+  it("maps ApiError 408 -> ERROR_API_TIMEOUT", async () => {
+    await expect(
       handleCommandError(new ApiError("Timeout", 408, "/x", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     expect(JSON.parse(captured()).code).toBe(ERROR_API_TIMEOUT);
   });
 
-  it("maps ApiError 429 -> ERROR_RATE_LIMITED", () => {
-    expect(() =>
+  it("maps ApiError 429 -> ERROR_RATE_LIMITED", async () => {
+    await expect(
       handleCommandError(new ApiError("Rate limited", 429, "/x", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     expect(JSON.parse(captured()).code).toBe(ERROR_RATE_LIMITED);
   });
 
-  it("maps ApiError 5xx -> ERROR_INTERNAL", () => {
-    expect(() =>
+  it("maps ApiError 5xx -> ERROR_INTERNAL", async () => {
+    await expect(
       handleCommandError(new ApiError("Server boom", 503, "/x", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     expect(JSON.parse(captured()).code).toBe(ERROR_INTERNAL);
   });
 
-  it("maps ApiError 404 on /companies -> ERROR_COMPANY_NOT_FOUND", () => {
-    expect(() =>
+  it("maps ApiError 404 on /companies -> ERROR_COMPANY_NOT_FOUND", async () => {
+    await expect(
       handleCommandError(new ApiError("Not Found", 404, "/companies/abc", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     expect(JSON.parse(captured()).code).toBe(ERROR_COMPANY_NOT_FOUND);
   });
 
-  it("maps ApiError 404 on /products -> ERROR_PRODUCT_NOT_FOUND", () => {
-    expect(() =>
+  it("maps ApiError 404 on /products -> ERROR_PRODUCT_NOT_FOUND", async () => {
+    await expect(
       handleCommandError(new ApiError("Not Found", 404, "/products/abc", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     expect(JSON.parse(captured()).code).toBe(ERROR_PRODUCT_NOT_FOUND);
   });
 
-  it("maps ApiError 404 on /subscriptions -> ERROR_SUBSCRIPTION_NOT_FOUND", () => {
-    expect(() =>
+  it("maps ApiError 404 on /subscriptions -> ERROR_SUBSCRIPTION_NOT_FOUND", async () => {
+    await expect(
       handleCommandError(new ApiError("Not Found", 404, "/subscriptions/abc", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     expect(JSON.parse(captured()).code).toBe(ERROR_SUBSCRIPTION_NOT_FOUND);
   });
 
-  it("falls back to ERROR_NOT_AUTHORIZED on a generic 404", () => {
-    expect(() =>
+  it("falls back to ERROR_NOT_AUTHORIZED on a generic 404", async () => {
+    await expect(
       handleCommandError(new ApiError("Not Found", 404, "/totallyrandom", "GET"))
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     expect(JSON.parse(captured()).code).toBe(ERROR_NOT_AUTHORIZED);
   });
 
-  it("emits ERROR_API_VALIDATION envelope for ZodError", () => {
+  it("emits ERROR_API_VALIDATION envelope for ZodError", async () => {
     const schema = z.object({ id: z.string() });
     const parsed = schema.safeParse({ id: 42 });
     if (parsed.success) throw new Error("expected parse to fail");
 
-    expect(() => handleCommandError(parsed.error)).toThrow("process.exit intercepted");
+    await expect(handleCommandError(parsed.error)).rejects.toThrow("process.exit intercepted");
 
     const env = JSON.parse(captured());
     expect(env.code).toBe(ERROR_API_VALIDATION);
@@ -334,8 +334,8 @@ describe("handleCommandError JSON envelope", () => {
     expect(env.recoverySteps).toBeDefined();
   });
 
-  it("emits ERROR_INTERNAL for a plain Error", () => {
-    expect(() => handleCommandError(new Error("oops"))).toThrow(
+  it("emits ERROR_INTERNAL for a plain Error", async () => {
+    await expect(handleCommandError(new Error("oops"))).rejects.toThrow(
       "process.exit intercepted"
     );
     const env = JSON.parse(captured());
@@ -343,50 +343,50 @@ describe("handleCommandError JSON envelope", () => {
     expect(env.message).toBe("oops");
   });
 
-  it("emits ERROR_INTERNAL for an unknown thrown value", () => {
-    expect(() => handleCommandError("nope")).toThrow("process.exit intercepted");
+  it("emits ERROR_INTERNAL for an unknown thrown value", async () => {
+    await expect(handleCommandError("nope")).rejects.toThrow("process.exit intercepted");
     const env = JSON.parse(captured());
     expect(env.code).toBe(ERROR_INTERNAL);
     expect(env.message).toContain("unexpected error");
   });
 
-  it("includes API error responseBody detail as causes when present", () => {
-    expect(() =>
+  it("includes API error responseBody detail as causes when present", async () => {
+    await expect(
       handleCommandError(
         new ApiError("Bad Request", 400, "/x", "POST", { detail: "missing field foo" })
       )
-    ).toThrow("process.exit intercepted");
+    ).rejects.toThrow("process.exit intercepted");
     const env = JSON.parse(captured());
     expect(env.causes).toEqual(["missing field foo"]);
   });
 });
 
 describe("extractErrorDetail", () => {
-  it("returns undefined for non-objects", () => {
+  it("returns undefined for non-objects", async () => {
     expect(extractErrorDetail(null)).toBeUndefined();
     expect(extractErrorDetail("string")).toBeUndefined();
     expect(extractErrorDetail(42)).toBeUndefined();
   });
 
-  it("extracts from message/error/detail/error_description in priority order", () => {
+  it("extracts from message/error/detail/error_description in priority order", async () => {
     expect(extractErrorDetail({ message: "m" })).toBe("m");
     expect(extractErrorDetail({ error: "e" })).toBe("e");
     expect(extractErrorDetail({ detail: "d" })).toBe("d");
     expect(extractErrorDetail({ error_description: "ed" })).toBe("ed");
   });
 
-  it("extracts message from a nested error object", () => {
+  it("extracts message from a nested error object", async () => {
     expect(extractErrorDetail({ error: { message: "nested" } })).toBe("nested");
   });
 
-  it("returns undefined when no recognized key holds a string", () => {
+  it("returns undefined when no recognized key holds a string", async () => {
     expect(extractErrorDetail({ unrelated: "x" })).toBeUndefined();
     expect(extractErrorDetail({ message: 42 })).toBeUndefined();
   });
 });
 
 describe("CliError with code", () => {
-  it("preserves the code property", () => {
+  it("preserves the code property", async () => {
     const err = new CliError(
       "msg",
       undefined,
@@ -395,5 +395,81 @@ describe("CliError with code", () => {
       ERROR_AUTH_EXPIRED
     );
     expect(err.code).toBe(ERROR_AUTH_EXPIRED);
+  });
+});
+
+describe("handleCommandError flushes telemetry before exit (#145)", () => {
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("awaits Telemetry.flushAndShutdown() before process.exit", async () => {
+    const { getTelemetry } = await import("@pax8/core");
+    const tel = getTelemetry();
+
+    // Order-of-operations spy: flushAndShutdown must complete before exit.
+    const callOrder: string[] = [];
+    let resolveFlush: () => void = () => {};
+    const flushSpy = vi
+      .spyOn(tel, "flushAndShutdown")
+      .mockImplementation(() => {
+        callOrder.push("flushAndShutdown:start");
+        return new Promise<void>((resolve) => {
+          resolveFlush = () => {
+            callOrder.push("flushAndShutdown:end");
+            resolve();
+          };
+        });
+      });
+
+    // Start the call but don't await it yet — we need to verify exit hasn't
+    // been triggered while flush is still pending.
+    const promise = handleCommandError(new CliError("boom")).catch(() => {
+      callOrder.push("exit-throw");
+    });
+
+    // Yield to let the async function run up to the await on flush.
+    await new Promise((r) => setImmediate(r));
+    expect(callOrder).toEqual(["flushAndShutdown:start"]);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    // Now release the flush. exit must follow.
+    resolveFlush();
+    await promise;
+
+    expect(callOrder).toContain("flushAndShutdown:end");
+    expect(callOrder.indexOf("flushAndShutdown:end"))
+      .toBeLessThan(callOrder.indexOf("exit-throw"));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    flushSpy.mockRestore();
+  });
+
+  it("still exits with 1 even if flushAndShutdown throws", async () => {
+    const { getTelemetry } = await import("@pax8/core");
+    const tel = getTelemetry();
+    const flushSpy = vi
+      .spyOn(tel, "flushAndShutdown")
+      .mockRejectedValue(new Error("posthog network down"));
+
+    await expect(handleCommandError(new CliError("boom"))).rejects.toThrow(
+      "process.exit intercepted",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    flushSpy.mockRestore();
   });
 });

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -12,9 +12,32 @@ import {
   ERROR_PRODUCT_NOT_FOUND,
   ERROR_RATE_LIMITED,
   ERROR_SUBSCRIPTION_NOT_FOUND,
+  getTelemetry,
   type Pax8ErrorCode,
 } from "@pax8/core";
 import { replCmd } from "./confirm.js";
+
+/**
+ * Flush buffered telemetry and shut down the PostHog client before the CLI
+ * exits. Bounded by a 2s timeout so a hung egress can never stall the user.
+ * No-op fast path when telemetry is disabled (the default), so opt-out users
+ * pay nothing for this guarantee. Errors are swallowed — telemetry must
+ * never crash the CLI.
+ *
+ * Exported so the top-level signal/error handlers in `index.ts` can reuse
+ * the same flush-before-exit semantics.
+ *
+ * See #145 — without this, the in-memory PostHog buffer was being dropped
+ * by `process.exit(1)` on every error path, making PostHog dashboards
+ * report ~100% success regardless of reality.
+ */
+export async function flushTelemetryBeforeExit(timeoutMs = 2000): Promise<void> {
+  try {
+    await getTelemetry().flushAndShutdown(timeoutMs);
+  } catch {
+    // Telemetry must never crash the CLI.
+  }
+}
 
 export class CliError extends Error {
   constructor(
@@ -174,11 +197,11 @@ function buildErrorEnvelope(error: unknown, context?: string): ErrorEnvelope {
   };
 }
 
-export function handleCommandError(
+export async function handleCommandError(
   error: unknown,
   spinner?: Ora,
   context?: string,
-): never {
+): Promise<never> {
   // Stop spinner if active
   if (spinner) {
     try {
@@ -192,6 +215,9 @@ export function handleCommandError(
   if (isJsonOutputRequested()) {
     const envelope = buildErrorEnvelope(error, context);
     process.stderr.write(JSON.stringify(envelope, null, 2) + "\n");
+    // Flush telemetry before exit (#145) so failure events actually reach
+    // PostHog. Bounded by a 2s timeout in flushAndShutdown.
+    await flushTelemetryBeforeExit();
     process.exit(1);
 
     // Honor never return contract when process.exit is mocked
@@ -263,6 +289,9 @@ export function handleCommandError(
     );
   }
 
+  // Flush telemetry before exit (#145) so failure events actually reach
+  // PostHog. Bounded by a 2s timeout in flushAndShutdown.
+  await flushTelemetryBeforeExit();
   process.exit(1);
 
   // If process.exit was overridden (e.g. REPL mode), throw to stop execution.

--- a/packages/cli/src/lib/instrumented-action.test.ts
+++ b/packages/cli/src/lib/instrumented-action.test.ts
@@ -127,3 +127,166 @@ describe("instrumentedAction", () => {
     await expect(wrapped({})).rejects.toThrow("test error");
   });
 });
+
+/**
+ * #146 — write commands (recommendations act, orders create) used to fire two
+ * `command_executed` events: one from the `postAction` hook in index.ts, and
+ * one manually inside the handler to attach aggregate counters. These tests
+ * pin the new invariant: handlers contribute via `setTelemetryFields()`, the
+ * postAction hook merges those fields into its single canonical track call.
+ *
+ * We don't run the whole Commander program here — we exercise the merge
+ * contract directly. The integration is small enough that a unit test is
+ * the right grain.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any -- accessing private members for testing */
+describe("postAction telemetry merge (#146)", () => {
+  beforeEach(async () => {
+    const { resetTelemetry } = await import("@pax8/core");
+    resetTelemetry();
+  });
+
+  afterEach(async () => {
+    const { _resetTelemetryFields } = await import("./telemetry-context.js");
+    _resetTelemetryFields();
+  });
+
+  it("merges setTelemetryFields contributions into a single command_executed event", async () => {
+    const { setTelemetryFields, consumeTelemetryFields } = await import(
+      "./telemetry-context.js"
+    );
+    const { getTelemetry } = await import("@pax8/core");
+
+    // Simulate a `recommendations act` handler contributing fields.
+    setTelemetryFields({
+      recs_presented: 3,
+      recs_ordered: 2,
+      recs_skipped: 1,
+      recs_mrr_captured: 250,
+    });
+
+    // Mimic exactly what the postAction hook does: drain + merge into the
+    // intrinsic event shape and emit ONE track() call.
+    const telemetry = getTelemetry();
+    (telemetry as any).enabled = true;
+
+    const handlerProps = consumeTelemetryFields();
+    const intrinsic = {
+      event: "command_executed" as const,
+      command: "recommendations",
+      subcommand: "recommendations.act",
+      flags: ["--priority"],
+      duration_ms: 42,
+      success: true,
+      cli_version: "0.1.0",
+      node_version: process.version,
+      os: process.platform,
+      demo_mode: false,
+    };
+    telemetry.track({ ...intrinsic, ...handlerProps });
+
+    const buffer = (telemetry as any).buffer as unknown[];
+    expect(buffer).toHaveLength(1);
+    const evt = buffer[0] as Record<string, unknown>;
+    // command/subcommand match the README #134 contract: top-level group +
+    // dotted path. No more `command: "recommendations.act"` from the manual
+    // track() call.
+    expect(evt.command).toBe("recommendations");
+    expect(evt.subcommand).toBe("recommendations.act");
+    // Aggregate counters come along on the same event.
+    expect(evt.recs_presented).toBe(3);
+    expect(evt.recs_ordered).toBe(2);
+    expect(evt.recs_skipped).toBe(1);
+    expect(evt.recs_mrr_captured).toBe(250);
+    // And the intrinsic props are still present.
+    expect(evt.success).toBe(true);
+    expect(evt.duration_ms).toBe(42);
+  });
+
+  it("merges orders.create revenue counters into a single event", async () => {
+    const { setTelemetryFields, consumeTelemetryFields } = await import(
+      "./telemetry-context.js"
+    );
+    const { getTelemetry } = await import("@pax8/core");
+
+    setTelemetryFields({
+      order_success: true,
+      order_total_dollars: 500,
+      order_mrr_impact: 50,
+      order_seats: 10,
+    });
+
+    const telemetry = getTelemetry();
+    (telemetry as any).enabled = true;
+
+    const handlerProps = consumeTelemetryFields();
+    telemetry.track({
+      event: "command_executed",
+      command: "orders",
+      subcommand: "orders.create",
+      flags: [],
+      duration_ms: 100,
+      success: true,
+      cli_version: "0.1.0",
+      node_version: process.version,
+      os: process.platform,
+      demo_mode: false,
+      ...handlerProps,
+    });
+
+    const buffer = (telemetry as any).buffer as unknown[];
+    expect(buffer).toHaveLength(1);
+    const evt = buffer[0] as Record<string, unknown>;
+    expect(evt.command).toBe("orders");
+    expect(evt.subcommand).toBe("orders.create");
+    expect(evt.order_success).toBe(true);
+    expect(evt.order_total_dollars).toBe(500);
+    expect(evt.order_mrr_impact).toBe(50);
+    expect(evt.order_seats).toBe(10);
+  });
+
+  it("a regular read-only command with no setTelemetryFields fires exactly one event with no extra props", async () => {
+    const { consumeTelemetryFields } = await import("./telemetry-context.js");
+    const { getTelemetry } = await import("@pax8/core");
+
+    const telemetry = getTelemetry();
+    (telemetry as any).enabled = true;
+
+    const handlerProps = consumeTelemetryFields(); // empty
+    telemetry.track({
+      event: "command_executed",
+      command: "companies",
+      subcommand: "companies.list",
+      flags: ["--json"],
+      duration_ms: 25,
+      success: true,
+      cli_version: "0.1.0",
+      node_version: process.version,
+      os: process.platform,
+      demo_mode: false,
+      ...handlerProps,
+    });
+
+    const buffer = (telemetry as any).buffer as unknown[];
+    expect(buffer).toHaveLength(1);
+    const evt = buffer[0] as Record<string, unknown>;
+    expect(evt.command).toBe("companies");
+    expect(evt.subcommand).toBe("companies.list");
+    expect(evt.recs_presented).toBeUndefined();
+    expect(evt.order_seats).toBeUndefined();
+  });
+
+  it("a leftover handlerProp from one consume does NOT leak to the next event", async () => {
+    const { setTelemetryFields, consumeTelemetryFields } = await import(
+      "./telemetry-context.js"
+    );
+
+    setTelemetryFields({ recs_presented: 5 });
+    const first = consumeTelemetryFields();
+    const second = consumeTelemetryFields();
+
+    expect(first).toEqual({ recs_presented: 5 });
+    expect(second).toEqual({});
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/cli/src/lib/signals.test.ts
+++ b/packages/cli/src/lib/signals.test.ts
@@ -90,16 +90,24 @@ describe("installSigintHandler — capture and invoke", () => {
     expect(sigintHandler).not.toBeNull();
   });
 
-  it("on first SIGINT exits with code 130", () => {
+  // The first-SIGINT path now awaits a bounded telemetry flush before
+  // exiting (#145), so `process.exit(130)` lands on a microtask rather
+  // than synchronously. Tests yield with an explicit microtask hop.
+  const settle = (): Promise<void> =>
+    new Promise((resolve) => setImmediate(resolve));
+
+  it("on first SIGINT exits with code 130", async () => {
     expect(sigintHandler).not.toBeNull();
     sigintHandler!();
+    await settle();
     expect(exitSpy).toHaveBeenCalledWith(130);
   });
 
-  it("on second SIGINT also exits with 130 (Node default takes over)", () => {
+  it("on second SIGINT also exits with 130 (Node default takes over)", async () => {
     expect(sigintHandler).not.toBeNull();
     sigintHandler!();
     sigintHandler!();
+    await settle();
     expect(exitSpy).toHaveBeenCalledTimes(2);
     expect(exitSpy).toHaveBeenLastCalledWith(130);
   });
@@ -110,6 +118,7 @@ describe("installSigintHandler — capture and invoke", () => {
     fresh.markWriteInFlight("orders", "(idempotency-key=xyz)");
 
     sigintHandler!();
+    await settle();
 
     const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
     expect(written).toContain("(cancelled)");
@@ -118,9 +127,10 @@ describe("installSigintHandler — capture and invoke", () => {
     expect(exitSpy).toHaveBeenCalledWith(130);
   });
 
-  it("on first SIGINT without an in-flight write skips the (cancelled) hint", () => {
+  it("on first SIGINT without an in-flight write skips the (cancelled) hint", async () => {
     expect(sigintHandler).not.toBeNull();
     sigintHandler!();
+    await settle();
     const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
     expect(written).not.toContain("(cancelled)");
     expect(exitSpy).toHaveBeenCalledWith(130);

--- a/packages/cli/src/lib/signals.ts
+++ b/packages/cli/src/lib/signals.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { getTelemetry } from "@pax8/core";
 import { stopAllActiveSpinners } from "./spinner.js";
 
 /**
@@ -111,6 +112,14 @@ export function installSigintHandler(): void {
       }
     }
 
-    process.exit(130);
+    // Best-effort telemetry flush before exit (#145). flushAndShutdown is a
+    // no-op fast path when telemetry is disabled, so opt-out users pay no
+    // latency. Bounded internally by a 1s timeout for the SIGINT path —
+    // tighter than the regular error path because the user is actively
+    // hitting Ctrl+C and expects an immediate exit.
+    void getTelemetry()
+      .flushAndShutdown(1000)
+      .catch(() => {})
+      .finally(() => process.exit(130));
   });
 }

--- a/packages/cli/src/lib/telemetry-context.test.ts
+++ b/packages/cli/src/lib/telemetry-context.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  setTelemetryFields,
+  consumeTelemetryFields,
+  _resetTelemetryFields,
+} from "./telemetry-context.js";
+
+describe("telemetry-context", () => {
+  beforeEach(() => {
+    _resetTelemetryFields();
+  });
+
+  it("returns an empty object when nothing has been set", () => {
+    expect(consumeTelemetryFields()).toEqual({});
+  });
+
+  it("captures fields contributed by a handler", () => {
+    setTelemetryFields({ recs_presented: 7, recs_ordered: 2 });
+    expect(consumeTelemetryFields()).toEqual({
+      recs_presented: 7,
+      recs_ordered: 2,
+    });
+  });
+
+  it("merges across multiple setTelemetryFields calls (later wins on collision)", () => {
+    setTelemetryFields({ order_seats: 1 });
+    setTelemetryFields({ order_seats: 5, order_total_dollars: 100 });
+    expect(consumeTelemetryFields()).toEqual({
+      order_seats: 5,
+      order_total_dollars: 100,
+    });
+  });
+
+  it("drops undefined values so callers can pass optional values through", () => {
+    setTelemetryFields({ order_mrr_impact: undefined, order_seats: 3 });
+    expect(consumeTelemetryFields()).toEqual({ order_seats: 3 });
+  });
+
+  it("consume drains state — a second consume returns an empty object", () => {
+    setTelemetryFields({ recs_mrr_captured: 42 });
+    expect(consumeTelemetryFields()).toEqual({ recs_mrr_captured: 42 });
+    expect(consumeTelemetryFields()).toEqual({});
+  });
+
+  it("consume returns a fresh object the caller owns", () => {
+    setTelemetryFields({ a: 1 });
+    const first = consumeTelemetryFields();
+    setTelemetryFields({ b: 2 });
+    const second = consumeTelemetryFields();
+    expect(first).toEqual({ a: 1 });
+    expect(second).toEqual({ b: 2 });
+  });
+});

--- a/packages/cli/src/lib/telemetry-context.ts
+++ b/packages/cli/src/lib/telemetry-context.ts
@@ -1,0 +1,55 @@
+/**
+ * Request-scoped telemetry fields contributed by command handlers.
+ *
+ * Background (#146): Most commands fire exactly one `command_executed` event
+ * via the program-level `postAction` hook in `index.ts`. A handful of write
+ * commands (`recommendations act`, `orders create`) used to call
+ * `getTelemetry().track()` directly to attach aggregate counters
+ * (`recs_mrr_captured`, `order_total_dollars`, `order_seats`, etc.) the
+ * generic hook didn't know about. That double-fired the event with two
+ * different `command` shapes (top-level vs dotted), corrupting any
+ * `count(*) GROUP BY command` analysis in PostHog.
+ *
+ * The fix: handlers write the extra fields here via `setTelemetryFields`,
+ * and the `postAction` hook drains them via `consumeTelemetryFields` and
+ * merges them into its single canonical `track()` call. One event per
+ * command run, with all the props.
+ *
+ * Scope is process-global because only one Commander action runs per CLI
+ * invocation. We `consume` (read + reset) inside postAction so a long-lived
+ * REPL parent process can't accidentally leak fields from one subprocess to
+ * the next.
+ */
+
+let pending: Record<string, unknown> = {};
+
+/**
+ * Merge additional telemetry fields into the pending event. Safe to call
+ * multiple times in one command run — later calls win on key collision,
+ * matching `Object.assign` semantics. Pass `undefined` to explicitly omit
+ * (callers that compute optional values can pass them through without an
+ * `if`).
+ */
+export function setTelemetryFields(fields: Record<string, unknown>): void {
+  for (const [k, v] of Object.entries(fields)) {
+    if (v !== undefined) {
+      pending[k] = v;
+    }
+  }
+}
+
+/**
+ * Take and clear the pending fields. Returns a fresh object the caller
+ * owns; the internal state is reset to empty so the next command starts
+ * clean.
+ */
+export function consumeTelemetryFields(): Record<string, unknown> {
+  const out = pending;
+  pending = {};
+  return out;
+}
+
+/** Test hook — reset state without consuming. */
+export function _resetTelemetryFields(): void {
+  pending = {};
+}

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -147,6 +147,69 @@ describe("Telemetry", () => {
     await expect(fs.access(tmpDir)).rejects.toThrow();
   });
 
+  it("flushAndShutdown is a no-op fast path when telemetry is disabled (#145)", async () => {
+    const t = new Telemetry();
+    expect(t.isEnabled()).toBe(false);
+
+    // Stub a posthog with a shutdown that would hang for a long time. The
+    // disabled fast path must skip it entirely so opt-out users pay no
+    // latency.
+    let posthogShutdownCalled = false;
+    (t as any).posthog = {
+      shutdown: () => {
+        posthogShutdownCalled = true;
+        return new Promise(() => {}); // never resolves
+      },
+    };
+
+    const start = Date.now();
+    await t.flushAndShutdown(2000);
+    const elapsed = Date.now() - start;
+
+    expect(posthogShutdownCalled).toBe(false);
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it("flushAndShutdown is bounded by the timeout when posthog hangs (#145)", async () => {
+    const t = new Telemetry();
+    (t as any).enabled = true;
+    // Buffer something so flush() actually runs.
+    t.track(makeEvent());
+
+    // Hanging shutdown — must not wedge the CLI on exit.
+    (t as any).posthog = {
+      capture: () => {},
+      flush: async () => {},
+      shutdown: () => new Promise(() => {}),
+    };
+
+    const start = Date.now();
+    await t.flushAndShutdown(50);
+    const elapsed = Date.now() - start;
+
+    // Allow some slack for CI; the point is "doesn't take seconds".
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it("flushAndShutdown awaits a fast posthog shutdown to completion (#145)", async () => {
+    const t = new Telemetry();
+    (t as any).enabled = true;
+    t.track(makeEvent());
+
+    let shutdownCalled = false;
+    (t as any).posthog = {
+      capture: () => {},
+      flush: async () => {},
+      shutdown: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        shutdownCalled = true;
+      },
+    };
+
+    await t.flushAndShutdown(2000);
+    expect(shutdownCalled).toBe(true);
+  });
+
   it("never includes sensitive data in events", () => {
     const event = makeEvent({
       flags: ["--company", "--json"],

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -212,6 +212,41 @@ export class Telemetry {
       this.posthog = null;
     }
   }
+
+  /**
+   * Flush any buffered events and shut down the PostHog client, bounded by
+   * `timeoutMs`. Used on the error-exit path so a hung PostHog connection
+   * cannot stall the user's CLI before `process.exit`.
+   *
+   * Returns immediately (a resolved promise) when telemetry is disabled —
+   * opt-out users pay no latency.
+   */
+  async flushAndShutdown(timeoutMs = 2000): Promise<void> {
+    if (!this.enabled) return;
+    if (this.buffer.length === 0 && !this.posthog) return;
+
+    const work = (async (): Promise<void> => {
+      try {
+        await this.flush();
+      } catch {
+        // flush() already swallows internally; defensive belt + suspenders.
+      }
+      await this.shutdown();
+    })();
+
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, timeoutMs);
+      // Don't keep the event loop alive on our account.
+      timer.unref?.();
+    });
+
+    try {
+      await Promise.race([work, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
 }
 
 // Singleton


### PR DESCRIPTION
## Summary

Two correctness fixes from the telemetry review (#144). Separate commits so each can be reviewed independently.

### Closes
- #145 — silent error events (release blocker for honest analytics)
- #146 — double-fire on recommendations act / orders create

## Approach

### Commit 1 — #145 flush before exit

- New `Telemetry.flushAndShutdown(timeoutMs)` on `@pax8/core` wraps `posthog.shutdown()`. Disabled telemetry takes a zero-cost fast path; an `AbortController`-style `Promise.race` bounds the wait at 2s so a hung egress can never wedge the user's CLI.
- `handleCommandError` is now `async` and `await`s `flushAndShutdown` immediately before `process.exit(1)`. All ~50 call sites across the command tree updated to `await handleCommandError(...)`.
- SIGINT path threads through the same flush (1s budget — Ctrl+C should feel snappy).
- Added top-level `uncaughtException` and `unhandledRejection` handlers that route through `handleCommandError`, so crashes that escape `parseAsync.catch` still emit a failure event.
- Tests: a flush-order-of-operations test (process.exit must NOT be called while flush is pending) and a posthog-throws test (still exits 1).

### Commit 2 — #146 single event per command

- New `lib/telemetry-context.ts` with `setTelemetryFields()` / `consumeTelemetryFields()` request-scoped state.
- The `postAction` hook in `index.ts` drains pending fields and merges them into its single canonical `track()` call.
- `recommendations act` and `orders create` drop their manual `getTelemetry().track()` calls in favor of `setTelemetryFields()`. `command` is now always the top-level group; `subcommand` is the dotted path — matches the README #134 contract.
- Backwards-compatible: the majority of commands that need no extra props are unchanged.

## Test plan

- [x] `pnpm -r exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors / 0 warnings
- [x] `PAX8_DEMO=1 NO_COLOR=1 pnpm test` — 951 passing (was 936, +15 new)
- [x] `pnpm test:coverage` — gate green
- [x] New tests added for each behavior change (flush-before-exit ordering, single-event merge invariant, telemetry-context module)
- [x] Manual repro of both bugs confirmed fixed under `PAX8_DEMO=1`

## Followups not in this PR

- The `instrumentedAction` wrapper in `lib/instrumented-action.ts` is still exported but unused — its built-in `track()` call hasn't been touched. Candidate for cleanup or for adoption by commands that want the wrapper-level guarantee.
- Issue #145 mentions adding `program.exitOverride()` so Commander parse errors throw rather than process-exit. Out of scope here — that's a separate, larger change to error handling and would deserve its own PR.
- The `command_executed` payload built in `parseAsync.catch` (top-level error path in `index.ts`) duplicates much of the postAction shape; could be unified with the same merge-via-context plumbing in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)