### PR TITLE
docs: v0.1.0 release prep — CHANGELOG + Known Limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **Per-command e2e UX matrix** (`e2e/per-command.test.ts` + `e2e/command-inventory.ts`): every CLI command runs through a fixed set of layers under `PAX8_DEMO=1` — smoke (exits 0, no stack traces), cross-cutting invariants (no `undefined` / `[object Object]` / debug-token leaks), per-command semantic checks (expected/forbidden output fragments), JSON contract (`--json` parses, required fields per spec, minRows for list shapes), and `--help` (exits 0, mentions command name). The inventory is the single source of truth — adding a new command means adding one entry. Catalogued bugs are marked `knownBroken` with issue links rather than papering over with weakened assertions, so regressions stay visible in CI output (#193 / #207).
+
+### Changed
+
+- **Display labels** — `report-bug` no-prior-error now exits 0 with a manual-file-a-bug pointer instead of exiting 1 silently; the with-context flow (sanitize, prompt, submit) is unchanged (#209).
+- **`auth status --json`** now emits valid JSON (`{ authenticated, mode, clientIdMasked? }`) and respects the agent-first non-TTY contract; previously it printed human-formatted text regardless of `--json` (#210).
+
+### Fixed
+
+- **`orders show <id>`** — rendered "Company: undefined" and an empty Line Items section. Now joins `companyId` → company name (matching `subscriptions show`/`invoices show` pattern) and resolves `orderItems[].productId` → product name; adds per-line-item unit price column. Same enrichment in human and `--json` output (#194).
+- **`<group> show <id> --json`** — every show command (`subscriptions`, `invoices`, `quotes`, `usage`, `products`, `contacts`) wrapped the singular resource in a length-1 array (`[{...}]`) instead of emitting a single object — agent-contract violation that broke `--json | jq '.id'` style scripting (#208).
+- **`pax8 cost sim` README examples** used shorthand product names ("M365 Business Premium", "AvePoint Cloud Backup") that didn't prefix-match the demo catalog. First-run users walking the docs hit "Product not found" (#211).
+- **List-table rendering** (`pax8 companies list`, etc.) — dropped per-row inter-row dividers and the duplicated 50-line per-row drill-in footer; lists now render cleanly with one drill-in hint at the bottom of the table (#192).
+
 ### Internal
 
-- Scheduled API-drift watcher (`.github/workflows/api-watch.yml`) opens maintainer issues when `ERROR_API_VALIDATION` spikes are detected in telemetry. First layer of the api-resilience plan tracked at #176.
-- Added `windows-latest` to the CI matrix; the test suite now runs on Windows under PowerShell on every PR. Added `fail-fast: false` so a Windows-only regression doesn't mask Ubuntu signal. Coverage step gated to `ubuntu-latest` + Node 22 only (#186).
+- Scheduled API-drift watcher (`.github/workflows/api-watch.yml`) opens maintainer issues when `ERROR_API_VALIDATION` spikes are detected in telemetry. First layer of the api-resilience plan tracked at #176 (#178).
+- Added `windows-latest` to the CI matrix; the test suite now runs on Windows under PowerShell on every PR. Added `fail-fast: false` so a Windows-only regression doesn't mask Ubuntu signal. Coverage step gated to `ubuntu-latest` + Node 22 only (#186 / #188).
+- **`e2e/test-utils.ts`** — `runCli()` now uses an isolated `PAX8_CONFIG_DIR` (mkdtemp) per call so e2e tests don't inherit the developer's `~/.pax8/last-error.json` between cases (load-bearing for the new `report-bug` live-run; general hygiene).
 
 ## [0.1.0] — 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -397,6 +397,27 @@ for (const r of report.items.slice(0, 5)) {
 
 The same pattern works for `auditInvoices(...)`, `computeMrr(...)`, `computeGrowth(...)`, and `getRecommendations(...)` — see [`packages/core/README.md`](packages/core/README.md) for the full surface.
 
+## Known Limitations
+
+These are tracked, prioritized for v0.1.x, and not blockers for v0.1.0. Each links to a GitHub issue with repro and fix shape.
+
+**Real-API surfaces (depend on Pax8 backend):**
+- `pax8 orders list` against busy tenants can hit the 30s default timeout — workaround: `--size 25` or smaller. A `--timeout <ms>` flag and `PAX8_API_TIMEOUT` env override are planned ([#199](https://github.com/pax8labs/pax8-cli/issues/199)).
+- `pax8 usage list` returns 404 against the live Pax8 sandbox tenant — likely a path-version mismatch in the client; demo mode works ([#212](https://github.com/pax8labs/pax8-cli/issues/212)).
+- `pax8 doctor` marks the `~/.pax8/config` file as ✗ (and exits 1) when credentials are configured purely via env vars or `PAX8_DEMO=1` ([#220](https://github.com/pax8labs/pax8-cli/issues/220)).
+
+**Demo-mode UX:**
+- Some demo fixtures are thin (`usage`, `quotes`, `webhooks`) — README quick-start commands work but produce minimal output ([#196](https://github.com/pax8labs/pax8-cli/issues/196)).
+- List commands with 0 rows render an empty table rather than a helpful empty-state message ([#197](https://github.com/pax8labs/pax8-cli/issues/197)).
+
+**Human-render UX invariants (tooling gap):**
+- The per-command e2e matrix exercises every command in subprocess (non-TTY) mode, where the CLI's agent-first contract auto-routes to JSON. Some UX invariants (no UUIDs leaking into table cells, density bounds on tables, drill-in hint visibility) only apply in TTY-render mode and need a node-pty harness — tracked as a follow-up to broaden matrix coverage.
+
+**Polish:**
+- The bare `pax8` welcome screen is static (logo + 4 hardcoded suggested commands); a "what's interesting now" live-data first-load is planned for v0.1.x.
+- No update-notifier — the CLI doesn't tell you when a newer version exists ([#183](https://github.com/pax8labs/pax8-cli/issues/183)).
+- The scheduled API-drift watcher only filters `ERROR_API_VALIDATION` events; widening to `ERROR_API_TIMEOUT` / `ERROR_API_NOT_FOUND` / etc. is tracked separately ([#213](https://github.com/pax8labs/pax8-cli/issues/213)). Also note: the watcher is silent until `POSTHOG_PROJECT_API_KEY` is provisioned in repo secrets, and telemetry is opt-in by default.
+
 ## Documentation
 
 - [Credential Setup Guide](docs/credential-setup.md)


### PR DESCRIPTION
## Summary
- Folds this session's bug-fix and infrastructure work into the `[Unreleased]` CHANGELOG section: per-command e2e matrix (#193 / #207), the four matrix-surfaced fixes (#194 / #208 / #209 / #210 / #211), list-render UX (#192), and the api-watch / Windows CI items already drafted there (#178, #186 / #188).
- Adds a "Known Limitations" section to README covering the deferred v0.1.x items: real-API issues (#199, #212, #220), demo-mode gaps (#196, #197), the matrix's TTY-mode coverage gap, welcome-screen redesign, update-notifier (#183), and api-watch widening (#213).

## Bundle sizes (`npm pack --dry-run`)
- `@pax8/core@0.1.0` — 98.3 kB packed / 522.4 kB unpacked / 5 files
- `@pax8/cli@0.1.0` — 204.3 kB packed / 988.7 kB unpacked / 7 files

No version bump — already at 0.1.0.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test` — 1320 passed / 8 skipped
- [x] `pnpm lint` clean
- [ ] Manual review of CHANGELOG copy + Known Limitations links

🤖 Generated with [Claude Code](https://claude.com/claude-code)