### PR TITLE
fix(output): show commands emit single object in --json (closes #208)

### DIFF
--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -286,13 +286,7 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
       const id = await resolveFirstId("products", ["products", "list"]);
       return ["products", "show", id];
     },
-    demo: {
-      knownBroken: {
-        issue: "#208",
-        reason:
-          "show commands return [{...}] (array of one) instead of the single object — JSON-shape inconsistency",
-      },
-    },
+    demo: {},
     jsonContract: { objectRequiredFields: ["id", "name"] },
   },
   // ── subscriptions ─────────────────────────────────────────────────────────
@@ -318,10 +312,6 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     },
     demo: {
       forbiddenFragments: ["undefined"],
-      knownBroken: {
-        issue: "#208",
-        reason: "show JSON returns array-of-1 instead of single object",
-      },
     },
     jsonContract: { objectRequiredFields: ["id"] },
   },
@@ -411,10 +401,6 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     },
     demo: {
       forbiddenFragments: ["undefined"],
-      knownBroken: {
-        issue: "#208",
-        reason: "show JSON returns array-of-1 instead of single object",
-      },
     },
     jsonContract: { objectRequiredFields: ["id"] },
   },
@@ -494,10 +480,6 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     },
     demo: {
       forbiddenFragments: ["undefined"],
-      knownBroken: {
-        issue: "#208",
-        reason: "show JSON returns array-of-1 instead of single object",
-      },
     },
     jsonContract: { objectRequiredFields: ["id"] },
   },
@@ -547,10 +529,6 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     },
     demo: {
       forbiddenFragments: ["undefined"],
-      knownBroken: {
-        issue: "#208",
-        reason: "show JSON returns array-of-1 instead of single object",
-      },
     },
     jsonContract: { objectRequiredFields: ["id"] },
   },
@@ -713,10 +691,6 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     },
     demo: {
       forbiddenFragments: ["undefined"],
-      knownBroken: {
-        issue: "#208",
-        reason: "show JSON returns array-of-1 instead of single object",
-      },
     },
     jsonContract: { objectRequiredFields: ["id"] },
   },

--- a/e2e/contacts-workflow.test.ts
+++ b/e2e/contacts-workflow.test.ts
@@ -43,7 +43,7 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
     expect(companyIds.size).toBe(1);
   });
 
