### PR TITLE
fix(e2e): distinguish runCli timeouts from real exit-1 failures and bump timeout to 30s

### DIFF
--- a/e2e/test-utils.test.ts
+++ b/e2e/test-utils.test.ts
@@ -1,0 +1,76 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+
+// These tests cover the timeout-detection logic in `runCli` (test-utils.ts).
+// `runCli` itself uses a fixed TIMEOUT_MS (30s) so we can't drive a real
+// timeout through it cheaply — instead we mirror its catch-block logic
+// against a deliberately short-timeout `execFile` call, asserting the same
+// observable contract: a SIGTERM-killed child surfaces as exitCode === -1
+// with a "(timed out after Xms)" suffix on stderr, NOT exitCode === 1
+// (which would be indistinguishable from a real failure).
+
+interface MirroredResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut?: boolean;
+}
+
+async function runWithTimeout(
+  cmd: string,
+  args: string[],
+  timeoutMs: number
+): Promise<MirroredResult> {
+  try {
+    const result = await exec(cmd, args, { timeout: timeoutMs });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (error: any) {
+    const timedOut = error.killed === true && error.signal === "SIGTERM";
+    return {
+      stdout: error.stdout ?? "",
+      stderr: timedOut
+        ? `${error.stderr ?? ""}\n(runCli timed out after ${timeoutMs}ms)`.trim()
+        : (error.stderr ?? ""),
+      exitCode: timedOut ? -1 : (error.code ?? 1),
+      timedOut: timedOut || undefined,
+    };
+  }
+}
+
+describe("runCli timeout detection", () => {
+  it("surfaces a hung child as exitCode -1 with a timed-out marker (not exit 1)", async () => {
+    // Spawn a node process that intentionally never exits within the budget.
+    // 200ms timeout against a 60s setTimeout — execFile will SIGTERM it.
+    const result = await runWithTimeout(
+      "node",
+      ["-e", "setTimeout(() => {}, 60000)"],
+      200
+    );
+
+    expect(result.exitCode).toBe(-1);
+    expect(result.timedOut).toBe(true);
+    expect(result.stderr).toContain("timed out after");
+    expect(result.stderr).toContain("200ms");
+  });
+
+  it("preserves real exit codes for non-timeout failures", async () => {
+    // process.exit(2) — completes well within the timeout budget, so the
+    // catch block should NOT mark it as timed out and should pass through
+    // the real exit code.
+    const result = await runWithTimeout(
+      "node",
+      ["-e", "process.exit(2)"],
+      30000
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(result.timedOut).toBeUndefined();
+    expect(result.stderr).not.toContain("timed out after");
+  });
+});

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -13,6 +13,13 @@ const exec = promisify(execFile);
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const CLI_PATH = resolve(__dirname, "../packages/cli/dist/index.js");
 
+// Hard upper bound for any single CLI invocation under runCli(). Bumped from
+// 15s → 30s after #252 / #277 flakes on Windows-22: node cold-start + CLI init
+// + Commander help under parallel test load can exceed 15s on slow runners.
+// 30s is "did the help even start?" territory, not a perf budget — real
+// commands return in well under a second under PAX8_DEMO=1.
+const TIMEOUT_MS = 30000;
+
 // Per-call isolated config dir. Without this, the e2e suite inherits the
 // developer's `~/.pax8/last-error.json` — and tests within the same process
 // also leak state to each other (a command that fails writes last-error.json
@@ -27,6 +34,12 @@ export interface CliResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  /**
+   * True when the child process was killed by `execFile`'s timeout (SIGTERM
+   * with `error.killed === true`). Distinguishes a hung-process flake from a
+   * real exit-1 failure — same surface area, very different remediation.
+   */
+  timedOut?: boolean;
 }
 
 export async function runCli(
@@ -42,14 +55,23 @@ export async function runCli(
         PAX8_CONFIG_DIR: makeIsolatedConfigDir(),
         ...env,
       },
-      timeout: 15000,
+      timeout: TIMEOUT_MS,
     });
     return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
   } catch (error: any) {
+    // execFile's timeout sends SIGTERM and sets killed=true; on those, the
+    // child has no real exit code (error.code === null), which would
+    // otherwise collapse to exitCode: 1 and be indistinguishable from a real
+    // command failure. Surface it explicitly so callers (and the per-command
+    // help test) can tell the two apart.
+    const timedOut = error.killed === true && error.signal === "SIGTERM";
     return {
       stdout: error.stdout ?? "",
-      stderr: error.stderr ?? "",
-      exitCode: error.code ?? 1,
+      stderr: timedOut
+        ? `${error.stderr ?? ""}\n(runCli timed out after ${TIMEOUT_MS}ms)`.trim()
+        : (error.stderr ?? ""),
+      exitCode: timedOut ? -1 : (error.code ?? 1),
+      timedOut: timedOut || undefined,
     };
   }
 }


### PR DESCRIPTION
## Summary

- Detect SIGTERM-killed timeouts in `e2e/test-utils.ts:runCli` and surface them as `exitCode: -1` with a `(runCli timed out after Xms)` suffix on stderr, so they're no longer indistinguishable from real `exit 1` failures.
- Bump the helper's `execFile` timeout from 15s → 30s and pull it into a top-of-file `TIMEOUT_MS` const.
- Add `timedOut?: boolean` to `CliResult` so callers can branch explicitly. No existing caller needs to change.

## Why

Two recent CI flakes on Windows-22 (#252 and #277) presented as `pax8 <cmd> --help` exiting 1 with empty stderr. Root cause: `runCli`'s 15s `execFile` timeout was firing on slow Windows runners. SIGTERM-killed children have `error.code === null`, so the existing `error.code ?? 1` fallback collapsed timeouts to `exitCode: 1` with empty stderr — looked like a real bug both times. Burned ~30 min of triage on each.

Fix is two-fold: (1) detect timeouts explicitly so the per-command help test's `${r.stderr.slice(0, 600)}` error message shows "(runCli timed out after 30000ms)" naturally, and (2) raise the budget to 30s — node cold-start + CLI init + Commander help under parallel test load on Windows-22 can exceed 15s; 30s is "did help even start?" territory, not a perf budget.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 1506 passed, 8 skipped (1 new test file `e2e/test-utils.test.ts` with 2 new tests)
- [x] `pnpm lint` — clean
- [x] New test exercises the timeout path against `node -e "setTimeout(() => {}, 60000)"` with a short timeout, asserting `exitCode === -1` and stderr contains "timed out after"
- [x] Second test confirms non-timeout failures still pass through real exit codes (`process.exit(2)` returns `exitCode: 2`, `timedOut` undefined)

## Notes

- No changeset (test infrastructure, not user-visible).
- Per-command help test contract unchanged — help still must exit 0; the new stderr suffix only appears in the failure message when a timeout actually fires.
- No retries added; per the spec, retries would mask real flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)