### PR TITLE
fix(auth): status command honors --json / non-TTY format (closes #210)

### DIFF
--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -168,11 +168,7 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
       // Under PAX8_DEMO=1 this should report demo mode somewhere in output.
       expectedFragments: [/demo|not authenticated|authenticated/i],
     },
-    // `auth status --json` currently prints human text, not JSON (#210).
-    // Skip contract until that's fixed; smoke + semantic still cover this.
-    jsonContract: {
-      skip: { reason: "auth status --json does not emit JSON (#210)" },
-    },
+    jsonContract: { objectRequiredFields: ["authenticated", "mode"] },
   },
   // ── config ────────────────────────────────────────────────────────────────
   {

--- a/e2e/onboarding.test.ts
+++ b/e2e/onboarding.test.ts
@@ -25,9 +25,12 @@ describe("E2E: Onboarding — first-time user experience", () => {
   });
 
   it("pax8 auth status shows auth info", async () => {
+    // Subprocess stdout is non-TTY, so the agent-first contract auto-emits
+    // JSON (#210). We assert on the structured shape rather than human copy.
     const result = await runCliExpectSuccess(["auth", "status"]);
-    expect(result.stdout).toContain("Authenticated");
-    expect(result.stdout).toContain("Demo");
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.authenticated).toBe(true);
+    expect(parsed.mode).toBe("demo");
   });
 
   it("pax8 companies list shows demo companies", async () => {

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -47,16 +47,20 @@ describe("pax8 auth", () => {
   });
 
   describe("auth status", () => {
-    it("shows demo mode status", async () => {
+    // Subprocess stdout is non-TTY, so per the agent-first contract (#210)
+    // `auth status` auto-emits JSON. We assert on the structured shape and
+    // separately verify the human path via the explicit format helpers.
+    it("emits JSON in non-TTY (agent-first default)", async () => {
       const result = await runCliExpectSuccess(["auth", "status"]);
-      expect(result.stdout).toContain("Authenticated");
-      expect(result.stdout).toContain("demo mode");
-      expect(result.stdout).toContain("Demo");
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.authenticated).toBe(true);
+      expect(parsed.mode).toBe("demo");
     });
 
-    it("shows mock data message", async () => {
-      const result = await runCliExpectSuccess(["auth", "status"]);
-      expect(result.stdout).toContain("mock data");
+    it("emits JSON when --json is passed explicitly", async () => {
+      const result = await runCliExpectSuccess(["auth", "status", "--json"]);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed).toEqual({ authenticated: true, mode: "demo" });
     });
   });
 

--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+
+// Mock CredentialStore so we can drive the "live + creds present" / "live + no
+// creds" branches deterministically without touching the real keychain.
+const getCredentialsMock = vi.fn();
+vi.mock("@pax8/core", async (importActual) => {
+  const actual = await importActual<typeof import("@pax8/core")>();
+  return {
+    ...actual,
+    CredentialStore: class {
+      getCredentials = getCredentialsMock;
+    },
+  };
+});
+
+import { authStatusCommand } from "./status.js";
+
+/**
+ * Build a tiny program with the same global flags as the real CLI so that
+ * `command.optsWithGlobals()` resolves --json correctly.
+ */
+function makeProgram(): Command {
+  const program = new Command()
+    .name("pax8")
+    .option("--json", "Output as JSON")
+    .option("--csv", "Output as CSV")
+    .option("--quiet", "Suppress all output")
+    .exitOverride();
+  const auth = new Command("auth").exitOverride();
+  auth.addCommand(authStatusCommand);
+  program.addCommand(auth);
+  return program;
+}
+
+describe("auth status", () => {
+  let stdoutWrite: ReturnType<typeof vi.spyOn>;
+  const originalIsTTY = process.stdout.isTTY;
+  const originalDemo = process.env.PAX8_DEMO;
+
+  beforeEach(() => {
+    stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    getCredentialsMock.mockReset();
+    // Default to TTY so the human path is the default unless we override
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    stdoutWrite.mockRestore();
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: originalIsTTY,
+      writable: true,
+    });
+    if (originalDemo === undefined) {
+      delete process.env.PAX8_DEMO;
+    } else {
+      process.env.PAX8_DEMO = originalDemo;
+    }
+  });
+
+  function captured(): string {
+    return stdoutWrite.mock.calls.map((c) => String(c[0])).join("");
+  }
+
+  it("emits JSON with authenticated:true and mode:demo under --json + PAX8_DEMO=1", async () => {
+    process.env.PAX8_DEMO = "1";
+    await makeProgram().parseAsync(["node", "pax8", "auth", "status", "--json"]);
+    const out = captured().trim();
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual({ authenticated: true, mode: "demo" });
+  });
+
+  it("emits human-formatted text in TTY mode without --json (demo)", async () => {
+    process.env.PAX8_DEMO = "1";
+    await makeProgram().parseAsync(["node", "pax8", "auth", "status"]);
+    const out = captured();
+    // Human output uses the checkmark + "demo mode" copy; no JSON braces.
+    expect(out).toContain("demo mode");
+    expect(out).not.toContain('"authenticated"');
+  });
+
+  it("auto-emits JSON when stdout is non-TTY (agent-first contract)", async () => {
+    process.env.PAX8_DEMO = "1";
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: false,
+      writable: true,
+    });
+    await makeProgram().parseAsync(["node", "pax8", "auth", "status"]);
+    const out = captured().trim();
+    const parsed = JSON.parse(out);
+    expect(parsed.authenticated).toBe(true);
+    expect(parsed.mode).toBe("demo");
+  });
+
+  it("emits authenticated:true mode:live when creds are present (--json)", async () => {
+    delete process.env.PAX8_DEMO;
+    getCredentialsMock.mockResolvedValue({
+      clientId: "abcdefghij1234567890",
+      clientSecret: "secret-value",
+    });
+    await makeProgram().parseAsync(["node", "pax8", "auth", "status", "--json"]);
+    const out = captured().trim();
+    const parsed = JSON.parse(out);
+    expect(parsed.authenticated).toBe(true);
+    expect(parsed.mode).toBe("live");
+    // Mask should be present and must NOT include the full secret.
+    expect(parsed.clientIdMasked).toBeDefined();
+    expect(out).not.toContain("secret-value");
+  });
+
+  it("emits authenticated:false mode:live when no creds are stored (--json)", async () => {
+    delete process.env.PAX8_DEMO;
+    getCredentialsMock.mockResolvedValue(null);
+    await makeProgram().parseAsync(["node", "pax8", "auth", "status", "--json"]);
+    const out = captured().trim();
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual({ authenticated: false, mode: "live" });
+  });
+});

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -5,6 +5,13 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { CredentialStore } from "@pax8/core";
 import { replCmd } from "../../lib/confirm.js";
