### PR TITLE
feat(webhooks): add show/update/enable/disable lifecycle commands

### DIFF
--- a/packages/cli/src/__tests__/webhooks.enable-disable.test.ts
+++ b/packages/cli/src/__tests__/webhooks.enable-disable.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import {
+  runCli,
+  runCliExpectSuccess,
+  runCliExpectFailure,
+} from "./test-utils.js";
+
+const ACTIVE_WEBHOOK_ID = "11111111-2222-3333-4444-555555555501";
+const DISABLED_WEBHOOK_ID = "11111111-2222-3333-4444-555555555503";
+
+describe("pax8 webhooks disable", () => {
+  it("disables an active webhook with --yes", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "disable",
+      ACTIVE_WEBHOOK_ID,
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.id).toBe(ACTIVE_WEBHOOK_ID);
+    expect(data.status).toBe("Disabled");
+  });
+
+  it("is idempotent on an already-disabled webhook (sets alreadyDisabled flag in JSON)", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "disable",
+      DISABLED_WEBHOOK_ID,
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.id).toBe(DISABLED_WEBHOOK_ID);
+    expect(data.status).toBe("Disabled");
+    expect(data.alreadyDisabled).toBe(true);
+  });
+
+  it("fails on unknown id", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "disable",
+      "00000000-0000-0000-0000-000000000000",
+      "--yes",
+    ]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("shows --help with examples", async () => {
+    const result = await runCli(["webhooks", "disable", "--help"]);
+    expect(result.stdout).toContain("Examples:");
+    expect(result.stdout).toContain("--yes");
+  });
+});
+
+describe("pax8 webhooks enable", () => {
+  it("enables a disabled webhook with --yes", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "enable",
+      DISABLED_WEBHOOK_ID,
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.id).toBe(DISABLED_WEBHOOK_ID);
+    expect(data.status).toBe("Active");
+  });
+
+  it("is idempotent on an already-active webhook (sets alreadyEnabled flag in JSON)", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "enable",
+      ACTIVE_WEBHOOK_ID,
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.id).toBe(ACTIVE_WEBHOOK_ID);
+    expect(data.status).toBe("Active");
+    expect(data.alreadyEnabled).toBe(true);
+  });
+
+  it("fails on unknown id", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "enable",
+      "00000000-0000-0000-0000-000000000000",
+      "--yes",
+    ]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("shows --help with examples", async () => {
+    const result = await runCli(["webhooks", "enable", "--help"]);
+    expect(result.stdout).toContain("Examples:");
+    expect(result.stdout).toContain("--yes");
+  });
+});

--- a/packages/cli/src/__tests__/webhooks.show.test.ts
+++ b/packages/cli/src/__tests__/webhooks.show.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import {
+  runCli,
+  runCliExpectSuccess,
+  runCliExpectFailure,
+} from "./test-utils.js";
+
+const ACTIVE_WEBHOOK_ID = "11111111-2222-3333-4444-555555555501";
+const DISABLED_WEBHOOK_ID = "11111111-2222-3333-4444-555555555503";
+
+describe("pax8 webhooks show", () => {
+  it("returns the full webhook in JSON format", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "show",
+      ACTIVE_WEBHOOK_ID,
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.id).toBe(ACTIVE_WEBHOOK_ID);
+    expect(data.url).toBeTruthy();
+    expect(data.status).toBe("Active");
+    expect(Array.isArray(data.topics)).toBe(true);
+    // New v2.1 fields are populated for demo data so agents can rely on them.
+    expect(data).toHaveProperty("displayName");
+    expect(data).toHaveProperty("contactEmail");
+    expect(data).toHaveProperty("errorThreshold");
+    expect(data).toHaveProperty("lastDeliveryStatus");
+  });
+
+  it("shows a Disabled webhook from demo data", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "show",
+      DISABLED_WEBHOOK_ID,
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.status).toBe("Disabled");
+  });
+
+  it("renders detail view in TTY mode (non-TTY also writes detail to stdout for human use, but tests assert presence)", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "show",
+      ACTIVE_WEBHOOK_ID,
+    ]);
+    // Non-TTY default → JSON. Test the JSON shape.
+    const data = JSON.parse(result.stdout);
+    expect(data.id).toBe(ACTIVE_WEBHOOK_ID);
+  });
+
+  it("fails on unknown id with a non-zero exit code", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "show",
+      "00000000-0000-0000-0000-000000000000",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined.length).toBeGreaterThan(0);
+  });
+
+  it("shows --help with examples", async () => {
+    const result = await runCliExpectSuccess(["webhooks", "show", "--help"]);
+    expect(result.stdout).toContain("Examples:");
+    expect(result.stdout).toContain("--json");
+  });
+
+  it("appears in `webhooks --help`", async () => {
+    const result = await runCli(["webhooks", "--help"]);
+    expect(result.stdout).toContain("show");
+    expect(result.stdout).toContain("update");
+    expect(result.stdout).toContain("enable");
+    expect(result.stdout).toContain("disable");
+  });
+});

