### PR TITLE
test(e2e): sync per-command matrix to new surface (PRs #255–#267)

### DIFF
--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -554,6 +554,46 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     demo: {},
     jsonContract: { skip: { reason: "write command" } },
   },
+  {
+    command: ["quotes", "send"],
+    group: "quotes",
+    type: "action",
+    isWrite: true,
+    skipLiveRun: { reason: "transitions quote status to Sent; needs id + confirm" },
+    demo: {},
+    jsonContract: { skip: { reason: "write command" } },
+  },
+  {
+    command: ["quotes", "line-items", "list"],
+    group: "quotes",
+    label: "quotes line-items list <quote-id>",
+    type: "list",
+    resolveArgsKey: "quotes:first",
+    resolveArgs: async () => {
+      const id = await resolveFirstId("quotes", ["quotes", "list"]);
+      return ["quotes", "line-items", "list", id];
+    },
+    demo: { forbiddenFragments: ["undefined"] },
+    jsonContract: { arrayItemRequiredFields: ["id", "productId", "quantity"] },
+  },
+  {
+    command: ["quotes", "line-items", "add"],
+    group: "quotes",
+    type: "action",
+    isWrite: true,
+    skipLiveRun: { reason: "needs quote-id + product + quantity + confirm" },
+    demo: {},
+    jsonContract: { skip: { reason: "write command" } },
+  },
+  {
+    command: ["quotes", "line-items", "remove"],
+    group: "quotes",
+    type: "action",
+    isWrite: true,
+    skipLiveRun: { reason: "destructive + needs quote-id + line-item-id + confirm" },
+    demo: {},
+    jsonContract: { skip: { reason: "write command" } },
+  },
   // ── webhooks ──────────────────────────────────────────────────────────────
   {
     command: ["webhooks", "list"],
@@ -561,6 +601,53 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     type: "list",
     demo: { minRows: 3, forbiddenFragments: ["undefined"] },
     jsonContract: { arrayItemRequiredFields: ["id"] },
+  },
+  {
+    command: ["webhooks", "show"],
+    group: "webhooks",
+    type: "show",
+    resolveArgsKey: "webhooks:first",
+    resolveArgs: async () => {
+      const id = await resolveFirstId("webhooks", ["webhooks", "list"]);
+      return ["webhooks", "show", id];
+    },
+    demo: { forbiddenFragments: ["undefined"] },
+    jsonContract: { objectRequiredFields: ["id", "url"] },
+  },
+  {
+    command: ["webhooks", "topics", "list"],
+    group: "webhooks",
+    label: "webhooks topics list",
+    type: "list",
+    demo: { minRows: 1, forbiddenFragments: ["undefined"] },
+    jsonContract: { arrayItemRequiredFields: ["topic"] },
+  },
+  {
+    command: ["webhooks", "update"],
+    group: "webhooks",
+    type: "action",
+    isWrite: true,
+    skipLiveRun: { reason: "needs id + fields + confirm" },
+    demo: {},
+    jsonContract: { skip: { reason: "write command" } },
+  },
+  {
+    command: ["webhooks", "enable"],
+    group: "webhooks",
+    type: "action",
+    isWrite: true,
+    skipLiveRun: { reason: "transitions delivery state; needs id + confirm" },
+    demo: {},
+    jsonContract: { skip: { reason: "write command" } },
+  },
+  {
+    command: ["webhooks", "disable"],
+    group: "webhooks",
+    type: "action",
+    isWrite: true,
+    skipLiveRun: { reason: "transitions delivery state; needs id + confirm" },
+    demo: {},
+    jsonContract: { skip: { reason: "write command" } },
   },
   {
     command: ["webhooks", "logs"],

--- a/packages/cli/src/__tests__/quotes.update.test.ts
+++ b/packages/cli/src/__tests__/quotes.update.test.ts
@@ -116,10 +116,13 @@ describe("pax8 quotes update", () => {
 
   describe("single-line quote", () => {
     it("uses the terser confirm (no destructive warning)", async () => {
+      // quote-acme-001 has exactly one line item — the terser-confirm path
+      // only fires when new-count matches existing-count. Uses Acme Corp
+      // because the other Draft demo quote (quote-bright-001) has two.
       const result = await runCliExpectSuccess([
         "quotes",
         "update",
-        "quote-bright-001",
+        "quote-acme-001",
         "--product",
         "Microsoft 365 E3",
         "--quantity",

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -1726,6 +1726,29 @@ export const quotes: Quote[] = [
     ],
   },
   {
+    // Single-line Draft quote — exercises the "terser confirm" path in
+    // `quotes update` (no destructive-warning UI when the new line-items
+    // count matches the existing count). The other Draft quote
+    // (quote-bright-001) has 2 items and triggers the destructive path.
+    id: "quote-acme-001",
+    companyId: ACME_ID,
+    createdDate: "2026-04-15",
+    expirationDate: "2026-05-15",
+    status: "Draft",
+    intentType: "PARTNER_TO_CLIENT",
+    published: false,
+    lineItems: [
+      {
+        id: "li-acme-001-a",
+        productId: "prod-m365-biz-prem-0001",
+        quantity: 10,
+        unitPrice: 22.0,
+        billingTerm: "Monthly",
+        subtotal: 220.0,
+      },
+    ],
+  },
+  {
     id: "quote-redwood-001",
     companyId: REDWOOD_ID,
     createdDate: "2026-02-20",


### PR DESCRIPTION
## Summary

Two small, related changes:

### 1. Add inventory entries for the commands shipped this evening

The recent domain-review PRs (#255–#267) added 9 new commands but the per-command matrix wasn't extended, so they ship without smoke / invariant / JSON-contract / help-flag gating. Adding them now:

| New command | Type | In matrix as |
|---|---|---|
| `webhooks show <id>` | read | resolveArgs → first webhook ID |
| `webhooks topics list` | read | minRows: 1, JSON contract on `topic` field |
| `webhooks update / enable / disable <id>` | write | `skipLiveRun` (3 entries, --help still tested) |
| `quotes send <quote-id>` | write | `skipLiveRun` |
| `quotes line-items list <quote-id>` | read | resolveArgs → first quote ID |
| `quotes line-items add / remove …` | write | `skipLiveRun` (2 entries) |

Matrix grows 207 → 231 tests (≈24 new). Green on first run — these commands all pass the invariants the matrix gates (no `undefined` leaks, valid single-object JSON for shows, working `--help`, etc).

### 2. Fix the pre-existing failure on `main`

`packages/cli/src/__tests__/quotes.update.test.ts` "uses the terser confirm" has been broken on `main` since #266 landed: the test was added in #264 expecting `quote-bright-001` to have a single line item, but #266 then changed that quote to two items, so the destructive-replace warning now fires. Result: `pnpm test` on a fresh `main` checkout fails 1 test.

Fix: add a new single-line Draft demo quote (`quote-acme-001`, on Acme Corp) and point the terser-confirm test at it. The destructive-warning test stays on `quote-bright-001` (still 2 items, correctly).

## Why bundled

The matrix sync exposed the failure on main (the full test suite runs alongside the matrix in CI). Fixing both in one PR keeps reviewer surface small and unblocks main from the test-fixture mismatch.

## Test plan
- [x] `pnpm build` clean
- [x] Matrix: 231 passed (was 207 — 24 new entries)
- [x] `pnpm test` — 1498 passed / 8 skipped (was 1497 + 1 fail before quotes-test fix)
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)