### PR TITLE
chore: add Apache-2.0 SPDX headers to all source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,4 +28,8 @@ Initial public release.
 - Display labels rebranded from "MRR" to "estimated MRR" to reflect that the value is computed locally and not the partner's actual billed revenue. Command paths (`pax8 report mrr`), JSON output keys (`mrr`, `mrrUplift`, etc.), and telemetry properties unchanged (#166).
 - `pax8 recommendations act` now shows a multi-select picker for batch ordering instead of a one-at-a-time `y/s/q` walk; `-y` / `--yes` bypass unchanged.
 
+### Internal
+
+- Added SPDX Apache-2.0 headers to all source files (no functional change).
+
 [0.1.0]: https://github.com/pax8labs/pax8-cli/releases/tag/v0.1.0

--- a/e2e/billing-workflow.test.ts
+++ b/e2e/billing-workflow.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/e2e/contacts-workflow.test.ts
+++ b/e2e/contacts-workflow.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 

--- a/e2e/error-handling.test.ts
+++ b/e2e/error-handling.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCli, runCliExpectSuccess } from "./test-utils.js";
 

--- a/e2e/onboarding.test.ts
+++ b/e2e/onboarding.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCli, runCliExpectSuccess } from "./test-utils.js";
 

--- a/e2e/output-formats.test.ts
+++ b/e2e/output-formats.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/e2e/product-discovery.test.ts
+++ b/e2e/product-discovery.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/e2e/quotes-workflow.test.ts
+++ b/e2e/quotes-workflow.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 

--- a/e2e/real-api.test.ts
+++ b/e2e/real-api.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";

--- a/e2e/subscription-management.test.ts
+++ b/e2e/subscription-management.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";

--- a/e2e/usage-workflow.test.ts
+++ b/e2e/usage-workflow.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 

--- a/e2e/webhooks-workflow.test.ts
+++ b/e2e/webhooks-workflow.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 

--- a/packages/claude-skill/src/tools/companies.ts
+++ b/packages/claude-skill/src/tools/companies.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execCli } from "../index.js";
 
 export const pax8_companies_list = {

--- a/packages/claude-skill/src/tools/index.ts
+++ b/packages/claude-skill/src/tools/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export { pax8_companies_list, pax8_companies_show } from "./companies.js";
 export {
   pax8_subscriptions_list,

--- a/packages/claude-skill/src/tools/invoices.ts
+++ b/packages/claude-skill/src/tools/invoices.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execCli } from "../index.js";
 
 export const pax8_invoices_list = {

--- a/packages/claude-skill/src/tools/products.ts
+++ b/packages/claude-skill/src/tools/products.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execCli } from "../index.js";
 
 export const pax8_products_search = {

--- a/packages/claude-skill/src/tools/recommendations.ts
+++ b/packages/claude-skill/src/tools/recommendations.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execCli } from "../index.js";
 
 export const pax8_recommendations = {

--- a/packages/claude-skill/src/tools/reports.ts
+++ b/packages/claude-skill/src/tools/reports.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execCli } from "../index.js";
 
 interface Subscription {

--- a/packages/claude-skill/src/tools/subscriptions.ts
+++ b/packages/claude-skill/src/tools/subscriptions.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execCli } from "../index.js";
 
 export const pax8_subscriptions_list = {

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCli, runCliExpectSuccess } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/companies.test.ts
+++ b/packages/cli/src/__tests__/companies.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 import * as os from "node:os";

--- a/packages/cli/src/__tests__/cost.test.ts
+++ b/packages/cli/src/__tests__/cost.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/packages/cli/src/__tests__/error-codes.test.ts
+++ b/packages/cli/src/__tests__/error-codes.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectFailure } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/idempotency.test.ts
+++ b/packages/cli/src/__tests__/idempotency.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/orders.test.ts
+++ b/packages/cli/src/__tests__/orders.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/products.test.ts
+++ b/packages/cli/src/__tests__/products.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCli, runCliExpectSuccess } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/cli/src/__tests__/report-bug.test.ts
+++ b/packages/cli/src/__tests__/report-bug.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";

