### PR TITLE
fix(types): align SubscriptionStatusSchema with public API enum

### DIFF
--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -17,8 +17,8 @@ export const SubscriptionStatusSchema = z.enum([
   "WaitingForDetails",
   "Trial",
   "Converted",
-  "Inactive",
-  "Deleted",
+  "PendingActivation",
+  "Activated",
 ]);
 export type SubscriptionStatus = z.infer<typeof SubscriptionStatusSchema>;
 


### PR DESCRIPTION
## Summary

Aligns `SubscriptionStatusSchema` in `packages/core/src/api/types.ts` with the public API's `Subscription.status` enum (per devx.pax8.com `partner-endpoints.json`).

## What changed

- Added `PendingActivation` to `SubscriptionStatusSchema`.
- Added `Activated` to `SubscriptionStatusSchema`.
- Removed `Inactive` from `SubscriptionStatusSchema` — not part of the public enum, and not produced by mock or real client code paths (only `CompanyStatus` uses it).
- Removed `Deleted` from `SubscriptionStatusSchema` — same rationale.

## Why

Real API responses with `PendingActivation` or `Activated` would have failed Zod validation, breaking `pax8 subscriptions list / show / renewals` for any partner with activation-required products.

## Verification

- Searched the codebase for hardcoded subscription status checks. All existing comparisons (`status === "Active"`, `.toLowerCase() === "active"`, `formatStatus(...)`) handle the new values gracefully — none break.
- `packages/core/src/mock/demo-data.ts`: mock `Subscription.status` union does not include `Inactive` or `Deleted`; only `Company.status` does. No mock data is affected.
- `pnpm build` passes.
- `pnpm test` passes (1326 passed, 8 skipped).

## Test plan

- [x] `pnpm build` succeeds.
- [x] `pnpm test` succeeds — full suite green.
- [ ] Reviewer sanity-check: `pax8 subscriptions list --json` under `PAX8_DEMO=1` still works.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)