### PR TITLE
fix(types): align InvoiceStatusSchema with public API spec example (closes #240)

### DIFF
--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -14,7 +14,7 @@ export const invoicesListCommand = new Command("list")
   .description("List invoices")
   .option("--month <YYYY-MM>", "Filter by month (YYYY-MM)")
   .option("--company <id|name>", "Filter by company ID or name")
-  .option("--status <status>", "Filter by status (Unpaid, Paid, Void, Overdue)")
+  .option("--status <status>", "Filter by status (Unpaid, Paid, Void, Carried)")
   .option("--page <number>", "Page number", "1")
   .option("--size <number>", "Page size", "25")
   .option("--ids-only", "Output only resource IDs, one per line")
@@ -96,8 +96,9 @@ Examples:
       if (ctx.outputFormat === "json" && options.withActions) {
         const nextActions: { command: string; description: string }[] = [];
         const invoices = result.content;
-        const unpaid = invoices.filter((inv) =>
-          ["unpaid", "overdue"].includes(String((inv as Record<string, unknown>).status ?? "").toLowerCase())
+        const unpaid = invoices.filter(
+          (inv) =>
+            String((inv as Record<string, unknown>).status ?? "").toLowerCase() === "unpaid"
         );
         if (unpaid.length > 0) {
           nextActions.push({

--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -469,8 +469,29 @@ describe("InvoiceSchema", () => {
     expect(InvoiceSchema.parse(valid)).toEqual(valid);
   });
 
-  it("rejects invalid status", () => {
+  it("validates Carried status", () => {
+    expect(InvoiceSchema.parse({ ...valid, status: "Carried" })).toEqual({
+      ...valid,
+      status: "Carried",
+    });
+  });
+
+  it("validates a payload with missing status (status is optional per spec gap)", () => {
+    // Strip status via destructure; rest-sibling idiom.
+    const { status, ...rest } = valid;
+    expect(InvoiceSchema.parse(rest)).toEqual(rest);
+  });
+
+  it("rejects invalid status (Overdue)", () => {
     expect(() => InvoiceSchema.parse({ ...valid, status: "Overdue" })).toThrow();
+  });
+
+  it("rejects legacy Carry status (typo replaced by Carried)", () => {
+    expect(() => InvoiceSchema.parse({ ...valid, status: "Carry" })).toThrow();
+  });
+
+  it("rejects legacy Nothing status (removed dead value)", () => {
+    expect(() => InvoiceSchema.parse({ ...valid, status: "Nothing" })).toThrow();
   });
 
   it("rejects missing total", () => {

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -33,12 +33,15 @@ export const BillingTermSchema = z.enum([
 ]);
 export type BillingTerm = z.infer<typeof BillingTermSchema>;
 
+// Values verified against the `invoices-paged` example in
+// `partner-endpoints.json` (devx.pax8.com). The spec's Invoice properties
+// block does not declare `status` — believed to be a docs gap on Pax8's
+// side; the field is on the wire.
 export const InvoiceStatusSchema = z.enum([
   "Unpaid",
   "Paid",
   "Void",
-  "Carry",
-  "Nothing",
+  "Carried",
 ]);
 export type InvoiceStatus = z.infer<typeof InvoiceStatusSchema>;
 
@@ -300,7 +303,11 @@ export const InvoiceSchema = z.object({
   companyId: z.string().uuid(),
   invoiceDate: z.string(),
   dueDate: z.string(),
-  status: InvoiceStatusSchema,
+  // Optional defensively: the public OpenAPI Invoice properties block does
+  // not declare `status`, even though the field appears in the spec's
+  // example response. Until the spec is fixed, partners reading the schema
+  // could legitimately produce payloads without this field.
+  status: InvoiceStatusSchema.optional(),
   total: z.number(),
   balance: z.number(),
   companyName: z.string().optional(),

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -98,7 +98,7 @@ export interface Invoice {
   invoiceDate: string;
   dueDate: string;
   /** Mirrors `InvoiceStatusSchema` from `@pax8/core`. */
-  status: "Unpaid" | "Paid" | "Void" | "Carry" | "Nothing";
+  status: "Unpaid" | "Paid" | "Void" | "Carried";
   total: number;
   balance: number;
   currency: string;


### PR DESCRIPTION
## Summary

Resolves #240. The previous agent investigation flagged `Invoice.status` as a CLI invention because the Pax8 OpenAPI `Invoice` schema's `properties` block doesn't declare a `status` field. A live API probe + spec audit since then established ground truth: the field IS on the wire, and the spec's own `invoices-paged` example response includes it. The CLI just had the wrong vocabulary.

## Spec evidence

Distinct invoice `status` values across `partner-endpoints.json` (devx.pax8.com), counted in `components.examples.invoices-paged`:

| Value     | Occurrences |
| --------- | ----------- |
| `Carried` | 8           |
| `Unpaid`  | 3           |
| `Paid`    | 2           |
| `Void`    | 2           |

Before this PR, `InvoiceStatusSchema` was `[Unpaid, Paid, Void, Carry, Nothing]`:

- `Carry` is a CLI typo — the API uses `Carried`. Any production invoice with `status=Carried` failed Zod validation.
- `Nothing` is dead — never on the wire, only ever appeared in the demo-data TS union.
- `Overdue` was advertised in `pax8 invoices list --status` help text but was never in the enum, never on the wire — `--status Overdue` silently returned zero results.

After: `[Unpaid, Paid, Void, Carried]`.

## Defensive: `Invoice.status` is now optional

The spec's `Invoice` `properties` block doesn't declare `status` even though the field is in the spec's own example response. Until Pax8 closes that docs gap, partners reading the spec could legitimately produce payloads without `status`. Marking it optional is the safer wire contract; demo data and live responses both still populate it.

## Pax8 internal followup

The OpenAPI Invoice schema's `properties` block at `https://devx.pax8.com/openapi/partner-endpoints.json` should add `status` (string, enum: `Unpaid | Paid | Void | Carried`). This PR can land independently — once the spec is fixed, the `.optional()` on `InvoiceSchema.status` can be tightened to required in a follow-up.

## Changes

- `packages/core/src/api/types.ts` — `InvoiceStatusSchema` values fixed; `InvoiceSchema.status` made optional; both have explanatory code comments tying back to the spec evidence.
- `packages/core/src/mock/demo-data.ts` — TS union updated to match. No literal `Carry`/`Nothing` invoices existed, so no data changes were needed.
- `packages/cli/src/commands/invoices/list.ts` — drop `Overdue` from `--status` help text; drop the `unpaid|overdue` bucket in the `--with-actions` builder.
- `packages/core/src/api/types.test.ts` — added asserts for `Carried` parses, missing `status` parses, `Carry`/`Nothing`/`Overdue` rejected.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` — 1331 passed, 8 skipped (all existing `toHaveProperty("status")` asserts on demo invoices still hold; demo data populates `status` on every invoice)
- [x] `pnpm lint` clean
- [ ] Reviewer: confirm `pax8 invoices list --status Carried` (under `PAX8_DEMO=1` it'll return zero rows because demo only seeds `Unpaid`/`Paid`, but the flag should be accepted; against prod it should pass through to the API).