--- a/packages/cli/src/__tests__/report.test.ts
+++ b/packages/cli/src/__tests__/report.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/sigint.test.ts
+++ b/packages/cli/src/__tests__/sigint.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/table-output.test.ts
+++ b/packages/cli/src/__tests__/table-output.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/packages/cli/src/__tests__/test-utils.ts
+++ b/packages/cli/src/__tests__/test-utils.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";

--- a/packages/cli/src/__tests__/version.test.ts
+++ b/packages/cli/src/__tests__/version.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
 

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { authLoginCommand } from "./login.js";
 import { authStatusCommand } from "./status.js";

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import prompts from "prompts";

--- a/packages/cli/src/commands/auth/logout.ts
+++ b/packages/cli/src/commands/auth/logout.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { CredentialStore } from "@pax8/core";

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { CredentialStore } from "@pax8/core";

--- a/packages/cli/src/commands/companies/create.ts
+++ b/packages/cli/src/commands/companies/create.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { createSpinner } from "../../lib/spinner.js";

--- a/packages/cli/src/commands/companies/index.ts
+++ b/packages/cli/src/commands/companies/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { companiesListCommand } from "./list.js";
 import { companiesShowCommand } from "./show.js";

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { getRecommendations, getPortfolioCoverage } from "@pax8/core";

--- a/packages/cli/src/commands/companies/more.ts
+++ b/packages/cli/src/commands/companies/more.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { categorizeProduct, ALL_CATEGORIES, getRecommendations, getPortfolioCoverage, type ProductCategory } from "@pax8/core";

--- a/packages/cli/src/commands/companies/show.ts
+++ b/packages/cli/src/commands/companies/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { createSpinner } from "../../lib/spinner.js";

--- a/packages/cli/src/commands/companies/update.ts
+++ b/packages/cli/src/commands/companies/update.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ERROR_INVALID_INPUT } from "@pax8/core";

--- a/packages/cli/src/commands/completions.ts
+++ b/packages/cli/src/commands/completions.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { configInitCommand } from "./init.js";
 import { configShowCommand } from "./show.js";

--- a/packages/cli/src/commands/config/init.ts
+++ b/packages/cli/src/commands/config/init.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";

--- a/packages/cli/src/commands/config/path.ts
+++ b/packages/cli/src/commands/config/path.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import * as path from "node:path";
 import * as os from "node:os";

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";

--- a/packages/cli/src/commands/config/show.ts
+++ b/packages/cli/src/commands/config/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";

--- a/packages/cli/src/commands/contacts/create.ts
+++ b/packages/cli/src/commands/contacts/create.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ERROR_INVALID_INPUT } from "@pax8/core";

--- a/packages/cli/src/commands/contacts/delete.ts
+++ b/packages/cli/src/commands/contacts/delete.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/contacts/index.ts
+++ b/packages/cli/src/commands/contacts/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { contactsListCommand } from "./list.js";
 import { contactsShowCommand } from "./show.js";

--- a/packages/cli/src/commands/contacts/list.ts
+++ b/packages/cli/src/commands/contacts/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ERROR_INVALID_INPUT } from "@pax8/core";

--- a/packages/cli/src/commands/contacts/show.ts
+++ b/packages/cli/src/commands/contacts/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/contacts/update.ts
+++ b/packages/cli/src/commands/contacts/update.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ERROR_INVALID_INPUT } from "@pax8/core";

--- a/packages/cli/src/commands/cost/index.ts
+++ b/packages/cli/src/commands/cost/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { costSimCommand } from "./sim.js";
 

--- a/packages/cli/src/commands/cost/sim.ts
+++ b/packages/cli/src/commands/cost/sim.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { createSpinner } from "../../lib/spinner.js";

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";

