### PR TITLE
fix(ux): drop list-table inter-row dividers and N-row drill-in footer

### DIFF
--- a/packages/cli/src/lib/next-step.test.ts
+++ b/packages/cli/src/lib/next-step.test.ts
@@ -90,7 +90,7 @@ describe("promptNextSteps", () => {
     expect(spawnedCommands).toHaveLength(0);
   });
 
-  it("renders each step's key, label, and command preview to stderr", async () => {
+  it("renders one concise drill-in hint with a sample, not a per-row block", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       value: true,
       writable: true,
@@ -106,12 +106,13 @@ describe("promptNextSteps", () => {
     await promptNextSteps(steps);
 
     const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
-    expect(written).toContain("[1]");
+    // The hint should reference the range and the first row's label / key as
+    // a sample, but not enumerate every row.
+    expect(written).toContain("Type 1-2");
+    expect(written).toContain("1");
     expect(written).toContain("List subscriptions");
-    expect(written).toContain("subscriptions list");
-    expect(written).toContain("[2]");
-    expect(written).toContain("Show renewals");
-    expect(written).toContain("subscriptions renewals");
+    // The second row's label should NOT be printed (the table itself is the menu).
+    expect(written).not.toContain("Show renewals");
     // No spawn since user skipped.
     expect(spawnedCommands).toHaveLength(0);
   });

--- a/packages/cli/src/lib/next-step.ts
+++ b/packages/cli/src/lib/next-step.ts
@@ -13,22 +13,33 @@ export interface NextStep {
 }
 
 /**
- * Show a numbered menu of next steps, prompt the user to pick one, and run it.
+ * Prompt the user to drill into a numbered row from the most-recent table.
  * Only interactive in TTY mode. Skips silently when piped.
+ *
+ * The table itself is the menu — every row already shows its index in the
+ * `#` column — so we don't re-print each option here. We just show one
+ * concise hint with a representative example, then read input.
  */
 export async function promptNextSteps(steps: NextStep[]): Promise<void> {
   if (!process.stdin.isTTY) return;
   if (steps.length === 0) return;
 
-  for (const step of steps) {
-    process.stderr.write(`  ${chalk.cyan.bold(`[${step.key}]`)} ${step.label}\n`);
-    process.stderr.write(chalk.dim(`      ${step.command.join(" ")}\n`));
-  }
-  process.stderr.write("\n");
+  // Pick a sample row to illustrate "what does typing a number do?"
+  // First row is representative for any list-style table.
+  const sample = steps[0];
+  const max = steps[steps.length - 1].key;
+
+  process.stderr.write(
+    "  " +
+      chalk.dim(
+        `Type 1-${max} to drill in (e.g. \`${sample.key}\` → ${sample.label.split(" — ")[0]}), or press Enter to skip.`
+      ) +
+      "\n\n"
+  );
 
   const rl = createInterface({ input: process.stdin, output: process.stderr });
   const answer = await new Promise<string>((resolve) => {
-    rl.question(chalk.dim("  Enter # to run, or press Enter to skip: "), (a) => {
+    rl.question(chalk.dim("  > "), (a) => {
       rl.close();
       resolve(a.trim());
     });

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -66,6 +66,15 @@ function formatTable(data: readonly Record<string, unknown>[], columns: Column[]
       "padding-left": 1,
       "padding-right": 1,
     },
+    // Drop the inter-row dividers. The bold/cyan header is enough visual
+    // separation; per-row dividers double the line count for no information
+    // value (gh, k9s, fly, stripe all render this way). The outer box stays.
+    chars: {
+      mid: "",
+      "left-mid": "",
+      "mid-mid": "",
+      "right-mid": "",
+    },
     colWidths,
     wordWrap: wrapEnabled,
   });


### PR DESCRIPTION
Two long-standing list-rendering issues. Output of `pax8 companies list` against ~140 real companies fills 6+ pages of terminal noise vs the gh / fly / k9s style.

## What changed

**`lib/output.ts`** — drop cli-table3 inter-row dividers. Bold-cyan header is enough visual separation; per-row dividers double line count for no information value. Outer box stays.

**`lib/next-step.ts`** — replace the per-row `[N] Label / command` block with one concise drill-in hint:

```
Type 1-25 to drill in (e.g. `1` → Summit Healthcare Partners), or press Enter to skip.
```

The table itself is the menu — every row already shows its index in the `#` column. Re-printing each row in the footer was pure duplication.

## Affects

Every list command (companies, subscriptions, invoices, quotes, webhooks, products, contacts, recommendations, orders, usage). Output ~half as long. Same data, same drill-in shortcut still works.

## Test plan

- [x] Smoke-tested `pax8 companies list` — table is compact, footer is one line
- [x] tsc, lint, full suite (1054 passing), coverage threshold all green
- [x] Updated `next-step.test.ts` to match new contract
- [x] No JSON / CSV output changes