### PR TITLE
fix(orders): create fails clearly at preview when commitment can't resolve (closes #230)

### DIFF
--- a/packages/cli/src/__tests__/orders.test.ts
+++ b/packages/cli/src/__tests__/orders.test.ts
@@ -165,5 +165,37 @@ describe("pax8 orders", () => {
       const combined = result.stdout + result.stderr;
       expect(combined).toMatch(/[Ii]nvalid quantity/);
     });
+
+    // Regression for #230: when a product requires a commitment term (every
+    // pricing plan has commitmentTerm) AND the customer has no existing
+    // subscription for that product (so resolveCommitmentTermId can't copy a
+    // UUID), the order command must fail at preview-time with a clear,
+    // actionable error — NOT proceed to a misleading preview ("Commitment:
+    // Monthly") and only fail after the user confirmed and the API rejected.
+    //
+    // Acme Corp does not have an M365 E3 subscription in the demo fixtures;
+    // M365 E3 has commitmentTerm on every pricing plan. Together that
+    // triggers the pre-flight check.
+    it("fails clearly when product requires commitment but no existing subscription (#230)", async () => {
+      const result = await runCliExpectFailure([
+        "orders",
+        "create",
+        "--company",
+        "Acme Corp",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "1",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      // Error is surfaced before the preview/confirm — there is no "Order
+      // Preview" or "Place order" prompt in the output.
+      expect(combined).not.toMatch(/Place order/);
+      // The error names the actual failure mode and includes recovery steps.
+      expect(combined).toMatch(/requires.*commitment/i);
+      expect(combined).toMatch(/--commitment-term/);
+      expect(combined).toMatch(/Pax8 portal/);
+    });
   });
 });

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -177,8 +177,35 @@ Examples:
 
       // Pre-flight checks
       if (productNotFound) warnings.push("Product not found in catalog — may not be orderable");
+
+      // Hard-fail before preview when commitment is required but couldn't be
+      // auto-resolved. Previously this was a soft warning and the order
+      // proceeded; the API then rejected, but only after the user had
+      // already confirmed a preview that misleadingly displayed
+      // "Commitment: <term>". Better to surface the actionable error up
+      // front (#230). The error matches the shape of the post-submit 422
+      // handler below, so the UX is consistent whether the failure is
+      // detected pre- or post-flight.
       if (requiresCommitment && !commitmentTermId) {
-        warnings.push("Product requires a commitment term but no commitmentTermId could be resolved — order may fail. Use --commitment-term-id <uuid> to provide one directly.");
+        const displayProduct = productName || allOpts.product;
+        const displayCompany = companyName || allOpts.company;
+        await handleCommandError(
+          new CliError(
+            `Can't order "${displayProduct}" for ${displayCompany}`,
+            [
+              `Product ${displayProduct} requires a commitment term`,
+              "This product requires a commitment term ID that couldn't be auto-resolved",
+            ],
+            [
+              "If the company has an existing subscription, try: --commitment-term Monthly or --commitment-term 1-Year",
+              "Or provide the UUID directly: --commitment-term-id <uuid> (from subscription commitment.id)",
+              "If no existing subscription, provision the first one through the Pax8 portal",
+              `View product details: ${replCmd("pax8 products show")} ${allOpts.product}`,
+            ],
+            undefined,
+            ERROR_INVALID_INPUT,
+          ),
+        );
       }
 
       const totalPrice = unitPrice ? unitPrice * quantity : null;


### PR DESCRIPTION
## Summary
- The closed-loop "follow recommendation → place order" flow misled users when a recommended product required a commitment term and the customer had no existing subscription for it: the preview happily showed "Commitment: Monthly", the user confirmed, and only THEN did the API reject with HTTP 422.
- Surfaces the same actionable error (cause + recovery steps + report-bug hint) at preview time instead, so the user sees the failure mode before being asked to confirm anything misleading.
- Regression test added: `orders create --company "Acme Corp" --product prod-m365-e3-0003` (Acme has no E3 subscription; E3 has commitment on every pricing plan) — must fail without producing a "Place order" prompt and must include `--commitment-term` and "Pax8 portal" hints.

## Discovered by
Real-API session against Pax8 sandbox tenant: \`recommendations list --company "1Demo Ltd"\` suggested cross-selling Microsoft Entra Internet Access; the orderCommand executed via REPL drill-in then crashed post-confirm with the cryptic post-submit error.

## Why the matrix didn't catch this
The per-command matrix exercises `recommendations list` (returns rows ✓) and `orders create --help` (works ✓), but never the closed-loop "follow recommendation → execute orderCommand → succeed" path because write commands are gated as `skipLiveRun`. The new regression test in `orders.test.ts` exercises the failure path directly via subprocess.

## Out of scope
The recommendations engine itself isn't changed here — it still generates plausible `orderCommand` strings, and orders create is now the right surface to fail clearly. A follow-up could enrich the recommendation surface with a `requiresPortalSetup` flag so we don't suggest orders that can't be fulfilled programmatically. (Tracking idea, no issue yet.)

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test` — 1327 passed / 8 skipped
- [x] `pnpm lint` clean
- [x] Manual repro: `orders create --company "Acme Corp" --product prod-m365-e3-0003 --quantity 1 --yes` exits 1 with the actionable error and no preview prompt

Closes #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)