--- a/packages/cli/src/commands/easter-eggs/coffee.ts
+++ b/packages/cli/src/commands/easter-eggs/coffee.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/packages/cli/src/commands/easter-eggs/moo.ts
+++ b/packages/cli/src/commands/easter-eggs/moo.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/packages/cli/src/commands/easter-eggs/time-quip.ts
+++ b/packages/cli/src/commands/easter-eggs/time-quip.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import chalk from "chalk";
 
 /**

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ERROR_INTERNAL, loadConfig, saveConfig } from "@pax8/core";

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext, warnIfTruncated } from "../../lib/context.js";

--- a/packages/cli/src/commands/invoices/dispute.test.ts
+++ b/packages/cli/src/commands/invoices/dispute.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";

--- a/packages/cli/src/commands/invoices/index.ts
+++ b/packages/cli/src/commands/invoices/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { invoicesListCommand } from "./list.js";
 import { invoicesShowCommand } from "./show.js";

--- a/packages/cli/src/commands/invoices/items.ts
+++ b/packages/cli/src/commands/invoices/items.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/invoices/show.ts
+++ b/packages/cli/src/commands/invoices/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/orders/create.test.ts
+++ b/packages/cli/src/commands/orders/create.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { runCli, runCliExpectSuccess } from "../../__tests__/test-utils.js";
 

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { createSpinner } from "../../lib/spinner.js";

--- a/packages/cli/src/commands/orders/index.ts
+++ b/packages/cli/src/commands/orders/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { ordersListCommand } from "./list.js";
 import { ordersShowCommand } from "./show.js";

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { createSpinner } from "../../lib/spinner.js";

--- a/packages/cli/src/commands/orders/show.ts
+++ b/packages/cli/src/commands/orders/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { createSpinner } from "../../lib/spinner.js";

--- a/packages/cli/src/commands/products/index.ts
+++ b/packages/cli/src/commands/products/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { productsListCommand } from "./list.js";
 import { productsShowCommand } from "./show.js";

--- a/packages/cli/src/commands/products/list.ts
+++ b/packages/cli/src/commands/products/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/products/search.ts
+++ b/packages/cli/src/commands/products/search.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/products/show.ts
+++ b/packages/cli/src/commands/products/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/quotes/create.ts
+++ b/packages/cli/src/commands/quotes/create.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/quotes/delete.ts
+++ b/packages/cli/src/commands/quotes/delete.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/quotes/index.ts
+++ b/packages/cli/src/commands/quotes/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { quotesListCommand } from "./list.js";
 import { quotesShowCommand } from "./show.js";

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/quotes/show.ts
+++ b/packages/cli/src/commands/quotes/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/quotes/update.ts
+++ b/packages/cli/src/commands/quotes/update.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import prompts from "prompts";

--- a/packages/cli/src/commands/recommendations/filter.test.ts
+++ b/packages/cli/src/commands/recommendations/filter.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { filterRecommendations, type RecFilterOptions } from "./filter.js";
 import type { Recommendation } from "@pax8/core";

--- a/packages/cli/src/commands/recommendations/filter.ts
+++ b/packages/cli/src/commands/recommendations/filter.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Recommendation } from "@pax8/core";
 
 export interface RecFilterOptions {

--- a/packages/cli/src/commands/recommendations/index.ts
+++ b/packages/cli/src/commands/recommendations/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { recommendationsListCommand } from "./list.js";
 import { recommendationsActCommand } from "./act.js";

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ALL_SUBS_PAGE_SIZE, getRecommendations, type Recommendation } from "@pax8/core";

--- a/packages/cli/src/commands/report-bug.ts
+++ b/packages/cli/src/commands/report-bug.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";

--- a/packages/cli/src/commands/report/growth.ts
+++ b/packages/cli/src/commands/report/growth.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/report/index.ts
+++ b/packages/cli/src/commands/report/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { reportMrrCommand } from "./mrr.js";
 import { reportGrowthCommand } from "./growth.js";

--- a/packages/cli/src/commands/report/mrr.ts
+++ b/packages/cli/src/commands/report/mrr.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext, warnIfTruncated } from "../../lib/context.js";

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext, warnIfTruncated } from "../lib/context.js";

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/subscriptions/index.ts
+++ b/packages/cli/src/commands/subscriptions/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { subscriptionsListCommand } from "./list.js";
 import { subscriptionsShowCommand } from "./show.js";

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ALL_SUBS_PAGE_SIZE, getUpcomingRenewals } from "@pax8/core";

--- a/packages/cli/src/commands/subscriptions/show.ts
+++ b/packages/cli/src/commands/subscriptions/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/subscriptions/update.ts
+++ b/packages/cli/src/commands/subscriptions/update.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { getTelemetry, TELEMETRY_NOTICE } from "@pax8/core";

--- a/packages/cli/src/commands/usage/index.ts
+++ b/packages/cli/src/commands/usage/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { usageListCommand } from "./list.js";
 import { usageShowCommand } from "./show.js";

--- a/packages/cli/src/commands/usage/list.ts
+++ b/packages/cli/src/commands/usage/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/usage/show.ts
+++ b/packages/cli/src/commands/usage/show.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 
 declare const __CLI_VERSION__: string;

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ERROR_INVALID_INPUT } from "@pax8/core";

--- a/packages/cli/src/commands/webhooks/delete.ts
+++ b/packages/cli/src/commands/webhooks/delete.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/webhooks/index.ts
+++ b/packages/cli/src/commands/webhooks/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import { webhooksListCommand } from "./list.js";
 import { webhooksCreateCommand } from "./create.js";

--- a/packages/cli/src/commands/webhooks/list.ts
+++ b/packages/cli/src/commands/webhooks/list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/commands/webhooks/logs.ts
+++ b/packages/cli/src/commands/webhooks/logs.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { ERROR_INVALID_INPUT } from "@pax8/core";

--- a/packages/cli/src/commands/webhooks/test.ts
+++ b/packages/cli/src/commands/webhooks/test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";

--- a/packages/cli/src/lib/confirm.test.ts
+++ b/packages/cli/src/lib/confirm.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Queue of answers the next `prompt()` call should hand back. Tests push

--- a/packages/cli/src/lib/confirm.ts
+++ b/packages/cli/src/lib/confirm.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { createInterface } from "readline";
 
 function shouldAutoConfirm(): boolean {

--- a/packages/cli/src/lib/context.test.ts
+++ b/packages/cli/src/lib/context.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Track spawn calls so we can assert on cache-warmer invocations without

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   MockPax8Client,
   Pax8Client,

--- a/packages/cli/src/lib/enrich-subscriptions.test.ts
+++ b/packages/cli/src/lib/enrich-subscriptions.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi } from "vitest";
 import { enrichProductNames } from "./enrich-subscriptions.js";
 import type { CommandContext } from "./context.js";

--- a/packages/cli/src/lib/enrich-subscriptions.ts
+++ b/packages/cli/src/lib/enrich-subscriptions.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CommandContext } from "./context.js";
 
 /** Minimal shape needed by enrichProductNames — any object with productId and optional productName. */

