### PR TITLE
feat(recs-act): multi-select picker for batch order placement (closes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,6 @@ Initial public release.
 ### Changed
 
 - Display labels rebranded from "MRR" to "estimated MRR" to reflect that the value is computed locally and not the partner's actual billed revenue. Command paths (`pax8 report mrr`), JSON output keys (`mrr`, `mrrUplift`, etc.), and telemetry properties unchanged (#166).
+- `pax8 recommendations act` now shows a multi-select picker for batch ordering instead of a one-at-a-time `y/s/q` walk; `-y` / `--yes` bypass unchanged.
 
 [0.1.0]: https://github.com/pax8labs/pax8-cli/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ PAX8_DEMO=1 pax8 status
 ```bash
 pax8 status                              # estimated MRR, renewals, growth opportunities
 pax8 recommendations list                # Cross-sell and seat gap opportunities
-pax8 recommendations act                 # Walk through and place orders (y/s/q)
+pax8 recommendations act                 # Multi-select picker → batch order
 pax8 companies list                      # Browse customers (type # to drill in)
 pax8 companies more "Acme Corp"          # Full customer summary
 ```
@@ -95,9 +95,10 @@ pax8 recommendations list                              # All growth opportunitie
 pax8 recommendations list --company "Acme Corp"        # For one customer
 pax8 recommendations list --product "AvePoint"         # Filter by product
 pax8 recommendations list --priority high              # High priority only
-pax8 recommendations act                               # Walk through and order
+pax8 recommendations act                               # Multi-select picker → batch order
 pax8 recommendations act --company "Acme Corp"         # Act on one customer
 pax8 recommendations act --product "backup"            # Add backup everywhere
+pax8 recommendations act --yes                         # Non-interactive: place all matches
 ```
 
 ### Orders
@@ -167,7 +168,7 @@ $ pax8
 pax8> status
 pax8> companies list
 pax8> 3                          # Drill into company #3
-pax8> recommendations act        # Walk through recs
+pax8> recommendations act        # Multi-select picker → batch order
 pax8> exit
 ```
 

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -85,7 +85,7 @@ pax8 invoices list --json [--company <id|name>] [--status Paid|Unpaid]
 pax8 invoices audit --json [--month YYYY-MM] [--company <id|name>]
 pax8 products search "<query>" --json
 pax8 recommendations list --json [--priority high|medium|low] [--company <id|name>] [--product <name>]
-pax8 recommendations act [--company <id|name>] [--product <name>]    # interactive — only for human-in-the-loop sessions
+pax8 recommendations act [--company <id|name>] [--product <name>] [--yes]    # multi-select picker; --yes places all without prompting
 pax8 orders list --json
 pax8 orders create --company <id|name> --product <id|name> --quantity <n> [--billing-term Monthly|Annual]
 pax8 cost sim --company <id|name> --product <id|name> --quantity <n> [--from <id|name>] [--billing-term Monthly|Annual] --json
@@ -123,6 +123,8 @@ pax8 recommendations list --json --priority high
 pax8 companies list --json
 ```
 For each rec, show: company, missing product, estimated MRR uplift. The JSON output includes an `orderCommand` field — that's the exact `pax8 orders create …` to run. **Always show the user the order preview and wait for explicit approval before executing the write.**
+
+For an interactive batch flow, hand the human `pax8 recommendations act` (with `--company` / `--product` / `--priority` filters as needed) — it presents a multi-select picker and a single batch confirmation rather than a per-rec y/s/q walk. The agent should not pass `--yes` unless the user has approved the entire matching set.
 
 ### Portfolio MRR
 Run in parallel:

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { runCliExpectSuccess } from "./test-utils.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import YAML from "yaml";
+import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 
 describe("pax8 recommendations", () => {
   describe("recommendations list", () => {
@@ -111,6 +115,97 @@ describe("pax8 recommendations", () => {
       // Both should return the same set since JSON output is pre-filter
       // (JSON returns all recs; filtering only affects table mode)
       expect(allRecs.length).toBe(defaultRecs.length);
+    });
+  });
+
+  describe("recommendations act", () => {
+    let tmpConfigDir: string;
+
+    beforeEach(async () => {
+      tmpConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-recs-act-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpConfigDir, { recursive: true, force: true });
+    });
+
+    it("--yes places all recommendations without prompting", async () => {
+      const result = await runCliExpectSuccess(
+        ["recommendations", "act", "--company", "Bright Minds Academy", "--yes"],
+      );
+      // Multi-select prompt should not appear at all in --yes mode.
+      expect(result.stderr).not.toMatch(/Select recommendations to act on/);
+      expect(result.stderr).not.toMatch(/About to place \d+ orders?/);
+      // We do expect to see the batch header and the per-order placement output.
+      expect(result.stderr).toMatch(/recommendations for batch ordering/);
+      // And the summary line at the end.
+      expect(result.stderr).toMatch(/ordered/);
+    });
+
+    it("non-TTY without --yes errors cleanly with guidance instead of hanging", async () => {
+      // Subprocesses spawned by execFile have a non-TTY stdin by default,
+      // so this exercises the production guard.
+      const result = await runCliExpectFailure(
+        ["recommendations", "act", "--company", "Bright Minds Academy"],
+      );
+      expect(result.stderr).toMatch(/stdin is not a TTY|interactive picker/i);
+      // Recovery guidance should mention --yes.
+      expect(result.stderr).toMatch(/--yes/);
+      // Should be the validated stable code (CliError without explicit code
+      // resolves to ERROR_INVALID_INPUT in this command).
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it("emits recs_* aggregate counts on the postAction telemetry event with --yes", async () => {
+      // Enable telemetry in an isolated config dir so we can read the JSONL
+      // backup the CLI writes alongside the PostHog send.
+      const configFile = path.join(tmpConfigDir, "config.yaml");
+      await fs.writeFile(
+        configFile,
+        YAML.stringify({
+          version: "1.0",
+          telemetry: { enabled: true },
+        }),
+        { encoding: "utf-8", mode: 0o600 },
+      );
+
+      const result = await runCli(
+        ["recommendations", "act", "--company", "Bright Minds Academy", "--yes"],
+        {
+          PAX8_CONFIG_DIR: tmpConfigDir,
+          // Make sure neither env-var opt-out path silently disables.
+          PAX8_TELEMETRY_DISABLED: "",
+          DO_NOT_TRACK: "",
+        },
+      );
+      expect(result.exitCode).toBe(0);
+
+      // Telemetry writes a JSONL file under <configDir>/telemetry/<date>.jsonl
+      const today = new Date().toISOString().slice(0, 10);
+      const jsonlPath = path.join(tmpConfigDir, "telemetry", `${today}.jsonl`);
+      const content = await fs.readFile(jsonlPath, "utf-8");
+      const events = content
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+      const cmdEvent = events.find(
+        (e) => e.event === "command_executed" && e.subcommand === "recommendations.act",
+      );
+      expect(cmdEvent).toBeDefined();
+      expect(cmdEvent).toMatchObject({
+        recs_presented: expect.any(Number),
+        recs_ordered: expect.any(Number),
+        recs_skipped: expect.any(Number),
+      });
+      // Bright Minds Academy has at least one actionable rec in demo data,
+      // so we should see a positive presented count.
+      expect(cmdEvent!.recs_presented as number).toBeGreaterThan(0);
+      // recs_mrr_captured is only emitted when >0; if any orders succeeded
+      // it should be present and positive.
+      if ((cmdEvent!.recs_ordered as number) > 0) {
+        expect(cmdEvent!.recs_mrr_captured).toBeDefined();
+        expect(cmdEvent!.recs_mrr_captured as number).toBeGreaterThan(0);
+      }
     });
   });
 });

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -1,70 +1,49 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { createInterface } from "readline";
-import { ALL_SUBS_PAGE_SIZE, getRecommendations, type Recommendation } from "@pax8/core";
+import prompts from "prompts";
+import { ALL_SUBS_PAGE_SIZE, getRecommendations, type Recommendation, ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext, type CommandContext } from "../../lib/context.js";
 import { createSpinner } from "../../lib/spinner.js";
-import { handleCommandError } from "../../lib/errors.js";
+import { handleCommandError, CliError } from "../../lib/errors.js";
 import { formatCurrency, formatCompanyName, formatQuantity, calculateMrr } from "../../lib/formatters.js";
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 import { filterRecommendations } from "./filter.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 import { setTelemetryFields } from "../../lib/telemetry-context.js";
+import { replCmd } from "../../lib/confirm.js";
 
-async function prompt(question: string): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
-    rl.question(question, (a) => { rl.close(); resolve(a.trim()); });
-  });
+interface PlacementResult {
+  ordered: boolean;
+  mrrCaptured: number;
 }
 
-async function actOnRec(rec: Recommendation, index: number, total: number, ctx: CommandContext): Promise<"ordered" | "skipped" | "quit"> {
+/**
+ * Place a single order for an already-confirmed recommendation. No prompts —
+ * the user has already approved the batch upstream (either via the
+ * multi-select + confirm flow, or via the `--yes` bypass).
+ */
+async function placeOrder(rec: Recommendation, ctx: CommandContext): Promise<PlacementResult> {
   const product = rec.suggestedProducts?.[0] ?? "product";
-  const seats = rec.targetSeats ?? "?";
-  const uplift = rec.estimatedMrrUplift ? chalk.green(` +${formatCurrency(rec.estimatedMrrUplift)}/mo`) : "";
-
-  process.stderr.write(chalk.bold(`\n  [${index + 1}/${total}] ${rec.companyName}\n`));
-  process.stderr.write(`  ${rec.type === "seat_gap" ? "Seat Gap" : "Cross-sell"}: ${product} (${seats} seats)${uplift}\n`);
-  process.stderr.write(chalk.dim(`  ${rec.reason.slice(0, 120)}\n`));
 
   if (!rec.orderCommand) {
-    process.stderr.write(chalk.dim("\n  No orderable product available — skipping.\n"));
-    return "skipped";
+    process.stderr.write(chalk.dim(`  No orderable product available for ${rec.companyName} — skipping.\n`));
+    return { ordered: false, mrrCaptured: 0 };
   }
 
-  const answer = await prompt(`\n  ${chalk.cyan("[y]")} order  ${chalk.dim("[c] change qty")}  ${chalk.dim("[s] skip")}  ${chalk.dim("[q] quit")}  > `);
-
-  if (answer === "q" || answer === "quit") return "quit";
-  if (answer !== "y" && answer !== "yes" && answer !== "c" && answer !== "change" && answer !== "") return "skipped";
-
-  // Parse and execute order
-  const companyMatch = rec.orderCommand.match(/--company\s+"([^"]+)"|--company\s+(\S+)/);
+  // Parse the existing orderCommand for company/product/quantity hints.
   const productMatch = rec.orderCommand.match(/--product\s+"([^"]+)"|--product\s+(\S+)/);
   const qtyMatch = rec.orderCommand.match(/--quantity\s+(\S+)/);
-  if (!companyMatch || !productMatch) {
-    process.stderr.write(chalk.red("  Could not parse order.\n"));
-    return "skipped";
+  if (!productMatch) {
+    process.stderr.write(chalk.red(`  Could not parse order for ${rec.companyName}.\n`));
+    return { ordered: false, mrrCaptured: 0 };
   }
 
-  let quantity = parseInt(qtyMatch?.[1] ?? String(rec.targetSeats ?? 1), 10);
+  const quantity = parseInt(qtyMatch?.[1] ?? String(rec.targetSeats ?? 1), 10);
 
-  if (answer === "c" || answer === "change") {
-    const qtyAnswer = await prompt(`  Quantity? [${quantity}] `);
-    if (qtyAnswer !== "") {
-      const parsed = parseInt(qtyAnswer, 10);
-      if (isNaN(parsed) || parsed <= 0) {
-        process.stderr.write(chalk.yellow("  Cancelled.\n"));
-        return "skipped";
-      }
-      quantity = parsed;
-    }
-  }
-
-  // Use companyId directly from the rec (already resolved)
-  // Resolve product: try the matched value as a product ID first, fall back to search
+  // Resolve product: try the matched value as a product ID first, fall back
+  // to a name search.
   const matchedProduct = productMatch[1] ?? productMatch[2];
   let productId = matchedProduct;
-  // If it doesn't look like a UUID/ID, resolve by name
   if (matchedProduct && !/^[0-9a-f-]{8,}$/i.test(matchedProduct) && !matchedProduct.startsWith("prod-")) {
     try {
       const searchResult = await ctx.api.products.search(matchedProduct);
@@ -75,9 +54,9 @@ async function actOnRec(rec: Recommendation, index: number, total: number, ctx: 
     } catch { /* use as-is */ }
   }
 
-  const spinner = createSpinner("Creating order...").start();
+  const spinner = createSpinner(`Ordering ${product} for ${rec.companyName}...`).start();
   try {
-    // Resolve commitmentTermId from existing subscription for the SAME product
+    // Resolve commitmentTermId from existing subscription for the SAME product.
     let commitmentTermId: string | undefined;
     try {
       const subs = await ctx.api.subscriptions.list({
@@ -106,7 +85,7 @@ async function actOnRec(rec: Recommendation, index: number, total: number, ctx: 
       doneOrder();
     }
 
-    // Look up unit price from product pricing
+    // Look up unit price from product pricing.
     let unitPrice: number | null = null;
     try {
       const pricing = await ctx.api.products.getPricing(productId).catch(() => null);
@@ -119,11 +98,9 @@ async function actOnRec(rec: Recommendation, index: number, total: number, ctx: 
       }
     } catch { /* best effort */ }
 
-    // Calculate cost impact
     const monthlyCost = unitPrice ? calculateMrr(unitPrice, quantity, "Monthly") : null;
     const annualCost = monthlyCost ? Number((monthlyCost * 12).toFixed(2)) : null;
 
-    // Fall back to recommendation's MRR estimate if no pricing found
     const displayMrr = monthlyCost ?? (rec.estimatedMrrUplift
       ? (rec.targetSeats && quantity !== rec.targetSeats
         ? Number((rec.estimatedMrrUplift * (quantity / rec.targetSeats)).toFixed(2))
@@ -154,20 +131,37 @@ async function actOnRec(rec: Recommendation, index: number, total: number, ctx: 
       process.stderr.write(`  ${chalk.dim("Annual cost:".padEnd(18))}${chalk.dim("—")}\n`);
     }
     process.stderr.write("\n");
-    return "ordered";
+
+    const mrrCaptured = displayMrr ?? rec.estimatedMrrUplift ?? 0;
+    return { ordered: true, mrrCaptured };
   } catch (error) {
-    spinner.fail("Order failed");
+    spinner.fail(`Order failed for ${rec.companyName}`);
     const msg = error instanceof Error ? error.message : String(error);
     process.stderr.write(chalk.dim(`  ${msg.slice(0, 100)}\n`));
-    return "skipped";
+    return { ordered: false, mrrCaptured: 0 };
   }
 }
 
+/**
+ * Build a one-line label for the multi-select picker. Companies with a
+ * `[demo]` prefix get cleaned up via `formatCompanyName` for display.
+ */
+function recLabel(rec: Recommendation): string {
+  const product = rec.suggestedProducts?.[0] ?? "product";
+  const seats = rec.targetSeats ?? "?";
+  const uplift = rec.estimatedMrrUplift
+    ? ` (+${formatCurrency(rec.estimatedMrrUplift)}/mo)`
+    : "";
+  const kind = rec.type === "seat_gap" ? "Bump" : "Add";
+  return `${formatCompanyName(rec.companyName)}: ${kind} ${product} (${seats} seats)${uplift}`;
+}
+
 export const recommendationsActCommand = new Command("act")
-  .description("Walk through recommendations one by one and place orders")
+  .description("Pick recommendations from a multi-select picker and place orders in a batch")
   .option("--company <id|name>", "Filter to a specific company")
   .option("--product <name>", "Filter to a specific product (e.g. 'AvePoint', 'Entra')")
   .option("--priority <level>", "Filter by priority (high, medium, low)")
+  .option("-y, --yes", "Skip the picker and confirmation; place all matching recommendations")
   .allowExcessArguments(true)
   .addHelpText(
     "after",
@@ -175,7 +169,8 @@ export const recommendationsActCommand = new Command("act")
 Examples:
   pax8 recommendations act
   pax8 recommendations act --company "Summit Healthcare"
-  pax8 recommendations act --priority high`
+  pax8 recommendations act --priority high
+  pax8 recommendations act --yes                    # non-interactive: place all`
   )
   .action(async (options, cmd) => {
     const allOpts = cmd.optsWithGlobals();
@@ -213,25 +208,139 @@ Examples:
 
       if (recs.length === 0) {
         process.stderr.write(chalk.green("\n  No actionable recommendations.\n\n"));
+        // Still emit zero-counters so dashboards see the run.
+        setTelemetryFields({
+          recs_presented: 0,
+          recs_ordered: 0,
+          recs_skipped: 0,
+        });
         return;
       }
 
-      process.stderr.write(`\n  ${chalk.bold(`${recs.length} recommendations`)} — let's go through them.\n`);
-      process.stderr.write(chalk.dim(`  Press y to order, s to skip, q to quit.\n`));
+      // Recommendations arrive ranked by priority/MRR uplift from
+      // getRecommendations(); preserve that order for the picker.
+      const totalUplift = recs.reduce((sum, r) => sum + (r.estimatedMrrUplift ?? 0), 0);
+      const totalUpliftLabel = totalUplift > 0
+        ? chalk.green(`${formatCurrency(totalUplift)}/mo MRR uplift available`)
+        : "";
 
-      let ordered = 0;
-      let skipped = 0;
-      let mrrCaptured = 0;
+      // Decide which recs to act on. Three paths:
+      //   1. --yes: bypass prompts entirely → all recs.
+      //   2. TTY interactive: multi-select picker + confirm.
+      //   3. Non-TTY without --yes: error cleanly.
+      let toPlace: Recommendation[];
 
-      for (let i = 0; i < recs.length; i++) {
-        const result = await actOnRec(recs[i], i, recs.length, ctx);
-        if (result === "ordered") {
-          ordered++;
-          mrrCaptured += recs[i].estimatedMrrUplift ?? 0;
+      if (options.yes) {
+        toPlace = recs;
+        process.stderr.write(
+          `\n  ${chalk.bold(`${recs.length} recommendations`)} for batch ordering` +
+          (totalUpliftLabel ? ` — ${totalUpliftLabel}` : "") + ".\n"
+        );
+      } else if (!process.stdin.isTTY) {
+        throw new CliError(
+          "Cannot show interactive picker — stdin is not a TTY",
+          ["pax8 recommendations act needs a terminal for the multi-select prompt"],
+          [
+            `Pass ${replCmd("--yes")} to place every matching recommendation without prompting`,
+            `Filter the list first: ${replCmd("pax8 recommendations act")} --company "<name>" --yes`,
+            `Or run ${replCmd("pax8 recommendations list --json")} to inspect them, then place orders individually with ${replCmd("pax8 orders create")}`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      } else {
+        process.stderr.write(
+          `\n  Found ${chalk.bold(`${recs.length} recommendations`)}` +
+          (totalUpliftLabel ? ` — ${totalUpliftLabel}` : "") + ".\n\n"
+        );
+
+        let cancelled = false;
+        const picked = await prompts(
+          {
+            type: "multiselect",
+            name: "selected",
+            message: "Select recommendations to act on",
+            choices: recs.map((rec) => ({
+              title: recLabel(rec),
+              value: rec,
+              selected: false,
+            })),
+            instructions: false,
+            hint: "space to toggle, a to toggle all, enter to submit",
+          },
+          {
+            onCancel: () => {
+              cancelled = true;
+              return false;
+            },
+          },
+        );
+
+        if (cancelled) {
+          process.stderr.write(chalk.yellow("\n  Cancelled — no orders placed.\n\n"));
+          process.exit(130);
         }
-        if (result === "skipped") skipped++;
-        if (result === "quit") break;
+
+        const selected = (picked.selected as Recommendation[] | undefined) ?? [];
+        if (selected.length === 0) {
+          process.stderr.write(chalk.dim("\n  No recommendations selected — nothing to do.\n\n"));
+          setTelemetryFields({
+            recs_presented: recs.length,
+            recs_ordered: 0,
+            recs_skipped: recs.length,
+          });
+          return;
+        }
+
+        const selectedUplift = selected.reduce((sum, r) => sum + (r.estimatedMrrUplift ?? 0), 0);
+        const upliftStr = selectedUplift > 0
+          ? ` for ${chalk.green(formatCurrency(selectedUplift) + "/mo")} MRR uplift`
+          : "";
+
+        const confirmAnswer = await prompts(
+          {
+            type: "confirm",
+            name: "go",
+            message: `About to place ${selected.length} order${selected.length === 1 ? "" : "s"}${upliftStr}. Proceed?`,
+            initial: false,
+          },
+          {
+            onCancel: () => {
+              cancelled = true;
+              return false;
+            },
+          },
+        );
+
+        if (cancelled) {
+          process.stderr.write(chalk.yellow("\n  Cancelled — no orders placed.\n\n"));
+          process.exit(130);
+        }
+
+        if (!confirmAnswer.go) {
+          process.stderr.write(chalk.dim("\n  Not confirmed — no orders placed.\n\n"));
+          setTelemetryFields({
+            recs_presented: recs.length,
+            recs_ordered: 0,
+            recs_skipped: recs.length,
+          });
+          return;
+        }
+
+        toPlace = selected;
       }
+
+      // Place each chosen order using the existing per-order placement logic.
+      let ordered = 0;
+      let mrrCaptured = 0;
+      for (const rec of toPlace) {
+        const result = await placeOrder(rec, ctx);
+        if (result.ordered) {
+          ordered++;
+          mrrCaptured += result.mrrCaptured;
+        }
+      }
+      const skipped = recs.length - ordered;
 
       // Summary
       process.stderr.write(chalk.dim("\n  ─────────────────────────────\n"));


### PR DESCRIPTION
## Summary

Closes #30. Converts `pax8 recommendations act` from the one-at-a-time `y/s/q` linear walk to a multi-select picker followed by a single batch confirmation. Uses the `prompts` library that landed via #160.

## Behavior

- TTY + no `--yes`: multi-select picker -> batch confirm -> place selected orders
- `--yes`: bypass both prompts; place all matching recommendations (new flag on this command, modeled on `orders create`)
- Non-TTY without `--yes`: clean `CliError` (`ERROR_INVALID_INPUT`) with guidance to pass `--yes`; no hang
- Ctrl+C from either prompt: exit 130, no orders placed (via `prompts`' `onCancel`)
- Initial selection is empty so a stray Enter never fires orders
- Telemetry: per-batch aggregate counts (`recs_presented`, `recs_ordered`, `recs_skipped`, `recs_mrr_captured`) via the `setTelemetryFields` context introduced in #162 - no manual `track()`

## Test plan

- [x] Subprocess test: `--yes` bypass still places all without prompting and emits the `recommendations for batch ordering` header
- [x] Subprocess test: non-TTY without `--yes` errors cleanly with guidance, exit code != 0
- [x] Subprocess test: `recs_*` aggregate counts populated on the single `command_executed` event in the telemetry JSONL backup
- [x] `pnpm build` clean
- [x] `pnpm -r exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] Full suite: 1022 passed / 8 skipped (was 1019 / 8 on main; +3 new)
- [x] `pnpm test:coverage` thresholds green

## Surface updates

- `README.md` - updated the demo flow + Recommendations example block to reflect the picker; added `--yes` example
- `CHANGELOG.md` - new "Changed" section under v0.1.0 with the behavior change line
- `packages/claude-skill/skill.md` - command synopsis now shows `--yes`; "Recommendation -> order" recipe gets a paragraph on the new interactive batch flow

## Coordination notes

- The MRR-rebrand work for #166 may sweep "MRR uplift" wording; mechanical rebase if so. Phrasing here matches the rest of `act.ts`.
- AGENTS.md PR #165 is docs-only; no conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)