### PR TITLE
fix(orders): show enriches company name and line-item product names (closes #194)

### DIFF
--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -367,17 +367,11 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
       return ["orders", "show", id];
     },
     demo: {
-      // The known #194 bug: orders show currently renders "Company: undefined"
-      // and empty Line Items. When that's fixed, drop knownBroken and add:
-      //   expectedFragments: [/Company:.*\S+/, /Line Items?\b/],
-      knownBroken: {
-        issue: "#194",
-        reason:
-          "orders show renders Company: undefined and empty Line Items — needs enrichment from companies+products fixtures",
-      },
       forbiddenFragments: ["undefined"],
     },
-    jsonContract: { objectRequiredFields: ["id"] },
+    jsonContract: {
+      objectRequiredFields: ["id", "companyId", "companyName", "lineItems"],
+    },
   },
   {
     command: ["orders", "create"],

--- a/packages/cli/src/commands/orders/show.test.ts
+++ b/packages/cli/src/commands/orders/show.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess } from "../../__tests__/test-utils.js";
+
+describe("orders show", () => {
+  it("--json includes enriched companyName for the order (#194)", async () => {
+    const result = await runCliExpectSuccess([
+      "orders",
+      "show",
+      "ord-summit-001",
+      "--json",
+    ]);
+    const order = JSON.parse(result.stdout);
+    expect(order.id).toBe("ord-summit-001");
+    expect(order.companyId).toBeTruthy();
+    expect(typeof order.companyName).toBe("string");
+    expect(order.companyName.length).toBeGreaterThan(0);
+    expect(order.companyName).not.toBe("undefined");
+  });
+
+  it("--json line items are non-empty and each has a productName (#194)", async () => {
+    const result = await runCliExpectSuccess([
+      "orders",
+      "show",
+      "ord-summit-001",
+      "--json",
+    ]);
+    const order = JSON.parse(result.stdout);
+    expect(Array.isArray(order.lineItems)).toBe(true);
+    expect(order.lineItems.length).toBeGreaterThan(0);
+    for (const li of order.lineItems) {
+      expect(typeof li.productId).toBe("string");
+      expect(typeof li.productName).toBe("string");
+      expect(li.productName.length).toBeGreaterThan(0);
+      expect(li.productName).not.toMatch(/^Product /); // not the placeholder
+    }
+  });
+
+  it("human render shows a non-empty Company line and a Line Items section (#194)", async () => {
+    const result = await runCliExpectSuccess([
+      "orders",
+      "show",
+      "ord-summit-001",
+    ]);
+    // The CLI auto-detects non-TTY → JSON, so re-parse and assert the shape
+    // matches what the human renderer would print. The render-side regression
+    // is covered by the e2e per-command matrix's forbiddenFragments=["undefined"].
+    const order = JSON.parse(result.stdout);
+    expect(order.companyName).toMatch(/\S+/);
+    expect(order.lineItems.length).toBeGreaterThan(0);
+    expect(order.lineItems[0].productName).toMatch(/\S+/);
+  });
+});

--- a/packages/cli/src/commands/orders/show.ts
+++ b/packages/cli/src/commands/orders/show.ts
@@ -7,12 +7,18 @@ import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { buildContext } from "../../lib/context.js";
 import { output, type Column } from "../../lib/output.js";
-import { formatStatus, formatDate } from "../../lib/formatters.js";
+import { formatStatus, formatDate, formatCurrency } from "../../lib/formatters.js";
+import { enrichProductNames } from "../../lib/enrich-subscriptions.js";
 
 const lineItemColumns: Column[] = [
   { key: "productName", header: "Product" },
   { key: "quantity", header: "Qty" },
   { key: "billingTerm", header: "Term" },
+  {
+    key: "unitPrice",
+    header: "Price",
+    format: (v) => (typeof v === "number" ? formatCurrency(v) : chalk.dim("—")),
+  },
 ];
 
 export const ordersShowCommand = new Command("show")
@@ -34,7 +40,53 @@ Examples:
       const ctx = await buildContext(allOpts);
       const order = await ctx.api.orders.get(id);
 
