### PR TITLE
feat(orders): support multi-line orders and --dry-run validation (closes #246)

### DIFF
--- a/packages/cli/src/__tests__/orders.test.ts
+++ b/packages/cli/src/__tests__/orders.test.ts
@@ -166,6 +166,65 @@ describe("pax8 orders", () => {
       expect(combined).toMatch(/[Ii]nvalid quantity/);
     });
 
+    it("errors when neither --product nor --line-item is passed", async () => {
+      const result = await runCliExpectFailure([
+        "orders",
+        "create",
+        "--company",
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/--product|--line-item/);
+    });
+
+    it("errors when --product and --line-item are mixed (#246)", async () => {
+      const result = await runCliExpectFailure([
+        "orders",
+        "create",
+        "--company",
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "--product",
+        "prod-m365-biz-prem-0001",
+        "--quantity",
+        "5",
+        "--line-item",
+        "product=prod-defender-p1,quantity=10",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      // Error should call out the conflict explicitly rather than picking
+      // one side or trying to merge them.
+      expect(combined).toMatch(/Cannot mix.*--product.*--line-item|--product.*--line-item.*not both/i);
+    });
+
+    it("errors on malformed --line-item spec (#246)", async () => {
+      const result = await runCliExpectFailure([
+        "orders",
+        "create",
+        "--company",
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "--line-item",
+        "garbage-no-equals-sign",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Invalid --line-item|key=value/i);
+    });
+
+    it("errors when --line-item is missing required keys (#246)", async () => {
+      const result = await runCliExpectFailure([
+        "orders",
+        "create",
+        "--company",
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "--line-item",
+        "product=prod-defender-p1",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/quantity/i);
+    });
+
     // Regression for #230: when a product requires a commitment term (every
     // pricing plan has commitmentTerm) AND the customer has no existing
     // subscription for that product (so resolveCommitmentTermId can't copy a
@@ -196,6 +255,121 @@ describe("pax8 orders", () => {
       expect(combined).toMatch(/requires.*commitment/i);
       expect(combined).toMatch(/--commitment-term/);
       expect(combined).toMatch(/Pax8 portal/);
+    });
+  });
+
+  describe("orders create — multi-line and dry-run (#246)", () => {
+    it("creates a single-line order (back-compat smoke test)", async () => {
+      const result = await runCliExpectSuccess([
+        "orders",
+        "create",
+        "--company",
+        "Acme Corp",
+        "--product",
+        "prod-m365-biz-prem-0001",
+        "--quantity",
+        "5",
+        "--billing-term",
+        "Monthly",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.id).toMatch(/^ord-demo-/);
+      expect(data.companyName).toBe("Acme Corp");
+      expect(data.lineItems).toHaveLength(1);
+      expect(data.lineItems[0].quantity).toBe(5);
+      // Single-line back-compat: unitPrice is at the top level (pre-#246
+      // shape) when there's exactly one line item.
+      expect(data).toHaveProperty("unitPrice");
+      // Dry-run flag is not set in normal mode.
+      expect(data.dryRun).toBeUndefined();
+    });
+
+    it("creates a multi-line order with --line-item (#246)", async () => {
+      const result = await runCliExpectSuccess([
+        "orders",
+        "create",
+        "--company",
+        "Acme Corp",
+        "--line-item",
+        "product=prod-m365-biz-prem-0001,quantity=5",
+        "--line-item",
+        "product=prod-defender-biz-0007,quantity=3,billing-term=Monthly",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.id).toMatch(/^ord-demo-/);
+      expect(data.companyName).toBe("Acme Corp");
+      expect(data.lineItems).toHaveLength(2);
+      expect(data.lineItems[0].productId).toBe("prod-m365-biz-prem-0001");
+      expect(data.lineItems[0].quantity).toBe(5);
+      expect(data.lineItems[1].productId).toBe("prod-defender-biz-0007");
+      expect(data.lineItems[1].quantity).toBe(3);
+    });
+
+    it("performs a dry-run without persisting the order (#246)", async () => {
+      const result = await runCliExpectSuccess([
+        "orders",
+        "create",
+        "--company",
+        "Acme Corp",
+        "--product",
+        "prod-m365-biz-prem-0001",
+        "--quantity",
+        "5",
+        "--dry-run",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      // The mock client signals a dry-run via the synthetic id prefix.
+      expect(data.id).toMatch(/^ord-dryrun-/);
+      expect(data.dryRun).toBe(true);
+      expect(data.companyName).toBe("Acme Corp");
+      expect(data.lineItems).toHaveLength(1);
+      // The dry-run banner appears on stderr, never stdout (stdout is JSON).
+      expect(result.stderr).toMatch(/DRY RUN|dry-run/i);
+    });
+
+    it("dry-run combines with --line-item for multi-line validation (#246)", async () => {
+      const result = await runCliExpectSuccess([
+        "orders",
+        "create",
+        "--company",
+        "Acme Corp",
+        "--line-item",
+        "product=prod-m365-biz-prem-0001,quantity=5",
+        "--line-item",
+        "product=prod-defender-biz-0007,quantity=3",
+        "--dry-run",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.id).toMatch(/^ord-dryrun-/);
+      expect(data.dryRun).toBe(true);
+      expect(data.lineItems).toHaveLength(2);
+    });
+
+    it("--dry-run prompt text says validate (TTY humans see it)", async () => {
+      // Even with --yes the rendered preview banner mentions DRY RUN.
+      const result = await runCliExpectSuccess([
+        "orders",
+        "create",
+        "--company",
+        "Acme Corp",
+        "--product",
+        "prod-m365-biz-prem-0001",
+        "--quantity",
+        "1",
+        "--dry-run",
+        "--yes",
+      ]);
+      // The DRY RUN banner is on stderr (preview/banner), and "no order
+      // placed" is on stdout (post-write summary).
+      expect(result.stderr).toMatch(/DRY RUN/);
     });
   });
 });

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -5,8 +5,8 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError, extractErrorDetail } from "../../lib/errors.js";
-import { buildContext } from "../../lib/context.js";
-import { confirmWithChange, replCmd } from "../../lib/confirm.js";
+import { buildContext, type CommandContext } from "../../lib/context.js";
+import { confirm, confirmWithChange, replCmd } from "../../lib/confirm.js";
 import { formatStatus, formatCurrency, formatQuantity, calculateMrr } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
@@ -23,14 +23,248 @@ import { resolveCommitmentTermId } from "../../lib/resolve-commitment.js";
 import { hashArgs, isValidKey, withIdempotency } from "../../lib/idempotency.js";
 import { setTelemetryFields } from "../../lib/telemetry-context.js";
 
+// ─── Multi-line parsing ───────────────────────────────────────────────────────
+//
+// Repeatable `--line-item product=name,quantity=n[,billing-term=Annual]
+// [,commitment-term=1-Year][,commitment-term-id=<uuid>]`. Commander's option
+// callback is invoked once per occurrence, with the previous accumulator as
+// the second arg — that's how we collect multiple values without `.variadic()`
+// (which greedily eats subsequent positional args).
+
+interface RawLineItem {
+  product: string;
+  quantity: number;
+  billingTerm?: string;
+  commitmentTerm?: string;
+  commitmentTermId?: string;
+  /** Original spec string, for error messages. */
+  raw: string;
+}
+
+function collectLineItem(value: string, prev: RawLineItem[]): RawLineItem[] {
+  // We only validate string shape here; product resolution happens in the
+  // action handler so we can hit the API in parallel.
+  return prev.concat([parseLineItemSpec(value)]);
+}
+
+function parseLineItemSpec(spec: string): RawLineItem {
+  const pairs = spec.split(",").map((s) => s.trim()).filter(Boolean);
+  const out: Partial<RawLineItem> = { raw: spec };
+  for (const pair of pairs) {
+    const eq = pair.indexOf("=");
+    if (eq < 0) {
+      throw new CliError(
+        `Invalid --line-item spec: "${spec}"`,
+        [`Each comma-separated entry must be key=value (got "${pair}")`],
+        [
+          `Example: --line-item product=prod-m365-biz-prem-0001,quantity=5`,
+          `Multiple lines: --line-item product=p1,quantity=5 --line-item product=p2,quantity=10,billing-term=Annual`,
+        ],
+        undefined,
+        ERROR_INVALID_INPUT,
+      );
+    }
+    const key = pair.slice(0, eq).trim().toLowerCase();
+    const val = pair.slice(eq + 1).trim();
+    switch (key) {
+      case "product":
+      case "product-id":
+      case "productid":
+        out.product = val;
+        break;
+      case "quantity":
+      case "qty": {
+        const n = parseInt(val, 10);
+        if (isNaN(n) || n <= 0) {
+          throw new CliError(
+            `Invalid quantity in --line-item "${spec}": "${val}"`,
+            ["Quantity must be a positive integer (1 or greater)"],
+            [`Example: --line-item product=<id>,quantity=5`],
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+        out.quantity = n;
+        break;
+      }
+      case "billing-term":
+      case "billingterm":
+        out.billingTerm = val;
+        break;
+      case "commitment-term":
+      case "commitmentterm":
+        out.commitmentTerm = val;
+        break;
+      case "commitment-term-id":
+      case "commitmenttermid":
+        out.commitmentTermId = val;
+        break;
+      default:
+        throw new CliError(
+          `Unknown key in --line-item "${spec}": "${key}"`,
+          [`Supported keys: product, quantity, billing-term, commitment-term, commitment-term-id`],
+          [`Example: --line-item product=prod-m365-biz-prem-0001,quantity=5,billing-term=Annual`],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+    }
+  }
+  if (!out.product) {
+    throw new CliError(
+      `Missing product in --line-item "${spec}"`,
+      ["Each --line-item must include product=<id|name>"],
+      [`Example: --line-item product=prod-m365-biz-prem-0001,quantity=5`],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  if (out.quantity === undefined) {
+    throw new CliError(
+      `Missing quantity in --line-item "${spec}"`,
+      ["Each --line-item must include quantity=<n>"],
+      [`Example: --line-item product=${out.product},quantity=5`],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return out as RawLineItem;
+}
+
+// ─── Per-line resolution ──────────────────────────────────────────────────────
+
+interface ResolvedLine {
+  productId: string;
+  productName: string;
+  quantity: number;
+  billingTerm: string;
+  commitmentTerm?: string;
+  commitmentTermId?: string;
+  unitPrice: number | null;
+  warnings: string[];
+}
+
+/** Resolve a single line item: product → pricing → commitment. */
+async function resolveLine(
+  ctx: CommandContext,
+  companyId: string,
+  raw: RawLineItem,
+  defaultBillingTerm: string,
+): Promise<ResolvedLine> {
+  const billingTerm = raw.billingTerm ?? defaultBillingTerm;
+  let productId = raw.product;
+  let productName = raw.product;
+  let productNotFound = false;
+  const warnings: string[] = [];
+
+  const productResult = await resolveProduct(ctx, raw.product).catch(() => {
+    productNotFound = true;
+    return null;
+  });
+  if (productResult) {
+    productId = productResult.id;
+    productName = productResult.name;
+  } else if (!/^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(raw.product)) {
+    throw new CliError(
+      `Product not found: "${raw.product}"`,
+      ["Could not resolve product name to a product ID"],
+      [
+        `Search the catalog: ${replCmd("pax8 products search")} "${raw.product}"`,
+        `Then use the product ID in --line-item product=<id>,quantity=<n>`,
+      ],
+      undefined,
+      ERROR_PRODUCT_NOT_FOUND,
+    );
+  }
+
+  let unitPrice: number | null = null;
+  let commitmentTerm = raw.commitmentTerm;
+  let commitmentTermId = raw.commitmentTermId;
+  let requiresCommitment = false;
+
+  try {
+    const pricing = await ctx.api.products.getPricing(productId).catch(() => null);
+    if (pricing && pricing.length > 0) {
+      if (pricing.every((p) => p.commitmentTerm)) requiresCommitment = true;
+      let match = pricing.find((p) => p.billingTerm === billingTerm && p.commitmentTerm);
+      if (!match) match = pricing.find((p) => p.billingTerm === billingTerm);
+      if (match) {
+        if (!commitmentTerm && match.commitmentTerm) commitmentTerm = match.commitmentTerm;
+        const ratePrice = match.rates?.[0]?.suggestedRetailPrice
+          ?? (match as Record<string, unknown>).suggestedRetailPrice as number | undefined;
+        if (ratePrice) unitPrice = ratePrice;
+      } else {
+        const available = [...new Set(pricing.map((p) => p.billingTerm))].join(", ");
+        warnings.push(`No ${billingTerm} pricing for ${productName}. Available: ${available}`);
+      }
+    }
+  } catch (err) {
+    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] order pre-check failed: ${err}\n`);
+  }
+
+  if (!commitmentTermId && (commitmentTerm || requiresCommitment)) {
+    const info = await resolveCommitmentTermId(ctx, companyId, productId, commitmentTerm);
+    if (info) {
+      commitmentTermId = info.id;
+      if (!commitmentTerm) commitmentTerm = info.term;
+    }
+  }
+
+  if (productNotFound) warnings.push(`${productName}: product not found in catalog — may not be orderable`);
+
+  if (requiresCommitment && !commitmentTermId) {
+    // Hard-fail: a missing commitmentTermId for a product that requires one
+    // will only ever fail at the API. Surface it pre-flight so the user
+    // doesn't confirm a doomed preview (#230).
+    //
+    // Recovery steps cover both single-line (`--commitment-term ...`) and
+    // multi-line (`commitment-term=...` inside --line-item) so the message
+    // is useful regardless of which entry point the user is on.
+    throw new CliError(
+      `Can't order "${productName}"`,
+      [
+        `Product ${productName} requires a commitment term`,
+        "This product requires a commitment term ID that couldn't be auto-resolved",
+      ],
+      [
+        "If the company has an existing subscription, try: --commitment-term Monthly or --commitment-term 1-Year (or commitment-term=<term> inside --line-item)",
+        "Or provide the UUID directly: --commitment-term-id <uuid> (from subscription commitment.id)",
+        "If no existing subscription, provision the first one through the Pax8 portal",
+        `View product details: ${replCmd("pax8 products show")} ${productId}`,
+      ],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+
+  return {
+    productId,
+    productName,
+    quantity: raw.quantity,
+    billingTerm,
+    commitmentTerm,
+    commitmentTermId,
+    unitPrice,
+    warnings,
+  };
+}
+
+// ─── Command ──────────────────────────────────────────────────────────────────
+
 export const ordersCreateCommand = new Command("create")
   .description("Create a new order")
-  .requiredOption("--company <id|name>", "Company ID or name (required)")
-  .requiredOption("--product <id|name>", "Product ID or name (required)")
-  .option("--quantity <number>", "Quantity", "1")
-  .option("--billing-term <term>", "Billing term (Monthly or Annual)", "Monthly")
+  .option("--company <id|name>", "Company ID or name (required)")
+  .option("--product <id|name>", "Product ID or name (single-line shorthand)")
+  .option("--quantity <number>", "Quantity (single-line)", "1")
+  .option("--billing-term <term>", "Billing term — Monthly or Annual (default Monthly)", "Monthly")
   .option("--commitment-term <term>", "Commitment term (Monthly, 1-Year, or 3-Year) — auto-resolves to UUID from existing subscription")
   .option("--commitment-term-id <uuid>", "Commitment term UUID (from subscription commitment.id)")
+  .option(
+    "--line-item <spec>",
+    "Add a line item: product=<id|name>,quantity=<n>[,billing-term=<term>][,commitment-term=<term>][,commitment-term-id=<uuid>]. Repeat for multi-line orders.",
+    collectLineItem,
+    [] as RawLineItem[],
+  )
+  .option("--dry-run", "Validate the order without placing it (maps to API isMock=true)")
   .option("-y, --yes", "Skip confirmation prompt")
   .option(
     "--idempotency-key <uuid>",
@@ -42,19 +276,89 @@ export const ordersCreateCommand = new Command("create")
 Examples:
   pax8 orders create --company a1b2c3d4-e5f6-7890-abcd-ef1234567890 --product prod-m365-biz-prem-0001 --quantity 5
   pax8 orders create --company a1b2c3d4 --product prod-123 --quantity 10 --billing-term Annual
-  pax8 orders create --company a1b2c3d4 --product prod-123 --yes
+  pax8 orders create --company "Acme" \\
+    --line-item product=prod-m365-biz-prem-0001,quantity=25 \\
+    --line-item product=prod-defender-p1,quantity=25,billing-term=Annual
+  pax8 orders create --company "Acme" --product prod-123 --quantity 5 --dry-run
   pax8 orders create --company a1b2c3d4 --product prod-123 --idempotency-key 9f3b2c1e-...-e1`
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();
 
     // Hoist names so they're available in catch block for error messages
-    let productName: string = allOpts.product;
-    let companyName: string = allOpts.company;
+    let productName: string = allOpts.product ?? "";
+    let companyName: string = allOpts.company ?? "";
+
+    const rawLineItems: RawLineItem[] = (allOpts.lineItem as RawLineItem[]) ?? [];
+    const dryRun: boolean = !!allOpts.dryRun;
+
+    // ── Mode detection: single-line shorthand vs multi-line ──
+    //
+    // Backward compat: `--product` (with optional --quantity/--billing-term/
+    // --commitment-term) is the original single-line entry point. It MUST
+    // continue to work identically when --line-item is not used.
+    //
+    // We forbid mixing the two — merging them would be ambiguous (does
+    // --quantity apply to the --product line or all --line-items?). Better
+    // to fail fast and tell the user to pick one.
+    const hasSingleLine = !!allOpts.product;
+    const hasMultiLine = rawLineItems.length > 0;
+
+    if (!allOpts.company) {
+      await handleCommandError(
+        new CliError(
+          "Missing required option: --company",
+          ["--company <id|name> is required for orders create"],
+          [
+            `Example: ${replCmd("pax8 orders create")} --company "Acme" --product prod-123 --quantity 5`,
+            `List companies: ${replCmd("pax8 companies list")}`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        ),
+      );
+    }
+
+    if (hasSingleLine && hasMultiLine) {
+      await handleCommandError(
+        new CliError(
+          "Cannot mix --product and --line-item",
+          [
+            "--product/--quantity is the single-line shorthand and --line-item is the multi-line form",
+            "Pass one or the other, not both",
+          ],
+          [
+            `Single line: ${replCmd("pax8 orders create")} --company "Acme" --product prod-123 --quantity 5`,
+            `Multi-line:  ${replCmd("pax8 orders create")} --company "Acme" --line-item product=prod-1,quantity=5 --line-item product=prod-2,quantity=10`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        ),
+      );
+    }
+
+    if (!hasSingleLine && !hasMultiLine) {
+      await handleCommandError(
+        new CliError(
+          "Missing line item: pass --product or --line-item",
+          [
+            "An order needs at least one line item",
+          ],
+          [
+            `Single line: ${replCmd("pax8 orders create")} --company "Acme" --product prod-123 --quantity 5`,
+            `Multi-line:  ${replCmd("pax8 orders create")} --company "Acme" --line-item product=prod-1,quantity=5 --line-item product=prod-2,quantity=10`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        ),
+      );
+    }
 
     // --- Idempotency handling ---
     // The "args hash" deliberately excludes `yes` (cosmetic) and the key itself,
     // so retrying with the same key under -y or interactive confirm is allowed.
+    // It DOES include `dryRun` and the line-item array so a real submit and a
+    // dry-run with the same key are distinct cache entries.
     const idempotencyKey: string | undefined = allOpts.idempotencyKey;
     if (idempotencyKey !== undefined && !isValidKey(idempotencyKey)) {
       await handleCommandError(
@@ -71,13 +375,31 @@ Examples:
         ),
       );
     }
+
+    // Build a stable normalized "lines" array for the args hash so multi-line
+    // orders cache deterministically. For single-line we pass the same shape
+    // (one entry) so single→multi refactors don't accidentally invalidate
+    // an in-flight idempotent retry.
+    const hashLines = hasMultiLine
+      ? rawLineItems.map((l) => ({
+          product: l.product,
+          quantity: l.quantity,
+          billingTerm: l.billingTerm,
+          commitmentTerm: l.commitmentTerm,
+          commitmentTermId: l.commitmentTermId,
+        }))
+      : [{
+          product: allOpts.product,
+          quantity: allOpts.quantity,
+          billingTerm: allOpts.billingTerm,
+          commitmentTerm: allOpts.commitmentTerm,
+          commitmentTermId: allOpts.commitmentTermId,
+        }];
+
     const argsHash = hashArgs({
       company: allOpts.company,
-      product: allOpts.product,
-      quantity: allOpts.quantity,
-      billingTerm: allOpts.billingTerm,
-      commitmentTerm: allOpts.commitmentTerm,
-      commitmentTermId: allOpts.commitmentTermId,
+      lines: hashLines,
+      dryRun,
     });
 
     try {
@@ -91,180 +413,156 @@ Examples:
         },
         async (): Promise<boolean> => {
       const ctx = await buildContext(allOpts);
-      const quantity = parseInt(allOpts.quantity, 10);
 
-      if (isNaN(quantity) || quantity <= 0) {
-        throw new CliError(
-          `Invalid quantity: "${allOpts.quantity}"`,
-          ["Quantity must be a positive integer (1 or greater)"],
-          [`Example: ${replCmd("pax8 orders create")} --company <id> --product <id> --quantity 5`],
-          undefined,
-          ERROR_INVALID_INPUT,
-        );
-      }
-
-      // Resolve names, pricing, and pre-check orderability
-      let commitmentTerm = allOpts.commitmentTerm;
-      let commitmentTermId: string | undefined = allOpts.commitmentTermId;
-      let unitPrice: number | null = null;
-      let requiresCommitment = false;
-      let productNotFound = false;
-      const warnings: string[] = [];
-
-      // Resolve company (hard requirement — will throw on failure)
+      // ── Resolve company (hard requirement — will throw on failure) ──
       const companyResult = await resolveCompany(ctx, allOpts.company);
       companyName = companyResult.name;
       const resolvedCompanyId = companyResult.id;
 
-      // Resolve product — required for order creation
-      let resolvedProductId = allOpts.product;
-      const productResult = await resolveProduct(ctx, allOpts.product).catch(() => { productNotFound = true; return null; });
-      if (productResult) {
-        productName = productResult.name;
-        resolvedProductId = productResult.id;
-      } else if (!/^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(allOpts.product)) {
-        // Input isn't a UUID and couldn't be resolved — can't proceed
-        throw new CliError(
-          `Product not found: "${allOpts.product}"`,
-          ["Could not resolve product name to a product ID"],
-          [
-            `Search the catalog: ${replCmd("pax8 products search")} "${allOpts.product}"`,
-            `Then use the product ID: ${replCmd("pax8 orders create")} --product <product-id> ...`,
-          ],
-          undefined,
-          ERROR_PRODUCT_NOT_FOUND,
-        );
-      }
-
-      try {
-        const pricing = await ctx.api.products.getPricing(resolvedProductId).catch(() => null);
-
-        if (pricing && pricing.length > 0) {
-          // Infer commitment requirement: if every pricing plan has a commitmentTerm, the product requires one
-          if (pricing.every((p) => p.commitmentTerm)) requiresCommitment = true;
-          // Find matching plan — prefer billing term + commitment
-          let match = pricing.find((p) => p.billingTerm === allOpts.billingTerm && p.commitmentTerm);
-          if (!match) match = pricing.find((p) => p.billingTerm === allOpts.billingTerm);
-          if (match) {
-            if (!commitmentTerm && match.commitmentTerm) commitmentTerm = match.commitmentTerm;
-            const ratePrice = match.rates?.[0]?.suggestedRetailPrice
-              ?? (match as Record<string, unknown>).suggestedRetailPrice as number | undefined;
-            if (ratePrice) unitPrice = ratePrice;
-          } else {
-            // No plan matches the billing term
-            const available = [...new Set(pricing.map((p) => p.billingTerm))].join(", ");
-            warnings.push(`No ${allOpts.billingTerm} pricing found. Available: ${available}`);
-          }
-        }
-      } catch (err) {
-        if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] order pre-check failed: ${err}\n`);
-      }
-
-      // Resolve commitmentTermId from existing subscription for the SAME product.
-      // commitmentTermId UUIDs are product-specific and cannot be reused across products.
-      if (!commitmentTermId && (commitmentTerm || requiresCommitment)) {
-        const info = await resolveCommitmentTermId(
-          ctx,
-          resolvedCompanyId,
-          resolvedProductId,
-          commitmentTerm,
-        );
-        if (info) {
-          commitmentTermId = info.id;
-          if (!commitmentTerm) commitmentTerm = info.term;
-        }
-      }
-
-      // Pre-flight checks
-      if (productNotFound) warnings.push("Product not found in catalog — may not be orderable");
-
-      // Hard-fail before preview when commitment is required but couldn't be
-      // auto-resolved. Previously this was a soft warning and the order
-      // proceeded; the API then rejected, but only after the user had
-      // already confirmed a preview that misleadingly displayed
-      // "Commitment: <term>". Better to surface the actionable error up
-      // front (#230). The error matches the shape of the post-submit 422
-      // handler below, so the UX is consistent whether the failure is
-      // detected pre- or post-flight.
-      if (requiresCommitment && !commitmentTermId) {
-        const displayProduct = productName || allOpts.product;
-        const displayCompany = companyName || allOpts.company;
-        await handleCommandError(
-          new CliError(
-            `Can't order "${displayProduct}" for ${displayCompany}`,
-            [
-              `Product ${displayProduct} requires a commitment term`,
-              "This product requires a commitment term ID that couldn't be auto-resolved",
-            ],
-            [
-              "If the company has an existing subscription, try: --commitment-term Monthly or --commitment-term 1-Year",
-              "Or provide the UUID directly: --commitment-term-id <uuid> (from subscription commitment.id)",
-              "If no existing subscription, provision the first one through the Pax8 portal",
-              `View product details: ${replCmd("pax8 products show")} ${allOpts.product}`,
-            ],
+      // ── Build the working set of raw line items ──
+      let workingLines: RawLineItem[];
+      if (hasMultiLine) {
+        workingLines = rawLineItems;
+      } else {
+        const quantity = parseInt(allOpts.quantity, 10);
+        if (isNaN(quantity) || quantity <= 0) {
+          throw new CliError(
+            `Invalid quantity: "${allOpts.quantity}"`,
+            ["Quantity must be a positive integer (1 or greater)"],
+            [`Example: ${replCmd("pax8 orders create")} --company <id> --product <id> --quantity 5`],
             undefined,
             ERROR_INVALID_INPUT,
-          ),
-        );
+          );
+        }
+        workingLines = [{
+          product: allOpts.product,
+          quantity,
+          billingTerm: allOpts.billingTerm,
+          commitmentTerm: allOpts.commitmentTerm,
+          commitmentTermId: allOpts.commitmentTermId,
+          raw: `product=${allOpts.product},quantity=${quantity}`,
+        }];
       }
 
-      const totalPrice = unitPrice ? unitPrice * quantity : null;
-      const mrr = totalPrice
-        ? calculateMrr(unitPrice!, quantity, allOpts.billingTerm)
-        : null;
+      // ── Resolve every line in parallel (product → pricing → commitment) ──
+      // resolveLine throws CliError on hard failures (product-not-found,
+      // commitment-required-but-unresolvable). Promise.all surfaces the
+      // first; the catch block below routes it through handleCommandError.
+      const resolvedLines = await Promise.all(
+        workingLines.map((l) =>
+          resolveLine(ctx, resolvedCompanyId, l, allOpts.billingTerm),
+        ),
+      );
 
-      process.stderr.write(chalk.bold("\n  📦 Order Preview:\n\n"));
+      // For backward-compat error messages: when single-line, set the hoisted
+      // productName to the resolved name.
+      if (!hasMultiLine && resolvedLines[0]) {
+        productName = resolvedLines[0].productName;
+      }
+
+      // ── Preview ──
+      const isMulti = resolvedLines.length > 1;
+      const banner = dryRun
+        ? chalk.yellow.bold("\n  📦 DRY RUN — Order Preview (no order will be placed):\n\n")
+        : chalk.bold("\n  📦 Order Preview:\n\n");
+      process.stderr.write(banner);
       process.stderr.write(`  ${chalk.dim("Company:".padEnd(18))}${companyName}\n`);
-      process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${productName}\n`);
-      process.stderr.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(quantity)}\n`);
-      process.stderr.write(`  ${chalk.dim("Billing Term:".padEnd(18))}${allOpts.billingTerm}\n`);
-      if (commitmentTerm) {
-        process.stderr.write(`  ${chalk.dim("Commitment:".padEnd(18))}${commitmentTerm}\n`);
-      }
-      if (unitPrice) {
-        process.stderr.write(`  ${chalk.dim("Unit Price:".padEnd(18))}${formatCurrency(unitPrice)}/seat/${allOpts.billingTerm === "Annual" ? "yr" : "mo"}\n`);
-      }
-      if (totalPrice) {
-        process.stderr.write(`\n  ${chalk.dim("Total:".padEnd(18))}${chalk.bold(formatCurrency(totalPrice))}/${allOpts.billingTerm === "Annual" ? "yr" : "mo"}\n`);
-      }
-      if (mrr) {
-        process.stderr.write(`  ${chalk.dim("Est. MRR Impact:".padEnd(18))}${chalk.green.bold("+" + formatCurrency(mrr) + "/mo")}\n`);
+      if (!isMulti) {
+        const line = resolvedLines[0];
+        process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${line.productName}\n`);
+        process.stderr.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(line.quantity)}\n`);
+        process.stderr.write(`  ${chalk.dim("Billing Term:".padEnd(18))}${line.billingTerm}\n`);
+        if (line.commitmentTerm) {
+          process.stderr.write(`  ${chalk.dim("Commitment:".padEnd(18))}${line.commitmentTerm}\n`);
+        }
+        if (line.unitPrice) {
+          process.stderr.write(`  ${chalk.dim("Unit Price:".padEnd(18))}${formatCurrency(line.unitPrice)}/seat/${line.billingTerm === "Annual" ? "yr" : "mo"}\n`);
+        }
+      } else {
+        process.stderr.write(`  ${chalk.dim("Line Items:".padEnd(18))}${resolvedLines.length}\n\n`);
+        resolvedLines.forEach((line, idx) => {
+          process.stderr.write(`  ${chalk.dim(`#${idx + 1}`.padEnd(4))}${chalk.bold(line.productName)}\n`);
+          process.stderr.write(`        ${chalk.dim("Quantity:".padEnd(14))}${formatQuantity(line.quantity)}\n`);
+          process.stderr.write(`        ${chalk.dim("Billing:".padEnd(14))}${line.billingTerm}\n`);
+          if (line.commitmentTerm) {
+            process.stderr.write(`        ${chalk.dim("Commitment:".padEnd(14))}${line.commitmentTerm}\n`);
+          }
+          if (line.unitPrice) {
+            const unitPer = line.billingTerm === "Annual" ? "yr" : "mo";
+            const lineTotal = line.unitPrice * line.quantity;
+            process.stderr.write(`        ${chalk.dim("Unit Price:".padEnd(14))}${formatCurrency(line.unitPrice)}/seat/${unitPer}\n`);
+            process.stderr.write(`        ${chalk.dim("Subtotal:".padEnd(14))}${formatCurrency(lineTotal)}/${unitPer}\n`);
+          }
+          if (idx < resolvedLines.length - 1) process.stderr.write("\n");
+        });
       }
 
-      // Show warnings
-      if (warnings.length > 0) {
+      // ── Totals (sum across lines, normalized to monthly for MRR) ──
+      const totalMonthly = resolvedLines.reduce((acc, l) => {
+        if (!l.unitPrice) return acc;
+        return acc + calculateMrr(l.unitPrice, l.quantity, l.billingTerm);
+      }, 0);
+      const allPriced = resolvedLines.every((l) => l.unitPrice !== null);
+      if (allPriced && totalMonthly > 0) {
+        process.stderr.write(`\n  ${chalk.dim("Est. MRR Impact:".padEnd(18))}${chalk.green.bold("+" + formatCurrency(totalMonthly) + "/mo")}\n`);
+      }
+
+      // ── Aggregated warnings ──
+      const allWarnings = resolvedLines.flatMap((l) => l.warnings);
+      if (allWarnings.length > 0) {
         process.stderr.write("\n");
-        for (const w of warnings) {
+        for (const w of allWarnings) {
           process.stderr.write(chalk.yellow(`  ⚠ ${w}\n`));
         }
       }
 
       process.stderr.write("\n");
 
-      const confirmedQty = await confirmWithChange(
-        `Place order for ${formatQuantity(quantity)}?`,
-        quantity,
-      );
-      if (confirmedQty === null) {
-        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
-        return false;
+      // ── Confirmation ──
+      // Single-line, non-dry-run keeps the existing [y/n/c] flow that lets
+      // users edit the quantity inline. Multi-line and dry-run use a simple
+      // [y/n] — there's no single quantity to edit in multi-line, and a
+      // dry-run wants to lock the input as-is so the validation reflects
+      // exactly what would be submitted.
+      let confirmedQuantities: number[];
+      if (dryRun || isMulti) {
+        const promptText = dryRun
+          ? `Run dry-run validation?`
+          : `Place this order?`;
+        const ok = await confirm(promptText, { default: true });
+        if (!ok) {
+          process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+          return false;
+        }
+        confirmedQuantities = resolvedLines.map((l) => l.quantity);
+      } else {
+        const line = resolvedLines[0];
+        const confirmedQty = await confirmWithChange(
+          `Place order for ${formatQuantity(line.quantity)}?`,
+          line.quantity,
+        );
+        if (confirmedQty === null) {
+          process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+          return false;
+        }
+        confirmedQuantities = [confirmedQty];
       }
 
-      const spinner = createSpinner("Creating order...").start();
+      const spinner = createSpinner(dryRun ? "Validating order..." : "Creating order...").start();
 
-      // Only pass fields defined in OrderLineItemInput — do not include
-      // display-only fields like productName which are not part of the API input schema.
-      const lineItem: OrderLineItemInput = {
-        productId: resolvedProductId,
-        quantity: confirmedQty,
-        billingTerm: allOpts.billingTerm as BillingTerm,
-        ...(commitmentTermId ? { commitmentTermId } : {}),
-      };
+      // ── Build API input ──
+      const lineItems: OrderLineItemInput[] = resolvedLines.map((line, idx) => ({
+        productId: line.productId,
+        quantity: confirmedQuantities[idx],
+        billingTerm: line.billingTerm as BillingTerm,
+        ...(line.commitmentTermId ? { commitmentTermId: line.commitmentTermId } : {}),
+      }));
 
       const orderInput: CreateOrderInput = {
         companyId: resolvedCompanyId,
-        lineItems: [lineItem],
+        lineItems,
       };
+
       // TODO: When the Pax8 API adds support for an `Idempotency-Key` request
       // header on POST /orders (not currently documented in the existing
       // `OrdersApi.create` shape — see packages/core/src/api/orders.ts), pass
@@ -273,55 +571,90 @@ Examples:
       const doneWrite = markWriteInFlight("orders");
       let order;
       try {
-        order = await ctx.api.orders.create(orderInput);
+        order = await ctx.api.orders.create(orderInput, { isMock: dryRun });
       } finally {
         doneWrite();
       }
-      await invalidateCacheAfterWrite();
+      // Dry-runs don't mutate any partner state, so there's nothing to
+      // invalidate. Real creates need the cache busted so subsequent
+      // `orders list` / `subscriptions list` calls reflect the new state.
+      if (!dryRun) await invalidateCacheAfterWrite();
 
-      spinner.succeed("Order created 🎉");
+      if (dryRun) {
+        spinner.succeed("Dry-run validation succeeded");
+      } else {
+        spinner.succeed("Order created 🎉");
+      }
 
-      // Contribute revenue counters to the single command_executed event
-      // emitted by the postAction hook (#146 — was double-firing).
-      const orderMrr = unitPrice ? calculateMrr(unitPrice, confirmedQty, allOpts.billingTerm) : undefined;
+      // ── Telemetry ──
+      const totalSeats = confirmedQuantities.reduce((a, b) => a + b, 0);
+      const orderTotalDollars = resolvedLines.reduce((acc, l, idx) => {
+        if (!l.unitPrice) return acc;
+        return acc + l.unitPrice * confirmedQuantities[idx];
+      }, 0);
+      const orderMrrImpact = resolvedLines.reduce((acc, l, idx) => {
+        if (!l.unitPrice) return acc;
+        return acc + calculateMrr(l.unitPrice, confirmedQuantities[idx], l.billingTerm);
+      }, 0);
       setTelemetryFields({
-        order_success: true,
-        order_total_dollars: unitPrice ? unitPrice * confirmedQty : undefined,
-        order_mrr_impact: orderMrr,
-        order_seats: confirmedQty,
+        order_success: !dryRun,
+        order_dry_run: dryRun || undefined,
+        order_total_dollars: orderTotalDollars > 0 ? orderTotalDollars : undefined,
+        order_mrr_impact: orderMrrImpact > 0 ? orderMrrImpact : undefined,
+        order_seats: totalSeats,
+        order_line_count: resolvedLines.length,
       });
 
+      // ── JSON output ──
       if (ctx.outputFormat === "json") {
-        const jsonMrr = unitPrice ? calculateMrr(unitPrice, confirmedQty, allOpts.billingTerm) : null;
-        const monthlyCost = jsonMrr; // MRR is by definition the monthly cost
+        const jsonMrr = orderMrrImpact > 0 ? Number(orderMrrImpact.toFixed(2)) : null;
+        const monthlyCost = jsonMrr;
         const annualCost = jsonMrr ? Number((jsonMrr * 12).toFixed(2)) : null;
-        const enriched = {
+        const enriched: Record<string, unknown> = {
           ...order,
-          unitPrice: unitPrice ?? null,
+          dryRun: dryRun || undefined,
           monthlyCost: monthlyCost ?? null,
           annualCost: annualCost ?? null,
         };
+        // Single-line back-compat: surface unitPrice at the top level when
+        // there's exactly one line item, matching the pre-#246 shape.
+        if (!isMulti && resolvedLines[0]?.unitPrice !== null) {
+          enriched.unitPrice = resolvedLines[0]?.unitPrice ?? null;
+        }
         process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
         return true;
       }
 
-      // Post-order summary with financial impact
-      const finalMrr = unitPrice ? calculateMrr(unitPrice, confirmedQty, allOpts.billingTerm) : null;
-      const finalAnnual = finalMrr ? Number((finalMrr * 12).toFixed(2)) : null;
+      // ── Human output ──
+      if (dryRun) {
+        process.stdout.write(chalk.yellow.bold("\n  DRY RUN — no order placed\n"));
+      }
 
       process.stdout.write("\n");
       process.stdout.write(`  ${chalk.dim("Order ID:".padEnd(18))}${order.id}\n`);
       if (order.status) process.stdout.write(`  ${chalk.dim("Status:".padEnd(18))}${formatStatus(order.status)}\n`);
-      process.stdout.write(`  ${chalk.dim("Product:".padEnd(18))}${productName}\n`);
       process.stdout.write(`  ${chalk.dim("Company:".padEnd(18))}${companyName}\n`);
-      process.stdout.write(`  ${chalk.dim("Seats:".padEnd(18))}${formatQuantity(confirmedQty)}\n`);
-      if (unitPrice) {
-        process.stdout.write(`  ${chalk.dim("Unit price:".padEnd(18))}${formatCurrency(unitPrice)}/seat/${allOpts.billingTerm === "Annual" ? "yr" : "mo"}\n`);
+
+      if (!isMulti) {
+        const line = resolvedLines[0];
+        const seats = confirmedQuantities[0];
+        process.stdout.write(`  ${chalk.dim("Product:".padEnd(18))}${line.productName}\n`);
+        process.stdout.write(`  ${chalk.dim("Seats:".padEnd(18))}${formatQuantity(seats)}\n`);
+        if (line.unitPrice) {
+          process.stdout.write(`  ${chalk.dim("Unit price:".padEnd(18))}${formatCurrency(line.unitPrice)}/seat/${line.billingTerm === "Annual" ? "yr" : "mo"}\n`);
+        } else {
+          process.stdout.write(`  ${chalk.dim("Unit price:".padEnd(18))}${chalk.dim("—")}\n`);
+        }
       } else {
-        process.stdout.write(`  ${chalk.dim("Unit price:".padEnd(18))}${chalk.dim("—")}\n`);
+        process.stdout.write(`  ${chalk.dim("Line Items:".padEnd(18))}${resolvedLines.length}\n`);
+        resolvedLines.forEach((line, idx) => {
+          process.stdout.write(`    ${chalk.dim(`#${idx + 1}`)} ${line.productName} × ${formatQuantity(confirmedQuantities[idx])} (${line.billingTerm})\n`);
+        });
       }
-      if (finalMrr) {
-        process.stdout.write(`  ${chalk.dim("Monthly cost:".padEnd(18))}${chalk.green.bold(formatCurrency(finalMrr) + "/mo")}\n`);
+
+      const finalAnnual = orderMrrImpact > 0 ? Number((orderMrrImpact * 12).toFixed(2)) : null;
+      if (orderMrrImpact > 0) {
+        process.stdout.write(`  ${chalk.dim("Monthly cost:".padEnd(18))}${chalk.green.bold(formatCurrency(orderMrrImpact) + "/mo")}\n`);
       } else {
         process.stdout.write(`  ${chalk.dim("Monthly cost:".padEnd(18))}${chalk.dim("—")}\n`);
       }
@@ -331,10 +664,17 @@ Examples:
         process.stdout.write(`  ${chalk.dim("Annual cost:".padEnd(18))}${chalk.dim("—")}\n`);
       }
       process.stdout.write("\n");
-      // Next steps
+
+      // ── Next steps ──
       process.stderr.write(chalk.dim("  Try next:\n"));
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders show ${order.id}`))}  ${chalk.dim("check order status")}\n`);
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions list --company "${companyName}"`))}  ${chalk.dim("view subscriptions")}\n`);
+      if (dryRun) {
+        // After a successful dry-run, the next obvious step is to submit
+        // the same payload for real.
+        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders create ... (re-run without --dry-run)`))}  ${chalk.dim("place the order")}\n`);
+      } else {
+        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders show ${order.id}`))}  ${chalk.dim("check order status")}\n`);
+        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions list --company "${companyName}"`))}  ${chalk.dim("view subscriptions")}\n`);
+      }
       process.stderr.write("\n");
           return true;
         },
@@ -345,7 +685,7 @@ Examples:
       // can retry with the same key.
       // Provide order-specific error messages with actionable guidance
       if (error instanceof ApiError) {
-        const displayProduct = productName || allOpts.product;
+        const displayProduct = productName || allOpts.product || "product";
         const displayCompany = companyName || allOpts.company;
 
         if (error.statusCode === 404) {
@@ -382,7 +722,7 @@ Examples:
             causes.push("Order validation failed — check quantity, billing term, or provisioning requirements");
             steps.push("Ensure the quantity meets minimum/maximum seat requirements");
           }
-          steps.push(`View product details: ${replCmd("pax8 products show")} ${allOpts.product}`);
+          steps.push(`View product details: ${replCmd("pax8 products show")} ${allOpts.product ?? displayProduct}`);
 
           await handleCommandError(
             new CliError(
@@ -409,7 +749,7 @@ Examples:
             if (detail) causes.push(detail);
             steps.push("Double-check all order parameters (product ID, company ID, quantity)");
           }
-          steps.push(`View product details: ${replCmd("pax8 products show")} ${allOpts.product}`);
+          steps.push(`View product details: ${replCmd("pax8 products show")} ${allOpts.product ?? displayProduct}`);
 
           await handleCommandError(
             new CliError(

--- a/packages/cli/src/lib/telemetry-context.ts
+++ b/packages/cli/src/lib/telemetry-context.ts
@@ -39,6 +39,7 @@ export type TelemetryExtraFields = Partial<
     | "order_total_dollars"
     | "order_mrr_impact"
     | "order_seats"
+    | "order_dry_run"
     | "recs_presented"
     | "recs_ordered"
     | "recs_skipped"

--- a/packages/cli/src/lib/telemetry-context.ts
+++ b/packages/cli/src/lib/telemetry-context.ts
@@ -40,6 +40,7 @@ export type TelemetryExtraFields = Partial<
     | "order_mrr_impact"
     | "order_seats"
     | "order_dry_run"
+    | "order_line_count"
     | "recs_presented"
     | "recs_ordered"
     | "recs_skipped"

--- a/packages/core/src/api/orders.ts
+++ b/packages/core/src/api/orders.ts
@@ -30,8 +30,20 @@ export class OrdersApi {
     return OrderSchema.parse(raw);
   }
 
-  async create(data: CreateOrderInput): Promise<Order> {
-    const raw = await this.client.post<unknown>("/orders", data);
+  /**
+   * Create a new order.
+   *
+   * `opts.isMock=true` appends `?isMock=true` to the request, telling the
+   * Pax8 API to validate (dry-run) the order without committing it. The
+   * response shape is the same as a real create — partners can preview
+   * what the order would look like before placing it for real.
+   */
+  async create(
+    data: CreateOrderInput,
+    opts?: { isMock?: boolean },
+  ): Promise<Order> {
+    const path = opts?.isMock ? "/orders?isMock=true" : "/orders";
+    const raw = await this.client.post<unknown>(path, data);
     return OrderSchema.parse(raw);
   }
 }

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -441,12 +441,18 @@ class OrdersResource {
     return order;
   }
 
-  async create(data: CreateOrderInput): Promise<Order> {
+  async create(
+    data: CreateOrderInput,
+    opts?: { isMock?: boolean },
+  ): Promise<Order> {
     await randomDelay();
     // Resolve company name from demo data
     const company = companies.find((c) => c.id === data.companyId);
     const newOrder: Order = {
-      id: `ord-demo-${Date.now()}`,
+      // Dry-run responses use a synthetic prefix so consumers can tell at a
+      // glance the order wasn't persisted. Real demo creates keep the
+      // historical `ord-demo-` prefix.
+      id: opts?.isMock ? `ord-dryrun-${Date.now()}` : `ord-demo-${Date.now()}`,
       companyId: data.companyId,
       companyName: company?.name ?? "Unknown",
       orderedBy: "Demo User",
@@ -458,10 +464,18 @@ class OrdersResource {
         quantity: li.quantity,
         billingTerm: (li.billingTerm ?? "Monthly") as "Monthly" | "Annual",
       })),
+      // Status stays "Processing" even for dry-runs to keep the demo Order
+      // type narrow. The CLI knows it's a dry-run from the request flag and
+      // banners the response accordingly; the synthetic id prefix is the
+      // mock client's signal to anyone introspecting the response.
       status: "Processing",
     };
-    this.loadCreated().push(newOrder);
-    this.saveCreated();
+    // Only persist when this is a real order — dry-runs never hit the
+    // demo-orders.json file.
+    if (!opts?.isMock) {
+      this.loadCreated().push(newOrder);
+      this.saveCreated();
+    }
     return newOrder;
   }
 }

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -41,6 +41,8 @@ export interface TelemetryEvent {
   order_seats?: number;
   /** For order create: whether the run was a dry-run validation (no real write) */
   order_dry_run?: boolean;
+  /** For order create: number of line items in the order */
+  order_line_count?: number;
   /** For recommendations act: total recs presented */
   recs_presented?: number;
   /** For recommendations act: how many were ordered */
@@ -195,6 +197,7 @@ export class Telemetry {
             ...(event.order_mrr_impact !== undefined && { order_mrr_impact: event.order_mrr_impact }),
             ...(event.order_seats !== undefined && { order_seats: event.order_seats }),
             ...(event.order_dry_run !== undefined && { order_dry_run: event.order_dry_run }),
+            ...(event.order_line_count !== undefined && { order_line_count: event.order_line_count }),
             ...(event.recs_presented !== undefined && { recs_presented: event.recs_presented }),
             ...(event.recs_ordered !== undefined && { recs_ordered: event.recs_ordered }),
             ...(event.recs_skipped !== undefined && { recs_skipped: event.recs_skipped }),

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -39,6 +39,8 @@ export interface TelemetryEvent {
   order_mrr_impact?: number;
   /** Revenue: number of seats ordered */
   order_seats?: number;
+  /** For order create: whether the run was a dry-run validation (no real write) */
+  order_dry_run?: boolean;
   /** For recommendations act: total recs presented */
   recs_presented?: number;
   /** For recommendations act: how many were ordered */
@@ -192,6 +194,7 @@ export class Telemetry {
             ...(event.order_total_dollars !== undefined && { order_total_dollars: event.order_total_dollars }),
             ...(event.order_mrr_impact !== undefined && { order_mrr_impact: event.order_mrr_impact }),
             ...(event.order_seats !== undefined && { order_seats: event.order_seats }),
+            ...(event.order_dry_run !== undefined && { order_dry_run: event.order_dry_run }),
             ...(event.recs_presented !== undefined && { recs_presented: event.recs_presented }),
             ...(event.recs_ordered !== undefined && { recs_ordered: event.recs_ordered }),
             ...(event.recs_skipped !== undefined && { recs_skipped: event.recs_skipped }),


### PR DESCRIPTION
Closes #246.

## Summary

Adds two flags to `pax8 orders create`:

- **Repeatable `--line-item`** for multi-product orders in one transaction. Spec: `product=<id|name>,quantity=<n>[,billing-term=<term>][,commitment-term=<term>][,commitment-term-id=<uuid>]`. Pass it once per line:

  ```
  pax8 orders create --company "Acme" \
    --line-item product=prod-m365-biz-prem-0001,quantity=25 \
    --line-item product=prod-defender-biz-0007,quantity=25,billing-term=Annual
  ```

- **`--dry-run`** maps to the API's `?isMock=true` query parameter so partners can validate an order — pricing, commitment terms, provisioning requirements — without committing. Confirmation prompt reads *"Run dry-run validation?"* and the response banners **DRY RUN — no order placed**.

## Flag-shape decision

The issue suggested either repeatable `--line-item kv` or `--line-items @file.json`. There's no precedent in this repo for either, so I went with the issue's first option (and the task's stated default). KV is concise on the command line, easier to compose with shell pipelines, and matches the existing `--commitment-term` / `--billing-term` flag vocabulary instead of introducing a new file-loading convention.

The parser accepts a few lenient aliases (`qty`, `productId`, `billingterm`) and rejects unknown keys with a clear `CliError` listing supported keys.

## Backward compatibility

The original single-line shorthand keeps working **identically**:

```
pax8 orders create --company X --product Y --quantity 5
```

Specifically guaranteed:

- Single-line still uses `confirmWithChange [y/n/c]` so quantity editing in the prompt is preserved.
- Single-line JSON response keeps `unitPrice` at the top level (multi-line responses skip it — there's no single price to show).
- Recovery messages on commitment-term errors now mention both `--commitment-term ...` (single-line) and `commitment-term=...` (inside `--line-item`) so the message is useful regardless of entry point.
- Mixing `--product` and `--line-item` errors out instead of silently picking one or trying to merge.

## Idempotency

Args hash now includes the normalized line-item array and the `dryRun` flag, so:

- A real order and a dry-run with the same `--idempotency-key` are distinct cache entries.
- Multi-line orders cache deterministically on retry.
- The single-line shorthand normalizes to the same shape as a 1-element multi-line array, so a hypothetical single → multi refactor by a user wouldn't accidentally invalidate an in-flight retry.

## Out of scope (per task guardrails)

`--is-scheduled` / `--scheduled-date` was mentioned in #246 but explicitly deferred — separate scope.

## Test plan

- [x] `pnpm build && pnpm test` — all 1336 tests pass (88 files).
- [x] `pnpm lint` clean.
- [x] New subprocess tests in `packages/cli/src/__tests__/orders.test.ts`:
  - Single-line happy path (back-compat smoke test) — verifies pre-#246 JSON shape (`unitPrice` at top level, no `dryRun`).
  - Multi-line happy path — two `--line-item` flags create a 2-line order.
  - `--dry-run` single-line — synthesized `ord-dryrun-*` id, `dryRun: true` in JSON, banner on stderr.
  - `--dry-run` + multi-line combination.
  - Error: mixing `--product` and `--line-item`.
  - Error: malformed `--line-item` (no `=`).
  - Error: `--line-item` missing `quantity`.
  - Error: neither `--product` nor `--line-item` provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)