### PR TITLE
docs: cost-sim README examples use prefix-matching names (closes #211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ The order preview shows unit price, total, and estimated MRR impact before you c
 ### Cost Simulation
 
 ```bash
-pax8 cost sim --company "Acme Corp" --product "M365 Business Premium" --quantity 50
-pax8 cost sim --company "Acme" --product "M365 Business Premium" --from "M365 Business Basic" --quantity 45
-pax8 cost sim --company "Acme" --product "AvePoint Cloud Backup" --quantity 30 --json
+pax8 cost sim --company "Acme Corp" --product "Microsoft 365 Business Premium" --quantity 50
+pax8 cost sim --company "Acme Corp" --product "Microsoft 365 Business Premium" --from "Microsoft 365 Business Basic" --quantity 45
+pax8 cost sim --company "Acme Corp" --product "AvePoint Cloud Backup for Microsoft 365" --quantity 30 --billing-term Monthly --json
 ```
 
 Model the financial impact of a SKU swap, quantity change, or new-product add before placing the order. The output shows current and proposed monthly/annual cost, the delta, and a per-seat breakdown — pure compute over existing pricing data, no writes.

--- a/e2e/ux-smoke.test.ts
+++ b/e2e/ux-smoke.test.ts
@@ -104,20 +104,7 @@ describe("README snippet smoke", () => {
   // silently regress — this isn't a workaround; it's a punchlist.
   // Re-running the matrix after each fix will green these without code
   // changes once the underlying CLI/README is fixed.
-  const KNOWN_FAILING = new Map<string, string>([
-    [
-      'pax8 cost sim --company "Acme Corp" --product "M365 Business Premium" --quantity 50',
-      "#211: README uses M365-shorthand product name; CLI matcher requires Microsoft 365 prefix",
-    ],
-    [
-      'pax8 cost sim --company "Acme" --product "M365 Business Premium" --from "M365 Business Basic" --quantity 45',
-      "#211: README uses M365-shorthand product name",
-    ],
-    [
-      'pax8 cost sim --company "Acme" --product "AvePoint Cloud Backup" --quantity 30 --json',
-      "#211: README product name AvePoint Cloud Backup vs demo full name AvePoint Cloud Backup for Microsoft 365",
-    ],
-  ]);
+  const KNOWN_FAILING = new Map<string, string>([]);
 
   const runnable = pax8Lines.filter(
     (l) =>


### PR DESCRIPTION
## Summary
- README cost-sim snippets used shorthand product names that didn't prefix-match the demo catalog
- Switched to exact prefix-match names
- Removed 3 KNOWN_FAILING entries in e2e/ux-smoke.test.ts (matrix flips them green)

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)