### PR TITLE
refactor(types): align InvoiceItem/Company/Quote field names with public API (refs #273)

### DIFF
--- a/.changeset/issue-273-json-field-renames.md
+++ b/.changeset/issue-273-json-field-renames.md
@@ -1,0 +1,14 @@
+---
+"@pax8/cli": minor
+"@pax8/core": minor
+---
+
+**Breaking (`--json` consumers): Field naming aligned with the public Pax8 API.**
+
+- `InvoiceItem.subtotal` → `subTotal`
+- `InvoiceItem.unitPrice` → `price`
+- `Company.modified` → `updatedDate`
+- `Quote.expirationDate` → `expiresOn`
+- `Quote.createdDate` → `createdOn`
+
+Acceptable while pre-1.0; the CLI now uses API field names directly so partners reading both surfaces don't have to translate. The `--expiration-date` CLI flag on `pax8 quotes create` and `pax8 quotes update` is unchanged — flag vocabulary and field vocabulary are intentionally separate concerns. (refs #273)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed
 
+- **`--json` field names aligned with the public Pax8 API** — `InvoiceItem.subtotal` → `subTotal`, `InvoiceItem.unitPrice` → `price`, `Company.modified` → `updatedDate`, `Quote.expirationDate` → `expiresOn`, `Quote.createdDate` → `createdOn`. Breaking for `--json` consumers; acceptable pre-1.0 since partners reading both surfaces no longer have to translate. The `--expiration-date` CLI flag on `pax8 quotes create`/`update` is intentionally unchanged — flag vocabulary and field vocabulary are separate concerns (#273).
 - **Display labels** — `report-bug` no-prior-error now exits 0 with a manual-file-a-bug pointer instead of exiting 1 silently; the with-context flow (sanitize, prompt, submit) is unchanged (#209).
 - **`auth status --json`** now emits valid JSON (`{ authenticated, mode, clientIdMasked? }`) and respects the agent-first non-TTY contract; previously it printed human-formatted text regardless of `--json` (#210).
 

--- a/docs/domain-review.md
+++ b/docs/domain-review.md
@@ -78,7 +78,7 @@ API `Company`: `id, name, address, phone, website, status, billOnBehalfOfEnabled
 | `address.stateOrProvince` (query) / `state` (body) | `--state` | API is inconsistent; CLI normalizes to `state` |
 | `address.postalCode` (query) / `zip` (body) | `--zip` | Same — CLI picks the shorter body field |
 | `externalId` | (not exposed) | API surfaces a partner-side external ID; CLI hides it |
-| `updatedDate` | `modified` | CLI rename |
+| `updatedDate` | `updatedDate` | Aligned with API in #273 (was `modified`) |
 | `createdDate` (Contact) | (not exposed on Contact) | Only surfaced on Company-ish resources |
 | `contacts[]` (embedded on Company) | (separate `contacts list`) | CLI separates rather than embeds |
 | `types[]` (array of `Admin\|Billing\|Technical`) | `--type <comma-list>` | CLI accepts multiple types as a comma-separated string [Resolved in #255] |
@@ -92,7 +92,7 @@ API `Company`: `id, name, address, phone, website, status, billOnBehalfOfEnabled
 
 - `--type` accepts one value; API accepts an array. [Resolved in #255 — comma-separated list now accepted on both create and update.]
 - `companies update` cannot change address or the three boolean billing flags. Confirm whether this is an intentional safety choice or an oversight.
-- CLI `Company.modified` vs API `updatedDate` — pick one and align.
+- CLI `Company.modified` vs API `updatedDate` — pick one and align. [Resolved in #273 — renamed to `updatedDate`.]
 
 ### Questions for Domain Owner
 
@@ -177,7 +177,7 @@ API `SubscriptionStatus` enum: `Active, Cancelled, PendingManual, PendingAutomat
 
 CLI `Invoice`: `id, companyId, invoiceDate, dueDate, status?, total, balance, companyName` [`status` is now optional, post-#260].
 CLI `InvoiceStatus` enum: `Unpaid, Paid, Void, Carried` [Aligned with the OpenAPI `Invoice.example` in #260 — `Carry` renamed to `Carried`; `Nothing` and the `Overdue` filter alias removed].
-CLI `InvoiceItem`: `id, invoiceId, productId, subscriptionId, quantity, unitPrice, subtotal, companyId, productName, companyName`.
+CLI `InvoiceItem`: `id, invoiceId, productId, subscriptionId, quantity, price, subTotal, companyId, productName, companyName` [`price`/`subTotal` aligned with API in #273; previously exposed as `unitPrice`/`subtotal`].
 
 ### Public API Surface
 
@@ -192,8 +192,8 @@ API `InvoiceItem` fields (32 total — selected): `id, productId, productName, s
 | API Term | CLI Term | Notes |
 |---|---|---|
 | `status` (in query param + spec example, missing from properties) | `status?` (typed enum, optional) | CLI now mirrors the spec example; pending docs fix on Pax8 side [Resolved in #260] |
-| `subTotal` (capital T) | `subtotal` | Casing change |
-| `price` | `unitPrice` | Rename |
+| `subTotal` (capital T) | `subTotal` | Aligned with API in #273 (was `subtotal`) |
+| `price` | `price` | Aligned with API in #273 (was `unitPrice`) |
 | `monthOffset` (draft-items query) | `--month YYYY-MM` | CLI normalizes to a calendar month |
 | `startPeriod`, `endPeriod`, `term`, `chargeType`, `rateType`, `type`, `billingFee`, `billingFeeRate`, `salesTax`, `cost`, `costTotal`, `amountDue`, `unitOfMeasure`, `vendorName`, `offeredBy`, `billedByPax8`, `purchaseOrderNumber`, `sku`, `externalId`, `description`, `details` | (not exposed) | InvoiceItem cost/period/category breakdown collapsed |
 | `carriedBalance`, `currencyCode`, `partnerName` (Invoice) | (not exposed) | |
@@ -213,7 +213,7 @@ API `InvoiceItem` fields (32 total — selected): `id, productId, productName, s
 ### Naming Drift Flags
 
 - `Invoice.status` is now aligned with the spec example (`Unpaid`, `Paid`, `Void`, `Carried`) and optional [Resolved in #260]. A docs ticket against the public OpenAPI to add `status` to `Invoice.properties` is the remaining follow-up.
-- `subtotal` vs `subTotal`, `unitPrice` vs `price` — pick one casing/term per concept.
+- `subtotal` vs `subTotal`, `unitPrice` vs `price` — pick one casing/term per concept. [Resolved in #273 — both renamed to match API: `subTotal` and `price`.]
 - The CLI hides everything between gross subtotal and net amount due (fees, tax, cost). Partners doing margin analysis cannot get `cost`/`partnerCost` from the CLI.
 
 ### Questions for Domain Owner
@@ -254,7 +254,7 @@ CLI `Order`: `id, companyId, companyName, orderedBy, orderedByEmail, status, cre
 | `pax8 quotes line-items remove <quote-id> <line-item-id>` | `-y` | | Removes a single line item [Added in #266] |
 | `pax8 quotes send <quote-id>` | `-y` | | Sets quote status to `sent` (generates customer-facing link) via `PUT /v2/quotes/{id}` [Added in #266] |
 
-CLI `Quote`: `id, companyId, createdDate, expirationDate, status, lineItems[{id, productId, quantity, billingTerm, unitPrice, subtotal}], acceptedBy?, declinedBy?, respondedOn?, revokedOn?, publishedOn?, published?, referenceCode?, salesMarginPercentage?, intentType?` [accept/decline workflow fields added in #261; line-item `id` surfaced for use with `line-items remove`].
+CLI `Quote`: `id, companyId, createdOn, expiresOn, status, lineItems[{id, productId, quantity, billingTerm, unitPrice, subtotal}], acceptedBy?, declinedBy?, respondedOn?, revokedOn?, publishedOn?, published?, referenceCode?, salesMarginPercentage?, intentType?` [accept/decline workflow fields added in #261; line-item `id` surfaced for use with `line-items remove`; top-level dates aligned with API in #273].
 
 ### Public API Surface — Quotes (v2)
 
@@ -272,8 +272,8 @@ API `Quote.status` enum: `draft, assigned, sent, closed, declined, accepted, cha
 | `orderedByUserId` | (not exposed) | |
 | `isScheduled` | (not exposed) | |
 | `isMock` (POST query) | `--dry-run` | [Resolved in #259] |
-| `expiresOn` | `expirationDate` | Rename |
-| `createdOn` | `createdDate` | Rename |
+| `expiresOn` | `expiresOn` | Aligned with API in #273 (was `expirationDate`); the `--expiration-date` CLI flag is intentionally unchanged |
+| `createdOn` | `createdOn` | Aligned with API in #273 (was `createdDate`) |
 | `intentType` | `intentType?` (read-only) | Surfaced in `Quote` schema [Added in #261]; not yet a `--intent-type` write flag |
 | `acceptedBy`, `declinedBy`, `respondedOn`, `revokedOn`, `publishedOn`, `published`, `referenceCode`, `salesMarginPercentage` | same names (read-only, optional) | [Resolved in #261] |
 | `partner`, `client`, `ownedBy`, `introMessage`, `termsAndDisclaimers`, `totals`, `quoteRequestId`, `attachments` | (not exposed) | Still flattened away |
@@ -289,7 +289,7 @@ API `Quote.status` enum: `draft, assigned, sent, closed, declined, accepted, cha
 
 - `Order.status` filter-help vocabulary still does not match any documented enum. Confirm what statuses partners actually see.
 - `Quote.status` filter help is now lowercase to match the API [Resolved in #261].
-- `expirationDate` (CLI) vs `expiresOn` (API): keep one.
+- `expirationDate` (CLI) vs `expiresOn` (API): keep one. [Resolved in #273 — schema renamed to `expiresOn`; the `--expiration-date` CLI flag is intentionally preserved as a deliberate ergonomics-vs-vocabulary split.]
 - The CLI quotes surface still hides about half of the v2 model (sections, attachments, access-list, take-ownership). The newly added line-items subcommands and `send` cover the most-requested workflow gaps.
 - `quotes update --product` is no longer silently destructive — it shows a default-no `REPLACES` confirmation [Resolved in #264]. The non-destructive path is `quotes line-items add/remove` [#266].
 

--- a/e2e/billing-workflow.test.ts
+++ b/e2e/billing-workflow.test.ts
@@ -30,7 +30,7 @@ describe("E2E: Billing workflow — invoice and audit", () => {
     expect(data.length).toBeGreaterThan(0);
     expect(data[0]).toHaveProperty("id");
     expect(data[0]).toHaveProperty("quantity");
-    expect(data[0]).toHaveProperty("unitPrice");
+    expect(data[0]).toHaveProperty("price");
   });
 
   it("pax8 invoices audit shows discrepancy report", async () => {

--- a/e2e/quotes-workflow.test.ts
+++ b/e2e/quotes-workflow.test.ts
@@ -14,7 +14,7 @@ describe("E2E: Quotes workflow — list, show, write commands", () => {
     expect(first).toHaveProperty("id");
     expect(first).toHaveProperty("companyId");
     expect(first).toHaveProperty("status");
-    expect(first).toHaveProperty("createdDate");
+    expect(first).toHaveProperty("createdOn");
     expect(first).toHaveProperty("lineItems");
   });
 
@@ -143,7 +143,7 @@ describe("E2E: Quotes workflow — list, show, write commands", () => {
     ]);
     const data = JSON.parse(result.stdout);
     expect(data[0].id).toBe(id);
-    expect(data[0].expirationDate).toBe("2026-12-31");
+    expect(data[0].expiresOn).toBe("2026-12-31");
   });
 
   it("pax8 quotes update fails when no fields are provided", async () => {

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -103,8 +103,8 @@ describe("pax8 invoices", () => {
       expect(data.length).toBeGreaterThan(0);
       expect(data[0]).toHaveProperty("productName");
       expect(data[0]).toHaveProperty("quantity");
-      expect(data[0]).toHaveProperty("unitPrice");
-      expect(data[0]).toHaveProperty("subtotal");
+      expect(data[0]).toHaveProperty("price");
+      expect(data[0]).toHaveProperty("subTotal");
     });
 
     it("filters items by invoice ID", async () => {

--- a/packages/cli/src/__tests__/quotes.test.ts
+++ b/packages/cli/src/__tests__/quotes.test.ts
@@ -14,7 +14,7 @@ describe("pax8 quotes", () => {
       expect(data[0]).toHaveProperty("id");
       expect(data[0]).toHaveProperty("companyId");
       expect(data[0]).toHaveProperty("status");
-      expect(data[0]).toHaveProperty("createdDate");
+      expect(data[0]).toHaveProperty("createdOn");
     });
 
     it("filters by lowercase status (matches API enum)", async () => {

--- a/packages/cli/src/commands/invoices/items.ts
+++ b/packages/cli/src/commands/invoices/items.ts
@@ -51,13 +51,13 @@ Examples:
         { key: "companyName", header: "Company", width: 22 },
         { key: "quantity", header: "Qty", width: 8 },
         {
-          key: "unitPrice",
+          key: "price",
           header: "Unit Price",
           width: 14,
           format: (v) => formatCurrency(Number(v)),
         },
         {
-          key: "subtotal",
+          key: "subTotal",
           header: "Subtotal",
           width: 14,
           format: (v) => formatCurrency(Number(v)),

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -80,8 +80,8 @@ Examples:
         { key: "id", header: "ID", width: 14, format: (v) => chalk.dim(String(v).slice(0, 12)) },
         { key: "companyId", header: "Company ID", width: 14, format: (v) => chalk.dim(String(v).slice(0, 12)) },
         { key: "status", header: "Status", width: 12 },
-        { key: "createdDate", header: "Created", width: 14, format: (v) => formatDate(String(v)) },
-        { key: "expirationDate", header: "Expires", width: 14, format: (v) => v ? formatDate(String(v)) : "—" },
+        { key: "createdOn", header: "Created", width: 14, format: (v) => formatDate(String(v)) },
+        { key: "expiresOn", header: "Expires", width: 14, format: (v) => v ? formatDate(String(v)) : "—" },
         { key: "_items", header: "Items", width: 7 },
         { key: "_total", header: "Total", width: 12, format: (v) => formatCurrency(Number(v)) },
       ];

--- a/packages/cli/src/commands/quotes/show.ts
+++ b/packages/cli/src/commands/quotes/show.ts
@@ -72,9 +72,9 @@ Examples:
       if (quote.intentType) {
         writeRow("Intent", quote.intentType);
       }
-      writeRow("Created", formatDate(quote.createdDate));
-      if (quote.expirationDate) {
-        writeRow("Expires", formatDate(quote.expirationDate));
+      writeRow("Created", formatDate(quote.createdOn));
+      if (quote.expiresOn) {
+        writeRow("Expires", formatDate(quote.expiresOn));
       }
       if (quote.publishedOn) {
         writeRow("Published", formatDate(quote.publishedOn));

--- a/packages/cli/src/commands/quotes/update.ts
+++ b/packages/cli/src/commands/quotes/update.ts
@@ -128,7 +128,10 @@ Note:
       }
 
       if (options.expirationDate) {
-        data.expirationDate = options.expirationDate;
+        // The `--expiration-date` CLI flag (camelCased to `options.expirationDate`
+        // by Commander) intentionally keeps its v0.1 vocabulary, but the schema
+        // field is `expiresOn` after #273 to match the public quoting API.
+        data.expiresOn = options.expirationDate;
       }
 
       if (Object.keys(data).length === 0) {
@@ -153,9 +156,9 @@ Note:
       process.stderr.write(chalk.bold("\n  Update Quote:\n\n"));
       process.stderr.write(`  ${chalk.dim("ID:".padEnd(18))}${current.id}\n`);
       process.stderr.write(`  ${chalk.dim("Current status:".padEnd(18))}${current.status}\n`);
-      if (data.expirationDate) {
+      if (data.expiresOn) {
         process.stderr.write(
-          `  ${chalk.dim("New expiration:".padEnd(18))}${chalk.green(data.expirationDate)}\n`,
+          `  ${chalk.dim("New expiration:".padEnd(18))}${chalk.green(data.expiresOn)}\n`,
         );
       }
 
@@ -254,8 +257,8 @@ Note:
       process.stdout.write("\n");
       process.stdout.write(`  ${chalk.dim("ID:".padEnd(14))}${updated.id}\n`);
       process.stdout.write(`  ${chalk.dim("Status:".padEnd(14))}${updated.status}\n`);
-      if (updated.expirationDate) {
-        process.stdout.write(`  ${chalk.dim("Expires:".padEnd(14))}${updated.expirationDate}\n`);
+      if (updated.expiresOn) {
+        process.stdout.write(`  ${chalk.dim("Expires:".padEnd(14))}${updated.expiresOn}\n`);
       }
       process.stdout.write(`  ${chalk.dim("Items:".padEnd(14))}${updated.lineItems?.length ?? 0}\n`);
       process.stdout.write("\n");

--- a/packages/core/src/api/invoices.test.ts
+++ b/packages/core/src/api/invoices.test.ts
@@ -35,8 +35,8 @@ const sampleInvoiceItem = {
   invoiceId: INVOICE_ID,
   productId: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
   quantity: 45,
-  unitPrice: 22.0,
-  subtotal: 990.0,
+  price: 22.0,
+  subTotal: 990.0,
   productName: "Microsoft 365 Business Premium [New Commerce Experience]",
 };
 

--- a/packages/core/src/api/quotes.test.ts
+++ b/packages/core/src/api/quotes.test.ts
@@ -22,8 +22,8 @@ const COMPANY_ID = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
 const sampleQuote = {
   id: QUOTE_ID,
   companyId: COMPANY_ID,
-  createdDate: "2026-01-15",
-  expirationDate: "2026-02-15",
+  createdOn: "2026-01-15",
+  expiresOn: "2026-02-15",
   status: "Draft",
   lineItems: [],
 };
@@ -77,14 +77,14 @@ describe("QuotesApi", () => {
   });
 
   it("update sends correct body", async () => {
-    const input = { expirationDate: "2026-03-15" };
-    const updated = { ...sampleQuote, expirationDate: "2026-03-15" };
+    const input = { expiresOn: "2026-03-15" };
+    const updated = { ...sampleQuote, expiresOn: "2026-03-15" };
     (client.put as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
 
     const result = await api.update(QUOTE_ID, input);
 
     expect(client.put).toHaveBeenCalledWith(`/quotes/${QUOTE_ID}`, input);
-    expect(result.expirationDate).toBe("2026-03-15");
+    expect(result.expiresOn).toBe("2026-03-15");
   });
 
   it("delete calls client.delete", async () => {

--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -48,7 +48,7 @@ describe("CompanySchema", () => {
     selfServiceAllowed: false,
     orderApprovalRequired: true,
     created: "2024-01-01T00:00:00Z",
-    modified: "2024-06-15T12:00:00Z",
+    updatedDate: "2024-06-15T12:00:00Z",
   };
 
   it("validates a correct payload", () => {
@@ -509,8 +509,8 @@ describe("InvoiceItemSchema", () => {
     productId: uuid,
     subscriptionId: uuid2,
     quantity: 45,
-    unitPrice: 22.5,
-    subtotal: 1012.5,
+    price: 22.5,
+    subTotal: 1012.5,
     companyId: uuid,
     productName: "Microsoft 365 Business Premium [New Commerce Experience]",
     companyName: "Acme Corp",
@@ -526,8 +526,8 @@ describe("InvoiceItemSchema", () => {
       invoiceId: uuid2,
       productId: uuid,
       quantity: 10,
-      unitPrice: 5.0,
-      subtotal: 50.0,
+      price: 5.0,
+      subTotal: 50.0,
     };
     expect(InvoiceItemSchema.parse(minimal)).toEqual(minimal);
   });
@@ -538,8 +538,8 @@ describe("InvoiceItemSchema", () => {
         id: uuid,
         invoiceId: uuid2,
         productId: uuid,
-        unitPrice: 5.0,
-        subtotal: 50.0,
+        price: 5.0,
+        subTotal: 50.0,
       }),
     ).toThrow();
   });
@@ -609,8 +609,8 @@ describe("QuoteSchema", () => {
   const valid = {
     id: uuid,
     companyId: uuid2,
-    createdDate: "2024-03-01",
-    expirationDate: "2024-04-01",
+    createdOn: "2024-03-01",
+    expiresOn: "2024-04-01",
     status: "Draft",
     lineItems: [
       { productId: uuid, quantity: 10, billingTerm: "Annual", unitPrice: 22.5, subtotal: 225.0 },
@@ -629,7 +629,7 @@ describe("QuoteSchema", () => {
 
   it("rejects missing status", () => {
     expect(() =>
-      QuoteSchema.parse({ id: uuid, companyId: uuid2, createdDate: "2024-03-01" }),
+      QuoteSchema.parse({ id: uuid, companyId: uuid2, createdOn: "2024-03-01" }),
     ).toThrow();
   });
 });

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -75,7 +75,7 @@ export const CompanySchema = z.object({
   selfServiceAllowed: z.boolean().optional(),
   orderApprovalRequired: z.boolean().optional(),
   created: z.string().optional(),
-  modified: z.string().optional(),
+  updatedDate: z.string().optional(),
 });
 export type Company = z.infer<typeof CompanySchema>;
 
@@ -321,8 +321,12 @@ export const InvoiceItemSchema = z.object({
   productId: z.string().uuid(),
   subscriptionId: z.string().uuid().optional(),
   quantity: z.number(),
-  unitPrice: z.number(),
-  subtotal: z.number(),
+  // Field names mirror the public Pax8 API: `price` (per-unit) and `subTotal`
+  // (line subtotal). Earlier CLI versions exposed these as `unitPrice` and
+  // `subtotal`; renamed in #273 (fixes #4) to align `--json` output with the
+  // upstream contract so partners reading both surfaces don't have to translate.
+  price: z.number(),
+  subTotal: z.number(),
   companyId: z.string().uuid().optional(),
   productName: z.string().optional(),
   companyName: z.string().optional(),
@@ -404,8 +408,13 @@ export type QuoteRespondedBy = z.infer<typeof QuoteRespondedBySchema>;
 export const QuoteSchema = z.object({
   id: z.string().uuid(),
   companyId: z.string().uuid(),
-  createdDate: z.string(),
-  expirationDate: z.string().optional(),
+  // Field names mirror the public quoting v2 API: `createdOn` and `expiresOn`.
+  // Earlier CLI versions exposed these as `createdDate` and `expirationDate`;
+  // renamed in #273 (fixes #8) to align `--json` output with the upstream
+  // contract. The `--expiration-date` CLI flag is unchanged — flag vocabulary
+  // and field vocabulary are intentionally separate concerns.
+  createdOn: z.string(),
+  expiresOn: z.string().optional(),
   status: z.string(),
   lineItems: z.array(QuoteLineItemSchema).optional(),
 
@@ -555,7 +564,7 @@ export const UpdateQuoteInputSchema = z.object({
     billingTerm: BillingTermSchema.optional(),
     provisioningDetails: z.record(z.string(), z.unknown()).optional(),
   })).optional(),
-  expirationDate: z.string().optional(),
+  expiresOn: z.string().optional(),
 });
 export type UpdateQuoteInput = z.infer<typeof UpdateQuoteInputSchema>;
 

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -112,9 +112,10 @@ export interface InvoiceItem {
   productId: string;
   productName: string;
   quantity: number;
-  unitPrice: number;
+  /** Per-unit price — mirrors the public `InvoiceItem` schema field name. */
+  price: number;
   /** Line subtotal — mirrors the public `InvoiceItem` schema field name. */
-  subtotal: number;
+  subTotal: number;
   subscriptionId?: string;
   billingPeriodStart: string;
   billingPeriodEnd: string;
@@ -178,8 +179,10 @@ export interface UsageLine {
 export interface Quote {
   id: string;
   companyId: string;
-  createdDate: string;
-  expirationDate?: string;
+  /** Mirrors the public quoting v2 API field name (was `createdDate`). */
+  createdOn: string;
+  /** Mirrors the public quoting v2 API field name (was `expirationDate`). */
+  expiresOn?: string;
   status: "Draft" | "Sent" | "Accepted" | "Declined";
   lineItems?: QuoteLineItem[];
 
@@ -1204,8 +1207,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-m365-biz-prem-0001",
     productName: "Microsoft 365 Business Premium [New Commerce Experience]",
     quantity: 95, // active is 85 → overcharge of 10 * $22 = $220
-    unitPrice: 22.0,
-    subtotal: 2090.0,
+    price: 22.0,
+    subTotal: 2090.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1217,8 +1220,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-defender-biz-0007",
     productName: "Microsoft Defender for Office 365 (Plan 1) [New Commerce Experience]",
     quantity: 85,
-    unitPrice: 3.0,
-    subtotal: 255.0,
+    price: 3.0,
+    subTotal: 255.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1230,8 +1233,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-s1-singularity-0010",
     productName: "CrowdStrike MSSP Complete Defend",
     quantity: 85,
-    unitPrice: 6.0,
-    subtotal: 510.0,
+    price: 6.0,
+    subTotal: 510.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1245,8 +1248,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-m365-e3-0003",
     productName: "Microsoft 365 E3 [New Commerce Experience]",
     quantity: 40,
-    unitPrice: 36.0,
-    subtotal: 1440.0,
+    price: 36.0,
+    subTotal: 1440.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1258,8 +1261,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-exo-plan2-0006",
     productName: "Exchange Online (Plan 2) [New Commerce Experience]",
     quantity: 40,
-    unitPrice: 8.0,
-    subtotal: 320.0,
+    price: 8.0,
+    subTotal: 320.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1274,8 +1277,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-m365-e3-0003",
     productName: "Microsoft 365 E3 [New Commerce Experience]",
     quantity: 100,
-    unitPrice: 36.0,
-    subtotal: 3600.0,
+    price: 36.0,
+    subTotal: 3600.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1288,8 +1291,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-exo-plan1-0005",
     productName: "Exchange Online (Plan 1) [New Commerce Experience]",
     quantity: 150,
-    unitPrice: 4.0,
-    subtotal: 600.0,
+    price: 4.0,
+    subTotal: 600.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1301,8 +1304,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-defender-biz-0007",
     productName: "Microsoft Defender for Office 365 (Plan 1) [New Commerce Experience]",
     quantity: 150,
-    unitPrice: 3.0,
-    subtotal: 450.0,
+    price: 3.0,
+    subTotal: 450.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1314,8 +1317,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-aad-p1-0008",
     productName: "Microsoft Entra ID P1 [New Commerce Experience]",
     quantity: 150,
-    unitPrice: 6.0,
-    subtotal: 900.0,
+    price: 6.0,
+    subTotal: 900.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1327,8 +1330,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-s1-singularity-0010",
     productName: "CrowdStrike MSSP Complete Defend",
     quantity: 150,
-    unitPrice: 6.0,
-    subtotal: 900.0,
+    price: 6.0,
+    subTotal: 900.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1340,8 +1343,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-acronis-backup-0009",
     productName: "AvePoint Cloud Backup for Microsoft 365",
     quantity: 30,
-    unitPrice: 8.5,
-    subtotal: 255.0,
+    price: 8.5,
+    subTotal: 255.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1356,8 +1359,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-m365-biz-basic-0002",
     productName: "Microsoft 365 Business Basic [New Commerce Experience]",
     quantity: 25,
-    unitPrice: 6.0,
-    subtotal: 150.0,
+    price: 6.0,
+    subTotal: 150.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1369,8 +1372,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-aad-p1-0008",
     productName: "Microsoft Entra ID P1 [New Commerce Experience]",
     quantity: 25, // No active Entra ID P1 subscription → unexpected charge
-    unitPrice: 6.0,
-    subtotal: 150.0,
+    price: 6.0,
+    subTotal: 150.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1385,8 +1388,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-m365-biz-prem-0001",
     productName: "Microsoft 365 Business Premium [New Commerce Experience]",
     quantity: 15,
-    unitPrice: 22.0,
-    subtotal: 330.0,
+    price: 22.0,
+    subTotal: 330.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1398,8 +1401,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-defender-biz-0007",
     productName: "Microsoft Defender for Office 365 (Plan 1) [New Commerce Experience]",
     quantity: 20, // active is 15 → overcharge of 5 * $3 = $15
-    unitPrice: 3.0,
-    subtotal: 60.0,
+    price: 3.0,
+    subTotal: 60.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1411,8 +1414,8 @@ export const invoiceItems: InvoiceItem[] = [
     productId: "prod-s1-singularity-0010",
     productName: "CrowdStrike MSSP Complete Defend",
     quantity: 15,
-    unitPrice: 6.0,
-    subtotal: 90.0,
+    price: 6.0,
+    subTotal: 90.0,
     billingPeriodStart: `${currentMonth}-01`,
     billingPeriodEnd: `${currentMonth}-28`,
   },
@@ -1671,8 +1674,8 @@ export const quotes: Quote[] = [
   {
     id: "quote-summit-001",
     companyId: SUMMIT_ID,
-    createdDate: "2026-03-10",
-    expirationDate: "2026-04-10",
+    createdOn: "2026-03-10",
+    expiresOn: "2026-04-10",
     status: "Sent",
     referenceCode: "Q-2026-001",
     intentType: "PARTNER_TO_CLIENT",
@@ -1701,8 +1704,8 @@ export const quotes: Quote[] = [
   {
     id: "quote-bright-001",
     companyId: BRIGHT_ID,
-    createdDate: "2026-03-05",
-    expirationDate: "2026-04-05",
+    createdOn: "2026-03-05",
+    expiresOn: "2026-04-05",
     status: "Draft",
     intentType: "PARTNER_TO_CLIENT",
     published: false,
@@ -1732,8 +1735,8 @@ export const quotes: Quote[] = [
     // (quote-bright-001) has 2 items and triggers the destructive path.
     id: "quote-acme-001",
     companyId: ACME_ID,
-    createdDate: "2026-04-15",
-    expirationDate: "2026-05-15",
+    createdOn: "2026-04-15",
+    expiresOn: "2026-05-15",
     status: "Draft",
     intentType: "PARTNER_TO_CLIENT",
     published: false,
@@ -1751,8 +1754,8 @@ export const quotes: Quote[] = [
   {
     id: "quote-redwood-001",
     companyId: REDWOOD_ID,
-    createdDate: "2026-02-20",
-    expirationDate: "2026-03-20",
+    createdOn: "2026-02-20",
+    expiresOn: "2026-03-20",
     status: "Accepted",
     referenceCode: "Q-2026-002",
     intentType: "PARTNER_TO_CLIENT",
@@ -1779,8 +1782,8 @@ export const quotes: Quote[] = [
   {
     id: "quote-coastline-001",
     companyId: COASTLINE_ID,
-    createdDate: "2026-02-12",
-    expirationDate: "2026-03-12",
+    createdOn: "2026-02-12",
+    expiresOn: "2026-03-12",
     status: "Declined",
     referenceCode: "Q-2026-003",
     intentType: "PARTNER_TO_CLIENT",

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -589,8 +589,8 @@ class QuotesResource {
     const newQuote: Quote = {
       id: `quote-demo-${Date.now()}`,
       companyId: data.companyId ?? "",
-      createdDate: new Date().toISOString().split("T")[0],
-      ...(data.expirationDate ? { expirationDate: data.expirationDate } : {}),
+      createdOn: new Date().toISOString().split("T")[0],
+      ...(data.expiresOn ? { expiresOn: data.expiresOn } : {}),
       status: "Draft",
       lineItems: data.lineItems ?? [],
     };

--- a/packages/core/src/services/invoice-auditor.ts
+++ b/packages/core/src/services/invoice-auditor.ts
@@ -7,7 +7,12 @@ import type { InvoiceItem, Subscription } from "../api/types.js";
 type AuditInvoiceItemInput = Partial<InvoiceItem> & {
   companyName?: string;
   productName?: string;
-  price?: number;
+  /**
+   * Legacy alias for the canonical `price` field. Kept on the input shape so
+   * callers still passing pre-#273 invoice items (with `unitPrice`) continue
+   * to work. New code should use `price` (the public API field name).
+   */
+  unitPrice?: number;
 };
 
 /** The subset of Subscription fields used by the invoice auditor. */
@@ -64,7 +69,9 @@ function normalizeInvoiceItem(item: AuditInvoiceItemInput): NormalizedInvoiceIte
     productId: item.productId,
     productName: item.productName ?? "",
     quantity: item.quantity ?? 0,
-    unitPrice: item.unitPrice ?? item.price ?? 0,
+    // Canonical first (`price` matches the public API after #273); fall back
+    // to `unitPrice` for any callers still passing the legacy shape.
+    unitPrice: item.price ?? item.unitPrice ?? 0,
   };
 }
 


### PR DESCRIPTION
## Summary

Consolidated `--json` field renames so partners reading both the CLI and the public Pax8 API surfaces don't have to translate. Implements fixes #4, #7, and #8 from #273 in a single PR (per the issue's coordination note — one Changeset entry, not three).

| Before | After | Schema |
|---|---|---|
| `InvoiceItem.subtotal` | `subTotal` | `@pax8/core` |
| `InvoiceItem.unitPrice` | `price` | `@pax8/core` |
| `Company.modified` | `updatedDate` | `@pax8/core` |
| `Quote.expirationDate` | `expiresOn` | `@pax8/core` |
| `Quote.createdDate` | `createdOn` | `@pax8/core` |

Breaking for `--json` consumers; acceptable while pre-1.0.

## Out of scope (intentional)

- The `--expiration-date` CLI flag on `pax8 quotes create`/`update` is unchanged. Flag vocabulary and field vocabulary are separate concerns; the issue calls this out explicitly.
- `Subscription`/`Product` schema changes — those are PR C's scope.
- Webhook `--events` → `--topics` flag rename (#3) — sibling PR B.

## Notable implementation choices

- Inline JSDoc on each renamed field in `packages/core/src/api/types.ts` records the rename, the issue link, and (for Quote) the deliberate flag-vs-field split — so the next reader has the rationale at the point-of-use.
- The invoice auditor's `AuditInvoiceItemInput` accepts both `price` (canonical) and the legacy `unitPrice` so any embeddings of `@pax8/core` that haven't migrated their inputs continue to work. Canonical-first lookup: `item.price ?? item.unitPrice ?? 0`.
- Demo data fixtures (`packages/core/src/mock/demo-data.ts`) were updated only inside the `invoiceItems` and `quotes` blocks; `usageSummaries`, `usageLines`, and `quote.lineItems[].{unitPrice, subtotal}` were intentionally left alone — those schemas (`UsageSummary`, `UsageLine`, `QuoteLineItem`) are out of scope.

## Files touched (18)

- `packages/core/src/api/types.ts` — schema renames + inline rationale
- `packages/core/src/api/types.test.ts`, `quotes.test.ts`, `invoices.test.ts` — fixture renames
- `packages/core/src/mock/demo-data.ts`, `mock-client.ts` — demo fixtures + create() output
- `packages/core/src/services/invoice-auditor.ts` — back-compat fallback
- `packages/cli/src/commands/invoices/items.ts` — column key renames
- `packages/cli/src/commands/quotes/{list,show,update}.ts` — column keys + read sites
- `packages/cli/src/__tests__/{invoices,quotes}.test.ts` — assertions
- `e2e/{billing,quotes}-workflow.test.ts` — assertions
- `docs/domain-review.md` — drift entries marked resolved
- `CHANGELOG.md` + `.changeset/issue-273-json-field-renames.md` — release notes

## Test plan

- [x] `pnpm build` succeeds for `@pax8/core` and `@pax8/cli`
- [x] `pnpm test` — 1498 passing, 8 skipped (no failures, no new skips)
- [x] `pnpm lint` clean
- [x] Branch rebased against latest `origin/main` immediately before push
- [x] Commit DCO-signed with Conventional Commits subject
- [ ] CI green on this PR

Closes the consolidated portion of #273 (fixes #4, #7, #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)