### PR TITLE
refactor(webhooks): rename --events to --topics with deprecation alias

### DIFF
--- a/.changeset/webhooks-events-topics-rename.md
+++ b/.changeset/webhooks-events-topics-rename.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+`pax8 webhooks create`: renamed `--events` to `--topics` for consistency with the API field name (`webhookTopics`) and the CLI's own `Webhook.topics[]` output schema. `--events` is preserved as a deprecated alias that still functions identically but prints a one-line deprecation notice on stderr; it will be removed in v1.0. Passing both `--topics` and `--events` simultaneously is rejected with `ERROR_INVALID_INPUT`. No-change for scripts already calling `--events`; new scripts and docs should prefer `--topics`. Refs #273.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - **Display labels** — `report-bug` no-prior-error now exits 0 with a manual-file-a-bug pointer instead of exiting 1 silently; the with-context flow (sanitize, prompt, submit) is unchanged (#209).
 - **`auth status --json`** now emits valid JSON (`{ authenticated, mode, clientIdMasked? }`) and respects the agent-first non-TTY contract; previously it printed human-formatted text regardless of `--json` (#210).
 
+### Deprecated
+
+- **`pax8 webhooks create --events`** renamed to `--topics` to match the API field name (`webhookTopics`) and the CLI's own `Webhook.topics[]` output. `--events` continues to function as a deprecated alias and prints a one-line deprecation notice on stderr; it will be removed in v1.0. Passing both `--topics` and `--events` is rejected with `ERROR_INVALID_INPUT` (#273).
+
 ### Fixed
 
 - **`orders show <id>`** — rendered "Company: undefined" and an empty Line Items section. Now joins `companyId` → company name (matching `subscriptions show`/`invoices show` pattern) and resolves `orderItems[].productId` → product name; adds per-line-item unit price column. Same enrichment in human and `--json` output (#194).

--- a/docs/domain-review.md
+++ b/docs/domain-review.md
@@ -401,7 +401,7 @@ The seven categories, the seven cross-sell rules, the seat-gap thresholds (10 se
 |---|---|---|---|
 | `pax8 webhooks list` | `--ids-only`, `--with-actions` | | |
 | `pax8 webhooks show <id>` | | | View a single webhook subscription [Added in #265] |
-| `pax8 webhooks create` | `--url`, `--events <comma-list>`, `-y` | | |
+| `pax8 webhooks create` | `--url`, `--topics <comma-list>`, `-y` (with `--events` as a deprecated alias) | | |
 | `pax8 webhooks update <id>` | `--display-name`, `--authorization`, `--contact-email`, `--error-threshold`, `-y` | | Configures the four mutable fields via `PUT /webhooks/{id}/configuration` [Added in #265]; redacts `--authorization` in echo |
 | `pax8 webhooks enable <id>` | `-y` | | Sets `active=true` via `PUT /webhooks/{id}/status` [Added in #265] |
 | `pax8 webhooks disable <id>` | `-y` | | Sets `active=false` via `PUT /webhooks/{id}/status` [Added in #265] |
@@ -427,7 +427,7 @@ API `Webhook` fields: `id, accountId, displayName, url, authorization, active, c
 |---|---|---|
 | `active` (boolean) | `status: 'Active'\|'Disabled'` | Boolean ↔ enum mapping |
 | `webhookTopics[]` (objects with filters/config) | `topics[]` (strings) | CLI flattens to topic names |
-| `--events` flag | `topics` (API) | Flag name disagrees with API field name |
+| `--events` flag | `topics` (API) | Renamed to `--topics`; `--events` kept as a deprecated alias [#273] |
 | `createdAt` / `updatedAt` | `createdDate` | Rename + `updatedAt` dropped |
 | `displayName`, `authorization`, `contactEmail`, `errorThreshold`, `integrationId`, `accountId`, `lastDeliveryStatus` | (not exposed) | |
 
@@ -438,14 +438,14 @@ API `Webhook` fields: `id, accountId, displayName, url, authorization, active, c
 
 ### Naming Drift Flags
 
-- `--events` flag vs `topics` in the API and in the CLI's own output schema. Pick one term.
+- `--events` flag vs `topics` in the API and in the CLI's own output schema. Resolved in #273: canonical flag is now `--topics`; `--events` retained as a deprecated alias until v1.0.
 - The CLI calls webhooks "subscriptions" in help text ("Create a webhook subscription") — collides with the Subscriptions domain.
 - API `active: true/false` vs CLI `status: 'Active'/'Disabled'` — same bit, different shape; the new `webhooks enable`/`disable` commands abstract the boolean away.
 - `secret` provenance is now documented in the schema's JSDoc (HMAC-signing secret, returned on POST response only) [Resolved in #254].
 
 ### Questions for Domain Owner
 
-1. Should `--events` be renamed `--topics` for consistency with the API and the CLI's own `Webhook.topics[]` field?
+1. ~~Should `--events` be renamed `--topics` for consistency with the API and the CLI's own `Webhook.topics[]` field?~~ Resolved in #273: yes, with `--events` kept as a deprecated alias.
 2. Should `webhooks` be called something else to avoid clashing with the Subscriptions domain?
 3. Should the CLI add `webhooks topics add/remove/replace` for fine-grained per-topic config, or is the current "set whole list at create time" enough?
 4. Should `webhooks update` also expose `--integration-id`?
@@ -503,7 +503,7 @@ The Pax8 internal **Preliminary Workflows** doc enumerates canonical end-to-end 
 | 1. CRM trigger creates a quote draft | `POST /v2/quotes` | `pax8 quotes create --company X --product Y --quantity N` |
 | 2. Add additional line items to the draft | `POST /v2/quotes/{id}/line-items` | `pax8 quotes line-items add <quote-id> --product Y --quantity N` (#266) |
 | 3. Set status to sent (generates customer-facing link) | `PUT /v2/quotes/{id}` with `status: "sent"` | `pax8 quotes send <quote-id>` (#266) |
-| 4. Subscribe to QUOTE.Accepted webhook events | `POST /webhooks` with `topics: ["QUOTE.Accepted"]` | `pax8 webhooks create --url X --events QUOTE.Accepted`; discover topics via `pax8 webhooks topics list` (#267) |
+| 4. Subscribe to QUOTE.Accepted webhook events | `POST /webhooks` with `topics: ["QUOTE.Accepted"]` | `pax8 webhooks create --url X --topics QUOTE.Accepted`; discover topics via `pax8 webhooks topics list` (#267) |
 | 5. On QUOTE.Accepted, trigger order placement | `POST /orders` | `pax8 orders create --company X --product Y --quantity N` |
 
 **Naming-coordination note:** the workflow assumes the `pax8-submit-order` MCP tool (Linear AI-865) and the CLI's `orders create` will eventually converge on the same vocabulary. Flag-naming coordination between the CLI team and the MCP team is worth doing once, before partners start building automations against both.

--- a/e2e/webhooks-workflow.test.ts
+++ b/e2e/webhooks-workflow.test.ts
@@ -35,7 +35,7 @@ describe("E2E: Webhooks workflow — list, create, test, logs, delete", () => {
     }
   });
 
-  it("pax8 webhooks create requires --url and --events", async () => {
+  it("pax8 webhooks create requires --url and --topics", async () => {
     const result = await runCliExpectFailure(["webhooks", "create"]);
     expect(result.stderr.length).toBeGreaterThan(0);
   });
@@ -46,7 +46,7 @@ describe("E2E: Webhooks workflow — list, create, test, logs, delete", () => {
       "create",
       "--url",
       "not-a-url",
-      "--events",
+      "--topics",
       "subscription.created",
       "--yes",
     ]);
@@ -59,7 +59,7 @@ describe("E2E: Webhooks workflow — list, create, test, logs, delete", () => {
       "create",
       "--url",
       "https://example.com/e2e-hook",
-      "--events",
+      "--topics",
       "subscription.created,invoice.paid",
       "--yes",
       "--json",

--- a/packages/cli/src/__tests__/webhooks.test.ts
+++ b/packages/cli/src/__tests__/webhooks.test.ts
@@ -89,3 +89,68 @@ describe("pax8 webhooks test", () => {
     expect(inner.responseCode).toBe(502);
   });
 });
+
+describe("pax8 webhooks create — --topics canonical with --events deprecated alias (#273)", () => {
+  it("accepts --topics and persists the webhook", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "create",
+      "--url",
+      "https://example.com/topics-hook",
+      "--topics",
+      "subscription.created,invoice.paid",
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.url).toBe("https://example.com/topics-hook");
+    expect(data.topics).toEqual(["subscription.created", "invoice.paid"]);
+    // Canonical flag must not emit the deprecation banner.
+    expect(result.stderr).not.toContain("--events is deprecated");
+  });
+
+  it("still accepts --events as a deprecated alias and warns on stderr", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "create",
+      "--url",
+      "https://example.com/events-hook",
+      "--events",
+      "subscription.created",
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.url).toBe("https://example.com/events-hook");
+    expect(data.topics).toEqual(["subscription.created"]);
+    expect(result.stderr).toContain(
+      "--events is deprecated; use --topics. Will be removed in v1.0.",
+    );
+  });
+
+  it("errors clearly when both --topics and --events are passed", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "create",
+      "--url",
+      "https://example.com/dup-hook",
+      "--topics",
+      "subscription.created",
+      "--events",
+      "invoice.paid",
+      "--yes",
+    ]);
+    expect(result.stderr).toContain("Specify only one of --topics or --events");
+  });
+
+  it("--help mentions --topics as canonical and --events as deprecated", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "create",
+      "--help",
+    ]);
+    expect(result.stdout).toContain("--topics");
+    expect(result.stdout).toContain("--events");
+    expect(result.stdout.toLowerCase()).toContain("deprecated");
+  });
+});

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -11,7 +11,7 @@ import { confirm, replCmd } from "../../lib/confirm.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 
-function parseEvents(input: string): string[] {
+function parseTopics(input: string): string[] {
   return input
     .split(",")
     .map((s) => s.trim())
@@ -30,17 +30,26 @@ function isValidUrl(input: string): boolean {
 export const webhooksCreateCommand = new Command("create")
   .description("Create a webhook subscription")
   .requiredOption("--url <url>", "Webhook delivery URL (https recommended)")
-  .requiredOption(
-    "--events <comma-separated-events>",
+  .option(
+    "--topics <comma-separated-topics>",
     'Topics to subscribe to, comma-separated (e.g. "subscription.created,invoice.paid")',
+  )
+  // Deprecated alias for `--topics`. Kept for backward compatibility with
+  // anyone who scripted against the v0.1 surface; emits a deprecation notice
+  // on stderr and will be removed in v1.0. Refs #273.
+  .option(
+    "--events <comma-separated-topics>",
+    "[deprecated] Alias for --topics. Will be removed in v1.0.",
   )
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
     `
 Examples:
-  pax8 webhooks create --url https://example.com/hook --events subscription.created,subscription.cancelled
-  pax8 webhooks create --url https://example.com/hook --events invoice.paid --yes`,
+  pax8 webhooks create --url https://example.com/hook --topics subscription.created,subscription.cancelled
+  pax8 webhooks create --url https://example.com/hook --topics invoice.paid --yes
+
+Note: --events is a deprecated alias for --topics; it still works but will be removed in v1.0.`,
   )
   .action(async (_options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -49,14 +58,53 @@ Examples:
       const ctx = await buildContext(allOpts);
 
       const url = String(allOpts.url);
-      const topics = parseEvents(String(allOpts.events));
+
+      // Resolve the canonical `--topics` value, accepting `--events` as a
+      // deprecated alias. Erroring if both are passed avoids a silent
+      // ambiguity when the two values disagree.
+      const topicsRaw = allOpts.topics as string | undefined;
+      const eventsRaw = allOpts.events as string | undefined;
+
+      if (topicsRaw !== undefined && eventsRaw !== undefined) {
+        throw new CliError(
+          "Specify only one of --topics or --events",
+          [
+            "--events is a deprecated alias for --topics; passing both is ambiguous.",
+          ],
+          [
+            `Example: ${replCmd("pax8 webhooks create")} --url ${url} --topics subscription.created,invoice.paid`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      if (topicsRaw === undefined && eventsRaw === undefined) {
+        throw new CliError(
+          "Missing required option: --topics",
+          ["--topics must contain one or more comma-separated topic names"],
+          [
+            `Example: ${replCmd("pax8 webhooks create")} --url ${url} --topics subscription.created,invoice.paid`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      if (eventsRaw !== undefined) {
+        process.stderr.write(
+          "warning: --events is deprecated; use --topics. Will be removed in v1.0.\n",
+        );
+      }
+
+      const topics = parseTopics(String(topicsRaw ?? eventsRaw));
 
       if (!isValidUrl(url)) {
         throw new CliError(
           `Invalid webhook URL: "${url}"`,
           ["URL must be an http:// or https:// URL"],
           [
-            `Example: ${replCmd("pax8 webhooks create")} --url https://example.com/hook --events subscription.created`,
+            `Example: ${replCmd("pax8 webhooks create")} --url https://example.com/hook --topics subscription.created`,
           ],
           undefined,
           ERROR_INVALID_INPUT,
@@ -66,9 +114,9 @@ Examples:
       if (topics.length === 0) {
         throw new CliError(
           "At least one event topic is required",
-          ["--events must contain one or more comma-separated topic names"],
+          ["--topics must contain one or more comma-separated topic names"],
           [
-            `Example: ${replCmd("pax8 webhooks create")} --url ${url} --events subscription.created,invoice.paid`,
+            `Example: ${replCmd("pax8 webhooks create")} --url ${url} --topics subscription.created,invoice.paid`,
           ],
           undefined,
           ERROR_INVALID_INPUT,

--- a/packages/cli/src/commands/webhooks/list.ts
+++ b/packages/cli/src/commands/webhooks/list.ts
@@ -45,7 +45,7 @@ Examples:
           const nextActions: { command: string; description: string }[] = [];
           if (webhooks.length === 0) {
             nextActions.push({
-              command: "pax8 webhooks create --url <url> --events <comma-separated-events>",
+              command: "pax8 webhooks create --url <url> --topics <comma-separated-topics>",
               description: "Create your first webhook subscription",
             });
           } else {
@@ -108,7 +108,7 @@ Examples:
         if (webhooks.length === 0) {
           process.stderr.write(chalk.dim("\n  Try next:\n"));
           process.stderr.write(
-            `    ${chalk.cyan(replCmd("pax8 webhooks create --url <url> --events <events>"))}  ${chalk.dim("create your first subscription")}\n`,
+            `    ${chalk.cyan(replCmd("pax8 webhooks create --url <url> --topics <topics>"))}  ${chalk.dim("create your first subscription")}\n`,
           );
         } else {
           const first = webhooks[0];

--- a/packages/cli/src/commands/webhooks/topics/list.ts
+++ b/packages/cli/src/commands/webhooks/topics/list.ts
@@ -53,7 +53,7 @@ Examples:
           if (sorted.length > 0) {
             nextActions.push({
               command:
-                "pax8 webhooks create --url https://example.com/hook --events " +
+                "pax8 webhooks create --url https://example.com/hook --topics " +
                 sorted[0].topic,
               description: "Create a webhook subscribed to this topic",
             });
@@ -86,7 +86,7 @@ Examples:
         if (sorted.length > 0) {
           process.stderr.write(chalk.dim("\n  Try next:\n"));
           process.stderr.write(
-            `    ${chalk.cyan(replCmd(`pax8 webhooks create --url https://example.com/hook --events ${sorted[0].topic}`))}  ${chalk.dim("subscribe to a topic")}\n`,
+            `    ${chalk.cyan(replCmd(`pax8 webhooks create --url https://example.com/hook --topics ${sorted[0].topic}`))}  ${chalk.dim("subscribe to a topic")}\n`,
           );
           process.stderr.write("\n");
         }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -497,7 +497,7 @@ export type WebhookLog = z.infer<typeof WebhookLogSchema>;
  * Discoverable topic exposed by `GET /webhooks/topic-definitions`.
  *
  * Per the public webhooks OpenAPI spec, every topic carries a `topic` slug
- * (the value passed to `--events` on create) plus a human `name` and
+ * (the value passed to `--topics` on create) plus a human `name` and
  * `description`. The optional `availableFilters` and `samplePayload` fields
  * are also defined by the upstream `TopicDefinition` schema; they're parsed
  * loosely (`z.unknown()`) because the CLI surface only needs `topic` and


### PR DESCRIPTION
## Summary

Implements **fix #3 from #273**: the webhook flag `--events` disagreed with the API's `webhookTopics` field and the CLI's own `Webhook.topics[]` output. This PR aligns the flag name with both, while preserving backward compatibility for anyone who scripted against the v0.1 surface.

- Rename `--events` → `--topics` on `pax8 webhooks create` (canonical).
- Keep `--events` as a **deprecated alias** that still functions identically but prints `warning: --events is deprecated; use --topics. Will be removed in v1.0.` to stderr.
- Passing both `--topics` and `--events` is rejected with `ERROR_INVALID_INPUT` to avoid silent ambiguity.
- Updated help text, hint strings on the empty-state `webhooks list` and on `webhooks topics list` Try-Next, e2e tests, the topic-definition JSDoc comment in `@pax8/core`, and `docs/domain-review.md`.
- Added a Changeset entry (`@pax8/cli: patch`), separate from the in-flight JSON-field-rename PR (PR A).

No file overlap with the sibling JSON-rename PR. The API call body is unchanged (`webhooks.create({ url, topics })`); only the user-facing flag name changes.

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` — full suite green (1502 passing)
- [x] `pnpm lint` clean
- [x] New tests in `packages/cli/src/__tests__/webhooks.test.ts`:
  - `--topics` works and does **not** emit the deprecation warning
  - `--events` still works **and** emits the deprecation warning to stderr
  - Specifying both flags errors with "Specify only one of --topics or --events"
  - `--help` mentions both flags and the word "deprecated"
- [x] e2e tests (`e2e/webhooks-workflow.test.ts`) updated to exercise `--topics`

## Out of scope

- `topics add/remove/replace` commands (deferred per issue's Out of Scope).
- Other fixes from #273 (the JSON field renames are PR A).

Refs #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)