--- a/packages/cli/src/lib/errors.test.ts
+++ b/packages/cli/src/lib/errors.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import chalk from "chalk";
 import { ZodError, ZodIssueCode } from "zod";
 import type { Ora } from "ora";

--- a/packages/cli/src/lib/formatters.test.ts
+++ b/packages/cli/src/lib/formatters.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   formatTimeAgo,

--- a/packages/cli/src/lib/formatters.ts
+++ b/packages/cli/src/lib/formatters.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import chalk from "chalk";
 import { subscriptionMrr } from "@pax8/core";
 

--- a/packages/cli/src/lib/idempotency.test.ts
+++ b/packages/cli/src/lib/idempotency.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/cli/src/lib/idempotency.ts
+++ b/packages/cli/src/lib/idempotency.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { homedir } from "node:os";

--- a/packages/cli/src/lib/index.ts
+++ b/packages/cli/src/lib/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export { output, type Column, type OutputOptions } from "./output.js";
 export { createSpinner } from "./spinner.js";
 export { CliError, handleCommandError } from "./errors.js";

--- a/packages/cli/src/lib/instrumented-action.test.ts
+++ b/packages/cli/src/lib/instrumented-action.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { classifyError, instrumentedAction } from "./instrumented-action.js";
 import { CliError } from "./errors.js";

