### PR TITLE
fix(quotes): warn before quotes update replaces line items (refs #245)

### DIFF
--- a/packages/cli/src/__tests__/quotes.update.test.ts
+++ b/packages/cli/src/__tests__/quotes.update.test.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import {
+  runCliExpectSuccess,
+  runCliWithInput,
+} from "./test-utils.js";
+
+// Demo-data fixtures the tests rely on:
+//   quote-summit-001 — 2 line items (multi-line, triggers destructive warning)
+//   quote-bright-001 — 1 line item (single-line, terser confirm)
+// Both expose `lineItems[].productId` so we can drive the diff path without
+// touching the live API.
+
+describe("pax8 quotes update", () => {
+  describe("destructive replace warning", () => {
+    it("shows REPLACES + DESTROYS language when collapsing a multi-line quote", async () => {
+      // Decline at the prompt so the write is not actually attempted; we are
+      // only asserting on the diff that gets printed before the question.
+      const result = await runCliWithInput(
+        [
+          "quotes",
+          "update",
+          "quote-summit-001",
+          "--product",
+          "Microsoft 365 E3",
+          "--quantity",
+          "10",
+          "--billing-term",
+          "Annual",
+        ],
+        "n\n",
+      );
+
+      // The diff itself.
+      expect(result.stderr).toContain("Current line items (will be REPLACED):");
+      expect(result.stderr).toContain("New line items:");
+
+      // The bright-red footer that names the cost. We don't lock the exact
+      // count so the test stays robust if demo data is rebalanced — but we
+      // do require partners to see they're losing data.
+      expect(result.stderr).toMatch(/DESTROYS \d+ existing line items/);
+
+      // The user typed "n", so the command should report cancellation and
+      // exit 0 (cancelled-by-user is not an error).
+      expect(result.stderr).toMatch(/Cancelled/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("default answer is NO for the destructive-replace prompt", async () => {
+      // Send empty input (just EOF). Default for the destructive prompt is
+      // false, so the command must NOT fall through to the write.
+      const result = await runCliWithInput(
+        [
+          "quotes",
+          "update",
+          "quote-summit-001",
+          "--product",
+          "Microsoft 365 E3",
+          "--quantity",
+          "10",
+        ],
+        "\n",
+      );
+
+      expect(result.stderr).toMatch(/Cancelled/);
+      // Should NOT have proceeded to update.
+      expect(result.stderr).not.toMatch(/Quote updated/);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("--yes bypass", () => {
+    it("skips the prompt and applies the change", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "update",
+        "quote-summit-001",
+        "--product",
+        "Microsoft 365 E3",
+        "--quantity",
+        "10",
+        "--billing-term",
+        "Annual",
+        "--yes",
+      ]);
+
+      // Diff still rendered (transparency), but no prompt blocked us and the
+      // update completed.
+      expect(result.stderr).toContain("Quote updated");
+    });
+  });
+
+  describe("expiration-only fast path", () => {
+    it("does not show the destructive warning when only --expiration-date is set", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "update",
+        "quote-summit-001",
+        "--expiration-date",
+        "2026-06-15",
+        "--yes",
+      ]);
+
+      // The destructive language must not appear when no line-item replace
+      // is happening.
+      expect(result.stderr).not.toMatch(/DESTROYS/);
+      expect(result.stderr).not.toMatch(/will be REPLACED/);
+      // But the fast-path still confirmed the date change and updated.
+      expect(result.stderr).toContain("New expiration:");
+      expect(result.stderr).toContain("2026-06-15");
+      expect(result.stderr).toContain("Quote updated");
+    });
+  });
+
+  describe("single-line quote", () => {
+    it("uses the terser confirm (no destructive warning)", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "update",
+        "quote-bright-001",
+        "--product",
+        "Microsoft 365 E3",
+        "--quantity",
+        "20",
+        "--yes",
+      ]);
+
+      // Single-item replace is still a write that gets confirmed, but it
+      // should NOT use the loud destructive language reserved for 2+ items.
+      expect(result.stderr).not.toMatch(/DESTROYS/);
+      expect(result.stderr).not.toMatch(/Current line items \(will be REPLACED\):/);
+      expect(result.stderr).toContain("Quote updated");
+    });
+  });
+
+  describe("update --help", () => {
+    it("documents the destructive-replace caveat", async () => {
+      const result = await runCliExpectSuccess(["quotes", "update", "--help"]);
+      // Help text should warn partners up front so the surprise is gone
+      // even before they run the command.
+      expect(result.stdout).toMatch(/replaces ALL existing line items/);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/test-utils.ts
+++ b/packages/cli/src/__tests__/test-utils.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -37,6 +37,45 @@ export async function runCli(
       exitCode: err.code ?? 1,
     };
   }
+}
+
+/**
+ * Run the CLI with the given string piped into stdin. Used to drive
+ * interactive `confirm()` prompts from subprocess tests — execFile pipes
+ * stdin but has no `input` option in the promisified form, so we drop to
+ * spawn() for this one case.
+ */
+export async function runCliWithInput(
+  args: string[],
+  input: string,
+  env?: Record<string, string>,
+): Promise<CliResult> {
+  return new Promise((resolveResult) => {
+    const child = spawn("node", [CLI_PATH, ...args], {
+      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...env },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, 15000);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolveResult({ stdout, stderr, exitCode: code ?? 1 });
+    });
+
+    child.stdin.write(input);
+    child.stdin.end();
+  });
 }
 
 export async function runCliExpectSuccess(

--- a/packages/cli/src/commands/quotes/update.ts
+++ b/packages/cli/src/commands/quotes/update.ts
@@ -11,8 +11,70 @@ import { confirm, replCmd } from "../../lib/confirm.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
-import { ERROR_INVALID_INPUT } from "@pax8/core";
-import type { UpdateQuoteInput, BillingTerm } from "@pax8/core";
+import { formatCurrency, formatQuantity } from "../../lib/formatters.js";
+import { ERROR_INVALID_INPUT, type Product } from "@pax8/core";
+import type { UpdateQuoteInput, BillingTerm, QuoteLineItem } from "@pax8/core";
+import type { CommandContext } from "../../lib/context.js";
+
+/**
+ * Best-effort lookup of product names for a set of productIds. Failures are
+ * ignored — the diff falls back to the raw ID, which is still actionable.
+ */
+async function fetchProductNames(
+  ctx: CommandContext,
+  productIds: string[],
+): Promise<Map<string, string>> {
+  const unique = [...new Set(productIds)];
+  const map = new Map<string, string>();
+  await Promise.all(
+    unique.map(async (pid) => {
+      try {
+        const product = await ctx.api.products.get(pid);
+        if (product?.name) map.set(pid, product.name);
+      } catch {
+        /* best effort — fall back to the ID */
+      }
+    }),
+  );
+  return map;
+}
+
+/** Render one line of the diff: "  N. <name>  ×<qty>  ($<price>/<term>)" */
+function renderLineItem(
+  index: number,
+  li: QuoteLineItem,
+  productNames: Map<string, string>,
+  nameWidth: number,
+): string {
+  const name = productNames.get(li.productId) ?? li.productId;
+  const padded = name.length > nameWidth ? name : name.padEnd(nameWidth);
+  const qty = `×${formatQuantity(li.quantity)}`;
+  let priceBit = "";
+  if (typeof li.unitPrice === "number") {
+    const term = li.billingTerm === "Annual" ? "yr" : "mo";
+    priceBit = chalk.dim(` (${formatCurrency(li.unitPrice)}/${term})`);
+  } else if (li.billingTerm) {
+    priceBit = chalk.dim(` (${li.billingTerm})`);
+  }
+  return `    ${index}. ${padded}  ${qty}${priceBit}`;
+}
+
+/**
+ * Width of the product-name column in the diff table. Picked so columns
+ * roughly align across current/new sections without truncating long names.
+ */
+function pickNameWidth(
+  items: QuoteLineItem[],
+  productNames: Map<string, string>,
+): number {
+  let max = 0;
+  for (const li of items) {
+    const name = productNames.get(li.productId) ?? li.productId;
+    if (name.length > max) max = name.length;
+  }
+  // Cap a reasonable minimum/maximum to keep things tidy.
+  return Math.min(Math.max(max, 24), 50);
+}
 
 export const quotesUpdateCommand = new Command("update")
   .description("Update a quote (replace line items or change expiration)")
@@ -27,7 +89,14 @@ export const quotesUpdateCommand = new Command("update")
     `
 Examples:
   pax8 quotes update quote-summit-001 --expiration-date 2026-05-15
-  pax8 quotes update quote-bright-001 --product "Microsoft 365 E3" --quantity 20`
+  pax8 quotes update quote-bright-001 --product "Microsoft 365 E3" --quantity 20
+
+Note:
+  --product replaces ALL existing line items with a single new line. The
+  Pax8 v1 quote API does not support per-line edits. If the quote has
+  multiple line items, you'll see a clear destructive-replace warning
+  before the change is applied. Cancel and use the marketplace UI if you
+  need to preserve other lines.`,
   )
   .action(async (id, options, command) => {
     const globalOpts = command.optsWithGlobals();
@@ -35,6 +104,7 @@ Examples:
 
     try {
       const data: UpdateQuoteInput = {};
+      let resolvedProduct: Product | undefined;
 
       if (options.product) {
         const quantity = parseInt(options.quantity, 10);
@@ -47,10 +117,10 @@ Examples:
             ERROR_INVALID_INPUT,
           );
         }
-        const product = await resolveProduct(ctx, options.product);
+        resolvedProduct = await resolveProduct(ctx, options.product);
         data.lineItems = [
           {
-            productId: product.id,
+            productId: resolvedProduct.id,
             quantity,
             billingTerm: options.billingTerm as BillingTerm,
           },
@@ -75,18 +145,89 @@ Examples:
       const current = await ctx.api.quotes.get(id);
       spinner.stop();
 
+      const currentLineItems = current.lineItems ?? [];
+      const replacingLineItems = data.lineItems !== undefined;
+      const destructiveReplace = replacingLineItems && currentLineItems.length >= 2;
+
+      // Header
       process.stderr.write(chalk.bold("\n  Update Quote:\n\n"));
       process.stderr.write(`  ${chalk.dim("ID:".padEnd(18))}${current.id}\n`);
       process.stderr.write(`  ${chalk.dim("Current status:".padEnd(18))}${current.status}\n`);
       if (data.expirationDate) {
-        process.stderr.write(`  ${chalk.dim("New expiration:".padEnd(18))}${chalk.green(data.expirationDate)}\n`);
+        process.stderr.write(
+          `  ${chalk.dim("New expiration:".padEnd(18))}${chalk.green(data.expirationDate)}\n`,
+        );
       }
-      if (data.lineItems) {
-        process.stderr.write(`  ${chalk.dim("New line items:".padEnd(18))}${chalk.green(`${data.lineItems.length} item(s)`)}\n`);
-      }
-      process.stderr.write("\n");
 
-      const ok = await confirm("Apply these changes?", { default: true });
+      let confirmMessage: string;
+      let confirmDefault: boolean;
+
+      if (destructiveReplace) {
+        // ── Loud destructive-replace diff ────────────────────────────────────
+        // Pull product names for both the existing items AND the new one so
+        // partners can read the diff at a glance instead of squinting at IDs.
+        const productIds = [
+          ...currentLineItems.map((li) => li.productId),
+          ...(data.lineItems ?? []).map((li) => li.productId),
+        ];
+        // Seed with the already-resolved product so we don't refetch it.
+        const productNames = await fetchProductNames(ctx, productIds);
+        if (resolvedProduct) {
+          productNames.set(resolvedProduct.id, resolvedProduct.name);
+        }
+        const nameWidth = pickNameWidth(
+          [...currentLineItems, ...(data.lineItems ?? [])],
+          productNames,
+        );
+
+        process.stderr.write("\n");
+        process.stderr.write(
+          `  ${chalk.yellow.bold("Current line items (will be REPLACED):")}\n`,
+        );
+        currentLineItems.forEach((li, i) => {
+          process.stderr.write(
+            renderLineItem(i + 1, li, productNames, nameWidth) + "\n",
+          );
+        });
+
+        process.stderr.write("\n");
+        process.stderr.write(`  ${chalk.green.bold("New line items:")}\n`);
+        (data.lineItems ?? []).forEach((li, i) => {
+          process.stderr.write(
+            renderLineItem(i + 1, li, productNames, nameWidth) + "\n",
+          );
+        });
+
+        process.stderr.write("\n");
+        process.stderr.write(
+          `  ${chalk.red.bold(`This DESTROYS ${currentLineItems.length} existing line items.`)}\n`,
+        );
+        process.stderr.write(
+          `  ${chalk.dim("The Pax8 v1 quote API has no per-line edit; the whole list is replaced.")}\n\n`,
+        );
+
+        confirmMessage = "Continue with destructive replace?";
+        confirmDefault = false;
+      } else if (replacingLineItems) {
+        // Single existing line item (or none) — terser, default-yes confirm.
+        const newLine = (data.lineItems ?? [])[0];
+        const productName = resolvedProduct?.name ?? newLine.productId;
+        process.stderr.write(
+          `  ${chalk.dim("New line item:".padEnd(18))}${chalk.green(productName)} ${chalk.dim(`×${formatQuantity(newLine.quantity)}`)}\n`,
+        );
+        process.stderr.write(
+          `  ${chalk.dim("Replaces:".padEnd(18))}${currentLineItems.length} existing item${currentLineItems.length === 1 ? "" : "s"}\n\n`,
+        );
+        confirmMessage = "Apply these changes?";
+        confirmDefault = true;
+      } else {
+        // Date-only fast path.
+        process.stderr.write("\n");
+        confirmMessage = "Apply these changes?";
+        confirmDefault = true;
+      }
+
+      const ok = await confirm(confirmMessage, { default: confirmDefault });
       if (!ok) {
         process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
         return;


### PR DESCRIPTION
## Summary

- `pax8 quotes update <id> --product X --quantity N` previously replaced **all** line items silently. A partner editing a 3-line quote to bump one quantity lost the other two SKUs without warning. This change makes the destructive replace loud — it now shows a current-vs-new diff (with enriched product names) and requires explicit confirmation with default = **no**.
- Single-line quotes keep the terser default-yes confirm; `--expiration-date`-only updates fast-path through with no destructive language; `-y` / `--yes` / `PAX8_YES=1` still skips the prompt.
- Help text now documents the caveat up front so partners aren't surprised even before they run the command.

This is a **minimal fix; full v2 line-item management (`POST/PUT/DELETE /v2/quotes/{id}/line-items`) is deferred pending design (still tracked in #245).** The Pax8 v1 quote API doesn't support per-line edits, so the scope here is bounded to making the existing replace safer — no new flags, no new endpoints, no broader confirm-flow refactor.

## What the new prompt looks like (multi-line quote)

```
  Update Quote:

  ID:               quote-summit-001
  Current status:   Sent

  Current line items (will be REPLACED):
    1. Microsoft 365 E3 [...]   ×5  ($36.00/yr)
    2. Microsoft Entra ID P1    ×5  ($6.00/yr)

  New line items:
    1. Microsoft 365 E3 [...]   ×10 (Annual)

  This DESTROYS 2 existing line items.
  The Pax8 v1 quote API has no per-line edit; the whole list is replaced.

  Continue with destructive replace? [y/n]
```

## Test plan

- [x] New subprocess test `quotes.update.test.ts` covers: destructive REPLACES/DESTROYS language on multi-line quote, default-no behavior, `--yes` bypass, `--expiration-date`-only fast path (no destructive warning), single-line terser confirm, help-text caveat.
- [x] Added `runCliWithInput()` helper to `test-utils.ts` so tests can drive the interactive `confirm()` prompt without hanging on a closed stdin.
- [x] `pnpm build && pnpm test` clean (1333 passed, 8 skipped).
- [x] `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)