### PR TITLE
feat(subscriptions): add --cancel-date for scheduled cancellation

### DIFF
--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -202,6 +202,7 @@ describe("pax8 subscriptions cancel", () => {
       "--help",
     ]);
     expect(result.stdout).toContain("Cancel a subscription");
+    expect(result.stdout).toContain("--cancel-date");
   });
 
   it("errors with invalid subscription ID", async () => {
@@ -213,6 +214,65 @@ describe("pax8 subscriptions cancel", () => {
     ]);
     const combined = result.stdout + result.stderr;
     expect(combined.length).toBeGreaterThan(0);
+  });
+
+  it("rejects malformed --cancel-date", async () => {
+    const result = await runCliExpectFailure([
+      "subscriptions",
+      "cancel",
+      "sub-summit-m365bp-001",
+      "--cancel-date",
+      "12/31/2026",
+      "--yes",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/cancel-date/i);
+    expect(combined).toMatch(/YYYY-MM-DD/);
+  });
+
+  it("rejects calendar-impossible --cancel-date", async () => {
+    const result = await runCliExpectFailure([
+      "subscriptions",
+      "cancel",
+      "sub-summit-m365bp-001",
+      "--cancel-date",
+      "2026-02-30",
+      "--yes",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/cancel-date/i);
+  });
+
+  it("emits ERROR_INVALID_INPUT for bad --cancel-date in --json mode", async () => {
+    const result = await runCliExpectFailure([
+      "subscriptions",
+      "cancel",
+      "sub-summit-m365bp-001",
+      "--cancel-date",
+      "not-a-date",
+      "--yes",
+      "--json",
+    ]);
+    expect(result.stderr).toContain("ERROR_INVALID_INPUT");
+  });
+
+  it("schedules cancellation with a valid --cancel-date", async () => {
+    const result = await runCliExpectSuccess([
+      "subscriptions",
+      "cancel",
+      "sub-summit-m365bp-001",
+      "--cancel-date",
+      "2026-12-31",
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0]).toMatchObject({
+      id: "sub-summit-m365bp-001",
+      status: "Cancelled",
+      cancelDate: "2026-12-31",
+    });
   });
 });
 

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -3,32 +3,81 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
-import { handleCommandError } from "../../lib/errors.js";
+import { CliError, handleCommandError } from "../../lib/errors.js";
 import { confirmDestructive } from "../../lib/confirm.js";
 import { formatCurrency, formatQuantity, calculateMrr } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { replCmd } from "../../lib/confirm.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 
