### PR TITLE
fix(report-bug): no-context exits 0 with instructions (closes #209)

### DIFF
--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -803,15 +803,10 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     command: ["report-bug"],
     group: "root",
     type: "meta",
-    // Bare `report-bug` requires a prior error in the session to report.
-    // Run with no context, it exits 1 — arguably should fall back to help
-    // text but that's a separate UX call (see #209). Skip the live run; the
-    // help-flag layer still covers --help.
-    skipLiveRun: {
-      reason:
-        "needs a prior error in session state; bare invocation exits 1 (see #209)",
-    },
-    demo: {},
+    // Fixed in #209: bare `report-bug` (no last-error context) now prints
+    // a short manual-file-a-bug pointer and exits 0. The "report the last
+    // error" flow is exercised by the unit suite.
+    demo: { expectedFragments: [/issues|github|file a bug|report/i] },
     jsonContract: { skip: { reason: "freeform / contextual output" } },
   },
 ];

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -5,11 +5,23 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as fs from "node:fs";
+import * as os from "node:os";
 
 const exec = promisify(execFile);
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const CLI_PATH = resolve(__dirname, "../packages/cli/dist/index.js");
+
+// Per-call isolated config dir. Without this, the e2e suite inherits the
+// developer's `~/.pax8/last-error.json` — and tests within the same process
+// also leak state to each other (a command that fails writes last-error.json
+// which then changes report-bug's behavior on the next call). A fresh tmpdir
+// per `runCli` call gives every command a clean slate, matching the unit
+// suite's `makeTmpConfigDir` pattern.
+function makeIsolatedConfigDir(): string {
+  return fs.mkdtempSync(resolve(os.tmpdir(), "pax8-e2e-cfg-"));
+}
 
 export interface CliResult {
   stdout: string;
@@ -23,7 +35,13 @@ export async function runCli(
 ): Promise<CliResult> {
   try {
     const result = await exec("node", [CLI_PATH, ...args], {
-      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...env },
+      env: {
+        ...process.env,
+        PAX8_DEMO: "1",
+        NO_COLOR: "1",
+        PAX8_CONFIG_DIR: makeIsolatedConfigDir(),
+        ...env,
+      },
       timeout: 15000,
     });
     return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };

--- a/e2e/ux-smoke.test.ts
+++ b/e2e/ux-smoke.test.ts
@@ -94,11 +94,6 @@ describe("README snippet smoke", () => {
     // execFile (no shell). Skip — these are advanced doc snippets.
     return /(\||\bxargs\b|\$\(|`)/.test(line);
   }
-  function needsPriorContext(line: string): boolean {
-    // Commands that depend on session state we don't simulate.
-    // `report-bug` (without an error to report) just exits 1 (#209).
-    return /^(PAX8_DEMO=1\s+)?pax8\s+report-bug(\s|$)/.test(line);
-  }
 
   // README snippets currently known to fail. Track here so they don't
   // silently regress — this isn't a workaround; it's a punchlist.
@@ -125,8 +120,7 @@ describe("README snippet smoke", () => {
       !isAuthLogin(l) &&
       !isReplOnly(l) &&
       !hasPlaceholder(l) &&
-      !hasShellPipeOrSubst(l) &&
-      !needsPriorContext(l)
+      !hasShellPipeOrSubst(l)
   );
 
   if (runnable.length === 0) {

--- a/packages/cli/src/__tests__/report-bug.test.ts
+++ b/packages/cli/src/__tests__/report-bug.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
-import { runCli, runCliExpectFailure, runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectFailure, runCliExpectSuccess } from "./test-utils.js";
 
 // Each test gets a unique config-dir so they can run in any order and pollute
 // nothing on the host machine. We rely on the `PAX8_CONFIG_DIR` seam from
@@ -42,11 +42,44 @@ describe("pax8 report-bug", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("exits 1 when no last-error.json exists", async () => {
-    const result = await runCliExpectFailure(["report-bug", "--print"], {
+  it("no last-error context exits 0 with manual-file-a-bug instructions (#209)", async () => {
+    // Bare `report-bug` with no captured error must be helpful, not a hard
+    // exit. README lists it as a quick-start example so first-run users
+    // hit this branch; #209 changed it from exit-1-on-stderr to exit-0
+    // with a short pointer to the issue tracker.
+    const result = await runCliExpectSuccess(["report-bug"], {
       PAX8_CONFIG_DIR: tmpDir,
     });
-    expect(result.stderr).toContain("No recent error found");
+    expect(result.stdout).toContain("No recent error in this session.");
+    expect(result.stdout).toContain(
+      "https://github.com/pax8labs/pax8-cli/issues/new"
+    );
+    expect(result.stdout).toContain("pax8 report-bug --help");
+    // Instructions go to stdout (not stderr) because this is a successful,
+    // informational response — not an error. (Demo-mode banner on stderr
+    // is fine; what matters is no "No recent error found" error line.)
+    expect(result.stderr).not.toContain("No recent error");
+  });
+
+  it("no last-error context with --print also exits 0 with instructions", async () => {
+    const result = await runCliExpectSuccess(["report-bug", "--print"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    expect(result.stdout).toContain("No recent error in this session.");
+  });
+
+  it("no last-error context with --json emits a no-context envelope", async () => {
+    const result = await runCliExpectSuccess(["report-bug", "--json"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    const parsed = JSON.parse(result.stdout) as {
+      status?: string;
+      issueUrl?: string;
+    };
+    expect(parsed.status).toBe("no-context");
+    expect(parsed.issueUrl).toBe(
+      "https://github.com/pax8labs/pax8-cli/issues/new"
+    );
   });
 
   it("--print outputs a redacted Markdown body and does not submit", async () => {
@@ -104,13 +137,15 @@ describe("pax8 report-bug", () => {
     expect(result.stdout).toContain("[ERROR_AUTH_EXPIRED]");
   });
 
-  it("rejects malformed last-error.json gracefully", async () => {
+  it("treats malformed last-error.json as no-context (graceful fallback)", async () => {
+    // Same path as "no last-error context": readEnvelope() returns null on
+    // parse failure, so the user gets the same helpful instructions rather
+    // than a stack trace or error exit.
     await fs.writeFile(path.join(tmpDir, "last-error.json"), "not json");
-    const result = await runCli(["report-bug", "--print"], {
+    const result = await runCliExpectSuccess(["report-bug", "--print"], {
       PAX8_CONFIG_DIR: tmpDir,
     });
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("No recent error found");
+    expect(result.stdout).toContain("No recent error in this session.");
   });
 
   it("shows help text", async () => {

--- a/packages/cli/src/commands/report-bug.ts
+++ b/packages/cli/src/commands/report-bug.ts
@@ -171,13 +171,51 @@ async function readEnvelope(): Promise<BugReportEnvelope | null> {
   }
 }
 
+/**
+ * Help text shown when `pax8 report-bug` is invoked without a captured
+ * last-error envelope. README lists the bare command as a quick-start
+ * example, so first-run users hit this branch — make it actionable rather
+ * than a hard exit (#209). The "report the last error" flow is unchanged
+ * when an envelope IS present.
+ */
+function noContextInstructions(): string {
+  return [
+    "No recent error in this session.",
+    "",
+    "To file a bug manually:",
+    `  ${ISSUE_NEW_URL}`,
+    "",
+    "After a failed command, run `pax8 report-bug` again and the CLI will",
+    "pre-fill a sanitized report (no IDs, names, paths, or credentials).",
+    "",
+    "For more options:",
+    "  pax8 report-bug --help",
+    "",
+  ].join("\n");
+}
+
 export async function runReportBug(opts: ReportBugOptions): Promise<number> {
   const raw = await readEnvelope();
   if (!raw) {
-    process.stderr.write(
-      "No recent error found. Run a command that fails and try again.\n"
-    );
-    return 1;
+    if (opts.json || jsonFlagInArgv()) {
+      // JSON consumers expect a parseable envelope-shaped response. Emit a
+      // minimal "no context" object rather than free-form text so scripts
+      // can branch on it without parsing prose.
+      process.stdout.write(
+        JSON.stringify(
+          {
+            status: "no-context",
+            message: "No recent error in this session.",
+            issueUrl: ISSUE_NEW_URL,
+          },
+          null,
+          2
+        ) + "\n"
+      );
+      return 0;
+    }
+    process.stdout.write(noContextInstructions());
+    return 0;
   }
 
   const env = redactEnvelope(raw);


### PR DESCRIPTION
## Summary
- Bare `pax8 report-bug` with no recent error in session now prints "how to file a bug manually" instructions and exits 0
- "Report the last error" flow unchanged when there IS a prior error
- Tested: matrix flips report-bug to live-run; README report-bug snippets pass

Closes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)