-  it("pax8 contacts show returns a single contact as JSON array", async () => {
+  it("pax8 contacts show returns a single contact object", async () => {
     const list = await runCliExpectSuccess([
       "contacts",
       "list",
@@ -55,9 +55,9 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
 
     const result = await runCliExpectSuccess(["contacts", "show", id, "--json"]);
     const data = JSON.parse(result.stdout);
-    expect(Array.isArray(data)).toBe(true);
-    expect(data).toHaveLength(1);
-    expect(data[0].id).toBe(id);
+    // `show` returns a single object, not an array (#208)
+    expect(Array.isArray(data)).toBe(false);
+    expect(data.id).toBe(id);
   });
 
   it("pax8 contacts show fails for unknown id", async () => {

--- a/e2e/quotes-workflow.test.ts
+++ b/e2e/quotes-workflow.test.ts
@@ -53,16 +53,16 @@ describe("E2E: Quotes workflow — list, show, write commands", () => {
     }
   });
 
-  it("pax8 quotes show returns a single quote as JSON array with computed total", async () => {
+  it("pax8 quotes show returns a single quote object with computed total", async () => {
     const list = await runCliExpectSuccess(["quotes", "list", "--json"]);
     const id = JSON.parse(list.stdout)[0].id;
 
     const result = await runCliExpectSuccess(["quotes", "show", id, "--json"]);
     const data = JSON.parse(result.stdout);
-    expect(Array.isArray(data)).toBe(true);
-    expect(data).toHaveLength(1);
-    expect(data[0].id).toBe(id);
-    expect(typeof data[0].total).toBe("number");
+    // `show` returns a single object, not an array (#208)
+    expect(Array.isArray(data)).toBe(false);
+    expect(data.id).toBe(id);
+    expect(typeof data.total).toBe("number");
   });
 
   it("pax8 quotes show fails for unknown id", async () => {

--- a/e2e/usage-workflow.test.ts
+++ b/e2e/usage-workflow.test.ts
@@ -55,15 +55,15 @@ describe("E2E: Usage workflow — list and show summaries", () => {
     }
   });
 
-  it("pax8 usage show returns a single summary as JSON array", async () => {
+  it("pax8 usage show returns a single summary object", async () => {
     const list = await runCliExpectSuccess(["usage", "list", "--json"]);
     const id = JSON.parse(list.stdout)[0].id;
 
     const result = await runCliExpectSuccess(["usage", "show", id, "--json"]);
     const data = JSON.parse(result.stdout);
-    expect(Array.isArray(data)).toBe(true);
-    expect(data).toHaveLength(1);
-    expect(data[0].id).toBe(id);
+    // `show` returns a single object, not an array (#208)
+    expect(Array.isArray(data)).toBe(false);
+    expect(data.id).toBe(id);
   });
 
   it("pax8 usage show --lines includes per-resource breakdown", async () => {
@@ -82,12 +82,13 @@ describe("E2E: Usage workflow — list and show summaries", () => {
       "--json",
     ]);
     const data = JSON.parse(result.stdout);
-    expect(data[0]).toHaveProperty("lines");
-    expect(Array.isArray(data[0].lines)).toBe(true);
-    expect(data[0].lines.length).toBeGreaterThan(0);
-    expect(data[0].lines[0]).toHaveProperty("description");
-    expect(data[0].lines[0]).toHaveProperty("subtotal");
-    expect(data[0].lines[0].usageSummaryId).toBe(summary.id);
+    expect(Array.isArray(data)).toBe(false);
+    expect(data).toHaveProperty("lines");
+    expect(Array.isArray(data.lines)).toBe(true);
+    expect(data.lines.length).toBeGreaterThan(0);
+    expect(data.lines[0]).toHaveProperty("description");
+    expect(data.lines[0]).toHaveProperty("subtotal");
+    expect(data.lines[0].usageSummaryId).toBe(summary.id);
   });
 
   it("pax8 usage show fails for unknown summary id", async () => {

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -80,12 +80,14 @@ describe("pax8 invoices", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data[0]).toHaveProperty("id", "inv-summit-curr-001");
-      expect(data[0]).toHaveProperty("companyName", "Summit Healthcare Partners");
-      expect(data[0]).toHaveProperty("total");
-      expect(data[0]).toHaveProperty("status");
-      expect(data[0]).toHaveProperty("balance");
-      expect(data[0]).toHaveProperty("currency");
+      // `show` returns a single object, not an array (#208)
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toHaveProperty("id", "inv-summit-curr-001");
+      expect(data).toHaveProperty("companyName", "Summit Healthcare Partners");
+      expect(data).toHaveProperty("total");
+      expect(data).toHaveProperty("status");
+      expect(data).toHaveProperty("balance");
+      expect(data).toHaveProperty("currency");
     });
   });
 

--- a/packages/cli/src/__tests__/products.test.ts
+++ b/packages/cli/src/__tests__/products.test.ts
@@ -53,8 +53,10 @@ describe("pax8 products", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data[0]).toHaveProperty("name", "Microsoft 365 Business Premium [New Commerce Experience]");
-      expect(data[0]).toHaveProperty("vendorName", "Microsoft");
+      // `show` returns a single object, not an array (#208)
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toHaveProperty("name", "Microsoft 365 Business Premium [New Commerce Experience]");
+      expect(data).toHaveProperty("vendorName", "Microsoft");
     });
 
     it("shows pricing with --pricing flag", async () => {
@@ -66,10 +68,11 @@ describe("pax8 products", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data[0]).toHaveProperty("pricingDetails");
-      expect(data[0].pricingDetails.length).toBeGreaterThan(0);
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toHaveProperty("pricingDetails");
+      expect(data.pricingDetails.length).toBeGreaterThan(0);
       // Verify pricing plan includes billingTerm, commitmentTerm, and price fields
-      const plan = data[0].pricingDetails[0];
+      const plan = data.pricingDetails[0];
       expect(plan).toHaveProperty("billingTerm");
       expect(plan).toHaveProperty("commitmentTerm");
       expect(plan).toHaveProperty("rates");
@@ -86,9 +89,10 @@ describe("pax8 products", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data[0]).toHaveProperty("provisioningDetails");
-      expect(data[0].provisioningDetails).toHaveProperty("productId");
-      expect(data[0].provisioningDetails).toHaveProperty("fields");
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toHaveProperty("provisioningDetails");
+      expect(data.provisioningDetails).toHaveProperty("productId");
+      expect(data.provisioningDetails).toHaveProperty("fields");
     });
 
     it("shows dependencies with --dependencies flag", async () => {
@@ -100,7 +104,8 @@ describe("pax8 products", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data[0]).toHaveProperty("dependencies");
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toHaveProperty("dependencies");
     });
   });
 

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -81,8 +81,10 @@ describe("pax8 subscriptions show", () => {
       "sub-summit-m365bp-001",
     ]);
     const data = JSON.parse(result.stdout);
-    expect(data[0].id).toBe("sub-summit-m365bp-001");
-    expect(data[0].productName).toBe("Microsoft 365 Business Premium [New Commerce Experience]");
+    // `show` returns a single object, not an array (#208)
+    expect(Array.isArray(data)).toBe(false);
+    expect(data.id).toBe("sub-summit-m365bp-001");
+    expect(data.productName).toBe("Microsoft 365 Business Premium [New Commerce Experience]");
   });
 
   it("shows subscription with --history", async () => {
@@ -93,10 +95,11 @@ describe("pax8 subscriptions show", () => {
       "--history",
     ]);
     const data = JSON.parse(result.stdout);
-    expect(data[0]).toHaveProperty("history");
-    expect(Array.isArray(data[0].history)).toBe(true);
-    expect(data[0].history.length).toBeGreaterThan(0);
-    expect(data[0].history[0]).toHaveProperty("field");
+    expect(Array.isArray(data)).toBe(false);
+    expect(data).toHaveProperty("history");
+    expect(Array.isArray(data.history)).toBe(true);
+    expect(data.history.length).toBeGreaterThan(0);
+    expect(data.history[0]).toHaveProperty("field");
   });
 
   it("shows help text", async () => {

--- a/packages/cli/src/commands/contacts/show.ts
+++ b/packages/cli/src/commands/contacts/show.ts
@@ -31,7 +31,7 @@ Examples:
       spinner.stop();
 
       if (ctx.outputFormat === "json") {
-        output([contact], { format: "json" });
+        process.stdout.write(JSON.stringify(contact, null, 2) + "\n");
         return;
       }
 

--- a/packages/cli/src/commands/invoices/show.ts
+++ b/packages/cli/src/commands/invoices/show.ts
@@ -32,7 +32,7 @@ Examples:
       spinner.stop();
 
       if (ctx.outputFormat === "json") {
-        output([invoice], { format: "json" });
+        process.stdout.write(JSON.stringify(invoice, null, 2) + "\n");
         return;
       }
 

--- a/packages/cli/src/commands/products/show.ts
+++ b/packages/cli/src/commands/products/show.ts
@@ -54,7 +54,7 @@ Examples:
         if (pricing) data.pricingDetails = pricing;
         if (provisioning) data.provisioningDetails = provisioning;
         if (dependencies) data.dependencies = dependencies;
-        output([data], { format: "json" });
+        process.stdout.write(JSON.stringify(data, null, 2) + "\n");
         return;
       }
 

--- a/packages/cli/src/commands/quotes/show.ts
+++ b/packages/cli/src/commands/quotes/show.ts
@@ -38,7 +38,9 @@ Examples:
       );
 
       if (ctx.outputFormat === "json") {
-        output([{ ...quote, total }], { format: "json" });
+        process.stdout.write(
+          JSON.stringify({ ...quote, total }, null, 2) + "\n"
+        );
         return;
       }
 

--- a/packages/cli/src/commands/subscriptions/show.ts
+++ b/packages/cli/src/commands/subscriptions/show.ts
@@ -58,11 +58,11 @@ Examples:
         if (options.history) {
           const history = await ctx.api.subscriptions.getHistory(id);
           const changes = Array.isArray(history) ? history : history.changes;
-          output([{ ...sub, history: changes }], {
-            format: "json",
-          });
+          process.stdout.write(
+            JSON.stringify({ ...sub, history: changes }, null, 2) + "\n"
+          );
         } else {
-          output([sub], { format: "json" });
+          process.stdout.write(JSON.stringify(sub, null, 2) + "\n");
         }
         return;
       }

--- a/packages/cli/src/commands/usage/show.ts
+++ b/packages/cli/src/commands/usage/show.ts
@@ -36,8 +36,8 @@ Examples:
       spinner.stop();
 
       if (ctx.outputFormat === "json") {
-        const payload = options.lines ? [{ ...summary, lines }] : [summary];
-        output(payload, { format: "json" });
+        const payload = options.lines ? { ...summary, lines } : summary;
+        process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
         return;
       }
 


### PR DESCRIPTION
## Summary
- Show commands emitted `[{resource}]` (array of one) instead of `{resource}` for `--json`
- Fixed in each show command (subscriptions/invoices/quotes/usage/products/contacts) — JSON.stringify the single resource directly, matching companies/orders show pattern
- Shared renderer left untouched
- 6 knownBroken entries dropped from per-command matrix; JSON-contract layer asserts the right shape

Closes #208. (Replaces auto-closed #217 — base branch deleted on #207 merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)