--- a/packages/cli/src/__tests__/webhooks.update.test.ts
+++ b/packages/cli/src/__tests__/webhooks.update.test.ts
@@ -1,0 +1,148 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import {
+  runCli,
+  runCliExpectSuccess,
+  runCliExpectFailure,
+} from "./test-utils.js";
+
+const ACTIVE_WEBHOOK_ID = "11111111-2222-3333-4444-555555555501";
+
+describe("pax8 webhooks update", () => {
+  it("requires at least one mutating flag", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--yes",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/[Nn]o fields to update/);
+  });
+
+  it("updates display name with --yes and emits the updated webhook in JSON", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--display-name",
+      "Subs prod",
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.id).toBe(ACTIVE_WEBHOOK_ID);
+    expect(data.displayName).toBe("Subs prod");
+  });
+
+  it("updates contactEmail and errorThreshold together", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--contact-email",
+      "ops@new.example.com",
+      "--error-threshold",
+      "7",
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.contactEmail).toBe("ops@new.example.com");
+    expect(data.errorThreshold).toBe(7);
+  });
+
+  it("rejects an invalid email", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--contact-email",
+      "not-an-email",
+      "--yes",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/[Ii]nvalid.*contact-email|email/);
+  });
+
+  it("rejects an out-of-range error threshold", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--error-threshold",
+      "0",
+      "--yes",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/[Ii]nvalid.*error-threshold|between 1 and 20/);
+  });
+
+  it("rejects a non-integer error threshold", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--error-threshold",
+      "abc",
+      "--yes",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/[Ii]nvalid.*error-threshold/);
+  });
+
+  it("rejects a too-large error threshold", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--error-threshold",
+      "21",
+      "--yes",
+    ]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/[Ii]nvalid.*error-threshold|between 1 and 20/);
+  });
+
+  it("redacts the authorization header in the confirm prompt (stderr) but leaves --json output intact", async () => {
+    const auth = "Bearer abcdefghijklmnopqrstuvwxyz";
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "update",
+      ACTIVE_WEBHOOK_ID,
+      "--authorization",
+      auth,
+      "--yes",
+      "--json",
+    ]);
+    // The full secret must never appear on stderr (the diff preview).
+    expect(result.stderr).not.toContain(auth);
+    // The redaction should include the first and last 4 chars.
+    expect(result.stderr).toContain("Bear");
+    expect(result.stderr).toContain("wxyz");
+    expect(result.stderr).toContain("...");
+  });
+
+  it("fails on unknown id", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "update",
+      "00000000-0000-0000-0000-000000000000",
+      "--display-name",
+      "x",
+      "--yes",
+    ]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("shows --help with examples", async () => {
+    const result = await runCli(["webhooks", "update", "--help"]);
+    expect(result.stdout).toContain("Examples:");
+    expect(result.stdout).toContain("--display-name");
+    expect(result.stdout).toContain("--authorization");
+    expect(result.stdout).toContain("--contact-email");
+    expect(result.stdout).toContain("--error-threshold");
+  });
+});