+import { getOutputFormat } from "../../lib/context.js";
+
+interface AuthStatusJson {
+  authenticated: boolean;
+  mode: "demo" | "live";
+  clientIdMasked?: string;
+}
 
 export const authStatusCommand = new Command("status")
   .description("Show current authentication status")
@@ -12,12 +19,24 @@ export const authStatusCommand = new Command("status")
     "after",
     `
 Examples:
-  pax8 auth status`
+  pax8 auth status
+  pax8 auth status --json`
   )
-  .action(async () => {
+  .action(async (_options, command: Command) => {
+    const allOpts = command.optsWithGlobals();
+    const format = getOutputFormat(allOpts);
     const isDemo = process.env.PAX8_DEMO === "1";
 
     if (isDemo) {
+      if (format === "json") {
+        const payload: AuthStatusJson = {
+          authenticated: true,
+          mode: "demo",
+        };
+        process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+        return;
+      }
+
       process.stdout.write("\n");
       process.stdout.write(
         chalk.green("  ✓ Authenticated (demo mode)\n")
@@ -32,6 +51,21 @@ Examples:
 
     const store = new CredentialStore();
     const creds = await store.getCredentials();
+
+    if (format === "json") {
+      const payload: AuthStatusJson = {
+        authenticated: !!creds,
+        mode: "live",
+      };
+      if (creds) {
+        payload.clientIdMasked =
+          creds.clientId.length > 8
+            ? creds.clientId.slice(0, 4) + "…" + creds.clientId.slice(-4)
+            : "****";
+      }
+      process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+      return;
+    }
 
     process.stdout.write("\n");
 


### PR DESCRIPTION
## Summary
- auth status emitted human text regardless of --json or stdout TTY state
- Now routes through getOutputFormat() like every other read command
- JSON shape: { authenticated, mode, clientIdMasked? } — consumers can detect demo vs live in CI

Closes #210. (Replaces auto-closed #218 — base branch deleted on #207 merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)