### PR TITLE
refactor: extract withIdempotency() + resolveCommitmentTermId() helpers — refs #173

### DIFF
--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -15,7 +15,7 @@ import { formatCurrency, formatQuantity } from "../../lib/formatters.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { confirm, replCmd } from "../../lib/confirm.js";
 import { markWriteInFlight } from "../../lib/signals.js";
-import { hashArgs, isValidKey, loadEntry, saveEntry } from "../../lib/idempotency.js";
+import { hashArgs, isValidKey, withIdempotency } from "../../lib/idempotency.js";
 
 /**
  * NOTE: The Pax8 v1 API does not expose a public dispute / write-off / credit
@@ -258,104 +258,44 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
 
     // ── Idempotency handling ────────────────────────────────────────────────
     const idempotencyKey: string | undefined = allOpts.idempotencyKey;
-    const commandName = "invoices.dispute";
-    let argsHash: string | null = null;
-    if (idempotencyKey !== undefined) {
-      if (!isValidKey(idempotencyKey)) {
-        await handleCommandError(
-          new CliError(
-            `Invalid idempotency key: "${idempotencyKey}"`,
-            [
-              "Idempotency keys must be 8–128 characters of letters, digits, '-', '_', or '.'",
-              "UUID v4 is recommended.",
-            ],
-            [
-              "Generate one with: uuidgen",
-              `Example: ${replCmd("pax8 invoices dispute")} ... --idempotency-key 9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d`,
-            ],
-            undefined,
-            ERROR_INVALID_INPUT satisfies Pax8ErrorCode,
-          ),
-        );
-      }
-      argsHash = hashArgs({
-        discrepancy: allOpts.discrepancy,
-        company: allOpts.company,
-        product: allOpts.product,
-        month: allOpts.month,
-        reason: allOpts.reason,
-      });
-      try {
-        const cached = await loadEntry(commandName, idempotencyKey);
-        if (cached) {
-          if (cached.argsHash !== argsHash) {
-            await handleCommandError(
-              new CliError(
-                "Idempotency key reused with different arguments — refusing to retry.",
-                [
-                  `The key "${idempotencyKey}" was previously used for ${cached.command} with a different argument set.`,
-                  "Replaying with new arguments would risk a double-write or a misleading 'cached' response.",
-                ],
-                [
-                  "Generate a new idempotency key for the new request.",
-                  `Or wait 24h for the old entry to expire (cached at ${cached.createdAt}).`,
-                ],
-              ),
-            );
-          }
-          process.stderr.write(chalk.dim("  (idempotent replay)\n"));
-          if (cached.output) process.stdout.write(cached.output);
-          process.exit(cached.exitCode);
-          return;
-        }
-      } catch (err) {
-        if (err instanceof CliError) throw err;
-        if (process.env.PAX8_DEBUG) {
-          process.stderr.write(`[debug] idempotency cache read failed: ${err}\n`);
-        }
-      }
+    if (idempotencyKey !== undefined && !isValidKey(idempotencyKey)) {
+      await handleCommandError(
+        new CliError(
+          `Invalid idempotency key: "${idempotencyKey}"`,
+          [
+            "Idempotency keys must be 8–128 characters of letters, digits, '-', '_', or '.'",
+            "UUID v4 is recommended.",
+          ],
+          [
+            "Generate one with: uuidgen",
+            `Example: ${replCmd("pax8 invoices dispute")} ... --idempotency-key 9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT satisfies Pax8ErrorCode,
+        ),
+      );
     }
-
-    // Capture stdout for idempotent replay
-    let captured = "";
-    let succeeded = false;
-    const realStdoutWrite = process.stdout.write.bind(process.stdout);
-    if (idempotencyKey) {
-      (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) = (
-        chunk: string | Uint8Array,
-      ): boolean => {
-        const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
-        captured += text;
-        return realStdoutWrite(chunk as string);
-      };
-    }
-    const restoreStdout = (): void => {
-      if (idempotencyKey) {
-        process.stdout.write = realStdoutWrite as typeof process.stdout.write;
-      }
-    };
-    const persistEntry = async (): Promise<void> => {
-      if (!idempotencyKey || !succeeded || argsHash === null) return;
-      try {
-        await saveEntry({
-          key: idempotencyKey,
-          command: commandName,
-          argsHash,
-          output: captured,
-          exitCode: 0,
-          createdAt: new Date().toISOString(),
-        });
-      } catch (err) {
-        if (process.env.PAX8_DEBUG) {
-          process.stderr.write(`[debug] idempotency cache write failed: ${err}\n`);
-        }
-      }
-    };
+    const argsHash = hashArgs({
+      discrepancy: allOpts.discrepancy,
+      company: allOpts.company,
+      product: allOpts.product,
+      month: allOpts.month,
+      reason: allOpts.reason,
+    });
 
     const ctx = await buildContext(allOpts);
     const spinner = createSpinner("Locating discrepancy...");
 
     try {
+      await withIdempotency<boolean>(
+        {
+          commandName: "invoices.dispute",
+          idempotencyKey,
+          argsHash,
+          // Don't cache "user cancelled at confirm" as a successful run.
+          shouldPersist: (didWrite) => didWrite,
+        },
+        async (): Promise<boolean> => {
       // Validate that we have something to look up
       if (!allOpts.discrepancy && !allOpts.company) {
         throw new CliError(
@@ -425,8 +365,7 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
         if (ctx.outputFormat !== "json" && ctx.outputFormat !== "quiet") {
           process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
         }
-        restoreStdout();
-        return;
+        return false;
       }
 
       // ── Persist the draft (the "write" half of the closed loop) ─────────
@@ -466,17 +405,11 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
           ],
         };
         process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
-        succeeded = true;
-        await persistEntry();
-        restoreStdout();
-        return;
+        return true;
       }
 
       if (ctx.outputFormat === "quiet") {
-        succeeded = true;
-        await persistEntry();
-        restoreStdout();
-        return;
+        return true;
       }
 
       process.stdout.write("\n");
@@ -492,11 +425,11 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
       process.stderr.write(`    ${chalk.cyan(`Paste the template above into the Pax8 portal billing support form.`)}\n`);
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 invoices audit`))} ${chalk.dim("re-audit later to confirm resolution")}\n\n`);
 
-      succeeded = true;
-      await persistEntry();
-      restoreStdout();
+          return true;
+        },
+      );
     } catch (error) {
-      restoreStdout();
+      // withIdempotency restores stdout via try/finally before bubbling here.
       if (error instanceof CliError) {
         await handleCommandError(error, spinner);
       }

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -19,7 +19,7 @@ import {
 import type { CreateOrderInput, OrderLineItemInput, BillingTerm } from "@pax8/core";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
-import { hashArgs, isValidKey, loadEntry, saveEntry } from "../../lib/idempotency.js";
+import { hashArgs, isValidKey, withIdempotency } from "../../lib/idempotency.js";
 import { setTelemetryFields } from "../../lib/telemetry-context.js";
 
 export const ordersCreateCommand = new Command("create")
@@ -55,106 +55,40 @@ Examples:
     // The "args hash" deliberately excludes `yes` (cosmetic) and the key itself,
     // so retrying with the same key under -y or interactive confirm is allowed.
     const idempotencyKey: string | undefined = allOpts.idempotencyKey;
-    const commandName = "orders.create";
-    let argsHash: string | null = null;
-    if (idempotencyKey !== undefined) {
-      if (!isValidKey(idempotencyKey)) {
-        await handleCommandError(
-          new CliError(
-            `Invalid idempotency key: "${idempotencyKey}"`,
-            [
-              "Idempotency keys must be 8–128 characters of letters, digits, '-', '_', or '.'",
-              "UUID v4 is recommended.",
-            ],
-            [
-              "Generate one with: uuidgen",
-              `Example: ${replCmd("pax8 orders create")} ... --idempotency-key 9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d`,
-            ],
-          ),
-        );
-      }
-      argsHash = hashArgs({
-        company: allOpts.company,
-        product: allOpts.product,
-        quantity: allOpts.quantity,
-        billingTerm: allOpts.billingTerm,
-        commitmentTerm: allOpts.commitmentTerm,
-        commitmentTermId: allOpts.commitmentTermId,
-      });
-
-      try {
-        const cached = await loadEntry(commandName, idempotencyKey);
-        if (cached) {
-          if (cached.argsHash !== argsHash) {
-            await handleCommandError(
-              new CliError(
-                "Idempotency key reused with different arguments — refusing to retry.",
-                [
-                  `The key "${idempotencyKey}" was previously used for ${cached.command} with a different argument set.`,
-                  "Replaying with new arguments would risk a double-write or a misleading 'cached' response.",
-                ],
-                [
-                  "Generate a new idempotency key for the new request.",
-                  `Or wait 24h for the old entry to expire (cached at ${cached.createdAt}).`,
-                ],
-              ),
-            );
-          }
-          process.stderr.write(chalk.dim("  (idempotent replay)\n"));
-          if (cached.output) process.stdout.write(cached.output);
-          process.exit(cached.exitCode);
-          return;
-        }
-      } catch (err) {
-        // Re-throw CliError thrown via handleCommandError; for other read errors,
-        // log in debug mode and proceed (fail-open: if cache is broken, the user
-        // still gets to make the call).
-        if (err instanceof CliError) throw err;
-        if (process.env.PAX8_DEBUG) {
-          process.stderr.write(`[debug] idempotency cache read failed: ${err}\n`);
-        }
-      }
+    if (idempotencyKey !== undefined && !isValidKey(idempotencyKey)) {
+      await handleCommandError(
+        new CliError(
+          `Invalid idempotency key: "${idempotencyKey}"`,
+          [
+            "Idempotency keys must be 8–128 characters of letters, digits, '-', '_', or '.'",
+            "UUID v4 is recommended.",
+          ],
+          [
+            "Generate one with: uuidgen",
+            `Example: ${replCmd("pax8 orders create")} ... --idempotency-key 9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d`,
+          ],
+        ),
+      );
     }
-
-    // Capture stdout so we can replay it on a future invocation with the
-    // same idempotency key. We only install the proxy when a key is present.
-    let captured = "";
-    let succeeded = false;
-    const realStdoutWrite = process.stdout.write.bind(process.stdout);
-    if (idempotencyKey) {
-      // Cast to satisfy the multi-overload signature of process.stdout.write.
-      (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) = (
-        chunk: string | Uint8Array,
-      ): boolean => {
-        const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
-        captured += text;
-        return realStdoutWrite(chunk as string);
-      };
-    }
-    const restoreStdout = (): void => {
-      if (idempotencyKey) {
-        process.stdout.write = realStdoutWrite as typeof process.stdout.write;
-      }
-    };
-    const persistEntry = async (): Promise<void> => {
-      if (!idempotencyKey || !succeeded || argsHash === null) return;
-      try {
-        await saveEntry({
-          key: idempotencyKey,
-          command: commandName,
-          argsHash,
-          output: captured,
-          exitCode: 0,
-          createdAt: new Date().toISOString(),
-        });
-      } catch (err) {
-        if (process.env.PAX8_DEBUG) {
-          process.stderr.write(`[debug] idempotency cache write failed: ${err}\n`);
-        }
-      }
-    };
+    const argsHash = hashArgs({
+      company: allOpts.company,
+      product: allOpts.product,
+      quantity: allOpts.quantity,
+      billingTerm: allOpts.billingTerm,
+      commitmentTerm: allOpts.commitmentTerm,
+      commitmentTermId: allOpts.commitmentTermId,
+    });
 
     try {
+      await withIdempotency<boolean>(
+        {
+          commandName: "orders.create",
+          idempotencyKey,
+          argsHash,
+          // Don't cache "user cancelled at confirm" as a successful run.
+          shouldPersist: (didWrite) => didWrite,
+        },
+        async (): Promise<boolean> => {
       const ctx = await buildContext(allOpts);
       const quantity = parseInt(allOpts.quantity, 10);
 
@@ -299,7 +233,7 @@ Examples:
       );
       if (confirmedQty === null) {
         process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
-        return;
+        return false;
       }
 
       const spinner = createSpinner("Creating order...").start();
@@ -354,10 +288,7 @@ Examples:
           annualCost: annualCost ?? null,
         };
         process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
-        succeeded = true;
-        await persistEntry();
-        restoreStdout();
-        return;
+        return true;
       }
 
       // Post-order summary with financial impact
@@ -391,14 +322,13 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders show ${order.id}`))}  ${chalk.dim("check order status")}\n`);
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions list --company "${companyName}"`))}  ${chalk.dim("view subscriptions")}\n`);
       process.stderr.write("\n");
-      succeeded = true;
-      await persistEntry();
-      restoreStdout();
+          return true;
+        },
+      );
     } catch (error) {
-      // Restore stdout before delegating to handleCommandError (which prints
-      // formatted error to stderr and calls process.exit). We don't persist the
-      // idempotency entry on error — the agent can retry.
-      restoreStdout();
+      // withIdempotency restores stdout via try/finally before bubbling the
+      // error here. We don't persist the cache entry on failure — the agent
+      // can retry with the same key.
       // Provide order-specific error messages with actionable guidance
       if (error instanceof ApiError) {
         const displayProduct = productName || allOpts.product;

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -19,6 +19,7 @@ import {
 import type { CreateOrderInput, OrderLineItemInput, BillingTerm } from "@pax8/core";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
+import { resolveCommitmentTermId } from "../../lib/resolve-commitment.js";
 import { hashArgs, isValidKey, withIdempotency } from "../../lib/idempotency.js";
 import { setTelemetryFields } from "../../lib/telemetry-context.js";
 
@@ -162,29 +163,15 @@ Examples:
       // Resolve commitmentTermId from existing subscription for the SAME product.
       // commitmentTermId UUIDs are product-specific and cannot be reused across products.
       if (!commitmentTermId && (commitmentTerm || requiresCommitment)) {
-        try {
-          const subs = await ctx.api.subscriptions.list({
-            companyId: resolvedCompanyId,
-            status: "Active",
-          });
-          // Only match subscriptions for the same product
-          const matches = subs.content.filter((s) =>
-            s.productId === resolvedProductId && s.commitment?.id
-          );
-          // Prefer matching commitment term label if specified
-          const match = (commitmentTerm
-            ? matches.find((s) => s.commitment?.term === commitmentTerm)
-            : null
-          ) ?? matches[0];
-          if (match?.commitment?.id) {
-            commitmentTermId = match.commitment.id;
-            if (!commitmentTerm) commitmentTerm = match.commitment.term;
-            if (process.env.PAX8_DEBUG) {
-              process.stderr.write(`[debug] resolved commitmentTermId=${commitmentTermId} from subscription ${match.id}\n`);
-            }
-          }
-        } catch (err) {
-          if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] subscription lookup for commitmentTermId failed: ${err}\n`);
+        const info = await resolveCommitmentTermId(
+          ctx,
+          resolvedCompanyId,
+          resolvedProductId,
+          commitmentTerm,
+        );
+        if (info) {
+          commitmentTermId = info.id;
+          if (!commitmentTerm) commitmentTerm = info.term;
         }
       }
 

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -14,6 +14,7 @@ import { filterRecommendations } from "./filter.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 import { setTelemetryFields } from "../../lib/telemetry-context.js";
 import { replCmd } from "../../lib/confirm.js";
+import { resolveCommitmentTermId } from "../../lib/resolve-commitment.js";
 
 interface PlacementResult {
   ordered: boolean;
@@ -60,17 +61,8 @@ async function placeOrder(rec: Recommendation, ctx: CommandContext): Promise<Pla
   const spinner = createSpinner(`Ordering ${product} for ${rec.companyName}...`).start();
   try {
     // Resolve commitmentTermId from existing subscription for the SAME product.
-    let commitmentTermId: string | undefined;
-    try {
-      const subs = await ctx.api.subscriptions.list({
-        companyId: rec.companyId,
-        status: "Active",
-      });
-      const match = subs.content.find((s) =>
-        s.productId === productId && s.commitment?.id
-      );
-      if (match?.commitment?.id) commitmentTermId = match.commitment.id;
-    } catch { /* best effort */ }
+    const commitmentInfo = await resolveCommitmentTermId(ctx, rec.companyId, productId);
+    const commitmentTermId = commitmentInfo?.id;
 
     const doneOrder = markWriteInFlight("orders");
     let order;

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -14,6 +14,7 @@ import { filterRecommendations } from "./filter.js";
 import { replCmd } from "../../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import { markWriteInFlight } from "../../lib/signals.js";