--- a/packages/cli/src/commands/webhooks/disable.ts
+++ b/packages/cli/src/commands/webhooks/disable.ts
@@ -1,0 +1,99 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../lib/context.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError } from "../../lib/errors.js";
+import { confirm, replCmd } from "../../lib/confirm.js";
+import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
+import { markWriteInFlight } from "../../lib/signals.js";
+
+export const webhooksDisableCommand = new Command("disable")
+  .description("Disable a webhook subscription so Pax8 stops sending deliveries")
+  .argument("<id>", "Webhook ID")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 webhooks disable 11111111-2222-3333-4444-555555555501
+  pax8 webhooks disable 11111111-2222-3333-4444-555555555501 --yes
+  pax8 webhooks disable 11111111-2222-3333-4444-555555555501 --json`,
+  )
+  .action(async (id: string, _options, command: Command) => {
+    const allOpts = command.optsWithGlobals();
+
+    try {
+      const ctx = await buildContext(allOpts);
+
+      const fetchSpinner = createSpinner("Fetching webhook...").start();
+      const current = await ctx.api.webhooks.get(id);
+      fetchSpinner.stop();
+
+      // Idempotent short-circuit — already disabled is a no-op.
+      if (current.status === "Disabled") {
+        if (ctx.outputFormat === "json") {
+          process.stdout.write(
+            JSON.stringify({ ...current, alreadyDisabled: true }, null, 2) + "\n",
+          );
+          return;
+        }
+        if (ctx.outputFormat === "quiet") return;
+        process.stderr.write(
+          chalk.dim(`\n  Webhook ${current.id} is already Disabled. No change made.\n\n`),
+        );
+        return;
+      }
+
+      process.stderr.write(chalk.bold("\n  Disable Webhook:\n\n"));
+      process.stderr.write(`  ${chalk.dim("ID:".padEnd(14))}${current.id}\n`);
+      process.stderr.write(`  ${chalk.dim("URL:".padEnd(14))}${current.url}\n`);
+      process.stderr.write(
+        `  ${chalk.dim("Status:".padEnd(14))}${chalk.green(current.status)} ${chalk.dim("→")} ${chalk.gray("Disabled")}\n\n`,
+      );
+      process.stderr.write(
+        chalk.yellow("  ⚠ Pax8 will stop delivering events to this URL until re-enabled.\n\n"),
+      );
+
+      const ok = await confirm("Disable this webhook?", { default: false });
+      if (!ok) {
+        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        return;
+      }
+
+      const spinner = createSpinner("Disabling webhook...").start();
+      const done = markWriteInFlight("webhooks");
+      let updated;
+      try {
+        updated = await ctx.api.webhooks.setStatus(id, false);
+      } finally {
+        done();
+      }
+      await invalidateCacheAfterWrite();
+      spinner.succeed("Webhook disabled");
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(JSON.stringify(updated, null, 2) + "\n");
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      process.stdout.write("\n");
+      process.stdout.write(`  ${chalk.dim("ID:".padEnd(14))}${updated.id}\n`);
+      process.stdout.write(
+        `  ${chalk.dim("Status:".padEnd(14))}${chalk.gray(updated.status)}\n`,
+      );
+      process.stdout.write("\n");
+
+      process.stderr.write(chalk.dim("  Try next:\n"));
+      process.stderr.write(
+        `    ${chalk.cyan(replCmd(`pax8 webhooks enable ${updated.id}`))}  ${chalk.dim("re-enable when ready")}\n`,
+      );
+      process.stderr.write("\n");
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to disable webhook");
+    }
+  });

--- a/packages/cli/src/commands/webhooks/enable.ts
+++ b/packages/cli/src/commands/webhooks/enable.ts
@@ -1,0 +1,98 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../lib/context.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError } from "../../lib/errors.js";
+import { confirm, replCmd } from "../../lib/confirm.js";
+import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
+import { markWriteInFlight } from "../../lib/signals.js";
+
+export const webhooksEnableCommand = new Command("enable")
+  .description("Enable a webhook subscription so Pax8 resumes deliveries")
+  .argument("<id>", "Webhook ID")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 webhooks enable 11111111-2222-3333-4444-555555555503
+  pax8 webhooks enable 11111111-2222-3333-4444-555555555503 --yes
+  pax8 webhooks enable 11111111-2222-3333-4444-555555555503 --json`,
+  )
+  .action(async (id: string, _options, command: Command) => {
+    const allOpts = command.optsWithGlobals();
+
+    try {
+      const ctx = await buildContext(allOpts);
+
+      const fetchSpinner = createSpinner("Fetching webhook...").start();
+      const current = await ctx.api.webhooks.get(id);
+      fetchSpinner.stop();
+
+      // Idempotent short-circuit — flipping an already-Active webhook is a
+      // no-op against the API too, but callers (including agents looping
+      // over a list) appreciate a deterministic "no change needed" path.
+      if (current.status === "Active") {
+        if (ctx.outputFormat === "json") {
+          process.stdout.write(
+            JSON.stringify({ ...current, alreadyEnabled: true }, null, 2) + "\n",
+          );
+          return;
+        }
+        if (ctx.outputFormat === "quiet") return;
+        process.stderr.write(
+          chalk.dim(`\n  Webhook ${current.id} is already Active. No change made.\n\n`),
+        );
+        return;
+      }
+
+      process.stderr.write(chalk.bold("\n  Enable Webhook:\n\n"));
+      process.stderr.write(`  ${chalk.dim("ID:".padEnd(14))}${current.id}\n`);
+      process.stderr.write(`  ${chalk.dim("URL:".padEnd(14))}${current.url}\n`);
+      process.stderr.write(
+        `  ${chalk.dim("Status:".padEnd(14))}${chalk.gray(current.status)} ${chalk.dim("→")} ${chalk.green("Active")}\n\n`,
+      );
+
+      const ok = await confirm("Enable this webhook?", { default: true });
+      if (!ok) {
+        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        return;
+      }
+
+      const spinner = createSpinner("Enabling webhook...").start();
+      const done = markWriteInFlight("webhooks");
+      let updated;
+      try {
+        updated = await ctx.api.webhooks.setStatus(id, true);
+      } finally {
+        done();
+      }
+      await invalidateCacheAfterWrite();
+      spinner.succeed("Webhook enabled");
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(JSON.stringify(updated, null, 2) + "\n");
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      process.stdout.write("\n");
+      process.stdout.write(`  ${chalk.dim("ID:".padEnd(14))}${updated.id}\n`);
+      process.stdout.write(
+        `  ${chalk.dim("Status:".padEnd(14))}${chalk.green(updated.status)}\n`,
+      );
+      process.stdout.write("\n");
+
+      process.stderr.write(chalk.dim("  Try next:\n"));
+      process.stderr.write(
+        `    ${chalk.cyan(replCmd(`pax8 webhooks test ${updated.id}`))}  ${chalk.dim("send a test delivery")}\n`,
+      );
+      process.stderr.write("\n");
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to enable webhook");
+    }
+  });