--- a/packages/cli/src/lib/instrumented-action.ts
+++ b/packages/cli/src/lib/instrumented-action.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   getTelemetry,
   AuthError,

--- a/packages/cli/src/lib/invalidate-cache.test.ts
+++ b/packages/cli/src/lib/invalidate-cache.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { invalidateCacheAfterWrite } from "./invalidate-cache.js";
 

--- a/packages/cli/src/lib/invalidate-cache.ts
+++ b/packages/cli/src/lib/invalidate-cache.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { FileCache } from "@pax8/core";
 
 /**

--- a/packages/cli/src/lib/last-list.test.ts
+++ b/packages/cli/src/lib/last-list.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/cli/src/lib/last-list.ts
+++ b/packages/cli/src/lib/last-list.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getConfigDir } from "@pax8/core";

--- a/packages/cli/src/lib/next-step.test.ts
+++ b/packages/cli/src/lib/next-step.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const answerQueue: string[] = [];

--- a/packages/cli/src/lib/next-step.ts
+++ b/packages/cli/src/lib/next-step.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import chalk from "chalk";
 import { createInterface } from "readline";
 import { spawn } from "child_process";

--- a/packages/cli/src/lib/output-extended.test.ts
+++ b/packages/cli/src/lib/output-extended.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { output, type Column } from "./output.js";
 

--- a/packages/cli/src/lib/output.test.ts
+++ b/packages/cli/src/lib/output.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { output, type Column } from "./output.js";
 

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import chalk from "chalk";
 import Table from "cli-table3";
 

--- a/packages/cli/src/lib/redactor.test.ts
+++ b/packages/cli/src/lib/redactor.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { redactString, redactEnvelope, type BugReportEnvelope } from "./redactor.js";
 

--- a/packages/cli/src/lib/redactor.ts
+++ b/packages/cli/src/lib/redactor.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Redactor for the `pax8 report-bug` command. Takes a structured error
  * envelope and returns a sanitized copy with anything that smells like PII,

--- a/packages/cli/src/lib/resolve-company.test.ts
+++ b/packages/cli/src/lib/resolve-company.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi } from "vitest";
 import { resolveCompany, resolveCompanyId } from "./resolve-company.js";
 import type { CommandContext } from "./context.js";

--- a/packages/cli/src/lib/resolve-company.ts
+++ b/packages/cli/src/lib/resolve-company.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { ERROR_COMPANY_NOT_FOUND, type Company } from "@pax8/core";
 import type { CommandContext } from "./context.js";
 import { CliError } from "./errors.js";

--- a/packages/cli/src/lib/resolve-product.test.ts
+++ b/packages/cli/src/lib/resolve-product.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi } from "vitest";
 import { resolveProduct } from "./resolve-product.js";
 import type { CommandContext } from "./context.js";

--- a/packages/cli/src/lib/resolve-product.ts
+++ b/packages/cli/src/lib/resolve-product.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { ERROR_PRODUCT_NOT_FOUND, type Product } from "@pax8/core";
 import type { CommandContext } from "./context.js";
 import { CliError } from "./errors.js";

--- a/packages/cli/src/lib/signals.test.ts
+++ b/packages/cli/src/lib/signals.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   installSigintHandler,

--- a/packages/cli/src/lib/signals.ts
+++ b/packages/cli/src/lib/signals.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import chalk from "chalk";
 import { getTelemetry } from "@pax8/core";
 import { stopAllActiveSpinners } from "./spinner.js";

--- a/packages/cli/src/lib/spinner.test.ts
+++ b/packages/cli/src/lib/spinner.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createSpinner, stopAllActiveSpinners, _getActiveSpinnerCount } from "./spinner.js";
 

--- a/packages/cli/src/lib/spinner.ts
+++ b/packages/cli/src/lib/spinner.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import ora, { type Ora } from "ora";
 
 /**

--- a/packages/cli/src/lib/telemetry-context.test.ts
+++ b/packages/cli/src/lib/telemetry-context.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   setTelemetryFields,

--- a/packages/cli/src/lib/telemetry-context.ts
+++ b/packages/cli/src/lib/telemetry-context.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Request-scoped telemetry fields contributed by command handlers.
  *

--- a/packages/core/src/api/client-extended.test.ts
+++ b/packages/core/src/api/client-extended.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Pax8Client } from "./client.js";
 import { ApiError } from "./errors.js";

--- a/packages/core/src/api/client.test.ts
+++ b/packages/core/src/api/client.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Pax8Client, getDefaultBaseUrl } from "./client.js";
 import { ApiError, RateLimitError } from "./errors.js";

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { type ZodType } from "zod";
 import { ApiError, RateLimitError } from "./errors.js";
 import { PageSchema } from "./types.js";

--- a/packages/core/src/api/companies.test.ts
+++ b/packages/core/src/api/companies.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CompaniesApi } from "./companies.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/companies.ts
+++ b/packages/core/src/api/companies.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import {
   CompanySchema,

--- a/packages/core/src/api/constants.ts
+++ b/packages/core/src/api/constants.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Page size used by commands that need to fetch "all" subscriptions
  * across an entire portfolio (status, audit, recommendations, MRR

--- a/packages/core/src/api/contacts.test.ts
+++ b/packages/core/src/api/contacts.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ContactsApi } from "./contacts.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/contacts.ts
+++ b/packages/core/src/api/contacts.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import {
   ContactSchema,

--- a/packages/core/src/api/errors.test.ts
+++ b/packages/core/src/api/errors.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { ApiError, AuthError, RateLimitError, NotFoundError, ValidationError } from "./errors.js";
 

--- a/packages/core/src/api/errors.ts
+++ b/packages/core/src/api/errors.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export class ApiError extends Error {
   public readonly statusCode: number;
   public readonly requestPath: string;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export { Pax8Client, type Pax8ClientOptions } from "./client.js";
 export { CompaniesApi } from "./companies.js";
 export { ContactsApi } from "./contacts.js";

--- a/packages/core/src/api/invoices.test.ts
+++ b/packages/core/src/api/invoices.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { InvoicesApi } from "./invoices.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/invoices.ts
+++ b/packages/core/src/api/invoices.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import {
   InvoiceSchema,

--- a/packages/core/src/api/orders.test.ts
+++ b/packages/core/src/api/orders.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { OrdersApi } from "./orders.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/orders.ts
+++ b/packages/core/src/api/orders.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import {
   OrderSchema,

--- a/packages/core/src/api/products.test.ts
+++ b/packages/core/src/api/products.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ProductsApi } from "./products.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/products.ts
+++ b/packages/core/src/api/products.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import { z } from "zod";
 import {

--- a/packages/core/src/api/quotes.test.ts
+++ b/packages/core/src/api/quotes.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QuotesApi } from "./quotes.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/quotes.ts
+++ b/packages/core/src/api/quotes.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import {
   QuoteSchema,

--- a/packages/core/src/api/subscriptions.test.ts
+++ b/packages/core/src/api/subscriptions.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SubscriptionsApi } from "./subscriptions.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/subscriptions.ts
+++ b/packages/core/src/api/subscriptions.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import { z } from "zod";
 import {

--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import {
   CompanySchema,

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { z } from "zod";
 
 // ─── Enums ───────────────────────────────────────────────────────────────────

--- a/packages/core/src/api/usage.test.ts
+++ b/packages/core/src/api/usage.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UsageApi } from "./usage.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/usage.ts
+++ b/packages/core/src/api/usage.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import {
   UsageSummarySchema,

--- a/packages/core/src/api/webhooks.test.ts
+++ b/packages/core/src/api/webhooks.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { WebhooksApi } from "./webhooks.js";
 import type { Pax8Client } from "./client.js";

--- a/packages/core/src/api/webhooks.ts
+++ b/packages/core/src/api/webhooks.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Pax8Client } from "./client.js";
 import { z } from "zod";
 import {

--- a/packages/core/src/auth/credential-store.test.ts
+++ b/packages/core/src/auth/credential-store.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CredentialStore } from "./credential-store.js";
 import * as fs from "node:fs/promises";

--- a/packages/core/src/auth/credential-store.ts
+++ b/packages/core/src/auth/credential-store.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs/promises";
 import { constants } from "node:fs";
 import * as path from "node:path";

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export { TokenManager } from "./token-manager.js";
 export { CredentialStore } from "./credential-store.js";
 export type { Credentials, PermissionCheckResult } from "./credential-store.js";

--- a/packages/core/src/auth/token-manager-extended.test.ts
+++ b/packages/core/src/auth/token-manager-extended.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TokenManager } from "./token-manager.js";
 import { AuthError } from "../api/errors.js";

--- a/packages/core/src/auth/token-manager.test.ts
+++ b/packages/core/src/auth/token-manager.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TokenManager } from "./token-manager.js";
 import { AuthError } from "../api/errors.js";

--- a/packages/core/src/auth/token-manager.ts
+++ b/packages/core/src/auth/token-manager.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { AuthError } from "../api/errors.js";
 import { getDefaultBaseUrl } from "../api/client.js";
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,2 +1,5 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export { ConfigSchema, type Config } from "./schema.js";
 export { loadConfig, saveConfig, getConfigDir, ensureConfigDir } from "./loader.js";

--- a/packages/core/src/config/loader-extended.test.ts
+++ b/packages/core/src/config/loader-extended.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { getConfigDir, ensureConfigDir } from "./loader.js";
 import * as path from "node:path";

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { loadConfig, saveConfig } from "./loader.js";
 import { type Config } from "./schema.js";

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs/promises";
 import { homedir } from "node:os";
 import * as path from "node:path";

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { z } from "zod";
 
 export const ConfigSchema = z.object({

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Machine-readable error codes for pax8-cli.
  *

--- a/packages/core/src/mock/demo-data.test.ts
+++ b/packages/core/src/mock/demo-data.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import {
   companies,

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Demo data for PAX8_DEMO=1 mode
 // All data is realistic but fictional. UUIDs are deterministic for testing.
 

--- a/packages/core/src/mock/index.ts
+++ b/packages/core/src/mock/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export {
   companies,
   subscriptions,

--- a/packages/core/src/mock/mock-client-extended.test.ts
+++ b/packages/core/src/mock/mock-client-extended.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { MockPax8Client } from "./mock-client.js";
 import { NotFoundError } from "../api/errors.js";

--- a/packages/core/src/mock/mock-client.test.ts
+++ b/packages/core/src/mock/mock-client.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { MockPax8Client } from "./mock-client.js";
 

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // MockPax8Client — drop-in replacement for the real API client in demo mode.
 // Returns demo data with simulated pagination, latency, and filtering.
 

--- a/packages/core/src/services/analytics.test.ts
+++ b/packages/core/src/services/analytics.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { computeMrr, computeGrowth } from "./analytics.js";
 

--- a/packages/core/src/services/analytics.ts
+++ b/packages/core/src/services/analytics.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Subscription, Invoice } from "../api/types.js";
 
 /** The subset of Subscription fields used by analytics. */

