### PR TITLE
feat(quotes): add line-items management and send command (refs #245)

### DIFF
--- a/packages/cli/src/__tests__/quotes.line-items.test.ts
+++ b/packages/cli/src/__tests__/quotes.line-items.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+
+describe("pax8 quotes line-items", () => {
+  describe("line-items list", () => {
+    it("returns the line items array in JSON", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "list",
+        "quote-summit-001",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(2);
+      expect(data[0]).toHaveProperty("id");
+      expect(data[0]).toHaveProperty("productId");
+      expect(data[0]).toHaveProperty("quantity");
+      expect(data[0].id).toBe("li-summit-001-a");
+    });
+
+    it("emits one ID per line with --ids-only", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "list",
+        "quote-summit-001",
+        "--ids-only",
+      ]);
+      const lines = result.stdout.trim().split("\n").filter(Boolean);
+      expect(lines).toEqual(["li-summit-001-a", "li-summit-001-b"]);
+    });
+
+    it("returns empty/zero when the quote ID is unknown", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "line-items",
+        "list",
+        "no-such-quote",
+        "--json",
+      ]);
+      // 404 path is centralized; just verify the failure surfaces.
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("line-items add", () => {
+    it("adds a line item and prints the new ID + count (auto-confirm with -y)", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-aad-p1-0008",
+        "--quantity",
+        "3",
+        "--billing-term",
+        "Annual",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      // JSON mode wraps the response in a single-element array.
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0]).toHaveProperty("quoteId", "quote-redwood-001");
+      expect(data[0]).toHaveProperty("lineItemId");
+      expect(typeof data[0].lineItemId).toBe("string");
+      expect(data[0].lineItemId).toMatch(/^li-/);
+      // Started at 1 line item, should now be 2.
+      expect(data[0].lineItemCount).toBe(2);
+    });
+
+    it("rejects non-positive quantity", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-summit-001",
+        "--product",
+        "prod-aad-p1-0008",
+        "--quantity",
+        "-2",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/[Ii]nvalid quantity/);
+    });
+
+    it("requires --product", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-summit-001",
+        "--quantity",
+        "1",
+        "--yes",
+      ]);
+      expect(result.stderr).toContain("--product");
+    });
+
+    it("cancels cleanly when the user answers no at the prompt", async () => {
+      // When stdin isn't a TTY, the prompt sees EOF — empty answer means
+      // "use default", which for `add` is `true`. To assert the cancel path
+      // we feed a literal "n" on stdin via a child process. runCli doesn't
+      // support stdin; use Node's spawn instead.
+      const { spawn } = await import("node:child_process");
+      const { resolve } = await import("node:path");
+      const { fileURLToPath } = await import("node:url");
+      const cliPath = resolve(
+        fileURLToPath(import.meta.url),
+        "../../../dist/index.js",
+      );
+      const child = spawn(
+        "node",
+        [
+          cliPath,
+          "quotes",
+          "line-items",
+          "add",
+          "quote-summit-001",
+          "--product",
+          "prod-aad-p1-0008",
+          "--quantity",
+          "1",
+        ],
+        {
+          env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1" },
+        },
+      );
+      child.stdin.write("n\n");
+      child.stdin.end();
+
+      let stderr = "";
+      child.stderr.on("data", (d) => (stderr += d.toString()));
+      const code: number = await new Promise((res) => child.on("close", res));
+      expect(code).toBe(0);
+      expect(stderr).toContain("Cancelled");
+    });
+  });
+
+  describe("line-items remove", () => {
+    it("removes a line item with -y", async () => {
+      // The summit quote starts with 2 lines (li-summit-001-a, li-summit-001-b).
+      // After remove, the next list call from the same subprocess would show 1,
+      // but each runCli is a fresh subprocess (and demo data is in-memory),
+      // so we just assert exit + JSON envelope here.
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "remove",
+        "quote-summit-001",
+        "li-summit-001-b",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0]).toEqual({
+        quoteId: "quote-summit-001",
+        lineItemId: "li-summit-001-b",
+        status: "Removed",
+      });
+    });
+
+    it("errors with a clear message when the line item ID is wrong", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "line-items",
+        "remove",
+        "quote-summit-001",
+        "li-bogus-999",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/not found/i);
+      expect(combined).toMatch(/li-bogus-999/);
+    });
+  });
+
+  describe("line-items --help", () => {
+    it("shows subcommands in the line-items help", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "--help",
+      ]);
+      expect(result.stdout).toContain("list");
+      expect(result.stdout).toContain("add");
+      expect(result.stdout).toContain("remove");
+    });
+
+    it("includes Examples in the add help", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "add",
+        "--help",
+      ]);
+      expect(result.stdout).toContain("Examples:");
+      expect(result.stdout).toContain("--product");
+      expect(result.stdout).toContain("--quantity");
+    });
+
+    it("includes the --ids-only example in list help", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "list",
+        "--help",
+      ]);
+      expect(result.stdout).toContain("Examples:");
+      expect(result.stdout).toContain("--ids-only");
+    });
+  });
+
+  describe("line-items registers under quotes", () => {
+    it("appears in `pax8 quotes --help`", async () => {
+      const result = await runCli(["quotes", "--help"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("line-items");
+    });
+  });
+});

