### PR TITLE
feat(contacts): accept multiple ContactType values on create/update (closes #244)

### DIFF
--- a/packages/cli/src/__tests__/contacts.test.ts
+++ b/packages/cli/src/__tests__/contacts.test.ts
@@ -1,0 +1,169 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+
+const SUMMIT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+describe("pax8 contacts", () => {
+  describe("contacts create --type", () => {
+    it("accepts a single ContactType (default Admin)", async () => {
+      const result = await runCliExpectSuccess(
+        [
+          "contacts",
+          "create",
+          "--company",
+          SUMMIT_ID,
+          "--email",
+          "single@example.com",
+          "--first-name",
+          "Single",
+          "--last-name",
+          "Type",
+          "--json",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0].types).toEqual(["Admin"]);
+    });
+
+    it("accepts comma-separated multiple ContactTypes", async () => {
+      const result = await runCliExpectSuccess(
+        [
+          "contacts",
+          "create",
+          "--company",
+          SUMMIT_ID,
+          "--email",
+          "multi@example.com",
+          "--first-name",
+          "Multi",
+          "--last-name",
+          "Type",
+          "--type",
+          "Admin,Billing",
+          "--json",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0].types).toEqual(["Admin", "Billing"]);
+    });
+
+    it("trims whitespace and dedupes types", async () => {
+      const result = await runCliExpectSuccess(
+        [
+          "contacts",
+          "create",
+          "--company",
+          SUMMIT_ID,
+          "--email",
+          "trim@example.com",
+          "--first-name",
+          "Trim",
+          "--last-name",
+          "Dedup",
+          "--type",
+          " Admin , Billing , Admin ",
+          "--json",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const data = JSON.parse(result.stdout);
+      expect(data[0].types).toEqual(["Admin", "Billing"]);
+    });
+
+    it("rejects invalid type values", async () => {
+      const result = await runCliExpectFailure(
+        [
+          "contacts",
+          "create",
+          "--company",
+          SUMMIT_ID,
+          "--email",
+          "bad@example.com",
+          "--first-name",
+          "Bad",
+          "--last-name",
+          "Type",
+          "--type",
+          "Admin,Bogus",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Invalid --type/);
+      expect(combined).toContain("Bogus");
+    });
+
+    it("shows the new --type help text", async () => {
+      const result = await runCliExpectSuccess(["contacts", "create", "--help"]);
+      expect(result.stdout).toContain("--type");
+      expect(result.stdout).toContain("Comma-separated");
+      expect(result.stdout).toContain("Admin");
+      expect(result.stdout).toContain("Billing");
+      expect(result.stdout).toContain("Technical");
+    });
+  });
+
+  describe("contacts update --type", () => {
+    it("accepts comma-separated multiple ContactTypes", async () => {
+      const result = await runCliExpectSuccess(
+        [
+          "contacts",
+          "update",
+          "contact-summit-001",
+          "--type",
+          "Admin,Technical",
+          "--json",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0].types).toEqual(["Admin", "Technical"]);
+    });
+
+    it("rejects an empty --type value", async () => {
+      const result = await runCliExpectFailure(
+        [
+          "contacts",
+          "update",
+          "contact-summit-001",
+          "--type",
+          " , ,",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/At least one contact type is required/);
+    });
+
+    it("rejects invalid type values", async () => {
+      const result = await runCliExpectFailure(
+        [
+          "contacts",
+          "update",
+          "contact-summit-001",
+          "--type",
+          "Admin,NotReal",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Invalid --type/);
+      expect(combined).toContain("NotReal");
+    });
+  });
+});

--- a/packages/cli/src/commands/contacts/create.ts
+++ b/packages/cli/src/commands/contacts/create.ts
@@ -16,6 +16,19 @@ import type { CreateContactInput, ContactType } from "@pax8/core";
 
 const VALID_TYPES: ContactType[] = ["Admin", "Billing", "Technical"];
 
+function parseTypes(input: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input.split(",")) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
 export const contactsCreateCommand = new Command("create")
   .description("Create a new contact for a company")
   .requiredOption("--company <id|name>", "Company ID or name (required)")
@@ -23,30 +36,42 @@ export const contactsCreateCommand = new Command("create")
   .requiredOption("--first-name <name>", "First name (required)")
   .requiredOption("--last-name <name>", "Last name (required)")
   .option("--phone <phone>", "Phone number")
-  .option("--type <type>", "Contact type: Admin, Billing, or Technical", "Admin")
+  .option("--type <types>", "Comma-separated contact types: Admin, Billing, Technical", "Admin")
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
     `
 Examples:
   pax8 contacts create --company "Summit Healthcare Partners" --email rachel@example.com --first-name Rachel --last-name Thornton
-  pax8 contacts create --company a1b2c3d4 --email tech@example.com --first-name Sam --last-name Lee --type Technical`
+  pax8 contacts create --company a1b2c3d4 --email tech@example.com --first-name Sam --last-name Lee --type Technical
+  pax8 contacts create --company a1b2c3d4 --email ops@example.com --first-name Pat --last-name Kim --type Admin,Billing`
   )
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();
     const ctx = await buildContext(globalOpts);
 
     try {
-      const type = String(options.type) as ContactType;
-      if (!VALID_TYPES.includes(type)) {
+      const parsed = parseTypes(String(options.type));
+      if (parsed.length === 0) {
         throw new CliError(
-          `Invalid --type "${options.type}"`,
-          [`Allowed values: ${VALID_TYPES.join(", ")}`],
-          [`Try: ${replCmd("pax8 contacts create")} --type Admin ...`],
+          "At least one contact type is required",
+          [`--type must contain one or more comma-separated values from: ${VALID_TYPES.join(", ")}`],
+          [`Try: ${replCmd("pax8 contacts create")} --type Admin,Billing ...`],
           undefined,
           ERROR_INVALID_INPUT,
         );
       }
+      const invalid = parsed.filter((t) => !VALID_TYPES.includes(t as ContactType));
+      if (invalid.length > 0) {
+        throw new CliError(
+          `Invalid --type value(s): ${invalid.map((v) => `"${v}"`).join(", ")}`,
+          [`Allowed values: ${VALID_TYPES.join(", ")}`],
+          [`Try: ${replCmd("pax8 contacts create")} --type Admin,Billing ...`],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+      const types = parsed as ContactType[];
 
       const company = await resolveCompany(ctx, options.company);
 
@@ -57,7 +82,7 @@ Examples:
       if (options.phone) {
         process.stderr.write(`  ${chalk.dim("Phone:".padEnd(14))}${options.phone}\n`);
       }
-      process.stderr.write(`  ${chalk.dim("Type:".padEnd(14))}${type}\n`);
+      process.stderr.write(`  ${chalk.dim("Types:".padEnd(14))}${types.join(", ")}\n`);
       process.stderr.write(`  ${chalk.dim("Company:".padEnd(14))}${company.name}\n\n`);
 
       const ok = await confirm("Create this contact?", { default: true });
@@ -71,7 +96,7 @@ Examples:
         lastName: options.lastName,
         email: options.email,
         companyId: company.id,
-        types: [type],
+        types,
         ...(options.phone ? { phone: options.phone } : {}),
       };
 

--- a/packages/cli/src/commands/contacts/update.ts
+++ b/packages/cli/src/commands/contacts/update.ts
@@ -15,6 +15,19 @@ import type { UpdateContactInput, ContactType } from "@pax8/core";
 
 const VALID_TYPES: ContactType[] = ["Admin", "Billing", "Technical"];
 
+function parseTypes(input: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input.split(",")) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
 export const contactsUpdateCommand = new Command("update")
   .description("Update a contact")
   .argument("<id>", "Contact ID")
@@ -22,7 +35,7 @@ export const contactsUpdateCommand = new Command("update")
   .option("--last-name <name>", "New last name")
   .option("--email <email>", "New email")
   .option("--phone <phone>", "New phone number")
-  .option("--type <type>", "New contact type: Admin, Billing, or Technical")
+  .option("--type <types>", "Comma-separated contact types: Admin, Billing, Technical")
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
@@ -30,6 +43,7 @@ export const contactsUpdateCommand = new Command("update")
 Examples:
   pax8 contacts update contact-summit-001 --email rachel.new@example.com
   pax8 contacts update contact-summit-001 --type Billing
+  pax8 contacts update contact-summit-001 --type Admin,Billing
   pax8 contacts update contact-summit-001 --phone "+1-303-555-9999" --yes`
   )
   .action(async (id, options, command) => {
@@ -42,18 +56,28 @@ Examples:
       if (options.lastName) data.lastName = options.lastName;
       if (options.email) data.email = options.email;
       if (options.phone) data.phone = options.phone;
-      if (options.type) {
-        const type = String(options.type) as ContactType;
-        if (!VALID_TYPES.includes(type)) {
+      if (options.type !== undefined) {
+        const parsed = parseTypes(String(options.type));
+        if (parsed.length === 0) {
           throw new CliError(
-            `Invalid --type "${options.type}"`,
-            [`Allowed values: ${VALID_TYPES.join(", ")}`],
-            undefined,
+            "At least one contact type is required when --type is provided",
+            [`--type must contain one or more comma-separated values from: ${VALID_TYPES.join(", ")}`],
+            [`Try: ${replCmd("pax8 contacts update")} ${id} --type Admin,Billing`],
             undefined,
             ERROR_INVALID_INPUT,
           );
         }
-        data.types = [type];
+        const invalid = parsed.filter((t) => !VALID_TYPES.includes(t as ContactType));
+        if (invalid.length > 0) {
+          throw new CliError(
+            `Invalid --type value(s): ${invalid.map((v) => `"${v}"`).join(", ")}`,
+            [`Allowed values: ${VALID_TYPES.join(", ")}`],
+            [`Try: ${replCmd("pax8 contacts update")} ${id} --type Admin,Billing`],
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+        data.types = parsed as ContactType[];
       }
 
       if (Object.keys(data).length === 0) {
@@ -74,7 +98,7 @@ Examples:
       process.stderr.write(`  ${chalk.dim("ID:".padEnd(14))}${current.id}\n`);
       process.stderr.write(`  ${chalk.dim("Current:".padEnd(14))}${current.firstName} ${current.lastName} <${current.email}>\n\n`);
       for (const [k, v] of Object.entries(data)) {
-        const label = k === "types" ? "type" : k;
+        const label = k === "types" ? "types" : k;
         const display = Array.isArray(v) ? v.join(", ") : String(v);
         process.stderr.write(`  ${chalk.dim((label + ":").padEnd(14))}${chalk.green(display)}\n`);
       }


### PR DESCRIPTION
## Summary

Closes #244.

The Pax8 API models `Contact.types` as `array<ContactType>` (`Admin`, `Billing`, `Technical`). The CLI's `--type` flag on `pax8 contacts create` and `pax8 contacts update` previously accepted only a single value, so multi-role contacts (e.g. an Admin + Billing contact at a small MSP) couldn't be created or updated in one call.

`--type` now accepts a comma-separated list, matching the style already in use by `pax8 webhooks create --events`:

- `pax8 contacts create ... --type Admin,Billing`
- `pax8 contacts update <id> --type Admin,Billing,Technical`

Behavior:
- Values are trimmed, deduped, and validated against the `ContactType` enum.
- `create` still defaults to `Admin` when `--type` is omitted (no behavior change).
- `update` rejects an empty `--type` (must contain at least one value when the flag is present).
- Help text updated: `--type <types>` with description `Comma-separated contact types: Admin, Billing, Technical`.
- The `@pax8/core` API client and Zod input schema already accept an array; no core changes were needed.

## Test plan

- [x] New subprocess test file `packages/cli/src/__tests__/contacts.test.ts` covers:
  - `create` with default (Admin), single, multi (`Admin,Billing`), and trim/dedupe (`" Admin , Billing , Admin "` -> `["Admin","Billing"]`).
  - `create` rejects invalid type values (`Admin,Bogus`).
  - `create --help` shows the new comma-separated description.
  - `update` accepts multi (`Admin,Technical`).
  - `update` rejects empty `--type` and invalid values.
- [x] `pnpm build && pnpm test` passes (1335 passed, 8 skipped).
- [x] `pnpm lint` clean.
- [x] DCO sign-off (`git commit -s`).

Generated with [Claude Code](https://claude.com/claude-code)