--- a/packages/core/src/services/bulk-executor.test.ts
+++ b/packages/core/src/services/bulk-executor.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { executeBulk, type BulkOp } from "./bulk-executor.js";
 

--- a/packages/core/src/services/bulk-executor.ts
+++ b/packages/core/src/services/bulk-executor.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export interface BulkOp<T = unknown> {
   id: string;
   execute: () => Promise<T>;

--- a/packages/core/src/services/cache.test.ts
+++ b/packages/core/src/services/cache.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { FileCache } from "./cache.js";
 import * as fs from "node:fs/promises";

--- a/packages/core/src/services/cache.ts
+++ b/packages/core/src/services/cache.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs/promises";
 import { homedir } from "node:os";
 import * as path from "node:path";

--- a/packages/core/src/services/cost-simulator.test.ts
+++ b/packages/core/src/services/cost-simulator.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { simulateCostChange, type SimulationInput } from "./cost-simulator.js";
 import type { ProductPricingPlan } from "../api/types.js";

--- a/packages/core/src/services/cost-simulator.ts
+++ b/packages/core/src/services/cost-simulator.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { ProductPricingPlan } from "../api/types.js";
 import { subscriptionMrr } from "./analytics.js";
 

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export { getUpcomingRenewals, type RenewalItem, type RenewalReport } from "./renewal-tracker.js";
 export { auditInvoices, type AuditDiscrepancy, type AuditReport } from "./invoice-auditor.js";
 export { subscriptionMrr, computeMrr, computeGrowth, type MrrReport, type GrowthReport } from "./analytics.js";

--- a/packages/core/src/services/invoice-auditor.test.ts
+++ b/packages/core/src/services/invoice-auditor.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { auditInvoices } from "./invoice-auditor.js";
 

--- a/packages/core/src/services/invoice-auditor.ts
+++ b/packages/core/src/services/invoice-auditor.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { InvoiceItem, Subscription } from "../api/types.js";
 
 /** The subset of InvoiceItem fields used by the invoice auditor. */

--- a/packages/core/src/services/recommendations-filter.test.ts
+++ b/packages/core/src/services/recommendations-filter.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { getRecommendations } from "./recommendations.js";
 

--- a/packages/core/src/services/recommendations.test.ts
+++ b/packages/core/src/services/recommendations.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { getRecommendations } from "./recommendations.js";
 

--- a/packages/core/src/services/recommendations.ts
+++ b/packages/core/src/services/recommendations.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Subscription } from "../api/types.js";
 import { subscriptionMrr } from "./analytics.js";
 