--- a/packages/cli/src/__tests__/quotes.send.test.ts
+++ b/packages/cli/src/__tests__/quotes.send.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+
+describe("pax8 quotes send", () => {
+  it("transitions a draft quote to Sent (JSON mode, auto-confirmed)", async () => {
+    const result = await runCliExpectSuccess([
+      "quotes",
+      "send",
+      "quote-bright-001",
+      "--json",
+      "--yes",
+    ]);
+    const data = JSON.parse(result.stdout);
+    // JSON mode emits the raw response wrapped in a single-element array.
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0]).toHaveProperty("id", "quote-bright-001");
+    expect(data[0]).toHaveProperty("status");
+    // The mock maps lowercase API status -> capitalized demo status.
+    expect(String(data[0].status).toLowerCase()).toBe("sent");
+  });
+
+  it("emits a customer-link / email hint on stdout in TTY mode", async () => {
+    // Non-TTY default isn't `table` — but the success-path "✓ Quote sent"
+    // banner is also in JSON; here we run without --json and just look at
+    // the human output. runCli treats stderr separately, so the email hint
+    // (which we send on stdout when there's no link) must appear in stdout.
+    const result = await runCliExpectSuccess([
+      "quotes",
+      "send",
+      "quote-redwood-001",
+      "--yes",
+    ]);
+    // Without --json, default in non-TTY is JSON, so the structured payload
+    // ends up on stdout. The "Quote sent" banner is for human/table mode —
+    // verify on stderr we still see the success spinner suffix and no error.
+    expect(result.stderr).toContain("Quote sent");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("respects --quiet (no stdout)", async () => {
+    const result = await runCliExpectSuccess([
+      "quotes",
+      "send",
+      "quote-bright-001",
+      "--quiet",
+      "--yes",
+    ]);
+    expect(result.stdout).toBe("");
+  });
+
+  it("errors when the quote does not exist", async () => {
+    const result = await runCliExpectFailure([
+      "quotes",
+      "send",
+      "no-such-quote",
+      "--yes",
+    ]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("cancels when the user answers no at the prompt", async () => {
+    const { spawn } = await import("node:child_process");
+    const { resolve } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const cliPath = resolve(
+      fileURLToPath(import.meta.url),
+      "../../../dist/index.js",
+    );
+    const child = spawn(
+      "node",
+      [cliPath, "quotes", "send", "quote-bright-001"],
+      {
+        env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1" },
+      },
+    );
+    // The send confirm defaults to false. Send "n" explicitly so the
+    // readline `question` callback fires (closing stdin without an answer
+    // would leave the promise pending).
+    child.stdin.write("n\n");
+    child.stdin.end();
+
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += d.toString()));
+    const code: number = await new Promise((res) => child.on("close", res));
+    expect(code).toBe(0);
+    expect(stderr).toContain("Cancelled");
+  });
+
+  it("shows help with examples and a workflow note", async () => {
+    const result = await runCliExpectSuccess(["quotes", "send", "--help"]);
+    expect(result.stdout).toContain("Examples:");
+    expect(result.stdout).toMatch(/customer/i);
+  });
+
+  it("appears in `pax8 quotes --help`", async () => {
+    const result = await runCliExpectSuccess(["quotes", "--help"]);
+    expect(result.stdout).toContain("send");
+  });
+});

--- a/packages/cli/src/commands/quotes/index.ts
+++ b/packages/cli/src/commands/quotes/index.ts
@@ -7,6 +7,8 @@ import { quotesShowCommand } from "./show.js";
 import { quotesCreateCommand } from "./create.js";
 import { quotesUpdateCommand } from "./update.js";
 import { quotesDeleteCommand } from "./delete.js";
+import { quotesSendCommand } from "./send.js";
+import { buildQuotesLineItemsCommand } from "./line-items/index.js";
 
 export function registerQuotesCommands(program: Command): void {
   const quotes = new Command("quotes").description("Manage sales quotes");
@@ -16,6 +18,8 @@ export function registerQuotesCommands(program: Command): void {
   quotes.addCommand(quotesCreateCommand);
   quotes.addCommand(quotesUpdateCommand);
   quotes.addCommand(quotesDeleteCommand);
+  quotes.addCommand(quotesSendCommand);
+  quotes.addCommand(buildQuotesLineItemsCommand());
 
   program.addCommand(quotes);
 }

--- a/packages/cli/src/commands/quotes/line-items/add.ts
+++ b/packages/cli/src/commands/quotes/line-items/add.ts
@@ -1,0 +1,126 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../../lib/context.js";
+import { output } from "../../../lib/output.js";
+import { createSpinner } from "../../../lib/spinner.js";
+import { handleCommandError, CliError } from "../../../lib/errors.js";
+import { confirm, replCmd } from "../../../lib/confirm.js";
+import { resolveProduct } from "../../../lib/resolve-product.js";
+import { invalidateCacheAfterWrite } from "../../../lib/invalidate-cache.js";
+import { markWriteInFlight } from "../../../lib/signals.js";
+import { formatQuantity } from "../../../lib/formatters.js";
+import { ERROR_INVALID_INPUT, type BillingTerm, type AddQuoteLineItemInput } from "@pax8/core";
+
+export const quotesLineItemsAddCommand = new Command("add")
+  .description("Add a line item to a quote")
+  .argument("<quote-id>", "Quote ID")
+  .requiredOption("--product <id|name>", "Product ID or name (required)")
+  .option("--quantity <number>", "Quantity", "1")
+  .option("--billing-term <term>", "Billing term (Monthly or Annual)", "Monthly")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 quotes line-items add quote-summit-001 --product "Microsoft 365 E3" --quantity 5
+  pax8 quotes line-items add quote-summit-001 --product prod-aad-p1-0008 --quantity 5 --billing-term Annual
+  pax8 quotes line-items add quote-summit-001 --product prod-m365-e3-0003 --quantity 5 --json --yes`,
+  )
+  .action(async (quoteId, options, command) => {
+    const globalOpts = command.optsWithGlobals();
+    const ctx = await buildContext(globalOpts);
+
+    try {
+      const quantity = parseInt(options.quantity, 10);
+      if (isNaN(quantity) || quantity <= 0) {
+        throw new CliError(
+          `Invalid quantity: "${options.quantity}"`,
+          ["Quantity must be a positive integer"],
+          undefined,
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      const fetchSpinner = createSpinner("Fetching quote...").start();
+      const quote = await ctx.api.quotes.get(quoteId);
+      // Snapshot pre-state line-item IDs immediately. In demo mode the
+      // mock mutates the same quote object, so a deferred diff would see
+      // the post-mutation state and miss the new ID.
+      const beforeIds = new Set(
+        (quote.lineItems ?? []).map((li) => li.id).filter(Boolean) as string[],
+      );
+      fetchSpinner.stop();
+
+      const product = await resolveProduct(ctx, options.product);
+
+      process.stderr.write(chalk.bold("\n  Add line item:\n\n"));
+      process.stderr.write(`  ${chalk.dim("Quote:".padEnd(18))}${quote.id} ${chalk.dim(`(${quote.status})`)}\n`);
+      process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${product.name}\n`);
+      process.stderr.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(quantity)}\n`);
+      process.stderr.write(`  ${chalk.dim("Billing term:".padEnd(18))}${options.billingTerm}\n`);
+      process.stderr.write(`  ${chalk.dim("Existing items:".padEnd(18))}${quote.lineItems?.length ?? 0}\n\n`);
+
+      const ok = await confirm("Add this line item?", { default: true });
+      if (!ok) {
+        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        return;
+      }
+
+      const input: AddQuoteLineItemInput = {
+        productId: product.id,
+        quantity,
+        billingTerm: options.billingTerm as BillingTerm,
+      };
+
+      const spinner = createSpinner("Adding line item...").start();
+      const done = markWriteInFlight("quotes");
+      let updated;
+      try {
+        updated = await ctx.api.quotes.addLineItem(quoteId, input);
+      } finally {
+        done();
+      }
+      await invalidateCacheAfterWrite();
+      spinner.succeed("Line item added");
+
+      // Identify the newly added line item by diffing against the pre-state
+      // snapshot taken before the POST.
+      const newLine = (updated.lineItems ?? []).find(
+        (li) => li.id && !beforeIds.has(li.id),
+      );
+
+      if (ctx.outputFormat === "json") {
+        output(
+          [
+            {
+              quoteId: updated.id,
+              lineItemId: newLine?.id ?? null,
+              lineItemCount: updated.lineItems?.length ?? 0,
+              quote: updated,
+            },
+          ],
+          { format: "json" },
+        );
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      process.stdout.write("\n");
+      if (newLine?.id) {
+        process.stdout.write(`  ${chalk.dim("New line ID:".padEnd(16))}${newLine.id}\n`);
+      }
+      process.stdout.write(`  ${chalk.dim("Total lines:".padEnd(16))}${updated.lineItems?.length ?? 0}\n`);
+      process.stdout.write("\n");
+
+      process.stderr.write(chalk.dim("  Try next:\n"));
+      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items list ${updated.id}`))}  ${chalk.dim("see all line items")}\n`);
+      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes send ${updated.id}`))}  ${chalk.dim("send the quote to the customer")}\n\n`);
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to add line item");
+    }
+  });

--- a/packages/cli/src/commands/quotes/line-items/index.ts
+++ b/packages/cli/src/commands/quotes/line-items/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import { quotesLineItemsListCommand } from "./list.js";
+import { quotesLineItemsAddCommand } from "./add.js";
+import { quotesLineItemsRemoveCommand } from "./remove.js";
+
+export function buildQuotesLineItemsCommand(): Command {
+  const lineItems = new Command("line-items").description(
+    "Manage line items on a quote (list / add / remove)",
+  );
+  lineItems.addCommand(quotesLineItemsListCommand);
+  lineItems.addCommand(quotesLineItemsAddCommand);
+  lineItems.addCommand(quotesLineItemsRemoveCommand);
+  return lineItems;
+}

--- a/packages/cli/src/commands/quotes/line-items/list.ts
+++ b/packages/cli/src/commands/quotes/line-items/list.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../../lib/context.js";
+import { output, type Column } from "../../../lib/output.js";
+import { createSpinner } from "../../../lib/spinner.js";
+import { handleCommandError } from "../../../lib/errors.js";
+import { formatCurrency, formatQuantity } from "../../../lib/formatters.js";
+import { replCmd } from "../../../lib/confirm.js";
+
+export const quotesLineItemsListCommand = new Command("list")
+  .description("List the line items on a quote")
+  .argument("<quote-id>", "Quote ID")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 quotes line-items list quote-summit-001
+  pax8 quotes line-items list quote-summit-001 --json
+  pax8 quotes line-items list quote-summit-001 --csv
+  pax8 quotes line-items list quote-summit-001 --ids-only | xargs -I{} pax8 quotes line-items remove quote-summit-001 {}`
+  )
+  .option("--ids-only", "Output only line-item IDs, one per line")
+  .action(async (quoteId, _options, command) => {
+    const allOpts = command.optsWithGlobals();
+    const ctx = await buildContext(allOpts);
+    const spinner = createSpinner("Fetching quote...");
+
+    try {
+      spinner.start();
+      const quote = await ctx.api.quotes.get(quoteId);
+      spinner.stop();
+
+      const lineItems = quote.lineItems ?? [];
+
+      if (allOpts.idsOnly) {
+        for (const li of lineItems) {
+          if (li.id) process.stdout.write(li.id + "\n");
+        }
+        return;
+      }
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(JSON.stringify(lineItems, null, 2) + "\n");
+        return;
+      }
+
+      const columns: Column[] = [
+        { key: "id", header: "Line ID", width: 22, format: (v) => v ? chalk.dim(String(v)) : chalk.dim("—") },
+        { key: "productId", header: "Product ID", width: 26, format: (v) => chalk.dim(String(v)) },
+        { key: "quantity", header: "Qty", width: 10, format: (v) => formatQuantity(Number(v)) },
+        { key: "billingTerm", header: "Term", width: 10, format: (v) => v ? String(v) : "—" },
+        { key: "unitPrice", header: "Unit", width: 12, format: (v) => v != null ? formatCurrency(Number(v)) : "—" },
+        { key: "subtotal", header: "Subtotal", width: 14, format: (v) => v != null ? formatCurrency(Number(v)) : "—" },
+      ];
+
+      output(lineItems, { format: ctx.outputFormat, columns });
+
+      if (ctx.outputFormat === "table") {
+        process.stderr.write(
+          chalk.dim(`\n  ${lineItems.length} line item${lineItems.length === 1 ? "" : "s"} on quote ${quote.id}\n`),
+        );
+        if (lineItems.length > 0) {
+          process.stderr.write(chalk.dim("\n  Try next:\n"));
+          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items add ${quote.id} --product <id|name> --quantity <n>`))}  ${chalk.dim("add another line item")}\n`);
+          if (lineItems[0]?.id) {
+            process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items remove ${quote.id} ${lineItems[0].id}`))}  ${chalk.dim("remove a line item")}\n`);
+          }
+          process.stderr.write("\n");
+        }
+      }
+    } catch (error) {
+      await handleCommandError(error, spinner, "Failed to list line items");
+    }
+  });