--- a/packages/cli/src/commands/webhooks/index.ts
+++ b/packages/cli/src/commands/webhooks/index.ts
@@ -3,7 +3,11 @@
 
 import { Command } from "commander";
 import { webhooksListCommand } from "./list.js";
+import { webhooksShowCommand } from "./show.js";
 import { webhooksCreateCommand } from "./create.js";
+import { webhooksUpdateCommand } from "./update.js";
+import { webhooksEnableCommand } from "./enable.js";
+import { webhooksDisableCommand } from "./disable.js";
 import { webhooksDeleteCommand } from "./delete.js";
 import { webhooksTestCommand } from "./test.js";
 import { webhooksLogsCommand } from "./logs.js";
@@ -14,7 +18,11 @@ export function registerWebhooksCommands(program: Command): void {
   );
 
   webhooks.addCommand(webhooksListCommand);
+  webhooks.addCommand(webhooksShowCommand);
   webhooks.addCommand(webhooksCreateCommand);
+  webhooks.addCommand(webhooksUpdateCommand);
+  webhooks.addCommand(webhooksEnableCommand);
+  webhooks.addCommand(webhooksDisableCommand);
   webhooks.addCommand(webhooksDeleteCommand);
   webhooks.addCommand(webhooksTestCommand);
   webhooks.addCommand(webhooksLogsCommand);