+import { resolveCommitmentTermId } from "../../lib/resolve-commitment.js";
 
 const columns: Column[] = [
   {
@@ -133,17 +134,8 @@ async function executeRecommendation(rec: Recommendation, ctx: CommandContext): 
   }
 
   // Resolve commitmentTermId from existing subscription for the SAME product
-  let commitmentTermId: string | undefined;
-  try {
-    const subs = await ctx.api.subscriptions.list({
-      companyId: rec.companyId,
-      status: "Active",
-    });
-    const match = subs.content.find((s) =>
-      s.productId === productId && s.commitment?.id
-    );
-    if (match?.commitment?.id) commitmentTermId = match.commitment.id;
-  } catch { /* best effort */ }
+  const commitmentInfo = await resolveCommitmentTermId(ctx, rec.companyId, productId);
+  const commitmentTermId = commitmentInfo?.id;
 
   const spinner = createSpinner("Creating order...").start();
   try {

--- a/packages/cli/src/lib/idempotency.test.ts
+++ b/packages/cli/src/lib/idempotency.test.ts
@@ -12,8 +12,10 @@ import {
   isValidKey,
   loadEntry,
   saveEntry,
+  withIdempotency,
   type IdempotencyEntry,
 } from "./idempotency.js";
+import { CliError } from "./errors.js";
 
 describe("idempotency", () => {
   let tmpDir: string;
@@ -189,6 +191,177 @@ describe("idempotency", () => {
     it("does not throw when the dir does not exist", async () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
       await expect(gc()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("withIdempotency", () => {
+    // The wrapper writes the cached payload to real stdout on a hit and then
+    // calls process.exit(). Stub stdout.write so we can assert what would have
+    // been replayed without actually exiting the test runner.
+    const stubStdoutWrite = (): { writes: string[]; restore: () => void } => {
+      const writes: string[] = [];
+      const real = process.stdout.write.bind(process.stdout);
+      // Multi-overload: accept the union of the variants we exercise.
+      (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) = (
+        chunk: string | Uint8Array,
+      ): boolean => {
+        const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+        writes.push(text);
+        return true;
+      };
+      return {
+        writes,
+        restore: () => {
+          process.stdout.write = real as typeof process.stdout.write;
+        },
+      };
+    };
+
+    it("passthrough: no key supplied → action runs once, no cache touched", async () => {
+      let calls = 0;
+      const result = await withIdempotency(
+        { commandName: "test.cmd", argsHash: "h1" },
+        async () => {
+          calls += 1;
+          return "value";
+        },
+      );
+      expect(result).toBe("value");
+      expect(calls).toBe(1);
+      // Cache directory must remain empty.
+      const files = await fs.readdir(tmpDir).catch(() => [] as string[]);
+      expect(files.filter((f) => f.endsWith(".json"))).toHaveLength(0);
+    });
+
+    it("cache miss: runs action, persists captured stdout under the key", async () => {
+      const stub = stubStdoutWrite();
+      try {
+        const result = await withIdempotency(
+          { commandName: "test.cmd", idempotencyKey: "miss1234", argsHash: "h1" },
+          async () => {
+            process.stdout.write("hello-from-action\n");
+            return 42;
+          },
+        );
+        expect(result).toBe(42);
+        // Real stdout (stubbed) saw the action's output too — it tees, not swallows.
+        expect(stub.writes.join("")).toContain("hello-from-action");
+      } finally {
+        stub.restore();
+      }
+
+      // Cache entry exists with the captured output.
+      const cached = await loadEntry("test.cmd", "miss1234");
+      expect(cached).not.toBeNull();
+      expect(cached?.argsHash).toBe("h1");
+      expect(cached?.output).toBe("hello-from-action\n");
+      expect(cached?.exitCode).toBe(0);
+    });
+
+    it("cache hit: replays cached stdout and does NOT re-run the action", async () => {
+      // Seed the cache with a known entry.
+      await saveEntry({
+        key: "hit12345",
+        command: "test.cmd",
+        argsHash: "h1",
+        output: "REPLAYED-PAYLOAD\n",
+        exitCode: 0,
+        createdAt: new Date().toISOString(),
+      });
+
+      // The wrapper calls process.exit() on a hit. Stub it.
+      const realExit = process.exit;
+      let exitedWith: number | undefined;
+      (process.exit as unknown as (code?: number) => never) = ((code?: number) => {
+        exitedWith = code;
+        // Throw a sentinel so the caller's code path stops without actually exiting.
+        throw new Error("__test_exit__");
+      }) as never;
+
+      let actionCalls = 0;
+      const stub = stubStdoutWrite();
+      try {
+        await expect(
+          withIdempotency(
+            { commandName: "test.cmd", idempotencyKey: "hit12345", argsHash: "h1" },
+            async () => {
+              actionCalls += 1;
+              return "should-not-run";
+            },
+          ),
+        ).rejects.toThrow("__test_exit__");
+      } finally {
+        stub.restore();
+        process.exit = realExit;
+      }
+
+      expect(actionCalls).toBe(0);
+      expect(exitedWith).toBe(0);
+      expect(stub.writes.join("")).toContain("REPLAYED-PAYLOAD");
+    });
+
+    it("cache hit with different argsHash: throws CliError, does not run action", async () => {
+      await saveEntry({
+        key: "diff1234",
+        command: "test.cmd",
+        argsHash: "original-hash",
+        output: "x",
+        exitCode: 0,
+        createdAt: new Date().toISOString(),
+      });
+
+      let actionCalls = 0;
+      await expect(
+        withIdempotency(
+          { commandName: "test.cmd", idempotencyKey: "diff1234", argsHash: "different-hash" },
+          async () => {
+            actionCalls += 1;
+            return null;
+          },
+        ),
+      ).rejects.toBeInstanceOf(CliError);
+      expect(actionCalls).toBe(0);
+    });
+
+    it("shouldPersist=false: action runs but cache entry is NOT written", async () => {
+      const stub = stubStdoutWrite();
+      try {
+        const result = await withIdempotency<boolean>(
+          {
+            commandName: "test.cmd",
+            idempotencyKey: "skip1234",
+            argsHash: "h1",
+            shouldPersist: (didWrite) => didWrite,
+          },
+          async () => {
+            process.stdout.write("user-cancelled\n");
+            return false; // signal: don't persist
+          },
+        );
+        expect(result).toBe(false);
+      } finally {
+        stub.restore();
+      }
+      // Cache entry should NOT exist.
+      const cached = await loadEntry("test.cmd", "skip1234");
+      expect(cached).toBeNull();
+    });
+
+    it("action throws: cache is not written, stdout is restored", async () => {
+      const beforeWrite = process.stdout.write;
+      await expect(
+        withIdempotency(
+          { commandName: "test.cmd", idempotencyKey: "fail1234", argsHash: "h1" },
+          async () => {
+            throw new Error("boom");
+          },
+        ),
+      ).rejects.toThrow("boom");
+      // stdout.write must be restored to the original (the wrapper temporarily proxies it).
+      expect(process.stdout.write).toBe(beforeWrite);
+      // No cache entry was persisted.
+      const cached = await loadEntry("test.cmd", "fail1234");
+      expect(cached).toBeNull();
     });
   });
 });

--- a/packages/cli/src/lib/idempotency.ts
+++ b/packages/cli/src/lib/idempotency.ts
@@ -1,10 +1,12 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
+import { CliError } from "./errors.js";
 
 /**
  * Idempotency cache for write commands.
@@ -146,4 +148,135 @@ export async function saveEntry(entry: IdempotencyEntry): Promise<void> {
   const tmp = fp + ".tmp";
   await fs.writeFile(tmp, JSON.stringify(entry), { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, fp);
+}
+
+export interface IdempotencyOptions<T = unknown> {
+  /** Cache key namespace, e.g. "orders.create". */
+  commandName: string;
+  /** User-supplied replay key. If undefined the wrapper is a passthrough. */
+  idempotencyKey?: string;
+  /**
+   * Stable hash of the action's effective arguments. Used to detect "same
+   * key, different args" reuse and refuse to replay. Callers compute this
+   * with `hashArgs()`.
+   */
+  argsHash: string;
+  /**
+   * Optional predicate to skip persisting the cache entry on certain
+   * "successful" returns — e.g. when the user cancels at a confirmation
+   * prompt. Defaults to "always persist on action success".
+   */
+  shouldPersist?: (result: T) => boolean;
+}
+
+/**
+ * Wrap a write action with idempotency-key handling.
+ *
+ * Behavior:
+ *   1. If `opts.idempotencyKey` is undefined → invoke `action()` as a
+ *      passthrough. No cache lookup, no stdout capture.
+ *   2. If a cached entry exists for `(commandName, idempotencyKey)`:
+ *        - If `argsHash` matches → write the cached stdout to the user's
+ *          terminal and `process.exit(cached.exitCode)`. The action does
+ *          NOT re-run.
+ *        - If `argsHash` differs → throw a `CliError` (refuse to replay
+ *          with different args; could double-write).
+ *   3. Otherwise: install a `process.stdout.write` proxy that tees output
+ *      both to the real terminal and an in-memory buffer; run `action`;
+ *      on success persist the captured buffer + exitCode 0 under the
+ *      cache key; restore stdout; return the action's value. On failure,
+ *      stdout is restored and the cache is NOT written (the agent retries).
+ *
+ * The caller is responsible for:
+ *   - Validating the key format with `isValidKey()` and throwing a
+ *     CliError before calling this wrapper.
+ *   - Computing `argsHash` from the action's effective arguments.
+ *   - Calling `markWriteInFlight()` around the actual write inside `action`.
+ */
+export async function withIdempotency<T>(
+  opts: IdempotencyOptions<T>,
+  action: () => Promise<T>,
+): Promise<T> {
+  const { commandName, idempotencyKey, argsHash, shouldPersist } = opts;
+
+  // Passthrough: no key supplied.
+  if (idempotencyKey === undefined) {
+    return action();
+  }
+
+  // Cache hit branch. `loadEntry` itself is wrapped so that a transient
+  // read failure leaves us in fail-open mode (we run the action). The
+  // replay path below is intentionally *not* inside that try/catch — once
+  // we have a cached entry, any further error must propagate so the user
+  // sees it (e.g. CliError on argsHash mismatch).
+  let cached: IdempotencyEntry | null = null;
+  try {
+    cached = await loadEntry(commandName, idempotencyKey);
+  } catch (err) {
+    if (process.env.PAX8_DEBUG) {
+      process.stderr.write(`[debug] idempotency cache read failed: ${err}\n`);
+    }
+  }
+  if (cached) {
+    if (cached.argsHash !== argsHash) {
+      throw new CliError(
+        "Idempotency key reused with different arguments — refusing to retry.",
+        [
+          `The key "${idempotencyKey}" was previously used for ${cached.command} with a different argument set.`,
+          "Replaying with new arguments would risk a double-write or a misleading 'cached' response.",
+        ],
+        [
+          "Generate a new idempotency key for the new request.",
+          `Or wait 24h for the old entry to expire (cached at ${cached.createdAt}).`,
+        ],
+      );
+    }
+    process.stderr.write(chalk.dim("  (idempotent replay)\n"));
+    if (cached.output) process.stdout.write(cached.output);
+    process.exit(cached.exitCode);
+  }
+
+  // Cache miss: tee stdout to memory while running the action.
+  let captured = "";
+  // Preserve a reference to the *original* function so we can restore it
+  // exactly (preserves identity for tests / nested wrappers). Use a bound
+  // copy for the actual passthrough call inside the proxy.
+  const originalStdoutWrite = process.stdout.write;
+  const writeBound = originalStdoutWrite.bind(process.stdout);
+  // Cast to satisfy the multi-overload signature of process.stdout.write.
+  (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) = (
+    chunk: string | Uint8Array,
+  ): boolean => {
+    const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+    captured += text;
+    return writeBound(chunk as string);
+  };
+
+  try {
+    const value = await action();
+    // Persist on success only — and skip when the caller's predicate says
+    // we shouldn't (e.g. user cancelled at a confirmation prompt).
+    const persist = shouldPersist ? shouldPersist(value) : true;
+    if (persist) {
+      try {
+        await saveEntry({
+          key: idempotencyKey,
+          command: commandName,
+          argsHash,
+          output: captured,
+          exitCode: 0,
+          createdAt: new Date().toISOString(),
+        });
+      } catch (err) {
+        if (process.env.PAX8_DEBUG) {
+          process.stderr.write(`[debug] idempotency cache write failed: ${err}\n`);
+        }
+      }
+    }
+    return value;
+  } finally {
+    // Always restore stdout, even on action failure. Restoring the
+    // original function (not a bound copy) preserves reference identity.
+    process.stdout.write = originalStdoutWrite;
+  }
 }

--- a/packages/cli/src/lib/resolve-commitment.test.ts
+++ b/packages/cli/src/lib/resolve-commitment.test.ts
@@ -1,0 +1,143 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from "vitest";
+import { resolveCommitmentTermId } from "./resolve-commitment.js";
+import type { CommandContext } from "./context.js";
+
+const COMPANY_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const PRODUCT_A = "f0000000-0000-0000-0000-000000000001";
+const PRODUCT_B = "f0000000-0000-0000-0000-000000000002";
+
+interface SubFixture {
+  id?: string;
+  productId: string;
+  commitment?: { id: string; term?: string };
+}
+
+function makeMockCtx(subs: SubFixture[]) {
+  const list = vi.fn().mockResolvedValue({ content: subs });
+  return {
+    api: {
+      subscriptions: { list },
+    },
+    isDemo: true,
+    outputFormat: "json",
+  } as unknown as CommandContext;
+}
+
+describe("resolveCommitmentTermId", () => {
+  it("returns the commitment id+term of a matching active subscription", async () => {
+    const ctx = makeMockCtx([
+      {
+        id: "sub-1",
+        productId: PRODUCT_A,
+        commitment: { id: "commit-aaaa", term: "1-Year" },
+      },
+    ]);
+
+    const result = await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A);
+    expect(result).toEqual({ id: "commit-aaaa", term: "1-Year" });
+  });
+
+  it("returns null when no subscription matches the productId", async () => {
+    const ctx = makeMockCtx([
+      {
+        id: "sub-1",
+        productId: PRODUCT_B,
+        commitment: { id: "commit-other", term: "Monthly" },
+      },
+    ]);
+
+    const result = await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when matching subscription has no commitment.id", async () => {
+    const ctx = makeMockCtx([
+      { id: "sub-1", productId: PRODUCT_A /* no commitment */ },
+    ]);
+
+    const result = await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A);
+    expect(result).toBeNull();
+  });
+
+  it("with multiple matches and no preferredTerm: picks the first", async () => {
+    const ctx = makeMockCtx([
+      {
+        id: "sub-1",
+        productId: PRODUCT_A,
+        commitment: { id: "commit-first", term: "Monthly" },
+      },
+      {
+        id: "sub-2",
+        productId: PRODUCT_A,
+        commitment: { id: "commit-second", term: "1-Year" },
+      },
+    ]);
+
+    const result = await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A);
+    expect(result).toEqual({ id: "commit-first", term: "Monthly" });
+  });
+
+  it("with preferredTerm: prefers a sub whose commitment.term matches", async () => {
+    const ctx = makeMockCtx([
+      {
+        id: "sub-1",
+        productId: PRODUCT_A,
+        commitment: { id: "commit-monthly", term: "Monthly" },
+      },
+      {
+        id: "sub-2",
+        productId: PRODUCT_A,
+        commitment: { id: "commit-annual", term: "1-Year" },
+      },
+    ]);
+
+    const result = await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A, "1-Year");
+    expect(result).toEqual({ id: "commit-annual", term: "1-Year" });
+  });
+
+  it("with preferredTerm but no exact term match: falls back to first product match", async () => {
+    const ctx = makeMockCtx([
+      {
+        id: "sub-1",
+        productId: PRODUCT_A,
+        commitment: { id: "commit-monthly", term: "Monthly" },
+      },
+    ]);
+
+    const result = await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A, "3-Year");
+    expect(result).toEqual({ id: "commit-monthly", term: "Monthly" });
+  });
+
+  it("passes companyId + status:Active to the SubscriptionsApi", async () => {
+    const ctx = makeMockCtx([
+      {
+        productId: PRODUCT_A,
+        commitment: { id: "commit-x", term: "Monthly" },
+      },
+    ]);
+
+    await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A);
+    expect(ctx.api.subscriptions.list).toHaveBeenCalledWith({
+      companyId: COMPANY_ID,
+      status: "Active",
+    });
+  });
+
+  it("returns null on API error (best-effort)", async () => {
+    const ctx = {
+      api: {
+        subscriptions: {
+          list: vi.fn().mockRejectedValue(new Error("network down")),
+        },
+      },
+      isDemo: true,
+      outputFormat: "json",
+    } as unknown as CommandContext;
+
+    const result = await resolveCommitmentTermId(ctx, COMPANY_ID, PRODUCT_A);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/cli/src/lib/resolve-commitment.ts
+++ b/packages/cli/src/lib/resolve-commitment.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CommandContext } from "./context.js";
+
+/**
+ * Result of looking up the commitment-term attached to a partner's
+ * existing active subscription for a given product.
+ *
+ * `id` is the value to pass back to the API as `commitmentTermId` on a
+ * follow-on order; `term` is the human-readable label ("Monthly",
+ * "1-Year", "3-Year") which callers may want to surface to the user
+ * when they didn't ask for a specific term up front.
+ */
+export interface CommitmentTermInfo {
+  id: string;
+  term?: string;
+}
+
+/**
+ * Find the commitment term info for a given (companyId, productId) pair
+ * by scanning the company's active subscriptions for one matching the
+ * product. Returns null if no matching subscription is found.
+ *
+ * Used by `orders/create` and `recommendations/{list,act}` to attach the
+ * existing commitment term to a new order so prices align with what the
+ * partner already has, rather than the API's default. `commitmentTermId`
+ * UUIDs are product-specific and cannot be reused across products.
+ *
+ * If `preferredTerm` is provided (e.g. user passed `--commitment-term
+ * Annual`), the helper prefers a subscription whose `commitment.term`
+ * matches it, falling back to the first matching subscription. This
+ * mirrors the orders/create call site's "user said Annual, find an
+ * Annual sub" behavior. Recommendations callers leave it undefined and
+ * get the first match.
+ *
+ * Errors during the API call are swallowed (returns null) — this is a
+ * best-effort hint, not a hard requirement. The caller decides whether
+ * a missing term should be a warning or an error.
+ */
+export async function resolveCommitmentTermId(
+  ctx: CommandContext,
+  companyId: string,
+  productId: string,
+  preferredTerm?: string,
+): Promise<CommitmentTermInfo | null> {
+  try {
+    const subs = await ctx.api.subscriptions.list({
+      companyId,
+      status: "Active",
+    });
+    const matches = subs.content.filter(
+      (s) => s.productId === productId && s.commitment?.id,
+    );
+    const match = (preferredTerm
+      ? matches.find((s) => s.commitment?.term === preferredTerm)
+      : null
+    ) ?? matches[0];
+    if (!match?.commitment?.id) return null;
+    return {
+      id: match.commitment.id,
+      term: match.commitment.term,
+    };
+  } catch (err) {
+    if (process.env.PAX8_DEBUG) {
+      process.stderr.write(`[debug] resolveCommitmentTermId failed: ${err}\n`);
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Two helper extractions from tech-debt master report (#173). Each pulls duplicated boilerplate out of write commands.

### Commit 1 — `withIdempotency()`

`orders/create.ts` and `invoices/dispute.ts` had ~95 LOC of identical idempotency-key handling each (key validation, cache lookup, replay branch, stdout-capture-and-persist). Extracted to `lib/idempotency.ts`:

```ts
withIdempotency<T>({ commandName, idempotencyKey, argsHash, shouldPersist? }, action)
```

The optional `shouldPersist` predicate is the one design call I made beyond the spec doc-block — it keeps the existing "user cancelled at confirm" semantics (don't persist a successful-but-empty cache entry that a future replay would silently honor). Both call sites pass `(didWrite) => didWrite` and return `false` from the cancel branch.

LOC delta:
- `packages/cli/src/commands/orders/create.ts`: -70 (-110 + 40)
- `packages/cli/src/commands/invoices/dispute.ts`: -67 (-107 + 40)
- `packages/cli/src/lib/idempotency.ts`: +133 (the wrapper itself)
- `packages/cli/src/lib/idempotency.test.ts`: +173 (6 new wrapper tests)

### Commit 2 — `resolveCommitmentTermId()`

The "find existing subscription's commitment-term to align prices with what the partner already has" logic was open-coded in `orders/create.ts`, `recommendations/list.ts`, and `recommendations/act.ts`. New helper at `lib/resolve-commitment.ts`.

The helper takes an optional `preferredTerm` (only `orders/create` uses it — recommendations leave it undefined and get the first match) and returns `{ id, term? } | null` so `orders/create` can still surface the term label when the user didn't ask for one.

LOC delta:
- `packages/cli/src/commands/orders/create.ts`: -13 (-23 + 10)
- `packages/cli/src/commands/recommendations/list.ts`: -8 (-11 + 3)
- `packages/cli/src/commands/recommendations/act.ts`: -8 (-11 + 3)
- `packages/cli/src/lib/resolve-commitment.ts`: +69 (helper)
- `packages/cli/src/lib/resolve-commitment.test.ts`: +146 (8 unit tests)

## Test plan

- [x] Existing idempotency replay subprocess tests pass unchanged (`__tests__/idempotency.test.ts` — 8 tests)
- [x] New unit tests for `withIdempotency` (passthrough, cache miss persists, cache hit replays without re-running action, argsHash-mismatch throws CliError, shouldPersist=false skips persistence, action-throws restores stdout)
- [x] New unit tests for `resolveCommitmentTermId` (matching sub, no match, no commitment.id, multi-match picks first, preferredTerm filter, preferredTerm fallback, API call shape, API error returns null)
- [x] `pnpm build` clean (CLI bundle dropped from 312.86 KB to 310.99 KB)
- [x] `pnpm -r exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `PAX8_DEMO=1 NO_COLOR=1 pnpm test` — 1051 passed, 8 skipped (was 1043; +8 from new helper tests)
- [x] `pnpm test:coverage` — thresholds green (67.82% statements / 52.39% branches / 71.81% functions / 67.37% lines, all above the 60/42/65/60 floors)

## Coordination

Concurrent agents in flight (per kickoff): the cleanup-bundle agent will also touch `orders/create.ts` and `invoices/dispute.ts` (only the redundant `as unknown as Record<string, unknown>[]` casts at output() sites). Conflicts likely; resolution is mechanical — drop the cast in the refactored block too.