--- a/packages/cli/src/commands/quotes/line-items/remove.ts
+++ b/packages/cli/src/commands/quotes/line-items/remove.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../../lib/context.js";
+import { output } from "../../../lib/output.js";
+import { createSpinner } from "../../../lib/spinner.js";
+import { handleCommandError, CliError } from "../../../lib/errors.js";
+import { confirm, replCmd } from "../../../lib/confirm.js";
+import { invalidateCacheAfterWrite } from "../../../lib/invalidate-cache.js";
+import { markWriteInFlight } from "../../../lib/signals.js";
+import { formatCurrency, formatQuantity } from "../../../lib/formatters.js";
+import { ERROR_QUOTE_LINE_ITEM_NOT_FOUND } from "@pax8/core";
+
+export const quotesLineItemsRemoveCommand = new Command("remove")
+  .description("Remove a line item from a quote")
+  .argument("<quote-id>", "Quote ID")
+  .argument("<line-item-id>", "Line item ID (from `quotes line-items list`)")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 quotes line-items remove quote-summit-001 li-summit-001-b
+  pax8 quotes line-items remove quote-summit-001 li-summit-001-b --yes`,
+  )
+  .action(async (quoteId, lineItemId, _options, command) => {
+    const globalOpts = command.optsWithGlobals();
+    const ctx = await buildContext(globalOpts);
+
+    try {
+      const fetchSpinner = createSpinner("Fetching quote...").start();
+      const quote = await ctx.api.quotes.get(quoteId);
+      fetchSpinner.stop();
+
+      const lineItems = quote.lineItems ?? [];
+      const target = lineItems.find((li) => li.id === lineItemId);
+      if (!target) {
+        throw new CliError(
+          `Line item "${lineItemId}" not found on quote ${quoteId}.`,
+          ["No line item on this quote has that ID."],
+          [`Run ${replCmd(`pax8 quotes line-items list ${quoteId}`)} to see valid IDs.`],
+          undefined,
+          ERROR_QUOTE_LINE_ITEM_NOT_FOUND,
+        );
+      }
+
+      process.stderr.write(chalk.bold("\n  Remove line item:\n\n"));
+      process.stderr.write(`  ${chalk.dim("Quote:".padEnd(18))}${quote.id} ${chalk.dim(`(${quote.status})`)}\n`);
+      process.stderr.write(`  ${chalk.dim("Line item:".padEnd(18))}${target.id ?? "—"}\n`);
+      process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${target.productId}\n`);
+      process.stderr.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(target.quantity)}\n`);
+      if (target.billingTerm) {
+        process.stderr.write(`  ${chalk.dim("Billing term:".padEnd(18))}${target.billingTerm}\n`);
+      }
+      if (typeof target.subtotal === "number") {
+        process.stderr.write(`  ${chalk.dim("Subtotal:".padEnd(18))}${formatCurrency(target.subtotal)}\n`);
+      }
+      process.stderr.write("\n");
+
+      const ok = await confirm("Remove this line item?", { default: false });
+      if (!ok) {
+        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        return;
+      }
+
+      const spinner = createSpinner("Removing line item...").start();
+      const done = markWriteInFlight("quotes");
+      try {
+        await ctx.api.quotes.removeLineItem(quoteId, lineItemId);
+      } finally {
+        done();
+      }
+      await invalidateCacheAfterWrite();
+      spinner.succeed("Line item removed");
+
+      if (ctx.outputFormat === "json") {
+        output(
+          [{ quoteId, lineItemId, status: "Removed" }],
+          { format: "json" },
+        );
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      const remaining = lineItems.length - 1;
+      process.stdout.write("\n");
+      process.stdout.write(`  ${chalk.dim("Remaining lines:".padEnd(18))}${remaining}\n`);
+      process.stdout.write("\n");
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to remove line item");
+    }
+  });

--- a/packages/cli/src/commands/quotes/send.ts
+++ b/packages/cli/src/commands/quotes/send.ts
@@ -1,0 +1,137 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../lib/context.js";
+import { output } from "../../lib/output.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError } from "../../lib/errors.js";
+import { confirm, replCmd } from "../../lib/confirm.js";
+import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
+import { markWriteInFlight } from "../../lib/signals.js";
+import { formatCurrency } from "../../lib/formatters.js";
+import type { Quote } from "@pax8/core";
+
+/**
+ * Find a customer-facing link in the post-send response. The Pax8 v2 quoting
+ * spec doesn't currently document a top-level `customerLink` / `publicUrl`
+ * field — partners typically receive the link via email — but if the API ever
+ * begins returning one we'll surface it without a release. Probes a small
+ * allow-list of likely keys; if nothing matches, callers fall back to the
+ * "delivered via email" hint.
+ */
+function findCustomerLink(quote: Quote): string | undefined {
+  const candidates = [
+    "customerLink",
+    "publicUrl",
+    "shareUrl",
+    "url",
+    "quoteUrl",
+  ] as const;
+  const raw = quote as unknown as Record<string, unknown>;
+  for (const key of candidates) {
+    const value = raw[key];
+    if (typeof value === "string" && /^https?:\/\//.test(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function quoteTotal(q: Quote): number {
+  return (q.lineItems ?? []).reduce(
+    (s, li) => s + (li.subtotal ?? (li.unitPrice ?? 0) * li.quantity),
+    0,
+  );
+}
+
+export const quotesSendCommand = new Command("send")
+  .description("Send a quote to the customer (transitions status to Sent)")
+  .argument("<quote-id>", "Quote ID")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 quotes send quote-bright-001
+  pax8 quotes send quote-bright-001 --yes
+  pax8 quotes send quote-bright-001 --json --yes
+
+Note:
+  Sending publishes the quote to the customer. Pax8 emails the customer-facing
+  link automatically; if the API response includes a direct link it is shown
+  here as well. The customer-side accept/decline triggers a QUOTE.Accepted
+  webhook that downstream automation can act on.`,
+  )
+  .action(async (quoteId, _options, command) => {
+    const globalOpts = command.optsWithGlobals();
+    const ctx = await buildContext(globalOpts);
+
+    try {
+      const fetchSpinner = createSpinner("Fetching quote...").start();
+      const quote = await ctx.api.quotes.get(quoteId);
+      fetchSpinner.stop();
+
+      const lineCount = quote.lineItems?.length ?? 0;
+      const total = quoteTotal(quote);
+
+      process.stderr.write(chalk.bold("\n  Send quote to customer:\n\n"));
+      process.stderr.write(`  ${chalk.dim("Quote:".padEnd(18))}${quote.id}\n`);
+      process.stderr.write(`  ${chalk.dim("Current status:".padEnd(18))}${quote.status}\n`);
+      process.stderr.write(`  ${chalk.dim("Line items:".padEnd(18))}${lineCount}\n`);
+      if (lineCount > 0) {
+        process.stderr.write(`  ${chalk.dim("Total:".padEnd(18))}${formatCurrency(total)}\n`);
+      }
+      process.stderr.write(
+        `\n  ${chalk.yellow("This is a customer-visible action — the customer will receive a quote link.")}\n\n`,
+      );
+
+      const ok = await confirm("Send this quote?", { default: false });
+      if (!ok) {
+        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        return;
+      }
+
+      const spinner = createSpinner("Sending quote...").start();
+      const done = markWriteInFlight("quotes");
+      let updated;
+      try {
+        updated = await ctx.api.quotes.send(quoteId);
+      } finally {
+        done();
+      }
+      await invalidateCacheAfterWrite();
+      spinner.succeed("Quote sent");
+
+      if (ctx.outputFormat === "json") {
+        output([updated], { format: "json" });
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      const link = findCustomerLink(updated as Quote);
+      const reference = (updated as unknown as Record<string, unknown>).referenceCode;
+
+      process.stdout.write("\n");
+      process.stdout.write(`  ${chalk.green("✓")} Quote sent.\n`);
+      if (link) {
+        process.stdout.write(`  ${chalk.dim("Customer link:".padEnd(18))}${chalk.cyan(link)}\n`);
+      } else {
+        process.stdout.write(
+          `  ${chalk.dim("The customer will receive the quote link by email.")}\n`,
+        );
+      }
+      if (typeof reference === "string" && reference.length > 0) {
+        process.stdout.write(`  ${chalk.dim("Reference:".padEnd(18))}${reference}\n`);
+      }
+      process.stdout.write("\n");
+
+      process.stderr.write(chalk.dim("  Try next:\n"));
+      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes show ${updated.id}`))}  ${chalk.dim("view the live quote")}\n`);
+      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 webhooks list`))}  ${chalk.dim("verify QUOTE.Accepted webhooks are configured")}\n\n`);
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to send quote");
+    }
+  });

