### PR TITLE
chore(release-prep): SPDX header gap + credential/internal-ref scan results

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Command } from "commander";
 import chalk from "chalk";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Public entrypoint for `@pax8/core`.
 //
 // This file is the single source of truth for what `@pax8/core` exposes to


### PR DESCRIPTION
## Summary
- Added Apache-2.0 SPDX headers to the last two source files missing them (`packages/cli/src/index.ts` and `packages/core/src/index.ts`)
- Closes the last gap from §7's "Apache 2.0 source-file headers" Open item

## Pre-publish scan results (no code change, captured for reviewer record)

### Credential history scan (re-confirmed)
Full `git log --all -p` against AWS keys, Stripe live keys, GitHub PATs, Slack tokens, JWTs, Bearer-shape strings, and high-entropy hex/UUID patterns. **No real credentials.** Same finding as the prior scan — all matches are env-var bindings (`PAX8_CLIENT_SECRET`, `POSTHOG_PROJECT_API_KEY`), test placeholders (`"secret-value"`, `MOCK_TOKEN`, the `a1b2c3d4...` redaction-test fixture), or doc references.

### Internal-reference scrub
Searched code, comments, and commit messages for: JIRA-style refs (`[A-Z]{2,5}-[0-9]+`), internal hostnames (`*.internal.pax8.com`), internal Slack channels (`#cs-internal`, etc.), Notion/Confluence URLs, and internal employee mentions beyond the public maintainers (@jdulberger, @cbrownpax8). **All zero.** TODOs reference public GitHub issues only.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test` — 1327 passed / 8 skipped
- [x] `pnpm lint` clean
- [x] `find packages/*/src -name '*.ts' | xargs grep -L 'SPDX-License-Identifier'` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)