+/**
+ * Validate a `YYYY-MM-DD` cancel date. Returns the normalized string on
+ * success, throws a `CliError(ERROR_INVALID_INPUT)` with recovery hints on
+ * failure. We accept the simple ISO calendar form only — the Pax8 API treats
+ * `cancelDate` as a date (not a timestamp), and accepting timestamps would
+ * silently drop the time portion.
+ */
+function parseCancelDate(raw: string): string {
+  const trimmed = raw.trim();
+  // Strict YYYY-MM-DD shape so "2026-1-1" and "1/15/2026" don't sneak through.
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    throw new CliError(
+      `Invalid --cancel-date "${raw}".`,
+      ["Expected ISO calendar form YYYY-MM-DD (e.g. 2026-12-31)."],
+      [
+        `Pass the date as YYYY-MM-DD: ${chalk.cyan(replCmd("pax8 subscriptions cancel <id> --cancel-date 2026-12-31"))}`,
+        "Omit --cancel-date for an immediate cancellation.",
+      ],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  // Reject calendar-impossible values (Feb 30, month 13, etc.) — the regex
+  // above is a shape check, this is the round-trip semantic check.
+  const parsed = new Date(`${trimmed}T00:00:00Z`);
+  const reserialized = Number.isNaN(parsed.getTime())
+    ? null
+    : parsed.toISOString().slice(0, 10);
+  if (reserialized !== trimmed) {
+    throw new CliError(
+      `Invalid --cancel-date "${raw}".`,
+      ["The value parses as a calendar-impossible date."],
+      [
+        `Pass a real calendar date as YYYY-MM-DD: ${chalk.cyan(replCmd("pax8 subscriptions cancel <id> --cancel-date 2026-12-31"))}`,
+      ],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return trimmed;
+}
+
 export const subscriptionsCancelCommand = new Command("cancel")
   .description("Cancel a subscription")
   .argument("<id>", "Subscription ID")
+  .option("--cancel-date <YYYY-MM-DD>", "Schedule cancellation for a future date (ISO YYYY-MM-DD)")
   .option("-y, --yes", "Skip confirmation prompts")
   .addHelpText(
     "after",
     `
 Examples:
   pax8 subscriptions cancel sub-summit-m365bp-001
-  pax8 subscriptions cancel sub-summit-m365bp-001 --yes`
+  pax8 subscriptions cancel sub-summit-m365bp-001 --yes
+  pax8 subscriptions cancel sub-summit-m365bp-001 --cancel-date 2026-12-31`
   )
   .action(async (id, options, cmd) => {
     const allOpts = cmd.optsWithGlobals();
     const ctx = await buildContext(allOpts);
 
     try {
+      const cancelDate = allOpts.cancelDate
+        ? parseCancelDate(String(allOpts.cancelDate))
+        : undefined;
+
       // Fetch subscription details to show what will be cancelled
       const spinner = createSpinner("Fetching subscription...").start();
       const sub = await ctx.api.subscriptions.get(id);
@@ -37,18 +86,29 @@ Examples:
       // Calculate estimated MRR impact
       const mrr = calculateMrr(sub.price ?? 0, sub.quantity, String(sub.billingTerm ?? "Monthly"));
 
-      if (ctx.outputFormat !== "quiet") {
-        process.stdout.write(chalk.red.bold("\n  Subscription to be cancelled:\n\n"));
+      if (ctx.outputFormat === "table") {
+        // Table format only: humans see the preview block.
+        // In --json/--csv/--quiet, stdout is reserved for the data envelope.
+        const heading = cancelDate
+          ? `\n  Subscription to be cancelled on ${cancelDate}:\n\n`
+          : "\n  Subscription to be cancelled:\n\n";
+        process.stdout.write(chalk.red.bold(heading));
         process.stdout.write(`  ${chalk.bold("Company")}      ${sub.companyName ?? sub.companyId}\n`);
         process.stdout.write(`  ${chalk.bold("Product")}      ${sub.productName}\n`);
         process.stdout.write(`  ${chalk.bold("Quantity")}     ${formatQuantity(sub.quantity)}\n`);
+        if (cancelDate) {
+          process.stdout.write(`  ${chalk.bold("Cancel Date")}  ${cancelDate}\n`);
+        }
         process.stdout.write(`  ${chalk.bold("Est. MRR Impact")}   ${chalk.red("-" + formatCurrency(mrr))}\n`);
         process.stdout.write("\n");
       }
 
-      // Destructive confirmation
+      // Destructive confirmation — surface the scheduled date so the user
+      // doesn't conflate scheduled with immediate cancellation.
       const confirmed = await confirmDestructive(
-        "This action cannot be undone.",
+        cancelDate
+          ? `This will schedule cancellation for ${cancelDate}. This action cannot be undone.`
+          : "This action cannot be undone.",
         "cancel"
       );
 
@@ -57,18 +117,29 @@ Examples:
         return;
       }
 
-      const cancelSpinner = createSpinner("Cancelling subscription...").start();
+      const cancelSpinner = createSpinner(
+        cancelDate ? `Scheduling cancellation for ${cancelDate}...` : "Cancelling subscription...",
+      ).start();
       const doneCancel = markWriteInFlight("subscriptions");
       try {
-        await ctx.api.subscriptions.delete(id);
+        await ctx.api.subscriptions.delete(id, cancelDate ? { cancelDate } : undefined);
       } finally {
         doneCancel();
       }
       await invalidateCacheAfterWrite();
-      cancelSpinner.succeed("Subscription cancelled");
+      cancelSpinner.succeed(
+        cancelDate ? `Cancellation scheduled for ${cancelDate}` : "Subscription cancelled",
+      );
 
       if (ctx.outputFormat === "json") {
-        output([{ id: sub.id, status: "Cancelled" }], { format: "json" });
+        output(
+          [
+            cancelDate
+              ? { id: sub.id, status: "Cancelled", cancelDate }
+              : { id: sub.id, status: "Cancelled" },
+          ],
+          { format: "json" },
+        );
       }
 
       // Next steps

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -88,8 +88,8 @@ export class Pax8Client {
     return this.request<T>("PATCH", path, body);
   }
 
-  async delete(path: string): Promise<void> {
-    await this.request<void>("DELETE", path);
+  async delete(path: string, params?: Record<string, string | number | undefined>): Promise<void> {
+    await this.request<void>("DELETE", path, undefined, params);
   }
 
   async *getPaginated<T>(

--- a/packages/core/src/api/subscriptions.test.ts
+++ b/packages/core/src/api/subscriptions.test.ts
@@ -100,7 +100,19 @@ describe("SubscriptionsApi", () => {
 
     await api.delete(SUB_ID);
 
-    expect(client.delete).toHaveBeenCalledWith(`/subscriptions/${SUB_ID}`);
+    // No `cancelDate` → no query string forwarded.
+    expect(client.delete).toHaveBeenCalledWith(`/subscriptions/${SUB_ID}`, undefined);
+  });
+
+  it("delete forwards cancelDate as a query parameter", async () => {
+    (client.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    await api.delete(SUB_ID, { cancelDate: "2026-12-31" });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `/subscriptions/${SUB_ID}`,
+      { cancelDate: "2026-12-31" },
+    );
   });
 
   it("throws on invalid response data", async () => {

--- a/packages/core/src/api/subscriptions.ts
+++ b/packages/core/src/api/subscriptions.ts
@@ -43,7 +43,13 @@ export class SubscriptionsApi {
     return SubscriptionSchema.parse(raw);
   }
 
-  async delete(id: string): Promise<void> {
-    await this.client.delete(`/subscriptions/${id}`);
+  /**
+   * Cancel a subscription. By default the cancellation is immediate; pass
+   * `cancelDate` (ISO `YYYY-MM-DD`) to schedule the cancellation for a future
+   * date — the Pax8 API forwards it as the `cancelDate` query parameter.
+   */
+  async delete(id: string, params?: { cancelDate?: string }): Promise<void> {
+    const query = params?.cancelDate ? { cancelDate: params.cancelDate } : undefined;
+    await this.client.delete(`/subscriptions/${id}`, query);
   }
 }

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -210,10 +210,13 @@ class SubscriptionsResource {
     return { ...sub, ...data, id: sub.id };
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, _params?: { cancelDate?: string }): Promise<void> {
     await randomDelay();
     const sub = subscriptions.find((s) => s.id === id);
     if (!sub) throw notFound("Subscription", id);
+    // Demo mode ignores `cancelDate`: scheduled cancellations don't materialize
+    // a future state-change in the in-memory data set, but the param is accepted
+    // so the CLI surface matches the real client signature.
   }
 }
 


### PR DESCRIPTION
Closes #242.

## Summary

- Adds `--cancel-date <YYYY-MM-DD>` to `pax8 subscriptions cancel`. Default behavior (no flag) is unchanged — still an immediate cancellation, no breaking change for existing users.
- Validates the date strictly as ISO `YYYY-MM-DD` (regex shape plus a round-trip semantic check, so `2026-02-30` and `12/31/2026` are both rejected). Bad input surfaces as `CliError(ERROR_INVALID_INPUT)` with recovery hints before any API call runs.
- The destructive confirmation prompt and the spinner copy both reflect the scheduled date, so the user can't conflate scheduled with immediate cancellation.
- `SubscriptionsApi.delete()` now accepts an optional `{ cancelDate }` and forwards it to the `DELETE /subscriptions/{id}` endpoint as the `cancelDate` query parameter. `Pax8Client.delete()` grew an optional `params` argument to mirror `get()` so query strings ride along on DELETE calls.
- The mock client matches the new signature (it accepts `cancelDate` but ignores the value in demo mode — there's no future-state simulation in the in-memory data set).
- The `--json` envelope echoes `cancelDate` alongside `Cancelled` so agents can verify the schedule landed.

## Test plan

- [x] `pnpm build` passes.
- [x] `pnpm test` — 1,332 tests pass including:
  - New: rejects malformed `--cancel-date` (e.g. `12/31/2026`).
  - New: rejects calendar-impossible dates (e.g. `2026-02-30`).
  - New: emits `ERROR_INVALID_INPUT` in `--json` mode for bad input.
  - New: schedules cancellation with a valid `--cancel-date` and surfaces the scheduled date in the JSON response.
  - New (core): `SubscriptionsApi.delete()` forwards `cancelDate` as a query parameter.
  - Updated (core): existing `delete` test reflects the new signature.
- [x] `pnpm lint` clean.

## Notes

- Side fix: in `--json` mode the cancel command was previously writing the human-readable preview block to stdout before the JSON record. That violated the "stdout is data" contract from `docs/UX_GUIDE.md` §3 and made the new test impossible to write cleanly. The preview is now gated to `table` format only — JSON pipes get clean JSON. Kept minimal; no behavior change for the default TTY path.