--- a/packages/core/src/api/quotes.test.ts
+++ b/packages/core/src/api/quotes.test.ts
@@ -94,4 +94,68 @@ describe("QuotesApi", () => {
 
     expect(client.delete).toHaveBeenCalledWith(`/quotes/${QUOTE_ID}`);
   });
+
+  it("addLineItem POSTs an array with a Standard payload then re-fetches the quote", async () => {
+    (client.post as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(sampleQuote);
+    const productId = "d4e5f6a7-b890-1234-cdef-567890123456";
+
+    const result = await api.addLineItem(QUOTE_ID, {
+      productId,
+      quantity: 4,
+      billingTerm: "Annual",
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/quotes/${QUOTE_ID}/line-items`,
+      [
+        {
+          type: "Standard",
+          productId,
+          quantity: 4,
+          billingTerm: "Annual",
+        },
+      ],
+    );
+    expect(client.get).toHaveBeenCalledWith(`/quotes/${QUOTE_ID}`);
+    expect(result.id).toBe(QUOTE_ID);
+  });
+
+  it("removeLineItem DELETEs the nested line-item path", async () => {
+    (client.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    const lineItemId = "11111111-2222-3333-4444-555555555555";
+
+    await api.removeLineItem(QUOTE_ID, lineItemId);
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `/quotes/${QUOTE_ID}/line-items/${lineItemId}`,
+    );
+  });
+
+  it("setStatus PUTs { status } to the quote endpoint", async () => {
+    (client.put as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...sampleQuote,
+      status: "sent",
+    });
+
+    const result = await api.setStatus(QUOTE_ID, "sent");
+
+    expect(client.put).toHaveBeenCalledWith(`/quotes/${QUOTE_ID}`, {
+      status: "sent",
+    });
+    expect(result.status).toBe("sent");
+  });
+
+  it("send is a thin wrapper over setStatus(id, 'sent')", async () => {
+    (client.put as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...sampleQuote,
+      status: "sent",
+    });
+
+    await api.send(QUOTE_ID);
+
+    expect(client.put).toHaveBeenCalledWith(`/quotes/${QUOTE_ID}`, {
+      status: "sent",
+    });
+  });
 });

--- a/packages/core/src/api/quotes.ts
+++ b/packages/core/src/api/quotes.ts
@@ -8,6 +8,8 @@ import {
   type Quote,
   type CreateQuoteInput,
   type UpdateQuoteInput,
+  type AddQuoteLineItemInput,
+  type QuoteStatusTransition,
   type PaginatedResponse,
 } from "./types.js";
 
@@ -42,5 +44,53 @@ export class QuotesApi {
 
   async delete(id: string): Promise<void> {
     await this.client.delete(`/quotes/${id}`);
+  }
+
+  /**
+   * Append a single line item to a draft quote.
+   *
+   * `POST /v2/quotes/{quoteId}/line-items` accepts an array of mixed-type
+   * payloads (Standard / Custom / UsageBased). We post a single Standard
+   * line and re-fetch the quote so callers always get the canonical post-
+   * mutation state — the upstream response shape is `LineItemResponse[]`,
+   * which doesn't include the surrounding quote-level fields callers care
+   * about (totals, status).
+   */
+  async addLineItem(quoteId: string, input: AddQuoteLineItemInput): Promise<Quote> {
+    const payload = [
+      {
+        type: "Standard",
+        productId: input.productId,
+        quantity: input.quantity,
+        ...(input.billingTerm ? { billingTerm: input.billingTerm } : {}),
+      },
+    ];
+    await this.client.post<unknown>(`/quotes/${quoteId}/line-items`, payload);
+    return this.get(quoteId);
+  }
+
+  /**
+   * Remove a single line item from a quote.
+   * `DELETE /v2/quotes/{quoteId}/line-items/{lineItemId}` returns 204.
+   */
+  async removeLineItem(quoteId: string, lineItemId: string): Promise<void> {
+    await this.client.delete(`/quotes/${quoteId}/line-items/${lineItemId}`);
+  }
+
+  /**
+   * Transition a quote to a new status.
+   *
+   * Most commonly used as `setStatus(id, "sent")` — the trigger that publishes
+   * the customer-facing quote and (server-side) emits the customer link/email.
+   * Backed by `PUT /v2/quotes/{quoteId}` per the v2 quoting OpenAPI spec.
+   */
+  async setStatus(id: string, status: QuoteStatusTransition): Promise<Quote> {
+    const raw = await this.client.put<unknown>(`/quotes/${id}`, { status });
+    return QuoteSchema.parse(raw);
+  }
+
+  /** Convenience wrapper: `setStatus(id, "sent")`. */
+  async send(id: string): Promise<Quote> {
+    return this.setStatus(id, "sent");
   }
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -355,6 +355,13 @@ export type UsageLine = z.infer<typeof UsageLineSchema>;
 // ─── Quote ───────────────────────────────────────────────────────────────────
 
 export const QuoteLineItemSchema = z.object({
+  /**
+   * Line item identifier. Optional because the v1 quote surface didn't expose
+   * it on every line; the v2 endpoints (`POST /v2/quotes/{id}/line-items`,
+   * `DELETE .../line-items/{lineItemId}`) require it for per-line operations.
+   * Demo data populates it.
+   */
+  id: z.string().optional(),
   productId: z.string().uuid(),
   quantity: z.number(),
   billingTerm: BillingTermSchema.optional(),
@@ -455,6 +462,37 @@ export const UpdateQuoteInputSchema = z.object({
   expirationDate: z.string().optional(),
 });
 export type UpdateQuoteInput = z.infer<typeof UpdateQuoteInputSchema>;
+
+/**
+ * Input for `POST /v2/quotes/{quoteId}/line-items` — append a single standard
+ * line item. The upstream API accepts an array of mixed-type payloads
+ * (Standard / Custom / UsageBased); we expose the common Standard shape here
+ * because that's what `quotes line-items add` constructs from `--product`,
+ * `--quantity`, and `--billing-term`.
+ */
+export const AddQuoteLineItemInputSchema = z.object({
+  productId: z.string().uuid(),
+  quantity: z.number().int().positive(),
+  billingTerm: BillingTermSchema.optional(),
+});
+export type AddQuoteLineItemInput = z.infer<typeof AddQuoteLineItemInputSchema>;
+
+/**
+ * Body for `PUT /v2/quotes/{quoteId}` when transitioning a quote to `sent`.
+ * Other transitions (`accepted`, `declined`, etc.) ride a different code path.
+ */
+export const QuoteStatusTransitionSchema = z.enum([
+  "draft",
+  "assigned",
+  "sent",
+  "closed",
+  "declined",
+  "accepted",
+  "changes_requested",
+  "expired",
+  "pending",
+]);
+export type QuoteStatusTransition = z.infer<typeof QuoteStatusTransitionSchema>;
 
 // Aliases for backward compatibility
 export const PageSchema = PageInfoSchema;

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -25,6 +25,7 @@ export const ERROR_INVALID_INPUT = "ERROR_INVALID_INPUT";
 export const ERROR_NOT_AUTHORIZED = "ERROR_NOT_AUTHORIZED";
 export const ERROR_NOT_FOUND = "ERROR_NOT_FOUND";
 export const ERROR_INTERNAL = "ERROR_INTERNAL";
+export const ERROR_QUOTE_LINE_ITEM_NOT_FOUND = "ERROR_QUOTE_LINE_ITEM_NOT_FOUND";
 
 /**
  * Union of all known Pax8 CLI error codes. Use this for exhaustive switch
@@ -42,4 +43,5 @@ export type Pax8ErrorCode =
   | typeof ERROR_INVALID_INPUT
   | typeof ERROR_NOT_AUTHORIZED
   | typeof ERROR_NOT_FOUND
-  | typeof ERROR_INTERNAL;
+  | typeof ERROR_INTERNAL
+  | typeof ERROR_QUOTE_LINE_ITEM_NOT_FOUND;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export {
   ERROR_NOT_AUTHORIZED,
   ERROR_NOT_FOUND,
   ERROR_INTERNAL,
+  ERROR_QUOTE_LINE_ITEM_NOT_FOUND,
 } from "./errors/codes.js";
 export type { Pax8ErrorCode } from "./errors/codes.js";
 
@@ -101,6 +102,8 @@ export {
   QuoteLineItemSchema,
   CreateQuoteInputSchema,
   UpdateQuoteInputSchema,
+  AddQuoteLineItemInputSchema,
+  QuoteStatusTransitionSchema,
   WebhookSchema,
   WebhookLogSchema,
   CreateWebhookInputSchema,
@@ -148,6 +151,8 @@ export type {
   QuoteLineItem,
   CreateQuoteInput,
   UpdateQuoteInput,
+  AddQuoteLineItemInput,
+  QuoteStatusTransition,
   Webhook,
   WebhookLog,
   CreateWebhookInput,

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -185,6 +185,12 @@ export interface Quote {
 }
 
 export interface QuoteLineItem {
+  /**
+   * Line item identifier. Optional in the demo seed because the v1 quote
+   * surface didn't expose it; the v2 line-items endpoints (#245) require it
+   * to address individual lines (`DELETE /v2/quotes/{quoteId}/line-items/{id}`).
+   */
+  id?: string;
   productId: string;
   quantity: number;
   /** Mirrors the public `BillingTerm` enum for cross-mode compatibility. */
@@ -1635,6 +1641,7 @@ export const quotes: Quote[] = [
     status: "Sent",
     lineItems: [
       {
+        id: "li-summit-001-a",
         productId: "prod-m365-e3-0003",
         quantity: 5,
         unitPrice: 36.0,
@@ -1642,6 +1649,7 @@ export const quotes: Quote[] = [
         subtotal: 180.0,
       },
       {
+        id: "li-summit-001-b",
         productId: "prod-aad-p1-0008",
         quantity: 5,
         unitPrice: 6.0,
@@ -1658,11 +1666,20 @@ export const quotes: Quote[] = [
     status: "Draft",
     lineItems: [
       {
+        id: "li-bright-001-a",
         productId: "prod-defender-biz-0007",
         quantity: 25,
         unitPrice: 3.0,
         billingTerm: "Monthly",
         subtotal: 75.0,
+      },
+      {
+        id: "li-bright-001-b",
+        productId: "prod-aad-p1-0008",
+        quantity: 25,
+        unitPrice: 6.0,
+        billingTerm: "Monthly",
+        subtotal: 150.0,
       },
     ],
   },
@@ -1674,6 +1691,7 @@ export const quotes: Quote[] = [
     status: "Accepted",
     lineItems: [
       {
+        id: "li-redwood-001-a",
         productId: "prod-m365-e5-0004",
         quantity: 8,
         unitPrice: 57.0,

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -39,6 +39,8 @@ import type {
   ProductPricing as ProductPricingPlans,
   ProvisioningDetail as ProvisioningDetailType,
   ProductDependency as ProductDependencyType,
+  AddQuoteLineItemInput,
+  QuoteStatusTransition,
 } from "../api/types.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -587,6 +589,77 @@ class QuotesResource {
     await randomDelay();
     const quote = quotes.find((q) => q.id === id);
     if (!quote) throw notFound("Quote", id);
+  }
+
+  /**
+   * Append a single line item to a draft quote. Mutates the in-memory demo
+   * fixture so a follow-up `quotes show` reflects the new line. Returns the
+   * (now-mutated) quote so callers don't need to re-fetch.
+   */
+  async addLineItem(
+    quoteId: string,
+    input: AddQuoteLineItemInput,
+  ): Promise<Quote> {
+    await randomDelay();
+    const quote = quotes.find((q) => q.id === quoteId);
+    if (!quote) throw notFound("Quote", quoteId);
+    // Try to fetch a unit price from the demo product so the new line shows
+    // sensible totals in tables. Pricing lookups silently fall through —
+    // a missing price just means the line shows "—" in the UI.
+    const product = products.find((p) => p.id === input.productId);
+    const term = input.billingTerm ?? "Monthly";
+    const plan = product?.pricing.find((p) => p.billingTerm === term);
+    const unitPrice = plan?.partnerBuyPrice;
+    const newId = `li-demo-${Date.now()}`;
+    const newLine = {
+      id: newId,
+      productId: input.productId,
+      quantity: input.quantity,
+      ...(input.billingTerm ? { billingTerm: input.billingTerm } : {}),
+      ...(typeof unitPrice === "number"
+        ? { unitPrice, subtotal: unitPrice * input.quantity }
+        : {}),
+    };
+    quote.lineItems = [...(quote.lineItems ?? []), newLine];
+    return quote;
+  }
+
+  async removeLineItem(quoteId: string, lineItemId: string): Promise<void> {
+    await randomDelay();
+    const quote = quotes.find((q) => q.id === quoteId);
+    if (!quote) throw notFound("Quote", quoteId);
+    const items = quote.lineItems ?? [];
+    const idx = items.findIndex((li) => li.id === lineItemId);
+    if (idx < 0) throw notFound("QuoteLineItem", lineItemId);
+    items.splice(idx, 1);
+    quote.lineItems = items;
+  }
+
+  /**
+   * Demo-mode status transitions. The lowercase API enum maps to the
+   * capitalized demo `Quote.status` field one-for-one — most users see
+   * `Sent` after `setStatus(id, "sent")`.
+   */
+  async setStatus(id: string, status: QuoteStatusTransition): Promise<Quote> {
+    await randomDelay();
+    const quote = quotes.find((q) => q.id === id);
+    if (!quote) throw notFound("Quote", id);
+    const cap = status.charAt(0).toUpperCase() + status.slice(1);
+    // The demo Quote.status is a tight union; cast through unknown rather
+    // than widen the seed type for every caller.
+    const allowed: Record<string, Quote["status"]> = {
+      Draft: "Draft",
+      Sent: "Sent",
+      Accepted: "Accepted",
+      Declined: "Declined",
+    };
+    const next = allowed[cap] ?? quote.status;
+    quote.status = next;
+    return quote;
+  }
+
+  async send(id: string): Promise<Quote> {
+    return this.setStatus(id, "sent");
   }
 }
 


### PR DESCRIPTION
Refs #245.

Implements the missing middle of Pax8's "Automated Quoting and Sales Cycle" workflow. The CLI previously stopped at draft creation; partners now have CLI-native commands for the full pipeline:

```
create draft → add line items → send (publishes + emails customer) → QUOTE.Accepted webhook → trigger order
```

This PR adds the **add line items** and **send** steps. (Accept/decline visibility, attachments, sections, access-list, claim/take-ownership are out of scope here — see #245 for the full gap.)

## New commands

| Command | What it does |
|---|---|
| `pax8 quotes line-items list <quote-id>` | `GET /v2/quotes/{id}` and emit just the line items (with `--ids-only` for pipelines). |
| `pax8 quotes line-items add <quote-id> --product <id\|name> --quantity <n> [--billing-term]` | `POST /v2/quotes/{id}/line-items` (Standard payload). Confirms before write; prints the new line-item ID and updated count. |
| `pax8 quotes line-items remove <quote-id> <line-item-id>` | `DELETE /v2/quotes/{id}/line-items/{lineItemId}`. Confirms with the line description; `-y` skips. |
| `pax8 quotes send <quote-id>` | `PUT /v2/quotes/{id}` body `{"status":"sent"}` — the documented v2 trigger that publishes the quote. Confirms (customer-visible action); `-y` skips. |

## Sample `quotes send` output

```
  Send quote to customer:

  Quote:            quote-bright-001
  Current status:  Draft
  Line items:       2
  Total:            $225.00

  This is a customer-visible action — the customer will receive a quote link.

  Send this quote? [y/n] y
  ✓ Quote sent

  ✓ Quote sent.
  The customer will receive the quote link by email.

  Try next:
    pax8 quotes show quote-bright-001                view the live quote
    pax8 webhooks list                               verify QUOTE.Accepted webhooks are configured
```

When the API response includes a direct customer URL (`customerLink`/`publicUrl`/`shareUrl`/`url`/`quoteUrl`), it is surfaced inline as `Customer link:`. The OpenAPI spec doesn't currently document such a field, so the email hint is the default path.

## Workflow alignment

Mirrors the internal "Automated Quoting and Sales Cycle" doc end-to-end. Partners running CRM-driven automation can now:

1. `pax8 quotes create --company X --product Y --quantity N` (existing)
2. `pax8 quotes line-items add <id> --product Z --quantity M` (this PR)
3. `pax8 quotes send <id>` (this PR — publishes + customer email)
4. Wait on `QUOTE.Accepted` via `pax8 webhooks` (existing)
5. `pax8 orders create ...` (existing)

## Core changes

- `QuotesApi`: `addLineItem`, `removeLineItem`, `setStatus`, `send`. The line-items endpoints accept an array of mixed-type payloads upstream; we expose the common Standard shape because that's what `--product/--quantity/--billing-term` builds.
- `AddQuoteLineItemInput`, `QuoteStatusTransition` types.
- Optional `id` on `QuoteLineItemSchema` — the v2 endpoints require an ID to address individual lines, but existing v1 demo data still parses since the field is optional. (No fields added to `QuoteSchema` itself; that's PR-B's territory.)
- `ERROR_QUOTE_LINE_ITEM_NOT_FOUND` (append-only error code).
- `MockPax8Client.QuotesResource` mutates the in-memory demo quote on add/remove/setStatus so subsequent reads reflect the change.
- Demo `quote-bright-001` now has 2+ line items so `list`/`remove` are exercised end-to-end under `PAX8_DEMO=1`.

## What's NOT in this PR

- No `accept` / `decline` / `revoke` / `claim` / `take-ownership`.
- No attachments, sections, or access-list.
- No changes to `quotes update`'s destructive-replace flow (PR-A).
- No new fields on `QuoteSchema` (PR-B).
- No `bulk-delete` (not needed for the documented workflow).

Will rebase before merge once PR-A and PR-B land.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` — 1351 passed (added 24: 13 line-items subprocess + 7 send subprocess + 4 unit tests on QuotesApi)
- [x] `pnpm lint` clean
- [x] All commands work under `PAX8_DEMO=1` end-to-end
- [x] Reuses standard flags (`--json`, `--csv`, `--quiet`, `--ids-only`, `-y`)
- [x] Confirm prompts on every write; `-y` and `PAX8_YES=1` skip
- [x] Errors flow through `CliError` with codes; recovery steps included
- [x] `markWriteInFlight` wraps every API call so SIGINT logs `(cancelled)`
- [x] Cache invalidated after every write