+      // ── Enrich company name ──────────────────────────────────────────────
+      // Real API doesn't return companyName directly — join from companies.
+      // Demo fixtures already populate companyName, so this is a no-op there.
+      const orderRecord = order as Record<string, unknown>;
+      if (!order.companyName && order.companyId) {
+        try {
+          const company = await ctx.api.companies.get(order.companyId);
+          orderRecord.companyName = company.name;
+        } catch {
+          // Best effort — fall through to "Unknown" below.
+        }
+      }
+
+      // ── Enrich line item product names + best-effort price ───────────────
+      // Reuses the same helper subscriptions/companies use; bulk-fetches the
+      // catalog and falls back to per-id lookups for anything missing.
+      const lineItems = (order.lineItems ?? []) as Array<
+        Record<string, unknown> & { productId: string; billingTerm?: string }
+      >;
+      if (lineItems.length > 0) {
+        await enrichProductNames(ctx, lineItems);
+
+        // Best-effort unit price lookup — pricing is product-specific and
+        // billing-term-specific. Failures are silently ignored (price column
+        // renders "—") so a missing pricing endpoint never breaks `orders show`.
+        await Promise.all(
+          lineItems.map(async (li) => {
+            if (typeof li.unitPrice === "number") return;
+            try {
+              const pricing = await ctx.api.products.getPricing(li.productId);
+              if (!pricing || pricing.length === 0) return;
+              const match =
+                pricing.find((p) => p.billingTerm === li.billingTerm) ??
+                pricing[0];
+              const rate = match?.rates?.[0]?.suggestedRetailPrice;
+              if (typeof rate === "number") li.unitPrice = rate;
+            } catch {
+              /* best effort */
+            }
+          })
+        );
+      }
+
       spinner.stop();
+
+      const companyDisplay =
+        order.companyName ?? chalk.dim("Unknown company");
 
       if (ctx.outputFormat === "json") {
         process.stdout.write(JSON.stringify(order, null, 2) + "\n");
@@ -58,15 +110,15 @@ Examples:
       // Table / detail view
       process.stdout.write("\n");
       process.stdout.write(chalk.bold(`  Order ${order.id}\n\n`));
-      process.stdout.write(`  ${chalk.dim("Company:".padEnd(18))}${order.companyName}\n`);
+      process.stdout.write(`  ${chalk.dim("Company:".padEnd(18))}${companyDisplay}\n`);
       if (order.status) process.stdout.write(`  ${chalk.dim("Status:".padEnd(18))}${formatStatus(order.status)}\n`);
       process.stdout.write(`  ${chalk.dim("Date:".padEnd(18))}${formatDate(order.createdDate)}\n`);
-      process.stdout.write(`  ${chalk.dim("Ordered By:".padEnd(18))}${order.orderedBy}${order.orderedByEmail ? ` (${order.orderedByEmail})` : ""}\n`);
+      process.stdout.write(`  ${chalk.dim("Ordered By:".padEnd(18))}${order.orderedBy ?? chalk.dim("—")}${order.orderedByEmail ? ` (${order.orderedByEmail})` : ""}\n`);
       process.stdout.write("\n");
 
-      if (order.lineItems && order.lineItems.length > 0) {
-        process.stdout.write(chalk.dim(`  Line Items (${order.lineItems.length}):\n\n`));
-        output(order.lineItems, { format: "table", columns: lineItemColumns });
+      if (lineItems.length > 0) {
+        process.stdout.write(chalk.dim(`  Line Items (${lineItems.length}):\n\n`));
+        output(lineItems, { format: "table", columns: lineItemColumns });
         process.stdout.write("\n");
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- orders show rendered "Company: undefined" + empty Line Items
- Now joins companyId → name (via companies.get) and orderItems[].productId → name (via existing enrichProductNames helper)
- Adds per-line-item unit price column
- Same enrichment in human + --json output

Closes #194. (Replaces auto-closed #219 — base branch deleted on #207 merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)