--- a/packages/cli/src/commands/webhooks/show.ts
+++ b/packages/cli/src/commands/webhooks/show.ts
@@ -1,0 +1,97 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../lib/context.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError } from "../../lib/errors.js";
+import { formatStatus, formatDate } from "../../lib/formatters.js";
+import { replCmd } from "../../lib/confirm.js";
+
+export const webhooksShowCommand = new Command("show")
+  .description("Show details for a single webhook subscription")
+  .argument("<id>", "Webhook ID")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 webhooks show 11111111-2222-3333-4444-555555555501
+  pax8 webhooks show 11111111-2222-3333-4444-555555555501 --json`,
+  )
+  .action(async (id: string, _options, command: Command) => {
+    const allOpts = command.optsWithGlobals();
+    const spinner = createSpinner("Fetching webhook...");
+
+    try {
+      const ctx = await buildContext(allOpts);
+      spinner.start();
+      const webhook = await ctx.api.webhooks.get(id);
+      spinner.stop();
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(JSON.stringify(webhook, null, 2) + "\n");
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      // Detail view: human-readable, padded label column on stderr would
+      // hide it from pipes — but `show` is detail-on-stdout (matches
+      // companies show / contacts show).
+      process.stdout.write("\n");
+      process.stdout.write(
+        chalk.bold(`  ${webhook.displayName ?? "Webhook"}\n\n`),
+      );
+      process.stdout.write(`  ${chalk.dim("ID:".padEnd(20))}${webhook.id}\n`);
+      process.stdout.write(
+        `  ${chalk.dim("Status:".padEnd(20))}${formatStatus(webhook.status)}\n`,
+      );
+      process.stdout.write(`  ${chalk.dim("URL:".padEnd(20))}${webhook.url}\n`);
+      if (webhook.displayName) {
+        process.stdout.write(
+          `  ${chalk.dim("Display Name:".padEnd(20))}${webhook.displayName}\n`,
+        );
+      }
+      if (webhook.contactEmail) {
+        process.stdout.write(
+          `  ${chalk.dim("Contact Email:".padEnd(20))}${webhook.contactEmail}\n`,
+        );
+      }
+      if (webhook.errorThreshold !== undefined) {
+        process.stdout.write(
+          `  ${chalk.dim("Error Threshold:".padEnd(20))}${webhook.errorThreshold}\n`,
+        );
+      }
+      process.stdout.write(
+        `  ${chalk.dim("Topics:".padEnd(20))}${webhook.topics.length === 0 ? chalk.dim("—") : webhook.topics.join(", ")}\n`,
+      );
+      if (webhook.lastDeliveryStatus) {
+        process.stdout.write(
+          `  ${chalk.dim("Last Delivery:".padEnd(20))}${webhook.lastDeliveryStatus}\n`,
+        );
+      }
+      process.stdout.write(
+        `  ${chalk.dim("Created:".padEnd(20))}${formatDate(webhook.createdDate)}\n`,
+      );
+      if (webhook.updatedAt) {
+        process.stdout.write(
+          `  ${chalk.dim("Updated:".padEnd(20))}${formatDate(webhook.updatedAt)}\n`,
+        );
+      }
+      process.stdout.write("\n");
+
+      if (ctx.outputFormat === "table") {
+        process.stderr.write(chalk.dim("  Try next:\n"));
+        process.stderr.write(
+          `    ${chalk.cyan(replCmd(`pax8 webhooks logs ${webhook.id}`))}  ${chalk.dim("view delivery history")}\n`,
+        );
+        process.stderr.write(
+          `    ${chalk.cyan(replCmd(`pax8 webhooks test ${webhook.id}`))}  ${chalk.dim("send a test delivery")}\n`,
+        );
+        process.stderr.write("\n");
+      }
+    } catch (error) {
+      await handleCommandError(error, spinner, "Failed to show webhook");
+    }
+  });

--- a/packages/cli/src/commands/webhooks/update.ts
+++ b/packages/cli/src/commands/webhooks/update.ts
@@ -1,0 +1,206 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
+import type { UpdateWebhookConfigurationInput } from "@pax8/core";
+import { buildContext } from "../../lib/context.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError, CliError } from "../../lib/errors.js";
+import { confirm, replCmd } from "../../lib/confirm.js";
+import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
+import { markWriteInFlight } from "../../lib/signals.js";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Redact a sensitive header value so we never echo a bearer token in plain text.
+ * Returns first 4 + last 4 chars separated by an ellipsis; fully masks
+ * anything ≤ 8 chars.
+ */
+export function redactAuthorization(value: string): string {
+  if (value.length <= 8) return "*".repeat(value.length);
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+export const webhooksUpdateCommand = new Command("update")
+  .description("Update mutable configuration on a webhook subscription")
+  .argument("<id>", "Webhook ID")
+  .option("--display-name <text>", "Human-friendly label for the webhook")
+  .option(
+    "--authorization <header-value>",
+    "Authorization header sent on each delivery (treated as sensitive)",
+  )
+  .option(
+    "--contact-email <email>",
+    "Email Pax8 notifies when delivery failures exceed the threshold",
+  )
+  .option(
+    "--error-threshold <number>",
+    "Consecutive failures before notifying contactEmail (1-20)",
+  )
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 webhooks update 11111111-2222-3333-4444-555555555501 --display-name "Subs prod"
+  pax8 webhooks update 11111111-2222-3333-4444-555555555501 --error-threshold 5 --yes
+  pax8 webhooks update 11111111-2222-3333-4444-555555555501 --authorization "Bearer abc123..." --json`,
+  )
+  .action(async (id: string, _options, command: Command) => {
+    const allOpts = command.optsWithGlobals();
+
+    try {
+      const ctx = await buildContext(allOpts);
+
+      const data: UpdateWebhookConfigurationInput = {};
+
+      if (allOpts.displayName !== undefined) {
+        const v = String(allOpts.displayName).trim();
+        if (v.length === 0) {
+          throw new CliError(
+            "Invalid --display-name",
+            ["--display-name must not be empty"],
+            [`Try: ${replCmd("pax8 webhooks update")} ${id} --display-name "My webhook"`],
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+        data.displayName = v;
+      }
+
+      if (allOpts.authorization !== undefined) {
+        data.authorization = String(allOpts.authorization);
+      }
+
+      if (allOpts.contactEmail !== undefined) {
+        const email = String(allOpts.contactEmail).trim();
+        if (!EMAIL_RE.test(email)) {
+          throw new CliError(
+            `Invalid --contact-email: "${allOpts.contactEmail}"`,
+            ["Value must look like an email address (user@domain.tld)"],
+            [
+              `Try: ${replCmd("pax8 webhooks update")} ${id} --contact-email ops@example.com`,
+            ],
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+        data.contactEmail = email;
+      }
+
+      if (allOpts.errorThreshold !== undefined) {
+        const raw = String(allOpts.errorThreshold);
+        const n = Number.parseInt(raw, 10);
+        if (!Number.isFinite(n) || String(n) !== raw.trim() || n < 1 || n > 20) {
+          throw new CliError(
+            `Invalid --error-threshold: "${allOpts.errorThreshold}"`,
+            ["Must be an integer between 1 and 20"],
+            [
+              `Try: ${replCmd("pax8 webhooks update")} ${id} --error-threshold 5`,
+            ],
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+        data.errorThreshold = n;
+      }
+
+      if (Object.keys(data).length === 0) {
+        throw new CliError(
+          "No fields to update",
+          [
+            "At least one of --display-name, --authorization, --contact-email, or --error-threshold is required",
+          ],
+          [
+            `Try: ${replCmd("pax8 webhooks update")} ${id} --display-name "My webhook"`,
+            `See: ${replCmd("pax8 webhooks update --help")}`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      // Look up the current webhook so we can show the user what they're
+      // changing and emit a clean error if the id doesn't exist.
+      const fetchSpinner = createSpinner("Fetching webhook...").start();
+      const current = await ctx.api.webhooks.get(id);
+      fetchSpinner.stop();
+
+      // Diff preview — redact `authorization` so we never echo a bearer token
+      // in plain text. JSON consumers see the raw payload via the response.
+      process.stderr.write(chalk.bold("\n  Update Webhook:\n\n"));
+      process.stderr.write(`  ${chalk.dim("ID:".padEnd(18))}${current.id}\n`);
+      process.stderr.write(
+        `  ${chalk.dim("URL:".padEnd(18))}${current.url}\n\n`,
+      );
+      for (const [k, v] of Object.entries(data)) {
+        const label =
+          k === "displayName"
+            ? "Display Name"
+            : k === "contactEmail"
+              ? "Contact Email"
+              : k === "errorThreshold"
+                ? "Error Threshold"
+                : k === "authorization"
+                  ? "Authorization"
+                  : k;
+        const display =
+          k === "authorization"
+            ? redactAuthorization(String(v))
+            : String(v);
+        process.stderr.write(
+          `  ${chalk.dim((label + ":").padEnd(18))}${chalk.green(display)}\n`,
+        );
+      }
+      process.stderr.write("\n");
+
+      const ok = await confirm("Apply these changes?", { default: true });
+      if (!ok) {
+        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        return;
+      }
+
+      const spinner = createSpinner("Updating webhook...").start();
+      const doneUpdate = markWriteInFlight("webhooks");
+      let updated;
+      try {
+        updated = await ctx.api.webhooks.updateConfiguration(id, data);
+      } finally {
+        doneUpdate();
+      }
+      await invalidateCacheAfterWrite();
+      spinner.succeed("Webhook updated");
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(JSON.stringify(updated, null, 2) + "\n");
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      process.stdout.write("\n");
+      process.stdout.write(`  ${chalk.dim("ID:".padEnd(18))}${updated.id}\n`);
+      process.stdout.write(`  ${chalk.dim("URL:".padEnd(18))}${updated.url}\n`);
+      if (updated.displayName) {
+        process.stdout.write(
+          `  ${chalk.dim("Display Name:".padEnd(18))}${updated.displayName}\n`,
+        );
+      }
+      if (updated.contactEmail) {
+        process.stdout.write(
+          `  ${chalk.dim("Contact Email:".padEnd(18))}${updated.contactEmail}\n`,
+        );
+      }
+      if (updated.errorThreshold !== undefined) {
+        process.stdout.write(
+          `  ${chalk.dim("Error Threshold:".padEnd(18))}${updated.errorThreshold}\n`,
+        );
+      }
+      process.stdout.write("\n");
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to update webhook");
+    }
+  });

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -382,6 +382,16 @@ export const WebhookSchema = z.object({
   status: WebhookStatusSchema,
   createdDate: z.string(),
   secret: z.string().optional(),
+  /** Human-friendly label for the webhook (Pax8 v2.1+). */
+  displayName: z.string().optional(),
+  /** Email Pax8 notifies when delivery failures exceed `errorThreshold`. */
+  contactEmail: z.string().optional(),
+  /** Consecutive failures before Pax8 notifies `contactEmail`. Server cap is 20. */
+  errorThreshold: z.number().int().optional(),
+  /** Last delivery outcome reported by Pax8 (PENDING | SUCCESS | FAILED | RETRYING). */
+  lastDeliveryStatus: z.string().optional(),
+  /** ISO timestamp of last update (Pax8 v2.1+). */
+  updatedAt: z.string().optional(),
 });
 export type Webhook = z.infer<typeof WebhookSchema>;
 
@@ -397,6 +407,21 @@ export const UpdateWebhookInputSchema = z.object({
   status: WebhookStatusSchema.optional(),
 });
 export type UpdateWebhookInput = z.infer<typeof UpdateWebhookInputSchema>;
+
+/**
+ * Mutable configuration fields for `POST /webhooks/{id}/configuration`.
+ * Mirrors the `UpdateWebhookConfiguration` shape in webhook-manager v2/v2.1.
+ * `authorization` is a sensitive header value — treat it as a secret in any
+ * non-`--json` output.
+ */
+export const UpdateWebhookConfigurationInputSchema = z.object({
+  displayName: z.string().min(1).optional(),
+  url: z.string().url().optional(),
+  authorization: z.string().optional(),
+  contactEmail: z.string().email().optional(),
+  errorThreshold: z.number().int().min(1).max(20).optional(),
+});
+export type UpdateWebhookConfigurationInput = z.infer<typeof UpdateWebhookConfigurationInputSchema>;
 
 // ─── Webhook Log ─────────────────────────────────────────────────────────────
 

--- a/packages/core/src/api/webhooks.test.ts
+++ b/packages/core/src/api/webhooks.test.ts
@@ -96,6 +96,51 @@ describe("WebhooksApi", () => {
     expect(result.status).toBe("Disabled");
   });
 
+  it("updateConfiguration POSTs to /configuration with the partial body", async () => {
+    const input = {
+      displayName: "Subs prod",
+      contactEmail: "ops@example.com",
+      errorThreshold: 5,
+    };
+    const updated = { ...sampleWebhook, ...input };
+    (client.post as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const result = await api.updateConfiguration(WEBHOOK_ID, input);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/webhooks/${WEBHOOK_ID}/configuration`,
+      input,
+    );
+    expect(result.displayName).toBe("Subs prod");
+    expect(result.errorThreshold).toBe(5);
+  });
+
+  it("setStatus(true) POSTs to /status with { active: true }", async () => {
+    const updated = { ...sampleWebhook, status: "Active" };
+    (client.post as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const result = await api.setStatus(WEBHOOK_ID, true);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/webhooks/${WEBHOOK_ID}/status`,
+      { active: true },
+    );
+    expect(result.status).toBe("Active");
+  });
+
+  it("setStatus(false) POSTs to /status with { active: false }", async () => {
+    const updated = { ...sampleWebhook, status: "Disabled" };
+    (client.post as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const result = await api.setStatus(WEBHOOK_ID, false);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/webhooks/${WEBHOOK_ID}/status`,
+      { active: false },
+    );
+    expect(result.status).toBe("Disabled");
+  });
+
   it("delete calls client.delete", async () => {
     (client.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 

--- a/packages/core/src/api/webhooks.ts
+++ b/packages/core/src/api/webhooks.ts
@@ -10,6 +10,7 @@ import {
   type WebhookLog,
   type CreateWebhookInput,
   type UpdateWebhookInput,
+  type UpdateWebhookConfigurationInput,
 } from "./types.js";
 
 export class WebhooksApi {
@@ -37,6 +38,32 @@ export class WebhooksApi {
 
   async updateStatus(id: string, status: string): Promise<Webhook> {
     const raw = await this.client.patch<unknown>(`/webhooks/${id}`, { status });
+    return WebhookSchema.parse(raw);
+  }
+
+  /**
+   * Update mutable configuration fields on a webhook. Mirrors the
+   * `updateConfiguration` operation (`POST /webhooks/{id}/configuration`) in
+   * webhook-manager v2/v2.1.
+   */
+  async updateConfiguration(
+    id: string,
+    data: UpdateWebhookConfigurationInput,
+  ): Promise<Webhook> {
+    const raw = await this.client.post<unknown>(
+      `/webhooks/${id}/configuration`,
+      data,
+    );
+    return WebhookSchema.parse(raw);
+  }
+
+  /**
+   * Toggle the `active` flag on a webhook. Mirrors the `updateStatus`
+   * operation (`POST /webhooks/{id}/status`) in webhook-manager v2/v2.1.
+   * The wire body is `{ active: boolean }`; the response is the full webhook.
+   */
+  async setStatus(id: string, active: boolean): Promise<Webhook> {
+    const raw = await this.client.post<unknown>(`/webhooks/${id}/status`, { active });
     return WebhookSchema.parse(raw);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,7 @@ export {
   WebhookLogSchema,
   CreateWebhookInputSchema,
   UpdateWebhookInputSchema,
+  UpdateWebhookConfigurationInputSchema,
   PageInfoSchema,
   PageSchema,
   PaginatedResponseSchema,
@@ -152,6 +153,7 @@ export type {
   WebhookLog,
   CreateWebhookInput,
   UpdateWebhookInput,
+  UpdateWebhookConfigurationInput,
   PageInfo,
   PaginatedResponse,
   // Enum types

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -200,6 +200,16 @@ export interface Webhook {
   topics: string[];
   createdDate: string;
   secret?: string;
+  /** Human-friendly label (Pax8 webhook-manager v2.1+). */
+  displayName?: string;
+  /** Email Pax8 notifies when delivery failures exceed `errorThreshold`. */
+  contactEmail?: string;
+  /** Consecutive failures before Pax8 notifies `contactEmail`. Capped at 20. */
+  errorThreshold?: number;
+  /** Last delivery outcome: PENDING | SUCCESS | FAILED | RETRYING. */
+  lastDeliveryStatus?: string;
+  /** ISO timestamp of last update. */
+  updatedAt?: string;
 }
 
 export interface WebhookLog {
@@ -1703,6 +1713,11 @@ export const webhooks: Webhook[] = [
     ],
     createdDate: "2025-06-01",
     secret: "whsec_demo_abc123",
+    displayName: "Subscription events",
+    contactEmail: "ops@example.com",
+    errorThreshold: 3,
+    lastDeliveryStatus: "SUCCESS",
+    updatedAt: "2026-03-18T14:23:00Z",
   },
   {
     id: WEBHOOK_INVOICES_ID,
@@ -1711,6 +1726,11 @@ export const webhooks: Webhook[] = [
     topics: ["invoice.created", "invoice.paid"],
     createdDate: "2025-08-15",
     secret: "whsec_demo_def456",
+    displayName: "Invoice events",
+    contactEmail: "billing@example.com",
+    errorThreshold: 5,
+    lastDeliveryStatus: "SUCCESS",
+    updatedAt: "2026-03-01T06:00:00Z",
   },
   {
     id: WEBHOOK_ORDERS_ID,
@@ -1719,6 +1739,11 @@ export const webhooks: Webhook[] = [
     topics: ["order.created", "order.completed"],
     createdDate: "2025-11-20",
     secret: "whsec_demo_ghi789",
+    displayName: "Order events",
+    contactEmail: "ops@example.com",
+    errorThreshold: 3,
+    lastDeliveryStatus: "FAILED",
+    updatedAt: "2026-02-10T10:00:00Z",
   },
 ];
 

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -594,8 +594,10 @@ class QuotesResource {
 //   list()       → Webhook[]
 //   create(data) → Webhook
 //   get(id)      → Webhook
-//   update(id, data)        → Webhook
-//   updateStatus(id, status)→ Webhook
+//   update(id, data)            → Webhook (legacy PUT shape)
+//   updateStatus(id, status)    → Webhook (legacy PATCH shape)
+//   updateConfiguration(id, c)  → Webhook (POST /webhooks/{id}/configuration)
+//   setStatus(id, active)       → Webhook (POST /webhooks/{id}/status)
 //   delete(id)   → void
 //   test(id)     → unknown (returns a small structured payload here)
 //   getLogs(id)  → WebhookLog[]
@@ -646,6 +648,43 @@ class WebhooksResource {
     const wh = webhooks.find((w) => w.id === id);
     if (!wh) throw notFound("Webhook", id);
     return { ...wh, status };
+  }
+
+  async updateConfiguration(
+    id: string,
+    data: {
+      displayName?: string;
+      url?: string;
+      authorization?: string;
+      contactEmail?: string;
+      errorThreshold?: number;
+    },
+  ): Promise<Webhook> {
+    await randomDelay();
+    const wh = webhooks.find((w) => w.id === id);
+    if (!wh) throw notFound("Webhook", id);
+    // Return a merged copy without mutating the canonical demo record — keeps
+    // tests order-independent. `authorization` is a write-only secret on the
+    // real API and is not echoed back on read, so we don't include it.
+    const { authorization: _ignored, ...rest } = data;
+    void _ignored;
+    return {
+      ...wh,
+      ...rest,
+      id: wh.id,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  async setStatus(id: string, active: boolean): Promise<Webhook> {
+    await randomDelay();
+    const wh = webhooks.find((w) => w.id === id);
+    if (!wh) throw notFound("Webhook", id);
+    return {
+      ...wh,
+      status: active ? "Active" : "Disabled",
+      updatedAt: new Date().toISOString(),
+    };
   }
 
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
Refs #243.

## Summary
- Adds `pax8 webhooks show <id>`, `webhooks update <id>`, `webhooks enable <id>`, and `webhooks disable <id>` — the lifecycle gap called out in #243. Partners can now manage a webhook end-to-end from the CLI without dropping to the API.
- Extends `@pax8/core`'s `WebhooksApi` with `get`, `updateConfiguration` (POST `/webhooks/{id}/configuration`), and `setStatus` (POST `/webhooks/{id}/status` with `{ active: boolean }`). Body shapes verified against `https://devx.pax8.com/openapi/webhooks-api.json`.
- `WebhookSchema` gains optional `displayName`, `contactEmail`, `errorThreshold`, `lastDeliveryStatus`, `updatedAt` so agents can rely on them when present without breaking existing list/create/delete callers.
- `update` requires at least one of `--display-name`, `--authorization`, `--contact-email`, `--error-threshold` (errors with `ERROR_INVALID_INPUT` and a usage hint otherwise). The `--authorization` value is redacted to first 4 + last 4 chars in the confirm prompt and any non-`--json` output; in `--json` mode the user already opted into raw, so it passes through unchanged.
- `enable` / `disable` are idempotent: when the state already matches we short-circuit, emit `alreadyEnabled` / `alreadyDisabled` in the `--json` envelope, and skip the write.
- `MockPax8Client` mirrors the new methods; demo data carries one Disabled webhook plus two Active ones so the toggle and the idempotent branch are both exercised under `PAX8_DEMO=1`.

## Out of scope (sibling PR)
A parallel PR (`feat/webhooks-logs-retry-topics`) handles `logs retry`, `topics list`, and `test --topic`. Refs (not closes) #243 because that PR also addresses the issue.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test` — 1354 passed, 8 skipped (24 new subprocess tests for the four commands)
- [x] `pnpm lint` clean
- [ ] Maintainer: confirm the `authorization` redaction behavior in the confirm prompt is what we want (first 4 + `...` + last 4, masked entirely if ≤ 8 chars)
- [ ] Maintainer: verify against real API once token is available — the path/body shapes were taken from `webhooks-api.json` (`Webhooks_get`, `updateConfiguration`, `updateStatus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)