### PR TITLE
feat(welcome): adapt Get started list based on auth state

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -234,7 +234,7 @@ async function main(): Promise<void> {
     if (process.stdin.isTTY) {
       await startRepl(createProgram);
     } else {
-      showWelcomeScreen();
+      await showWelcomeScreen();
     }
   } else {
     const program = createProgram();

--- a/packages/cli/src/lib/repl.ts
+++ b/packages/cli/src/lib/repl.ts
@@ -68,7 +68,7 @@ export async function startRepl(createProgram: () => Command): Promise<void> {
 
   const cliPath = resolveCliPath(process.argv[1]);
 
-  showWelcomeScreen();
+  await showWelcomeScreen();
   process.stdout.write(chalk.dim("  Type a command, or ") + chalk.cyan("help") + chalk.dim(" / ") + chalk.cyan("exit") + "\n\n");
 
   const rl = createInterface({

--- a/packages/cli/src/lib/welcome.test.ts
+++ b/packages/cli/src/lib/welcome.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { showWelcomeScreen } from "./welcome.js";
+
+// Mock the @pax8/core CredentialStore so the test doesn't depend on a real
+// ~/.pax8/credentials.json on the runner. We assert against both branches
+// by toggling hasCredentials() per test. vi.hoisted is needed because
+// vi.mock factory bodies are hoisted above other top-level statements.
+const mockState = vi.hoisted(() => ({
+  hasCredentials: vi.fn<[], Promise<boolean>>(),
+  shouldThrow: false,
+}));
+vi.mock("@pax8/core", () => ({
+  CredentialStore: class {
+    async hasCredentials(): Promise<boolean> {
+      if (mockState.shouldThrow) throw new Error("boom");
+      return mockState.hasCredentials();
+    }
+  },
+}));
+
+describe("showWelcomeScreen", () => {
+  const originalEnv = { ...process.env };
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let captured: string;
+
+  beforeEach(() => {
+    captured = "";
+    stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        captured += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+        return true;
+      });
+    // Start with a clean env each test so PAX8_DEMO etc. doesn't leak.
+    process.env = { ...originalEnv };
+    delete process.env.PAX8_DEMO;
+    delete process.env.PAX8_CLIENT_ID;
+    delete process.env.PAX8_CLIENT_SECRET;
+    mockState.hasCredentials.mockReset();
+    mockState.shouldThrow = false;
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    process.env = originalEnv;
+  });
+
+  it("renders the unauthenticated layout when no credentials are configured", async () => {
+    mockState.hasCredentials.mockResolvedValueOnce(false);
+
+    await showWelcomeScreen();
+
+    expect(captured).toContain("Try it:");
+    expect(captured).toContain("init --demo");
+    expect(captured).toContain("auth login");
+    expect(captured).toContain("Stuck?");
+    expect(captured).toContain("doctor");
+    expect(captured).toContain("Sample data, no auth required");
+    expect(captured).toContain("Connect your Pax8 partner account");
+
+    // The authenticated-only command headings/items must NOT appear.
+    // Note: "recommendations" appears in the value-prop blurb ("upsell
+    // recommendations"), so we anchor on the command-block markers
+    // instead of the bare word.
+    expect(captured).not.toContain("Common commands:");
+    expect(captured).not.toContain("subscriptions renewals");
+    expect(captured).not.toContain("invoices audit");
+    expect(captured).not.toContain("Portfolio at a glance");
+    expect(captured).not.toContain("doctor for setup checks");
+
+    // Value-prop blurb is present and PAX8 art is preserved.
+    expect(captured).toContain("Pax8 CLI turns the marketplace API");
+    expect(captured).toContain("renewals, invoice audits, MRR");
+    expect(captured).toContain("██████╗");
+  });
+
+  it("renders the authenticated layout when credentials are configured", async () => {
+    mockState.hasCredentials.mockResolvedValueOnce(true);
+
+    await showWelcomeScreen();
+
+    expect(captured).toContain("Common commands:");
+    expect(captured).toContain("status");
+    expect(captured).toContain("subscriptions renewals");
+    expect(captured).toContain("recommendations");
+    expect(captured).toContain("invoices audit");
+    expect(captured).toContain("Portfolio at a glance");
+    expect(captured).toContain("doctor for setup checks");
+
+    // The unauthenticated-only sections must NOT appear.
+    expect(captured).not.toContain("Try it:");
+    expect(captured).not.toContain("Stuck?");
+    expect(captured).not.toContain("Sample data, no auth required");
+    expect(captured).not.toContain("Connect your Pax8 partner account");
+
+    expect(captured).toContain("Pax8 CLI turns the marketplace API");
+  });
+
+  it("treats PAX8_DEMO=1 as authenticated without consulting CredentialStore", async () => {
+    process.env.PAX8_DEMO = "1";
+    // hasCredentials is intentionally NOT primed — the demo short-circuit
+    // should mean it is never called.
+
+    await showWelcomeScreen();
+
+    expect(mockState.hasCredentials).not.toHaveBeenCalled();
+    expect(captured).toContain("Common commands:");
+    expect(captured).toContain("subscriptions renewals");
+  });
+
+  it("falls back to the unauthenticated layout if the credential check throws", async () => {
+    mockState.shouldThrow = true;
+
+    await showWelcomeScreen();
+
+    expect(captured).toContain("Try it:");
+    expect(captured).toContain("init --demo");
+    expect(captured).not.toContain("Common commands:");
+  });
+});

--- a/packages/cli/src/lib/welcome.ts
+++ b/packages/cli/src/lib/welcome.ts
@@ -2,10 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import chalk from "chalk";
+import { CredentialStore } from "@pax8/core";
 
 declare const __CLI_VERSION__: string;
 
-export function showWelcomeScreen(): void {
+/**
+ * Determines whether the user has any credentials configured (env vars or
+ * file). Demo mode short-circuits to "authenticated" since the CLI works
+ * end-to-end against MockPax8Client without real creds.
+ *
+ * Designed to be fast (<50 ms): no network, just a file `stat` and env
+ * var read. Falls back to `false` (unauthenticated layout) on any error.
+ */
+async function isAuthenticated(): Promise<boolean> {
+  if (process.env.PAX8_DEMO === "1") return true;
+  try {
+    const store = new CredentialStore();
+    return await store.hasCredentials();
+  } catch {
+    return false;
+  }
+}
+
+export async function showWelcomeScreen(): Promise<void> {
   const version = typeof __CLI_VERSION__ !== "undefined" ? __CLI_VERSION__ : "0.1.0";
 
   const W = 48;
@@ -24,6 +43,41 @@ export function showWelcomeScreen(): void {
   const tagline = "   Manage your cloud marketplace from the terminal";
   const versionLine = `   v${version} · Open Source · Pax8 Labs`;
 
+  // Short value-prop blurb above the command list. Pre-wrapped to keep
+  // each line under ~70 chars.
+  const blurb = [
+    "  Pax8 CLI turns the marketplace API into computed answers —",
+    "  renewals, invoice audits, MRR, and upsell recommendations.",
+  ];
+
+  const authed = await isAuthenticated();
+
+  // Column width is sized to the longest command across both branches
+  // (`subscriptions renewals` = 22 chars). +2 for trailing padding so the
+  // descriptions line up cleanly under either layout.
+  const COL = 24;
+  const cmd = (name: string): string => chalk.cyan(name.padEnd(COL));
+
+  const commandBlock = authed
+    ? [
+        `  ${chalk.dim("Common commands:")}`,
+        `    ${cmd("status")}${chalk.dim("Portfolio at a glance")}`,
+        `    ${cmd("subscriptions renewals")}${chalk.dim("What's renewing in 30 days")}`,
+        `    ${cmd("recommendations")}${chalk.dim("Upsell opportunities")}`,
+        `    ${cmd("invoices audit")}${chalk.dim("Reconcile invoices vs subscriptions")}`,
+        "",
+        `    ${cmd("help")}${chalk.dim("All commands · doctor for setup checks")}`,
+      ]
+    : [
+        `  ${chalk.dim("Try it:")}`,
+        `    ${cmd("init --demo")}${chalk.dim("Sample data, no auth required")}`,
+        `    ${cmd("auth login")}${chalk.dim("Connect your Pax8 partner account")}`,
+        "",
+        `  ${chalk.dim("Stuck?")}`,
+        `    ${cmd("doctor")}${chalk.dim("Check your setup")}`,
+        `    ${cmd("help")}${chalk.dim("All commands")}`,
+      ];
+
   const lines = [
     "",
     `  ${rule}`,
@@ -37,13 +91,9 @@ export function showWelcomeScreen(): void {
     "",
     `  ${rule}`,
     "",
-    `  ${chalk.dim("Get started:")}`,
-    `    ${chalk.cyan("auth login")}        ${chalk.dim("Set up API credentials")}`,
-    `    ${chalk.cyan("init --demo")}       ${chalk.dim("Try with sample data")}`,
-    `    ${chalk.cyan("companies list")}    ${chalk.dim("List your customers")}`,
-    `    ${chalk.cyan("doctor")}            ${chalk.dim("Check your setup")}`,
+    ...blurb.map((l) => chalk.dim(l)),
     "",
-    `  ${chalk.dim("Run")} help ${chalk.dim("for all commands.")}`,
+    ...commandBlock,
     "",
   ];
   process.stdout.write(lines.join("\n"));

--- a/packages/core/src/auth/credential-store.test.ts
+++ b/packages/core/src/auth/credential-store.test.ts
@@ -130,6 +130,47 @@ describe("CredentialStore", () => {
     });
   });
 
+  describe("hasCredentials", () => {
+    it("returns true when env vars are set, without touching the file", async () => {
+      process.env.PAX8_CLIENT_ID = "env-id";
+      process.env.PAX8_CLIENT_SECRET = "env-secret";
+
+      expect(await store.hasCredentials()).toBe(true);
+      expect(fs.access).not.toHaveBeenCalled();
+    });
+
+    it("returns true when only the credentials file exists", async () => {
+      delete process.env.PAX8_CLIENT_ID;
+      delete process.env.PAX8_CLIENT_SECRET;
+      vi.mocked(fs.access).mockResolvedValueOnce(undefined);
+
+      expect(await store.hasCredentials()).toBe(true);
+      expect(fs.access).toHaveBeenCalledWith(CREDENTIALS_FILE, expect.any(Number));
+      // hasCredentials must NOT read or parse the file body.
+      expect(fs.readFile).not.toHaveBeenCalled();
+    });
+
+    it("returns false when neither env vars nor file are present", async () => {
+      delete process.env.PAX8_CLIENT_ID;
+      delete process.env.PAX8_CLIENT_SECRET;
+      vi.mocked(fs.access).mockRejectedValueOnce(
+        Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+      );
+
+      expect(await store.hasCredentials()).toBe(false);
+    });
+
+    it("returns false when only one env var half is set", async () => {
+      process.env.PAX8_CLIENT_ID = "partial";
+      delete process.env.PAX8_CLIENT_SECRET;
+      vi.mocked(fs.access).mockRejectedValueOnce(
+        Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+      );
+
+      expect(await store.hasCredentials()).toBe(false);
+    });
+  });
+
   describe.skipIf(process.platform === "win32")("saveCredentials", () => {
     it("creates config dir, secures it, and writes credentials file on Unix", async () => {
       // #262: saveCredentials now uses safeWriteFileSync for the file

--- a/packages/core/src/auth/credential-store.ts
+++ b/packages/core/src/auth/credential-store.ts
@@ -55,6 +55,24 @@ export class CredentialStore {
   }
 
   /**
+   * Fast check for whether any credential source is configured. Does NOT
+   * read or parse the file — just verifies the env vars or that the file
+   * exists. Intended for UX branching on the welcome screen, where we
+   * need a sub-millisecond answer and don't care about content validity.
+   *
+   * Returns false on any error (missing file, permission denied, etc.).
+   */
+  async hasCredentials(): Promise<boolean> {
+    if (this.getFromEnv() !== null) return true;
+    try {
+      await fs.access(CREDENTIALS_FILE, constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Saves credentials to ~/.pax8/credentials.json with secure permissions.
    * On Unix: chmod 700 on dir, chmod 600 on file.
    * On Windows: restrict ACLs to the current user via icacls.


### PR DESCRIPTION
## Summary

The bare `pax8` welcome screen used to show the same four-command list to every user, with `auth login` listed first (even though a first-timer likely has nothing to plug in yet) and `doctor` listed alongside `companies list` (even though it's a debug tool, not a daily-driver). None of the CLI's actual value props — renewals, invoice audits, MRR, upsell recs — appeared.

This makes the welcome screen branch on whether credentials are configured:

- **No credentials** → "Try it:" points at `init --demo` first, then `auth login`. `doctor`/`help` move to a "Stuck?" group below.
- **Credentials present** (or `PAX8_DEMO=1`) → "Common commands:" surfaces the value commands: `status`, `subscriptions renewals`, `recommendations`, `invoices audit`. `help` carries an inline pointer to `doctor`.

A short value-prop blurb sits above the command list so first-time users see what the CLI is actually for. The PAX8 ASCII art and version line are unchanged.

To support this without a network call, this PR adds `CredentialStore.hasCredentials()` — a fast env-var + `fs.access` check that does no JSON parsing. The welcome path catches any throw and falls back to the unauthenticated layout, keeping render time well under 50 ms.

`showWelcomeScreen()` becomes `async`; both call sites (`packages/cli/src/index.ts` and the REPL bootstrap in `packages/cli/src/lib/repl.ts`) already operate inside async functions, so the signature change is contained.

### Unauthenticated layout

```
  ────────────────────────────────────────────────

      ██████╗  █████╗ ██╗  ██╗ █████╗
      ██╔══██╗██╔══██╗╚██╗██╔╝██╔══██╗
      ██████╔╝███████║ ╚███╔╝ ╚█████╔╝
      ██╔═══╝ ██╔══██║ ██╔██╗ ██╔══██╗
      ██║     ██║  ██║██╔╝ ██╗╚█████╔╝
      ╚═╝     ╚═╝  ╚═╝╚═╝  ╚═╝ ╚════╝

      C O M M A N D   L I N E

     Manage your cloud marketplace from the terminal
     v0.2.0 · Open Source · Pax8 Labs

  ────────────────────────────────────────────────

  Pax8 CLI turns the marketplace API into computed answers —
  renewals, invoice audits, MRR, and upsell recommendations.

  Try it:
    init --demo             Sample data, no auth required
    auth login              Connect your Pax8 partner account

  Stuck?
    doctor                  Check your setup
    help                    All commands
```

### Authenticated layout

```
  ────────────────────────────────────────────────

      [PAX8 ASCII art unchanged]

      C O M M A N D   L I N E

     Manage your cloud marketplace from the terminal
     v0.2.0 · Open Source · Pax8 Labs

  ────────────────────────────────────────────────

  Pax8 CLI turns the marketplace API into computed answers —
  renewals, invoice audits, MRR, and upsell recommendations.

  Common commands:
    status                  Portfolio at a glance
    subscriptions renewals  What's renewing in 30 days
    recommendations         Upsell opportunities
    invoices audit          Reconcile invoices vs subscriptions

    help                    All commands · doctor for setup checks
```

This addresses the long-standing UX concern that the welcome screen didn't help first-time vs returning users distinguish their next step.

## Test plan

- [x] New unit tests in `packages/cli/src/lib/welcome.test.ts` cover both branches (mock `CredentialStore.hasCredentials`), the `PAX8_DEMO=1` short-circuit, and the throw-fallback.
- [x] New unit tests in `packages/core/src/auth/credential-store.test.ts` cover `hasCredentials()` against env-only, file-only, neither, and partial-env states; assert the file is never `readFile`d.
- [x] `pnpm build` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test` — 1508 pass; the 6 failures (in `context.test.ts`, `version.test.ts`, `doctor.test.ts`) reproduce on a clean `origin/main` checkout and are unrelated to this change (env/version drift).