### PR TITLE
fix(quotes): add single-line draft quote for terser-confirm test

### DIFF
--- a/packages/cli/src/__tests__/quotes.update.test.ts
+++ b/packages/cli/src/__tests__/quotes.update.test.ts
@@ -9,7 +9,8 @@ import {
 
 // Demo-data fixtures the tests rely on:
 //   quote-summit-001 — 2 line items (multi-line, triggers destructive warning)
-//   quote-bright-001 — 1 line item (single-line, terser confirm)
+//   quote-bright-001 — 2 line items (multi-line, destructive-replace warning)
+//   quote-bright-002 — 1 line item (single-line, terser confirm)
 // Both expose `lineItems[].productId` so we can drive the diff path without
 // touching the live API.
 
@@ -119,7 +120,7 @@ describe("pax8 quotes update", () => {
       const result = await runCliExpectSuccess([
         "quotes",
         "update",
-        "quote-bright-001",
+        "quote-bright-002",
         "--product",
         "Microsoft 365 E3",
         "--quantity",

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -1726,6 +1726,25 @@ export const quotes: Quote[] = [
     ],
   },
   {
+    id: "quote-bright-002",
+    companyId: BRIGHT_ID,
+    createdDate: "2026-03-08",
+    expirationDate: "2026-04-08",
+    status: "Draft",
+    intentType: "PARTNER_TO_CLIENT",
+    published: false,
+    lineItems: [
+      {
+        id: "li-bright-002-a",
+        productId: "prod-m365-bp-0001",
+        quantity: 10,
+        unitPrice: 22.0,
+        billingTerm: "Monthly",
+        subtotal: 220.0,
+      },
+    ],
+  },
+  {
     id: "quote-redwood-001",
     companyId: REDWOOD_ID,
     createdDate: "2026-02-20",


### PR DESCRIPTION
## Summary

Test regression on `main` after the wave of quote PRs landed.

#266 (quotes line-items + send) changed `quote-bright-001` from 1 line item to 2, so it could be used to exercise the new `quotes line-items add/remove` flows. That broke #264's "single-line quote uses the terser confirm" test, which depended on `quote-bright-001` being single-line. Both PRs were green individually; the regression only surfaced once both landed on `main` together.

## Fix

- Add a new demo quote `quote-bright-002` (Draft, 1 line item) dedicated to the terser-confirm test.
- Switch the test in `packages/cli/src/__tests__/quotes.update.test.ts` to use it.
- `quote-bright-001` keeps its 2-line shape for line-items add/remove tests.

## Test plan

- `pnpm test packages/cli/src/__tests__/quotes.update.test.ts` — 6 tests pass locally.
- Should unblock CI on #270 (the domain-review refresh PR), which inherited the broken test from main.