### PR TITLE
feat: pax8 cost sim — model SKU/quantity changes before ordering (closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Initial public release.
 - **Idempotency keys on write commands** — `--idempotency-key <uuid>` is accepted on every mutation command (#91).
 - **Machine-readable error codes** — every `CliError` carries a stable `code` (one of the `ERROR_*` constants from `@pax8/core`) so agents and scripts can branch on outcome without parsing strings (#90).
 - **Output formats** — `--json`, `--csv`, `--quiet`, plus `--with-actions` (envelope mode) and `--ids-only` (one ID per line, for piping into the next command's `--company` filter).
+- **Cost simulator (`pax8 cost sim`)** — model SKU swaps, quantity changes, and add-product scenarios with monthly/annual MRR delta, before actually placing the order. Pure compute over pricing data; `simulateCostChange()` is also exported from `@pax8/core` for embedders (#3).
 - **Vitest test suite** — ~840 tests across unit, CLI integration (subprocess), and e2e flows, runnable end-to-end under `PAX8_DEMO=1`.
 
 [0.1.0]: https://github.com/pax8labs/pax8-cli/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ When the user asks ANYTHING about Pax8 data (companies, subscriptions, MRR, reco
 | invoices / billing | `pax8 invoices list --json 2>/dev/null` |
 | invoice audit | `pax8 invoices audit --json 2>/dev/null` |
 | products / catalog | `pax8 products search "query" --json 2>/dev/null` |
+| cost sim / what if / pricing change / SKU swap | `pax8 cost sim --company <name> --product <name> --quantity <n> --json 2>/dev/null` |
 | place an order | `pax8 orders create --company <id> --product <id> --quantity <n>` (confirm first) |
 | act on a recommendation | Extract `orderCommand` from `pax8 recommendations list --json` and run it (confirm first), or use `pax8 recommendations act` for the interactive flow |
 | invoice dispute | `pax8 invoices dispute --discrepancy <id>` (id from `invoices audit`) |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ pax8 orders show <id>                                  # Check order status
 
 The order preview shows unit price, total, and MRR impact before you confirm.
 
+### Cost Simulation
+
+```bash
+pax8 cost sim --company "Acme Corp" --product "M365 Business Premium" --quantity 50
+pax8 cost sim --company "Acme" --product "M365 Business Premium" --from "M365 Business Basic" --quantity 45
+pax8 cost sim --company "Acme" --product "AvePoint Cloud Backup" --quantity 30 --json
+```
+
+Model the financial impact of a SKU swap, quantity change, or new-product add before placing the order. The output shows current and proposed monthly/annual cost, the delta, and a per-seat breakdown — pure compute over existing pricing data, no writes.
+
 ### Invoices
 
 ```bash

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -21,6 +21,7 @@ These never mutate state. Run them freely, in parallel, and as often as needed.
 - `pax8 subscriptions renewals` — computes renewals from existing data
 - `pax8 invoices items` — line items for an invoice
 - `pax8 invoices audit` — read-only computation, no writes
+- `pax8 cost sim` — what-if pricing simulation, no writes
 - `pax8 status`, `pax8 status --all|--renewals|--growth`
 - `pax8 doctor` — diagnostics only
 - `pax8 webhooks logs <id>` — delivery history (read-only)
@@ -87,6 +88,7 @@ pax8 recommendations list --json [--priority high|medium|low] [--company <id|nam
 pax8 recommendations act [--company <id|name>] [--product <name>]    # interactive — only for human-in-the-loop sessions
 pax8 orders list --json
 pax8 orders create --company <id|name> --product <id|name> --quantity <n> [--billing-term Monthly|Annual]
+pax8 cost sim --company <id|name> --product <id|name> --quantity <n> [--from <id|name>] [--billing-term Monthly|Annual] --json
 pax8 report mrr --json
 pax8 report growth --json
 pax8 doctor                                                  # diagnostics, not for data
@@ -129,6 +131,12 @@ pax8 report mrr --json
 pax8 companies list --json
 ```
 `report mrr` already breaks down by company. Lead with total MRR and top 5 customers; offer per-vendor or per-product breakdown if the user asks.
+
+### "What if?" — cost simulation
+```
+pax8 cost sim --company "<name>" --product "<name>" --quantity <n> --json
+```
+Use for SKU swaps (`--from "<current sku>"`), quantity changes (omit `--from`; the CLI auto-detects the existing subscription), or add-new (no current subscription). Lead with the delta number — "+$N/mo" or "−$N/mo" — and mention the per-seat impact when seats are unchanged. Read-only; no order is placed.
 
 ### "Who's missing X?" (cross-sell)
 ```

--- a/packages/cli/src/__tests__/cost.test.ts
+++ b/packages/cli/src/__tests__/cost.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+
+describe("pax8 cost", () => {
+  describe("cost --help", () => {
+    it("shows the sim subcommand", async () => {
+      const result = await runCliExpectSuccess(["cost", "--help"]);
+      expect(result.stdout).toContain("sim");
+    });
+
+    it("describes the cost group as no-write / what-if", async () => {
+      const result = await runCliExpectSuccess(["cost", "--help"]);
+      // Top-level group description should hint that this is read-only
+      expect(result.stdout.toLowerCase()).toMatch(/cost|simul|what.?if/);
+    });
+  });
+
+  describe("cost sim --help", () => {
+    it("shows the documented flags", async () => {
+      const result = await runCliExpectSuccess(["cost", "sim", "--help"]);
+      expect(result.stdout).toContain("--company");
+      expect(result.stdout).toContain("--product");
+      expect(result.stdout).toContain("--quantity");
+      expect(result.stdout).toContain("--from");
+      expect(result.stdout).toContain("--billing-term");
+      expect(result.stdout).toContain("Examples:");
+    });
+  });
+
+  describe("cost sim — JSON output", () => {
+    it("returns a structured simulation result for an SKU swap", async () => {
+      const result = await runCliExpectSuccess([
+        "cost",
+        "sim",
+        "--company",
+        "Bright Minds Academy",
+        "--product",
+        "Microsoft 365 Business Premium",
+        "--from",
+        "Microsoft 365 Business Basic",
+        "--quantity",
+        "25",
+        "--billing-term",
+        "Monthly",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.companyName).toBe("Bright Minds Academy");
+      expect(data.current).not.toBeNull();
+      expect(data.current.productName).toMatch(/Business Basic/);
+      expect(data.proposed.productName).toMatch(/Business Premium/);
+      expect(data.proposed.quantity).toBe(25);
+      // Premium $22 × 25 = 550/mo; Basic $6 × 25 = 150/mo → delta 400/mo
+      expect(data.current.monthly).toBe(150);
+      expect(data.proposed.monthly).toBe(550);
+      expect(data.delta.monthly).toBe(400);
+      expect(data.delta.annual).toBe(4800);
+      expect(Array.isArray(data.nextActions)).toBe(true);
+      expect(data.nextActions[0].command).toMatch(/pax8 orders create/);
+    });
+
+    it("auto-detects existing subscription when --from is omitted (qty change)", async () => {
+      // Pinnacle has Premium @ 15 seats Annual @ $22. Bumping to 25 seats.
+      const result = await runCliExpectSuccess([
+        "cost",
+        "sim",
+        "--company",
+        "Pinnacle Financial Advisors",
+        "--product",
+        "Microsoft 365 Business Premium",
+        "--quantity",
+        "25",
+        "--billing-term",
+        "Annual",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.current).not.toBeNull();
+      expect(data.current.quantity).toBe(15);
+      expect(data.proposed.quantity).toBe(25);
+      // Annual: 22 × 15 / 12 = 27.5/mo current; 22 × 25 / 12 = 45.83/mo proposed
+      expect(data.current.monthly).toBeCloseTo(27.5, 2);
+      expect(data.proposed.monthly).toBeCloseTo(45.83, 2);
+      expect(data.delta.monthly).toBeGreaterThan(0);
+    });
+
+    it("treats unknown product+company combo as add-new (no current)", async () => {
+      // Bright Minds Academy doesn't have AvePoint Cloud Backup.
+      const result = await runCliExpectSuccess([
+        "cost",
+        "sim",
+        "--company",
+        "Bright Minds Academy",
+        "--product",
+        "AvePoint Cloud Backup",
+        "--quantity",
+        "20",
+        "--billing-term",
+        "Monthly",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.current).toBeNull();
+      expect(data.proposed.quantity).toBe(20);
+      expect(data.delta.monthly).toBe(data.proposed.monthly);
+    });
+  });
+
+  describe("cost sim — CSV output", () => {
+    it("returns one row per scenario field", async () => {
+      const result = await runCliExpectSuccess([
+        "cost",
+        "sim",
+        "--company",
+        "Bright Minds Academy",
+        "--product",
+        "Microsoft 365 Business Premium",
+        "--from",
+        "Microsoft 365 Business Basic",
+        "--quantity",
+        "25",
+        "--billing-term",
+        "Monthly",
+        "--csv",
+      ]);
+      const lines = result.stdout.trim().split("\n");
+      // Header + current + proposed + delta = 4 lines minimum
+      expect(lines.length).toBeGreaterThanOrEqual(4);
+      expect(lines[0]).toContain("Scenario");
+      expect(lines[0]).toContain("Monthly");
+      expect(result.stdout).toContain("current");
+      expect(result.stdout).toContain("proposed");
+      expect(result.stdout).toContain("delta");
+    });
+  });
+
+  describe("cost sim — default (non-TTY) output", () => {
+    it("falls back to JSON when stdout isn't a TTY", async () => {
+      // Subprocess tests run with no TTY, so the CLI's getOutputFormat()
+      // contract is to emit JSON. Confirm the contract holds for cost sim.
+      const result = await runCliExpectSuccess([
+        "cost",
+        "sim",
+        "--company",
+        "Bright Minds Academy",
+        "--product",
+        "Microsoft 365 Business Premium",
+        "--from",
+        "Microsoft 365 Business Basic",
+        "--quantity",
+        "25",
+        "--billing-term",
+        "Monthly",
+      ]);
+      // Should parse as JSON without an explicit --json flag
+      const data = JSON.parse(result.stdout);
+      expect(data.companyName).toBe("Bright Minds Academy");
+      expect(data.delta.monthly).toBe(400);
+    });
+  });
+
+  describe("cost sim — error cases", () => {
+    it("errors when --company is missing", async () => {
+      const result = await runCliExpectFailure([
+        "cost",
+        "sim",
+        "--product",
+        "Microsoft 365 Business Premium",
+        "--quantity",
+        "10",
+      ]);
+      expect(result.stderr).toContain("--company");
+    });
+
+    it("errors when --product is missing", async () => {
+      const result = await runCliExpectFailure([
+        "cost",
+        "sim",
+        "--company",
+        "Bright Minds Academy",
+        "--quantity",
+        "10",
+      ]);
+      expect(result.stderr).toContain("--product");
+    });
+
+    it("errors on unknown company", async () => {
+      const result = await runCliExpectFailure([
+        "cost",
+        "sim",
+        "--company",
+        "Nonexistent Company XYZ",
+        "--product",
+        "Microsoft 365 Business Premium",
+        "--quantity",
+        "10",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined.toLowerCase()).toMatch(/company|not found/);
+    });
+
+    it("errors on unknown product", async () => {
+      const result = await runCliExpectFailure([
+        "cost",
+        "sim",
+        "--company",
+        "Bright Minds Academy",
+        "--product",
+        "ZZZ Bogus Product Name",
+        "--quantity",
+        "10",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined.toLowerCase()).toMatch(/product|not found/);
+    });
+
+    it("errors on negative quantity", async () => {
+      const result = await runCliExpectFailure([
+        "cost",
+        "sim",
+        "--company",
+        "Bright Minds Academy",
+        "--product",
+        "Microsoft 365 Business Premium",
+        "--quantity",
+        "-5",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined.toLowerCase()).toMatch(/quantity|invalid/);
+    });
+  });
+});

--- a/packages/cli/src/commands/cost/index.ts
+++ b/packages/cli/src/commands/cost/index.ts
@@ -1,0 +1,12 @@
+import { Command } from "commander";
+import { costSimCommand } from "./sim.js";
+
+export function registerCostCommands(program: Command): void {
+  const cost = new Command("cost").description(
+    "Cost simulations and what-if analysis (no writes)",
+  );
+
+  cost.addCommand(costSimCommand);
+
+  program.addCommand(cost);
+}

--- a/packages/cli/src/commands/cost/sim.ts
+++ b/packages/cli/src/commands/cost/sim.ts
@@ -1,0 +1,344 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError, CliError } from "../../lib/errors.js";
+import { buildContext } from "../../lib/context.js";
+import { replCmd } from "../../lib/confirm.js";
+import { formatCurrency } from "../../lib/formatters.js";
+import { output } from "../../lib/output.js";
+import {
+  ERROR_INVALID_INPUT,
+  simulateCostChange,
+  ALL_SUBS_PAGE_SIZE,
+  type SimulationInput,
+  type SimulationResult,
+} from "@pax8/core";
+import type { Subscription } from "@pax8/core";
+import { resolveCompany } from "../../lib/resolve-company.js";
+import { resolveProduct } from "../../lib/resolve-product.js";
+
+/**
+ * Pick the most plausible "current" subscription for a company × product pair.
+ * Prefers Active subscriptions; falls back to the first match of any status.
+ */
+function pickCurrentSubscription(
+  subs: Subscription[],
+  productId: string,
+): Subscription | undefined {
+  const matching = subs.filter((s) => s.productId === productId);
+  if (matching.length === 0) return undefined;
+  return (
+    matching.find((s) => (s.status ?? "").toLowerCase() === "active") ??
+    matching[0]
+  );
+}
+
+function deltaSign(n: number): string {
+  if (n > 0) return "+";
+  if (n < 0) return ""; // formatCurrency handles the leading '-'
+  return "";
+}
+
+export const costSimCommand = new Command("sim")
+  .description("Simulate the financial impact of a subscription change before placing the order")
+  .requiredOption("--company <id|name>", "Company ID or name (required)")
+  .requiredOption("--product <id|name>", "Proposed product ID or name (required)")
+  .option("--quantity <number>", "Proposed quantity", "1")
+  .option(
+    "--from <id|name>",
+    "Current product (for SKU swaps). Omit to model a quantity change on --product, or to model an add-new.",
+  )
+  .option(
+    "--from-quantity <number>",
+    "Current quantity. Defaults to the existing subscription's quantity, or 0 if no current subscription.",
+  )
+  .option(
+    "--billing-term <term>",
+    "Billing term for the proposed subscription (Monthly or Annual)",
+    "Annual",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  # Bump M365 Business Premium from current quantity to 50 seats
+  pax8 cost sim --company "Pinnacle Financial Advisors" --product "M365 Business Premium" --quantity 50
+
+  # Upgrade SKU: Business Basic → Business Premium, keep 25 seats
+  pax8 cost sim --company "Bright Minds Academy" --product "M365 Business Premium" --from "M365 Business Basic" --quantity 25
+
+  # Add a brand-new product (no current subscription)
+  pax8 cost sim --company "Coastline Legal Group" --product "AvePoint Cloud Backup" --quantity 30 --json`,
+  )
+  .action(async (options, command: Command) => {
+    const allOpts = command.optsWithGlobals();
+    const spinner = createSpinner("Resolving company and product...");
+
+    try {
+      const ctx = await buildContext(allOpts);
+      const proposedQuantity = parseInt(allOpts.quantity, 10);
+
+      if (isNaN(proposedQuantity) || proposedQuantity < 0) {
+        throw new CliError(
+          `Invalid quantity: "${allOpts.quantity}"`,
+          ["Quantity must be a non-negative integer."],
+          [`Example: ${replCmd("pax8 cost sim")} --company <name> --product <name> --quantity 25`],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      spinner.start();
+
+      // Resolve company (hard requirement)
+      const company = await resolveCompany(ctx, allOpts.company);
+
+      // Resolve proposed product
+      const proposedProduct = await resolveProduct(ctx, allOpts.product);
+
+      // Fetch the company's existing subscriptions — used to:
+      //   (a) auto-detect a current subscription matching --product (when --from is omitted)
+      //   (b) pull the current quantity/price/billingTerm for the "current" leg
+      let companySubs: Subscription[] = [];
+      try {
+        const subsResult = await ctx.api.subscriptions.list({
+          companyId: company.id,
+          size: ALL_SUBS_PAGE_SIZE,
+        });
+        companySubs = subsResult.content;
+      } catch {
+        // Best-effort: if the subscriptions list fails, we can still
+        // simulate against an empty current state (i.e. add-new).
+      }
+
+      // Resolve the "current" leg.
+      let currentInput: SimulationInput["current"] | undefined;
+      if (allOpts.from) {
+        // Explicit --from: resolve it as a separate product.
+        const fromProduct = await resolveProduct(ctx, allOpts.from);
+        const existing = pickCurrentSubscription(companySubs, fromProduct.id);
+        const fromQty = allOpts.fromQuantity !== undefined
+          ? parseInt(allOpts.fromQuantity, 10)
+          : existing?.quantity ?? 0;
+        if (isNaN(fromQty) || fromQty < 0) {
+          throw new CliError(
+            `Invalid --from-quantity: "${allOpts.fromQuantity}"`,
+            ["Must be a non-negative integer."],
+            [],
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+        // Resolve current price + billingTerm. Prefer the existing
+        // subscription's actual numbers; fall back to the product's pricing.
+        let price: number | undefined = existing?.price;
+        let billingTerm: string | undefined = existing?.billingTerm;
+        if (price === undefined || billingTerm === undefined) {
+          const fromPricing = await ctx.api.products
+            .getPricing(fromProduct.id)
+            .catch(() => null);
+          const wantTerm = (billingTerm ?? "Annual").toLowerCase();
+          const plan = fromPricing?.find((p) => p.billingTerm.toLowerCase() === wantTerm)
+            ?? fromPricing?.[0];
+          if (plan) {
+            price = price ?? plan.rates?.[0]?.suggestedRetailPrice ?? 0;
+            billingTerm = billingTerm ?? plan.billingTerm;
+          }
+        }
+        currentInput = {
+          productId: fromProduct.id,
+          productName: fromProduct.name,
+          quantity: fromQty,
+          billingTerm: billingTerm ?? "Monthly",
+          price: price ?? 0,
+        };
+      } else {
+        // No --from: try to auto-detect a matching subscription on the proposed product.
+        const existing = pickCurrentSubscription(companySubs, proposedProduct.id);
+        if (existing && (existing.price !== undefined) && (existing.billingTerm !== undefined)) {
+          currentInput = {
+            productId: proposedProduct.id,
+            productName: proposedProduct.name,
+            quantity: existing.quantity ?? 0,
+            billingTerm: existing.billingTerm,
+            price: existing.price,
+          };
+        }
+        // If no existing match, currentInput stays undefined → add-new simulation.
+      }
+
+      // Fetch pricing for the proposed product
+      const proposedPricing = await ctx.api.products
+        .getPricing(proposedProduct.id)
+        .catch(() => null);
+
+      spinner.stop();
+
+      if (!proposedPricing || proposedPricing.length === 0) {
+        throw new CliError(
+          `No pricing data available for "${proposedProduct.name}"`,
+          ["The Pax8 API returned no pricing plans for this product."],
+          [
+            `View product details: ${replCmd("pax8 products show")} ${proposedProduct.id}`,
+            "Some products require contacting Pax8 for a quote — they have no public pricing.",
+          ],
+        );
+      }
+
+      let result: SimulationResult;
+      try {
+        result = simulateCostChange({
+          current: currentInput,
+          proposed: {
+            productId: proposedProduct.id,
+            productName: proposedProduct.name,
+            quantity: proposedQuantity,
+            billingTerm: allOpts.billingTerm,
+          },
+          pricing: proposedPricing,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new CliError(
+          `Simulation failed: ${msg}`,
+          [],
+          [
+            `Verify pricing exists: ${replCmd("pax8 products show")} ${proposedProduct.id}`,
+            "Or try a different --billing-term (Monthly | Annual).",
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      // ── Output ─────────────────────────────────────────────────────────────
+
+      if (ctx.outputFormat === "quiet") return;
+
+      if (ctx.outputFormat === "json") {
+        const nextActions = [
+          {
+            command: `pax8 orders create --company "${company.name}" --product "${proposedProduct.name}" --quantity ${proposedQuantity} --billing-term ${result.proposed.billingTerm}`,
+            description: `Place this change as an order for ${company.name}`,
+          },
+        ];
+        process.stdout.write(
+          JSON.stringify(
+            {
+              companyName: company.name,
+              companyId: company.id,
+              ...result,
+              nextActions,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+        return;
+      }
+
+      if (ctx.outputFormat === "csv") {
+        const rows: Array<Record<string, string | number>> = [];
+        if (result.current) {
+          rows.push({
+            scenario: "current",
+            productName: result.current.productName,
+            billingTerm: result.current.billingTerm,
+            quantity: result.current.quantity,
+            unitPrice: result.current.unitPrice,
+            monthly: result.current.monthly,
+            annual: result.current.annual,
+          });
+        }
+        rows.push({
+          scenario: "proposed",
+          productName: result.proposed.productName,
+          billingTerm: result.proposed.billingTerm,
+          quantity: result.proposed.quantity,
+          unitPrice: result.proposed.unitPrice,
+          monthly: result.proposed.monthly,
+          annual: result.proposed.annual,
+        });
+        rows.push({
+          scenario: "delta",
+          productName: "",
+          billingTerm: "",
+          quantity: 0,
+          unitPrice: 0,
+          monthly: result.delta.monthly,
+          annual: result.delta.annual,
+        });
+        output(rows, {
+          format: "csv",
+          columns: [
+            { key: "scenario", header: "Scenario" },
+            { key: "productName", header: "Product" },
+            { key: "billingTerm", header: "Billing Term" },
+            { key: "quantity", header: "Quantity" },
+            { key: "unitPrice", header: "Unit Price" },
+            { key: "monthly", header: "Monthly" },
+            { key: "annual", header: "Annual" },
+          ],
+        });
+        return;
+      }
+
+      // Table / human-readable output
+      const title = result.current
+        ? "SKU change simulation"
+        : "Add-product simulation";
+
+      process.stdout.write(`\n  ${chalk.bold(company.name)} — ${title}\n\n`);
+
+      // Compute label width to align the columns.
+      const labelWidth = result.current ? 10 : 10; // "Current:" / "Proposed:" / "Delta:"
+
+      const renderLeg = (
+        label: string,
+        leg: { productName: string; quantity: number; monthly: number; annual: number; billingTerm: string },
+      ): string => {
+        const left = `${label.padEnd(labelWidth)}${leg.productName} × ${leg.quantity}`;
+        const monthlyStr = `${formatCurrency(leg.monthly)}/mo`;
+        const annualStr = `${formatCurrency(leg.annual)}/yr`;
+        return `  ${left.padEnd(56)}  ${chalk.cyan(monthlyStr.padEnd(14))} ${chalk.cyan(annualStr)}`;
+      };
+
+      if (result.current) {
+        process.stdout.write(renderLeg("Current:", result.current) + "\n");
+      }
+      process.stdout.write(renderLeg("Proposed:", result.proposed) + "\n");
+
+      // Delta line
+      const dMonthly = `${deltaSign(result.delta.monthly)}${formatCurrency(result.delta.monthly)}/mo`;
+      const dAnnual = `${deltaSign(result.delta.annual)}${formatCurrency(result.delta.annual)}/yr`;
+      const dPerSeat = `${deltaSign(result.delta.perSeat)}${formatCurrency(result.delta.perSeat)}/seat/mo`;
+      const deltaColor = result.delta.monthly >= 0 ? chalk.green : chalk.yellow;
+      process.stdout.write(
+        `  ${"Delta:".padEnd(labelWidth)}` +
+          `${deltaColor.bold(dMonthly)}  ${deltaColor(dAnnual)}  ${chalk.dim("(" + dPerSeat + ")")}\n`,
+      );
+
+      // Notes
+      if (result.notes.length > 0) {
+        process.stdout.write("\n");
+        for (const n of result.notes) {
+          process.stdout.write(chalk.dim(`  • ${n}\n`));
+        }
+      }
+
+      // Suggested next step
+      process.stderr.write("\n");
+      process.stderr.write(chalk.dim("  Try next:\n"));
+      process.stderr.write(
+        `    ${chalk.cyan(
+          replCmd(
+            `pax8 orders create --company "${company.name}" --product "${proposedProduct.name}" --quantity ${proposedQuantity} --billing-term ${result.proposed.billingTerm}`,
+          ),
+        )}  ${chalk.dim("place this change")}\n`,
+      );
+      process.stderr.write("\n");
+    } catch (error) {
+      spinner.stop();
+      handleCommandError(error, undefined, "Cost simulation failed");
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import { registerUsageCommands } from "./commands/usage/index.js";
 import { registerWebhooksCommands } from "./commands/webhooks/index.js";
 import { registerContactsCommands } from "./commands/contacts/index.js";
 import { registerQuotesCommands } from "./commands/quotes/index.js";
+import { registerCostCommands } from "./commands/cost/index.js";
 import { statusCommand } from "./commands/status.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { completionsCommand } from "./commands/completions.js";
@@ -96,6 +97,7 @@ export function createProgram(): Command {
   registerWebhooksCommands(program);
   registerContactsCommands(program);
   registerQuotesCommands(program);
+  registerCostCommands(program);
   program.addCommand(statusCommand);
   program.addCommand(initCommand);
   program.addCommand(doctorCommand);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -203,6 +203,18 @@ export type {
   ProductCategory,
 } from "./services/recommendations.js";
 
+export {
+  simulateCostChange,
+} from "./services/cost-simulator.js";
+export type {
+  SimulationCurrent,
+  SimulationProposed,
+  SimulationInput,
+  SimulationLeg,
+  SimulationDelta,
+  SimulationResult,
+} from "./services/cost-simulator.js";
+
 /**
  * On-disk cache for API responses, keyed by request path + params.
  *

--- a/packages/core/src/services/cost-simulator.test.ts
+++ b/packages/core/src/services/cost-simulator.test.ts
@@ -1,0 +1,444 @@
+import { describe, it, expect } from "vitest";
+import { simulateCostChange, type SimulationInput } from "./cost-simulator.js";
+import type { ProductPricingPlan } from "../api/types.js";
+
+/** Build a one-rate pricing plan for a given billing term + price. */
+function plan(
+  billingTerm: string,
+  suggestedRetailPrice: number,
+  productId: string = "prod-x",
+  productName: string = "Test Product",
+): ProductPricingPlan {
+  return {
+    productId,
+    productName,
+    billingTerm,
+    rates: [
+      {
+        partnerBuyRate: suggestedRetailPrice * 0.9,
+        suggestedRetailPrice,
+      },
+    ],
+  };
+}
+
+/** Build a multi-rate pricing plan with explicit volume tiers. */
+function tieredPlan(
+  billingTerm: string,
+  tiers: { startQuantityRange: number; suggestedRetailPrice: number }[],
+): ProductPricingPlan {
+  return {
+    productId: "prod-tiered",
+    productName: "Tiered Product",
+    billingTerm,
+    rates: tiers.map((t) => ({
+      partnerBuyRate: t.suggestedRetailPrice * 0.9,
+      suggestedRetailPrice: t.suggestedRetailPrice,
+      startQuantityRange: t.startQuantityRange,
+    })),
+  };
+}
+
+describe("simulateCostChange", () => {
+  describe("SKU upgrade — same quantity", () => {
+    it("computes delta when upgrading Business Basic → Premium", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-basic",
+          productName: "M365 Business Basic",
+          quantity: 45,
+          billingTerm: "Monthly",
+          price: 6,
+        },
+        proposed: {
+          productId: "prod-prem",
+          productName: "M365 Business Premium",
+          quantity: 45,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 22, "prod-prem", "M365 Business Premium")],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.current?.monthly).toBe(270); // 6 × 45
+      expect(result.proposed.monthly).toBe(990); // 22 × 45
+      expect(result.delta.monthly).toBe(720);
+      expect(result.delta.annual).toBe(8640);
+      expect(result.delta.perSeat).toBe(16); // 22 - 6
+    });
+
+    it("includes both billing terms in the proposed plan and picks the right one", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-basic",
+          productName: "Basic",
+          quantity: 10,
+          billingTerm: "Annual",
+          price: 60,
+        },
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Annual",
+        },
+        pricing: [
+          plan("Monthly", 22, "prod-prem", "Premium"),
+          plan("Annual", 264, "prod-prem", "Premium"),
+        ],
+      };
+
+      const result = simulateCostChange(input);
+      // Annual: 264 × 10 / 12 = 220/mo; current: 60 × 10 / 12 = 50/mo
+      expect(result.proposed.monthly).toBe(220);
+      expect(result.current?.monthly).toBe(50);
+      expect(result.delta.monthly).toBe(170);
+      expect(result.proposed.billingTerm).toBe("Annual");
+    });
+  });
+
+  describe("SKU downgrade — same quantity", () => {
+    it("returns negative delta when moving to a cheaper SKU", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 20,
+          billingTerm: "Monthly",
+          price: 22,
+        },
+        proposed: {
+          productId: "prod-basic",
+          productName: "Basic",
+          quantity: 20,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 6, "prod-basic", "Basic")],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.delta.monthly).toBe(-320); // (6 - 22) × 20
+      expect(result.delta.annual).toBe(-3840);
+      expect(result.delta.perSeat).toBe(-16);
+    });
+  });
+
+  describe("Quantity change — same SKU", () => {
+    it("handles a quantity increase", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Monthly",
+          price: 22,
+        },
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 25,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 22, "prod-prem", "Premium")],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.current?.monthly).toBe(220);
+      expect(result.proposed.monthly).toBe(550);
+      expect(result.delta.monthly).toBe(330);
+      // Quantities differ → perSeat falls back to proposed per-seat cost
+      expect(result.delta.perSeat).toBe(22);
+    });
+
+    it("handles a quantity decrease", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 100,
+          billingTerm: "Monthly",
+          price: 22,
+        },
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 60,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 22, "prod-prem", "Premium")],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.delta.monthly).toBe(-880); // (60 - 100) × 22
+    });
+  });
+
+  describe("Add new product (no current)", () => {
+    it("treats the proposed cost as the full delta", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 30,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 22, "prod-prem", "Premium")],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.current).toBeNull();
+      expect(result.proposed.monthly).toBe(660);
+      expect(result.delta.monthly).toBe(660);
+      expect(result.delta.annual).toBe(7920);
+      expect(result.delta.perSeat).toBe(22);
+    });
+
+    it("defaults to Annual term when no current and no explicit term", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+        },
+        pricing: [
+          plan("Monthly", 22, "prod-prem", "Premium"),
+          plan("Annual", 264, "prod-prem", "Premium"),
+        ],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.proposed.billingTerm).toBe("Annual");
+      expect(result.notes.some((n) => n.toLowerCase().includes("annual"))).toBe(true);
+    });
+  });
+
+  describe("Billing-term swap", () => {
+    it("notes when current and proposed billing terms differ", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Annual",
+          price: 264,
+        },
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Monthly",
+        },
+        pricing: [
+          plan("Monthly", 22, "prod-prem", "Premium"),
+          plan("Annual", 264, "prod-prem", "Premium"),
+        ],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.notes.some((n) => /Annual.*Monthly/i.test(n))).toBe(true);
+      // Annual current: 264 × 10 / 12 = 220/mo; Monthly proposed: 22 × 10 = 220/mo
+      expect(result.delta.monthly).toBe(0);
+    });
+
+    it("does not emit a swap note when terms match", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Monthly",
+          price: 22,
+        },
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 12,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 22, "prod-prem", "Premium")],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.notes.some((n) => /switching/i.test(n))).toBe(false);
+    });
+  });
+
+  describe("Volume-tier transitions", () => {
+    it("picks the rate row whose startQuantityRange <= quantity", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-tiered",
+          productName: "Tiered",
+          quantity: 75,
+          billingTerm: "Monthly",
+        },
+        pricing: [
+          tieredPlan("Monthly", [
+            { startQuantityRange: 1, suggestedRetailPrice: 10 },
+            { startQuantityRange: 50, suggestedRetailPrice: 8 },
+            { startQuantityRange: 100, suggestedRetailPrice: 6 },
+          ]),
+        ],
+      };
+
+      const result = simulateCostChange(input);
+      // 75 falls into the 50+ tier → $8/seat
+      expect(result.proposed.unitPrice).toBe(8);
+      expect(result.proposed.monthly).toBe(600);
+      expect(result.notes.some((n) => /tier/i.test(n))).toBe(true);
+    });
+
+    it("picks the entry-level rate when quantity is below all tier boundaries", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-tiered",
+          productName: "Tiered",
+          quantity: 5,
+          billingTerm: "Monthly",
+        },
+        pricing: [
+          tieredPlan("Monthly", [
+            { startQuantityRange: 1, suggestedRetailPrice: 10 },
+            { startQuantityRange: 50, suggestedRetailPrice: 8 },
+          ]),
+        ],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.proposed.unitPrice).toBe(10);
+      // Entry-level tier: should NOT emit a "tier applied" note
+      expect(result.notes.some((n) => /tier/i.test(n))).toBe(false);
+    });
+
+    it("crosses a tier boundary on quantity increase", () => {
+      const tiered = tieredPlan("Monthly", [
+        { startQuantityRange: 1, suggestedRetailPrice: 10 },
+        { startQuantityRange: 50, suggestedRetailPrice: 8 },
+      ]);
+      const input: SimulationInput = {
+        current: {
+          productId: "prod-tiered",
+          productName: "Tiered",
+          quantity: 40,
+          billingTerm: "Monthly",
+          price: 10,
+        },
+        proposed: {
+          productId: "prod-tiered",
+          productName: "Tiered",
+          quantity: 60,
+          billingTerm: "Monthly",
+        },
+        pricing: [tiered],
+      };
+
+      const result = simulateCostChange(input);
+      expect(result.current?.monthly).toBe(400); // 10 × 40
+      expect(result.proposed.monthly).toBe(480); // 8 × 60 (crossed into the cheaper tier)
+      expect(result.delta.monthly).toBe(80);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("throws when the proposed billingTerm has no matching plan", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Annual", 264, "prod-prem", "Premium")],
+      };
+
+      expect(() => simulateCostChange(input)).toThrow(/Monthly/);
+    });
+
+    it("throws when the pricing array is empty", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Monthly",
+        },
+        pricing: [],
+      };
+
+      expect(() => simulateCostChange(input)).toThrow(/No pricing plans/);
+    });
+
+    it("throws when the chosen plan has no rate rows", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: 10,
+          billingTerm: "Monthly",
+        },
+        pricing: [{
+          productId: "prod-prem",
+          productName: "Premium",
+          billingTerm: "Monthly",
+          rates: [],
+        }],
+      };
+
+      expect(() => simulateCostChange(input)).toThrow(/no rate rows/);
+    });
+
+    it("throws when proposed quantity is negative", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "prod-prem",
+          productName: "Premium",
+          quantity: -5,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 22, "prod-prem", "Premium")],
+      };
+
+      expect(() => simulateCostChange(input)).toThrow(/quantity/);
+    });
+  });
+
+  describe("Result shape invariants", () => {
+    it("returns annual = monthly × 12 for both legs", () => {
+      const input: SimulationInput = {
+        current: {
+          productId: "p",
+          productName: "P",
+          quantity: 7,
+          billingTerm: "Monthly",
+          price: 11,
+        },
+        proposed: {
+          productId: "p",
+          productName: "P",
+          quantity: 13,
+          billingTerm: "Monthly",
+        },
+        pricing: [plan("Monthly", 11, "p", "P")],
+      };
+      const result = simulateCostChange(input);
+      expect(result.current!.annual).toBe(result.current!.monthly * 12);
+      expect(result.proposed.annual).toBe(result.proposed.monthly * 12);
+    });
+
+    it("rounds cents to 2 decimal places", () => {
+      const input: SimulationInput = {
+        proposed: {
+          productId: "p",
+          productName: "P",
+          quantity: 3,
+          billingTerm: "Annual",
+        },
+        pricing: [plan("Annual", 100, "p", "P")],
+      };
+      const result = simulateCostChange(input);
+      // 100 × 3 / 12 = 25 exactly, but verify representation
+      expect(result.proposed.monthly).toBe(25);
+      expect(Number.isFinite(result.delta.monthly)).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/services/cost-simulator.ts
+++ b/packages/core/src/services/cost-simulator.ts
@@ -1,0 +1,281 @@
+import type { ProductPricingPlan } from "../api/types.js";
+import { subscriptionMrr } from "./analytics.js";
+
+/**
+ * The "current" subscription state — what the partner already has on the
+ * customer today. Optional: omit when modeling a brand-new add.
+ */
+export interface SimulationCurrent {
+  productId: string;
+  productName: string;
+  quantity: number;
+  billingTerm: string;
+  /** Per-seat unit price already on the existing subscription. */
+  price: number;
+}
+
+/**
+ * The "proposed" subscription change. `billingTerm` defaults to the current
+ * billingTerm (when there is one) or "Annual" (when there isn't).
+ */
+export interface SimulationProposed {
+  productId: string;
+  productName: string;
+  quantity: number;
+  billingTerm?: string;
+}
+
+export interface SimulationInput {
+  /** Current subscription, if any. Omit for "add new product". */
+  current?: SimulationCurrent;
+  proposed: SimulationProposed;
+  /**
+   * Pricing plans for the proposed product (the same shape returned by
+   * `ProductsApi.getPricing()`). Used to look up the proposed unit price.
+   */
+  pricing: ProductPricingPlan[];
+}
+
+export interface SimulationLeg {
+  unitPrice: number;
+  quantity: number;
+  monthly: number;
+  annual: number;
+  productName: string;
+  billingTerm: string;
+}
+
+export interface SimulationDelta {
+  monthly: number;
+  annual: number;
+  /** Per-seat monthly delta. Falls back to per-seat for whichever side has seats. */
+  perSeat: number;
+}
+
+export interface SimulationResult {
+  current: SimulationLeg | null;
+  proposed: SimulationLeg;
+  delta: SimulationDelta;
+  notes: string[];
+}
+
+/**
+ * Round to 2 decimal places — matches `formatCurrency` precision so the
+ * structured result and the rendered table never disagree about a penny.
+ */
+function round2(n: number): number {
+  return Number(n.toFixed(2));
+}
+
+/**
+ * Normalize a billing term string to a canonical "Monthly" or "Annual" label
+ * for display. Falls through any other value so commitment-style terms
+ * (e.g. "1-Year", "3-Year") still appear sensibly in notes/output.
+ */
+function normalizeTerm(term: string): string {
+  const lower = term.toLowerCase();
+  if (lower.includes("annual") || lower.includes("yearly") || lower.includes("year")) {
+    if (lower === "monthly") return "Monthly";
+    if (lower.includes("year") && !lower.includes("annual") && !lower.includes("yearly")) {
+      // Preserve commitment-style labels like "1-Year" verbatim.
+      return term;
+    }
+    return "Annual";
+  }
+  if (lower.includes("month")) return "Monthly";
+  return term;
+}
+
+/**
+ * Pick the rate row whose `startQuantityRange` is the largest value still
+ * <= `quantity`. Mirrors the volume-tier resolution that
+ * `commands/orders/create.ts` relies on (which currently just takes
+ * `rates[0]` because demo data has a single rate per plan, but real Pax8
+ * pricing can carry multiple tiers).
+ */
+function pickRate(plan: ProductPricingPlan, quantity: number): { unitPrice: number; tierStart: number } {
+  const rates = plan.rates ?? [];
+  if (rates.length === 0) {
+    throw new Error(`Pricing plan for "${plan.productName ?? plan.productId}" has no rate rows`);
+  }
+
+  // Sort by startQuantityRange ascending; rows without one are treated as 0.
+  const sorted = [...rates].sort(
+    (a, b) => (a.startQuantityRange ?? 0) - (b.startQuantityRange ?? 0),
+  );
+
+  let chosen = sorted[0];
+  for (const r of sorted) {
+    if ((r.startQuantityRange ?? 0) <= quantity) {
+      chosen = r;
+    } else {
+      break;
+    }
+  }
+  return {
+    unitPrice: chosen.suggestedRetailPrice,
+    tierStart: chosen.startQuantityRange ?? 0,
+  };
+}
+
+/**
+ * Find the pricing plan matching a billing term. Match is case-insensitive
+ * and tolerant of "Annual" vs "Yearly" naming.
+ */
+function findPlan(
+  pricing: ProductPricingPlan[],
+  billingTerm: string,
+): ProductPricingPlan | undefined {
+  if (pricing.length === 0) return undefined;
+  const want = billingTerm.toLowerCase();
+  // Exact match first
+  const exact = pricing.find((p) => p.billingTerm.toLowerCase() === want);
+  if (exact) return exact;
+  // Annual ≈ Yearly fallback
+  if (want.includes("annual") || want.includes("yearly")) {
+    return pricing.find(
+      (p) =>
+        p.billingTerm.toLowerCase().includes("annual") ||
+        p.billingTerm.toLowerCase().includes("yearly"),
+    );
+  }
+  if (want.includes("month")) {
+    return pricing.find((p) => p.billingTerm.toLowerCase().includes("month"));
+  }
+  return undefined;
+}
+
+/**
+ * Compute the financial impact of a single subscription change — SKU swap,
+ * quantity change, billing-term swap, or add-new — without placing the
+ * order. Pure compute over pricing data; safe to run anywhere.
+ *
+ * Returns a structured `SimulationResult` containing both legs of the
+ * comparison (current vs. proposed), the delta, and human-readable notes
+ * about any non-obvious choices the simulator made.
+ */
+export function simulateCostChange(input: SimulationInput): SimulationResult {
+  const { current, proposed, pricing } = input;
+  const notes: string[] = [];
+
+  if (!pricing || pricing.length === 0) {
+    throw new Error(
+      `No pricing plans available for product "${proposed.productName}" (id: ${proposed.productId}). Cannot simulate.`,
+    );
+  }
+
+  if (proposed.quantity < 0) {
+    throw new Error(`Proposed quantity must be >= 0 (got ${proposed.quantity})`);
+  }
+
+  // Resolve the proposed billing term: explicit > current > default Annual.
+  let proposedTerm = proposed.billingTerm;
+  if (!proposedTerm) {
+    if (current?.billingTerm) {
+      proposedTerm = current.billingTerm;
+    } else {
+      proposedTerm = "Annual";
+      notes.push("Annual term selected (default — typically cheaper than monthly)");
+    }
+  }
+
+  const proposedPlan = findPlan(pricing, proposedTerm);
+  if (!proposedPlan) {
+    const available = [...new Set(pricing.map((p) => p.billingTerm))].join(", ");
+    throw new Error(
+      `No ${proposedTerm} pricing plan found for "${proposed.productName}". Available: ${available}`,
+    );
+  }
+
+  const { unitPrice: proposedUnitPrice, tierStart: proposedTier } = pickRate(
+    proposedPlan,
+    proposed.quantity,
+  );
+
+  // Note the volume tier if it's not the entry-level (>= 1) tier.
+  if (proposedTier > 1 && (proposedPlan.rates?.length ?? 0) > 1) {
+    notes.push(
+      `Volume tier applied: ${proposed.quantity} seats falls into the ${proposedTier}+ rate (${formatPriceShort(proposedUnitPrice)}/seat)`,
+    );
+  }
+
+  const proposedNormalized = normalizeTerm(proposedPlan.billingTerm);
+  const proposedMonthly = round2(
+    subscriptionMrr(proposedUnitPrice, proposed.quantity, proposedPlan.billingTerm),
+  );
+  const proposedAnnual = round2(proposedMonthly * 12);
+
+  const proposedLeg: SimulationLeg = {
+    unitPrice: proposedUnitPrice,
+    quantity: proposed.quantity,
+    monthly: proposedMonthly,
+    annual: proposedAnnual,
+    productName: proposed.productName,
+    billingTerm: proposedNormalized,
+  };
+
+  let currentLeg: SimulationLeg | null = null;
+  if (current) {
+    const currentMonthly = round2(
+      subscriptionMrr(current.price, current.quantity, current.billingTerm),
+    );
+    const currentAnnual = round2(currentMonthly * 12);
+    currentLeg = {
+      unitPrice: current.price,
+      quantity: current.quantity,
+      monthly: currentMonthly,
+      annual: currentAnnual,
+      productName: current.productName,
+      billingTerm: normalizeTerm(current.billingTerm),
+    };
+
+    // Note billing-term swap if the user is implicitly switching.
+    if (
+      normalizeTerm(current.billingTerm).toLowerCase() !==
+      proposedNormalized.toLowerCase()
+    ) {
+      notes.push(
+        `Switching from ${normalizeTerm(current.billingTerm)} to ${proposedNormalized} billing`,
+      );
+    }
+  }
+
+  const deltaMonthly = round2(proposedMonthly - (currentLeg?.monthly ?? 0));
+  const deltaAnnual = round2(proposedAnnual - (currentLeg?.annual ?? 0));
+
+  // Per-seat delta: difference in per-seat monthly cost. When quantities
+  // match, this is meaningful as a "what does each user cost more/less now?"
+  // value. When they differ, fall back to the proposed per-seat monthly
+  // (the more useful number for "what does each new seat cost?").
+  let perSeat: number;
+  if (
+    currentLeg &&
+    currentLeg.quantity === proposedLeg.quantity &&
+    proposedLeg.quantity > 0
+  ) {
+    perSeat = round2(
+      proposedMonthly / proposedLeg.quantity -
+        currentLeg.monthly / currentLeg.quantity,
+    );
+  } else if (proposedLeg.quantity > 0) {
+    perSeat = round2(proposedMonthly / proposedLeg.quantity);
+  } else {
+    perSeat = 0;
+  }
+
+  return {
+    current: currentLeg,
+    proposed: proposedLeg,
+    delta: { monthly: deltaMonthly, annual: deltaAnnual, perSeat },
+    notes,
+  };
+}
+
+/**
+ * Compact dollar formatter for embedding inside notes (avoids a dependency
+ * on the CLI-side `formatCurrency` helper so this stays runnable from the
+ * core package or any embedder).
+ */
+function formatPriceShort(n: number): string {
+  return `$${n.toFixed(2)}`;
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -4,3 +4,12 @@ export { subscriptionMrr, computeMrr, computeGrowth, type MrrReport, type Growth
 export { FileCache } from "./cache.js";
 export { executeBulk, type BulkOp, type BulkResult } from "./bulk-executor.js";
 export { getRecommendations, getPortfolioCoverage, categorizeProduct, ALL_CATEGORIES, type Recommendation, type RecommendationReport, type CompanyCoverage, type ProductCategory } from "./recommendations.js";
+export {
+  simulateCostChange,
+  type SimulationCurrent,
+  type SimulationProposed,
+  type SimulationInput,
+  type SimulationLeg,
+  type SimulationDelta,
+  type SimulationResult,
+} from "./cost-simulator.js";


### PR DESCRIPTION
## Summary

Closes #3. New `pax8 cost sim` command for modeling the financial impact of subscription changes (SKU swap, quantity change, add-product) before actually placing the order. Pure compute over existing pricing data — no new API endpoints, no writes.

## What ships

- `@pax8/core`: new `simulateCostChange()` exported from `packages/core/src/services/cost-simulator.ts` with full unit-test coverage (18 tests). Embeddable from the Claude skill or external consumers.
- `@pax8/cli`: new `pax8 cost sim` command (`--company`, `--product`, `--quantity`, `--from`, `--from-quantity`, `--billing-term`, plus the standard `--json | --csv | --quiet` set). 13 subprocess integration tests.
- README (new "Cost Simulation" section), CHANGELOG (added bullet under v0.1.0), CLAUDE.md (ACT-FIRST table row), and skill.md (read-only command list + workflow recipe) updated.

## Behavior highlights

- Auto-detects a "current" subscription when `--from` is omitted but the customer already has the proposed product. Pure quantity-bump simulations need just `--company`, `--product`, `--quantity`.
- Volume-tier resolution picks the rate row whose `startQuantityRange <= quantity` (matches the production `orders create` math; works against multi-tier real-API pricing even though demo data only has single-rate plans).
- Billing-term swap detected and noted in `result.notes` (e.g. `"Switching from Annual to Monthly billing"`).
- JSON output includes a `nextActions` array pointing at the equivalent `pax8 orders create` so agents can chain into an actual write after presenting the delta.

## Out of scope

Multi-change simulation from a YAML file (mentioned in the issue spec) — deferred to v0.2.x. The single-change version ships first, well-tested and well-documented.

## Test plan

- [x] `simulateCostChange` unit tests for all edge cases (SKU swap up/down, qty +/-, add-new, billing-term swap, volume tiers, missing pricing, empty rates, negative qty, result-shape invariants)
- [x] Subprocess test for `pax8 cost sim` covering all flag combinations + JSON/CSV/non-TTY output, plus error cases (missing flags, unknown company, unknown product, negative qty)
- [x] Build, lint, typecheck green (\`pnpm build && pnpm -r exec tsc --noEmit && pnpm lint\`)
- [x] Full suite green: 967 tests passing (was 936+) under \`PAX8_DEMO=1 NO_COLOR=1\`
- [x] Coverage threshold green