--- a/packages/core/src/services/renewal-tracker.test.ts
+++ b/packages/core/src/services/renewal-tracker.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 import { getUpcomingRenewals } from "./renewal-tracker.js";
 

--- a/packages/core/src/services/renewal-tracker.ts
+++ b/packages/core/src/services/renewal-tracker.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Subscription } from "../api/types.js";
 import { subscriptionMrr } from "./analytics.js";
 

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 export {
   Telemetry,
   getTelemetry,

--- a/packages/core/src/telemetry/telemetry-extended.test.ts
+++ b/packages/core/src/telemetry/telemetry-extended.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /* eslint-disable @typescript-eslint/no-explicit-any -- accessing private members for testing */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /* eslint-disable @typescript-eslint/no-explicit-any -- accessing private members for testing */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";


### PR DESCRIPTION
## Summary

Adds the SPDX-style two-line Apache-2.0 license header to every TypeScript source file in the repo. Mechanical pass; no functional change. Idempotent — files that already had the header were skipped.

## Header format

```typescript
// Copyright 2026 Pax8, Inc.
// SPDX-License-Identifier: Apache-2.0
```

## Files headered

217 TypeScript source files (packages/*/src/**/*.ts and e2e/*.ts). 0 skipped — none had the header before this PR.

## Verification

- `git grep -L "SPDX-License-Identifier: Apache-2.0" -- 'packages/*/src/**/*.ts' 'e2e/*.ts'` returns empty
- `pnpm build` — green
- `pnpm -r exec tsc --noEmit` — 0 errors
- `pnpm lint` — 0 errors / 0 warnings
- `PAX8_DEMO=1 NO_COLOR=1 pnpm test` — 1022 passed, 8 skipped (80 test files)
- `PAX8_DEMO=1 NO_COLOR=1 pnpm test:coverage` — threshold gate green

CHANGELOG updated under v0.1.0 "Internal".