### PR TITLE
fix: v0.1.0 must-fixes — config-test isolation + complete CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 Initial public release.
 
-### Security
-
-- `pax8 report-bug` now redacts positional argument values (e.g. customer / company / product names typed at the CLI) from both the `command` and `Message` fields of the persisted error envelope and the submitted report. The command *structure* is preserved (`companies show <REDACTED:ARG>`) but the user-supplied value is replaced everywhere, including inside interpolated error messages like `Company not found: "<name>"`. Closes #170.
-
 ### Added
 
 - **Seven core workflows** computed locally from raw Pax8 data: `status`, `companies list --coverage`, `subscriptions renewals`, `invoices audit`, `recommendations list`, `recommendations act`, and `report mrr` / `report growth`.
 - **Closed-loop ordering** — `recommendations act` walks portfolio gaps and places the orders interactively; `invoices audit → invoices dispute` files billing disputes against detected discrepancies.
 - **`@pax8/core` standalone SDK** — all renewal, audit, recommendation, and analytics logic exposed as an importable library with zero CLI dependencies, suitable for embedding in portals, Lambdas, or partner tooling.
-- **`@pax8/claude-skill`** — agent skill that wraps the CLI as AI tools for Claude Code, Cursor, Copilot, and any framework that can run shell commands; ships with a read-only vs. write safety contract.
-- `AGENTS.md` at repo root — cross-runtime agent entry point (Cursor, aider, OpenCode, etc.).
+- **`@pax8/claude-skill`** — agent skill that wraps the CLI as AI tools for Claude Code, Cursor, Copilot, and any framework that can run shell commands; ships with a read-only vs. write safety contract (#136).
+- **`pax8 cost sim`** — model SKU swaps, quantity changes, and add-product scenarios with monthly/annual estimated MRR delta, before actually placing the order. Pure compute over pricing data; `simulateCostChange()` is also exported from `@pax8/core` for embedders (#163).
+- **`pax8 report-bug`** — opens a sanitized, prefilled GitHub issue from the most recent failure. Strips UUIDs, emails, `$HOME` paths, JWTs, and long token-shaped strings; uses `gh` if available, otherwise a prefilled URL via the platform open command. Nothing leaves the machine without explicit `[y/N]` confirmation (#161).
 - **Demo mode** (`PAX8_DEMO=1`) — every command runs against an in-memory fixture, so partners can evaluate the tool with no credentials and CI runs end-to-end against the same surface.
 - **OAuth 2.0 client-credentials flow** — secure local credential storage at `~/.pax8/credentials.json` with mode `0600`, tokens cached in memory only and never persisted, automatic refresh at 23h.
 - **Structured `--json` output with `nextActions`** — `status`, `report mrr/growth`, and `invoices audit` always include contextual next-step hints; list commands opt in via `--with-actions` to ride a `{ data, nextActions }` envelope alongside the flat JSON array (#97).
 - **Idempotency keys on write commands** — `--idempotency-key <uuid>` is accepted on every mutation command (#91).
 - **Machine-readable error codes** — every `CliError` carries a stable `code` (one of the `ERROR_*` constants from `@pax8/core`) so agents and scripts can branch on outcome without parsing strings (#90).
 - **Output formats** — `--json`, `--csv`, `--quiet`, plus `--with-actions` (envelope mode) and `--ids-only` (one ID per line, for piping into the next command's `--company` filter).
-- **Cost simulator (`pax8 cost sim`)** — model SKU swaps, quantity changes, and add-product scenarios with monthly/annual estimated MRR delta, before actually placing the order. Pure compute over pricing data; `simulateCostChange()` is also exported from `@pax8/core` for embedders (#3).
-- **Vitest test suite** — ~840 tests across unit, CLI integration (subprocess), and e2e flows, runnable end-to-end under `PAX8_DEMO=1`.
-- `pax8 auth login` now masks the client secret in interactive mode (no more plaintext echo).
+- **`PAX8_API_BASE` env var** — point the CLI at sandbox / staging environments without rebuilding (#135).
+- **`AGENTS.md`** at repo root — cross-runtime agent entry point (Cursor, aider, OpenCode, etc.) (#165).
+- **`pax8 auth login` masks the client secret** in interactive mode — introduces the `prompts` library for secure input; no more plaintext echo (#160).
+- Comprehensive test suite (1022+ tests across unit, CLI integration, and e2e flows; see CI for current count).
 
 ### Changed
 
-- Display labels rebranded from "MRR" to "estimated MRR" to reflect that the value is computed locally and not the partner's actual billed revenue. Command paths (`pax8 report mrr`), JSON output keys (`mrr`, `mrrUplift`, etc.), and telemetry properties unchanged (#166).
-- `pax8 recommendations act` now shows a multi-select picker for batch ordering instead of a one-at-a-time `y/s/q` walk; `-y` / `--yes` bypass unchanged.
+- List commands return a flat array by default; `--with-actions` opts in to the `{ data, nextActions }` envelope. Breaking shape change relative to early prototypes.
+- Display labels rebranded from "MRR" to "estimated MRR" to reflect that the value is computed locally and not the partner's actual billed revenue. Command paths (`pax8 report mrr`), JSON output keys (`mrr`, `mrrUplift`, etc.), and telemetry properties unchanged (#168).
+- `pax8 recommendations act` now shows a multi-select picker for batch ordering instead of a one-at-a-time `y/s/q` walk; `-y` / `--yes` bypass unchanged (#167).
+
+### Fixed
+
+- **Telemetry — failed commands now emit events.** `handleCommandError` previously called `process.exit(1)` before the `parseAsync.catch` failure-track block could run; failure events now fire (and flush) synchronously inside the error handler. Commander parse errors route through the same path via `exitOverride()` (#145).
+- **Telemetry — no more double-fire on write commands.** `recommendations act` and `orders create` were emitting two `command_executed` events per invocation (#146).
+- **Telemetry — `error_code` aligned with the canonical `ERROR_*` vocabulary** from `@pax8/core` so dashboards can group by stable codes (#147).
+- **Telemetry — orphaned `company_count` and `rec_count` fields** removed from the schema; they were documented but never actually emitted (#148/#149).
+- **Telemetry test storage** isolated per test to eliminate full-suite flake (#118/#128).
+- **`pax8 report-bug`** now redacts positional argument values (e.g. customer / company / product names typed at the CLI) from both the `command` and `Message` fields of the persisted error envelope and the submitted report. The command *structure* is preserved (`companies show <REDACTED:ARG>`) but the user-supplied value is replaced everywhere, including inside interpolated error messages like `Company not found: "<name>"` (#170/#171).
 
 ### Internal
 
-- Added SPDX Apache-2.0 headers to all source files (no functional change).
+- **Subprocess coverage instrumentation + CI-enforced threshold gate** so `vitest --coverage` reflects code paths exercised by the CLI integration tests (#150).
+- **Test gap fill: +93 unit tests in `cli/lib`** plus `PAX8_API_BASE` coverage (#151).
+- **Apache-2.0 SPDX headers** on every source file across the workspace (#169).
+- **Release workflow with changesets + npm OIDC trusted publishing** (#133).
+- **Lint clean + CI Lint step** added (#117/#130).
+- **`tsc --noEmit` clean + CI Typecheck step** restored (#93/#131).
+- **Governance cleanup** — co-owner added; legacy ESLint config removed (#132).
+- **Test isolation** — `config.test.ts` now uses an isolated `mkdtemp` config dir per test (closes #172).
+- Documentation revisions: `CLAUDE.md` excellence + cross-doc consistency (#143); README / SECURITY / CONTRIBUTING polish for v0.1.0 (#134); v0.1.0 CHANGELOG cut (#137).
 
 [0.1.0]: https://github.com/pax8labs/pax8-cli/releases/tag/v0.1.0

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1,29 +1,45 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
 describe("pax8 config", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-config-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
   describe("config path", () => {
     it("prints the config directory path", async () => {
-      const result = await runCliExpectSuccess(["config", "path"]);
-      const expected = path.join(os.homedir(), ".pax8");
-      expect(result.stdout.trim()).toBe(expected);
+      const result = await runCliExpectSuccess(["config", "path"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      expect(result.stdout.trim()).toBe(tmpDir);
     });
   });
 
   describe("config init", () => {
     it("creates or reports existing config", async () => {
-      const result = await runCliExpectSuccess(["config", "init", "--force"]);
+      const result = await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("Config created");
       expect(result.stdout).toContain("config.yaml");
     });
 
     it("outputs YAML content", async () => {
-      const result = await runCliExpectSuccess(["config", "init", "--force"]);
+      const result = await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("version:");
       expect(result.stdout).toContain("output_format");
     });
@@ -32,8 +48,12 @@ describe("pax8 config", () => {
   describe("config show", () => {
     it("displays config after init", async () => {
       // Ensure config exists
-      await runCliExpectSuccess(["config", "init", "--force"]);
-      const result = await runCliExpectSuccess(["config", "show"]);
+      await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      const result = await runCliExpectSuccess(["config", "show"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("version:");
       expect(result.stdout).toContain("output_format");
     });
@@ -42,22 +62,20 @@ describe("pax8 config", () => {
   describe("config set", () => {
     it("sets a config value", async () => {
       // Ensure config exists
-      await runCliExpectSuccess(["config", "init", "--force"]);
-      const result = await runCliExpectSuccess([
-        "config",
-        "set",
-        "defaults.page_size",
-        "25",
-      ]);
+      await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      const result = await runCliExpectSuccess(
+        ["config", "set", "defaults.page_size", "25"],
+        { PAX8_CONFIG_DIR: tmpDir },
+      );
       expect(result.stdout).toContain("Set defaults.page_size = 25");
     });
 
     it("shows help with examples", async () => {
-      const result = await runCliExpectSuccess([
-        "config",
-        "set",
-        "--help",
-      ]);
+      const result = await runCliExpectSuccess(["config", "set", "--help"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("Examples:");
       expect(result.stdout).toContain("defaults.output_format");
     });
@@ -65,7 +83,9 @@ describe("pax8 config", () => {
 
   describe("config --help", () => {
     it("shows config subcommands", async () => {
-      const result = await runCliExpectSuccess(["config", "--help"]);
+      const result = await runCliExpectSuccess(["config", "--help"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("init");
       expect(result.stdout).toContain("show");
       expect(result.stdout).toContain("set");

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -1,13 +1,28 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { runCliExpectSuccess } from "./test-utils.js";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 
 describe("pax8 telemetry", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-telemetry-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
   describe("telemetry --help", () => {
     it("shows telemetry subcommands", async () => {
-      const result = await runCliExpectSuccess(["telemetry", "--help"]);
+      const result = await runCliExpectSuccess(["telemetry", "--help"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("status");
       expect(result.stdout).toContain("enable");
       expect(result.stdout).toContain("disable");
@@ -16,7 +31,9 @@ describe("pax8 telemetry", () => {
 
   describe("telemetry status", () => {
     it("reports telemetry status", async () => {
-      const result = await runCliExpectSuccess(["telemetry", "status"]);
+      const result = await runCliExpectSuccess(["telemetry", "status"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       // Should say either enabled or disabled
       expect(result.stdout).toMatch(/Telemetry is (enabled|disabled)/);
     });
@@ -25,30 +42,46 @@ describe("pax8 telemetry", () => {
   describe("telemetry enable", () => {
     it("enables telemetry", async () => {
       // First ensure config exists
-      await runCliExpectSuccess(["config", "init", "--force"]);
-      const result = await runCliExpectSuccess(["telemetry", "enable"]);
+      await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      const result = await runCliExpectSuccess(["telemetry", "enable"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("Telemetry enabled");
     });
   });
 
   describe("telemetry disable", () => {
     it("disables telemetry", async () => {
-      await runCliExpectSuccess(["config", "init", "--force"]);
-      const result = await runCliExpectSuccess(["telemetry", "disable"]);
+      await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      const result = await runCliExpectSuccess(["telemetry", "disable"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("Telemetry disabled");
     });
   });
 
   describe("telemetry status after toggle", () => {
     it("enable command reports success", async () => {
-      await runCliExpectSuccess(["config", "init", "--force"]);
-      const result = await runCliExpectSuccess(["telemetry", "enable"]);
+      await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      const result = await runCliExpectSuccess(["telemetry", "enable"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("Telemetry enabled");
     });
 
     it("disable command reports success", async () => {
-      await runCliExpectSuccess(["config", "init", "--force"]);
-      const result = await runCliExpectSuccess(["telemetry", "disable"]);
+      await runCliExpectSuccess(["config", "init", "--force"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      const result = await runCliExpectSuccess(["telemetry", "disable"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
       expect(result.stdout).toContain("Telemetry disabled");
     });
   });

--- a/packages/cli/src/commands/config/init.ts
+++ b/packages/cli/src/commands/config/init.ts
@@ -5,11 +5,8 @@ import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 import YAML from "yaml";
-
-const CONFIG_DIR = path.join(os.homedir(), ".pax8");
-const CONFIG_FILE = path.join(CONFIG_DIR, "config.yaml");
+import { getConfigDir } from "@pax8/core";
 
 const DEFAULT_CONFIG = {
   version: "1.0",
@@ -35,6 +32,8 @@ Examples:
   pax8 config init --force`
   )
   .action(async (options) => {
+    const CONFIG_DIR = getConfigDir();
+    const CONFIG_FILE = path.join(CONFIG_DIR, "config.yaml");
     try {
       const exists = await fs
         .access(CONFIG_FILE)

--- a/packages/cli/src/commands/config/path.ts
+++ b/packages/cli/src/commands/config/path.ts
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Command } from "commander";
-import * as path from "node:path";
-import * as os from "node:os";
-
-const CONFIG_DIR = path.join(os.homedir(), ".pax8");
+import { getConfigDir } from "@pax8/core";
 
 export const configPathCommand = new Command("path")
   .description("Print config directory path")
@@ -16,5 +13,5 @@ Examples:
   pax8 config path`
   )
   .action(async () => {
-    process.stdout.write(CONFIG_DIR + "\n");
+    process.stdout.write(getConfigDir() + "\n");
   });

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -5,11 +5,8 @@ import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 import YAML from "yaml";
-
-const CONFIG_DIR = path.join(os.homedir(), ".pax8");
-const CONFIG_FILE = path.join(CONFIG_DIR, "config.yaml");
+import { getConfigDir } from "@pax8/core";
 
 function setNestedValue(obj: Record<string, unknown>, keyPath: string, value: string): void {
   const keys = keyPath.split(".");
@@ -42,6 +39,8 @@ Examples:
   pax8 config set cache.enabled false`
   )
   .action(async (key: string, value: string) => {
+    const CONFIG_DIR = getConfigDir();
+    const CONFIG_FILE = path.join(CONFIG_DIR, "config.yaml");
     try {
       let config: Record<string, unknown> = {};
       try {

--- a/packages/cli/src/commands/config/show.ts
+++ b/packages/cli/src/commands/config/show.ts
@@ -5,12 +5,8 @@ import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 import { replCmd } from "../../lib/confirm.js";
-import YAML from "yaml";
-
-const CONFIG_DIR = path.join(os.homedir(), ".pax8");
-const CONFIG_FILE = path.join(CONFIG_DIR, "config.yaml");
+import { getConfigDir } from "@pax8/core";
 
 export const configShowCommand = new Command("show")
   .description("Display current configuration")
@@ -21,6 +17,7 @@ Examples:
   pax8 config show`
   )
   .action(async () => {
+    const CONFIG_FILE = path.join(getConfigDir(), "config.yaml");
     try {
       const content = await fs.readFile(CONFIG_FILE, "utf-8");
       process.stdout.write(content);


### PR DESCRIPTION
## Summary

Two must-fixes from the tech-debt review (#173) before v0.1.0 ships.

### Closes #172 — config.test.ts polluted developer's real ~/.pax8

The four `config` subcommands (`init`, `show`, `set`, `path`) hardcoded `path.join(os.homedir(), ".pax8")` instead of routing through `getConfigDir()` from `@pax8/core` (which already honors `PAX8_CONFIG_DIR`). That meant *no* test could isolate config-command state — even tests that passed `PAX8_CONFIG_DIR` would still mutate the developer's real config. Two test files were affected: `config.test.ts` (the one called out in #172) and `telemetry.test.ts` (which calls `config init --force` to seed state before its own assertions).

Fix: switch the four config command files to `getConfigDir()`, and add `beforeEach` / `afterEach` `mkdtemp` isolation in both test files. Mirrors the pattern already used in `recommendations.test.ts` and `report-bug.test.ts`.

Verified: ran the full suite, captured `~/.pax8/config.yaml` mtime before and after — unchanged.

### CHANGELOG completeness

The v0.1.0 entry was cut in #137 before the heavy release-prep wave. Refreshed to include the work that landed since:

- **Added**: `pax8 report-bug` (#161), `pax8 cost sim` (#163), multi-select recs-act (#167), auth-login secret masking (#160), AGENTS.md (#165), MRR display rebrand (#168), PAX8_API_BASE env var (#135)
- **Fixed**: telemetry silent-error / double-fire / vocab-drift / orphaned-fields (#145/#146/#147/#148/#149), redactor positional-arg leak (#170/#171)
- **Internal**: subprocess coverage instrumentation + threshold gate (#150), +93 unit tests in `cli/lib` (#151), Apache-2.0 SPDX headers everywhere (#169), release workflow with changesets + npm OIDC (#133), lint / typecheck CI steps restored (#117/#130, #93/#131)

Also bumped the test-count phrasing from "~840 tests" to "1022+ tests across unit, CLI integration, and e2e flows".

## Judgment calls

- Telemetry-test isolation was outside the issue body's scope ("the only test file in `__tests__/` that exercises real on-disk config without a `tmpDir` override" — the review missed `telemetry.test.ts`'s `config init --force` calls). Including it because it has the same root cause and otherwise the real-config-mutation assertion would still fail.
- Updated the four config command files to honor `PAX8_CONFIG_DIR` rather than only patching the test. The minimum-line fix in #172 assumes the env var already plumbs through, which it didn't — so this is the actual root cause.

## Test plan

- [x] config.test.ts isolated — `~/.pax8/config.yaml` mtime unchanged across full `pnpm test` run
- [x] 1037 tests pass; build, lint, typecheck, coverage gate all green
- [x] CHANGELOG renders cleanly in Markdown (Keep-a-Changelog format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)