### PR TITLE
chore(phase1): five Cassie quick wins (#235, #236, #237, #258, partial #257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ pax8 status
 PAX8_DEMO=1 pax8 status
 ```
 
+### Running from source (contributors / unmerged branches)
+
+If you're contributing to the CLI or trying it before it's published:
+
+```bash
+git clone https://github.com/pax8labs/pax8-cli
+cd pax8-cli
+pnpm install
+pnpm build
+
+# Use directly:
+node packages/cli/dist/index.js status
+
+# Or symlink for global use:
+cd packages/cli && npm link
+pax8 status
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full dev workflow.
+
 ## Demo Flow (90 seconds)
 
 ```bash

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,35 @@
+# Support
+
+Looking for help with `pax8-cli`? Here's where to start.
+
+## Try first
+
+- **`pax8 doctor`** — runs diagnostics on your setup (Node version, credentials, API reachability, config file)
+- **`pax8 <command> --help`** — every command documents its flags and gives runnable examples
+- **`pax8 --verbose <command>`** — prints the API path and method to stderr; helpful for troubleshooting
+
+## Bug reports and feature requests
+
+File an issue: https://github.com/pax8labs/pax8-cli/issues
+
+The CLI itself can pre-fill a sanitized bug report from the most recent failure:
+
+```bash
+pax8 report-bug
+```
+
+This redacts UUIDs, emails, paths, and tokens before opening the issue draft.
+
+## Security issues
+
+Don't file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the disclosure path (security@pax8.com, 48-hour acknowledgment).
+
+## Questions, ideas, troubleshooting
+
+GitHub Discussions: https://github.com/pax8labs/pax8-cli/discussions
+
+(If Discussions isn't enabled yet, file a question-tagged issue and we'll route it.)
+
+## Pax8 marketplace API itself
+
+Bugs in the Pax8 API (not the CLI) belong with the Pax8 developer team. The CLI's `pax8 doctor` will flag if your token can't reach the API at all; for everything else, file with Pax8 support.

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -13,9 +13,6 @@
     "build": "echo 'no build needed'",
     "typecheck": "tsc --noEmit"
   },
-  "peerDependencies": {
-    "@pax8/cli": "workspace:*"
-  },
   "devDependencies": {
     "@types/node": "^25.6.2",
     "typescript": "^5.5.0"

--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -379,7 +379,7 @@ paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
       };
 
       const writeSpinner = createSpinner("Filing dispute...").start();
-      const done = markWriteInFlight("invoices");
+      const done = markWriteInFlight("invoices", undefined, idempotencyKey);
       let filePath: string;
       try {
         filePath = await writeDraft(draft);

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -568,7 +568,7 @@ Examples:
       // `OrdersApi.create` shape — see packages/core/src/api/orders.ts), pass
       // `idempotencyKey` through here so the server dedupes natively. Until
       // then, deduplication is purely local via the file cache below.
-      const doneWrite = markWriteInFlight("orders");
+      const doneWrite = markWriteInFlight("orders", undefined, idempotencyKey);
       let order;
       try {
         order = await ctx.api.orders.create(orderInput, { isMock: dryRun });

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -50,6 +50,37 @@ export interface ApiClient {
   webhooks: WebhooksApi;
 }
 
+// Compile-time assertion that `MockPax8Client` (used in demo mode) exposes
+// every public method on the real `ApiClient`. We can't simply write
+// `MockPax8Client extends ApiClient` because the real `*Api` classes carry a
+// private `client` field used internally for HTTP, which TypeScript treats as
+// a brand and refuses to consider compatible across class boundaries. Today's
+// mock and real signatures also drift slightly (e.g. mock `companies.create`
+// accepts `Partial<Company>` rather than `CreateCompanyInput`), and tightening
+// those contracts is out of scope here — but adding or removing a method on
+// either side IS what we want to catch automatically.
+//
+// So we project both sides through `MethodNames` and assert the mock has at
+// least every public function-typed key the real client exposes. If a new
+// method is added to any of the real `*Api` classes and to `ApiClient`, but
+// not to its `*Resource` mirror in `MockPax8Client`, this assertion fails to
+// type-check — turning the eventual runtime `TypeError` under `PAX8_DEMO=1`
+// into a build-time error.
+type MethodNames<T> = {
+  [K in keyof T]: T[K] extends (...args: never[]) => unknown ? K : never;
+}[keyof T];
+type ApiClientMethodNames = {
+  [K in keyof ApiClient]: MethodNames<ApiClient[K]>;
+};
+type MockMethodNames = {
+  [K in keyof ApiClient]: MethodNames<MockPax8Client[K & keyof MockPax8Client]>;
+};
+type _AssertMockSatisfiesReal = ApiClientMethodNames extends MockMethodNames
+  ? true
+  : false;
+const _mockSatisfiesReal: _AssertMockSatisfiesReal = true;
+void _mockSatisfiesReal;
+
 export interface CommandContext {
   api: ApiClient | MockPax8Client;
   outputFormat: "table" | "json" | "csv" | "quiet";

--- a/packages/cli/src/lib/signals.test.ts
+++ b/packages/cli/src/lib/signals.test.ts
@@ -40,7 +40,20 @@ describe("markWriteInFlight", () => {
 
   it("preserves the optional hint", () => {
     markWriteInFlight("orders", "id=abc");
-    expect(_getWriteInFlight()).toEqual({ resource: "orders", hint: "id=abc" });
+    expect(_getWriteInFlight()).toEqual({
+      resource: "orders",
+      hint: "id=abc",
+      idempotencyKey: undefined,
+    });
+  });
+
+  it("preserves the optional idempotency key", () => {
+    markWriteInFlight("orders", undefined, "9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d");
+    expect(_getWriteInFlight()).toEqual({
+      resource: "orders",
+      hint: undefined,
+      idempotencyKey: "9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d",
+    });
   });
 });
 
@@ -127,6 +140,39 @@ describe("installSigintHandler — capture and invoke", () => {
     expect(written).toContain("(cancelled)");
     expect(written).toContain("orders");
     expect(written).toContain("idempotency-key=xyz");
+    expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+
+  it("on first SIGINT with an idempotency key includes a Retry hint", async () => {
+    expect(sigintHandler).not.toBeNull();
+    const fresh = await import("./signals.js");
+    fresh.markWriteInFlight(
+      "orders",
+      undefined,
+      "9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d",
+    );
+
+    sigintHandler!();
+    await settle();
+
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("(cancelled)");
+    expect(written).toContain("Retry with: --idempotency-key");
+    expect(written).toContain("9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d");
+    expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+
+  it("on first SIGINT without an idempotency key skips the Retry hint", async () => {
+    expect(sigintHandler).not.toBeNull();
+    const fresh = await import("./signals.js");
+    fresh.markWriteInFlight("orders");
+
+    sigintHandler!();
+    await settle();
+
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("(cancelled)");
+    expect(written).not.toContain("Retry with: --idempotency-key");
     expect(exitSpy).toHaveBeenCalledWith(130);
   });
 

--- a/packages/cli/src/lib/signals.ts
+++ b/packages/cli/src/lib/signals.ts
@@ -20,6 +20,7 @@ import { stopAllActiveSpinners } from "./spinner.js";
 interface InFlightWrite {
   resource: string;
   hint?: string;
+  idempotencyKey?: string;
 }
 
 let currentWrite: InFlightWrite | null = null;
@@ -29,9 +30,14 @@ let currentWrite: InFlightWrite | null = null;
  * function the caller MUST invoke (in a `finally`, ideally) when the write
  * settles — successful, failed, or otherwise.
  *
+ * If the caller has computed an `idempotencyKey` for the request, pass it as
+ * the third argument. The SIGINT handler will surface it in the cancellation
+ * hint so the user can copy-paste a retry command instead of generating a new
+ * key.
+ *
  * Example:
  * ```ts
- * const done = markWriteInFlight("order");
+ * const done = markWriteInFlight("order", undefined, idempotencyKey);
  * try {
  *   await ctx.api.orders.create(...);
  * } finally {
@@ -39,8 +45,12 @@ let currentWrite: InFlightWrite | null = null;
  * }
  * ```
  */
-export function markWriteInFlight(resource: string, hint?: string): () => void {
-  const entry: InFlightWrite = { resource, hint };
+export function markWriteInFlight(
+  resource: string,
+  hint?: string,
+  idempotencyKey?: string,
+): () => void {
+  const entry: InFlightWrite = { resource, hint, idempotencyKey };
   currentWrite = entry;
 
   return () => {
@@ -102,12 +112,16 @@ export function installSigintHandler(): void {
 
     const write = currentWrite;
     if (write) {
-      // TODO: wire up the idempotency key once #91 lands so this hint can
-      // include it directly. For now we just emit `(cancelled)` plus a
-      // resource-aware show hint.
       const showCmd = `pax8 ${write.resource} show ...`;
       const extra = write.hint ? ` ${write.hint}` : "";
-      const msg = `(cancelled) Write was in flight. Run ${showCmd} to confirm state.${extra}\n`;
+      const lines = [
+        `(cancelled) Write was in flight. Run ${showCmd} to confirm state.${extra}`,
+      ];
+      if (write.idempotencyKey) {
+        // Indent so the retry line visibly hangs under the cancelled line.
+        lines.push(`            Retry with: --idempotency-key ${write.idempotencyKey}`);
+      }
+      const msg = lines.join("\n") + "\n";
       try {
         process.stderr.write(chalk.dim(msg));
       } catch {

--- a/packages/core/src/mock/mock-client.test.ts
+++ b/packages/core/src/mock/mock-client.test.ts
@@ -225,4 +225,88 @@ describe("MockPax8Client", () => {
       expect(result[0]).toHaveProperty("topics");
     });
   });
+
+  // ─── Real-vs-mock parity ─────────────────────────────────────────────────
+  //
+  // Belt-and-suspenders runtime check that every public method present on
+  // each real `*Api` class also exists on the corresponding mock resource.
+  // The load-bearing version of this assertion is at compile time in
+  // `packages/cli/src/lib/context.ts`; this test exists so that drift is
+  // also surfaced by `pnpm test`, not only by typecheck.
+
+  describe("parity with real API client", () => {
+    const resourceMethodNames = (obj: object): string[] => {
+      const proto = Object.getPrototypeOf(obj) as object;
+      return Object.getOwnPropertyNames(proto).filter((n) => {
+        if (n === "constructor") return false;
+        const desc = Object.getOwnPropertyDescriptor(proto, n);
+        return typeof desc?.value === "function";
+      });
+    };
+
+    it("every mock resource exposes a stable set of public methods", () => {
+      // We can't instantiate the real `*Api` classes here without an HTTP
+      // client and credentials, so we settle for a smoke check that each
+      // mock resource has at least the load-bearing methods. The fuller
+      // `extends`-style check is the compile-time assertion in context.ts.
+      expect(resourceMethodNames(client.companies)).toEqual(
+        expect.arrayContaining(["list", "get", "create", "update"]),
+      );
+      expect(resourceMethodNames(client.subscriptions)).toEqual(
+        expect.arrayContaining(["list", "get", "getHistory", "update", "delete"]),
+      );
+      expect(resourceMethodNames(client.products)).toEqual(
+        expect.arrayContaining([
+          "list",
+          "search",
+          "get",
+          "getPricing",
+          "getProvisioningDetails",
+          "getDependencies",
+        ]),
+      );
+      expect(resourceMethodNames(client.invoices)).toEqual(
+        expect.arrayContaining(["list", "get", "listItems", "listDraftItems"]),
+      );
+      expect(resourceMethodNames(client.orders)).toEqual(
+        expect.arrayContaining(["list", "get", "create"]),
+      );
+      expect(resourceMethodNames(client.contacts)).toEqual(
+        expect.arrayContaining(["list", "get", "create", "update", "delete"]),
+      );
+      expect(resourceMethodNames(client.usage)).toEqual(
+        expect.arrayContaining(["listSummaries", "getSummary", "listLines"]),
+      );
+      expect(resourceMethodNames(client.quotes)).toEqual(
+        expect.arrayContaining([
+          "list",
+          "get",
+          "create",
+          "update",
+          "delete",
+          "addLineItem",
+          "removeLineItem",
+          "setStatus",
+          "send",
+        ]),
+      );
+      expect(resourceMethodNames(client.webhooks)).toEqual(
+        expect.arrayContaining([
+          "list",
+          "get",
+          "create",
+          "update",
+          "updateStatus",
+          "updateConfiguration",
+          "setStatus",
+          "delete",
+          "test",
+          "testTopic",
+          "getLogs",
+          "retryLog",
+          "getTopicDefinitions",
+        ]),
+      );
+    });
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,10 +49,6 @@ importers:
         version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/claude-skill:
-    dependencies:
-      '@pax8/cli':
-        specifier: workspace:*
-        version: link:../cli
     devDependencies:
       '@types/node':
         specifier: ^25.6.2


### PR DESCRIPTION
## Summary

Five small mechanical fixes from Cassie's open-issue queue. All independent, bundled here for one review pass.

- **#258** — pnpm install no longer warns about missing pax8 bin on fresh checkout. claude-skill declared `@pax8/cli` as a peerDependency but never imports from it (the skill shells out to the `pax8` binary on PATH), so the workspace symlink had nothing valid to point at until after build. Dropping the peerDep removes the warning entirely.
- **#236** — added SUPPORT.md at repo root.
- **#237** — SIGINT hint now includes the active idempotency key when set, so users can copy-paste a retry command instead of minting a new one. Closes the TODO at `signals.ts:105`. Wired through `orders create` and `invoices dispute` (the two write commands that currently support `--idempotency-key`).
- **#235** — MockPax8Client compile-time parity with ApiClient. Adding a method to a real `*Api` class now fails the build immediately instead of producing a runtime `TypeError` under `PAX8_DEMO=1`. The check is method-name presence, not signature equality — fixing existing signature drift (e.g. mock `companies.create` accepts `Partial<Company>` rather than `CreateCompanyInput`) is intentionally out of scope here.
- **#257 (partial)** — README "Running from source" section so contributors and pre-publish evaluators have a documented dev path alongside the npm install line. The npm-404 piece self-resolved when #276 merged.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test` — same 6 pre-existing baseline failures as `origin/main`; no new ones. The 5 added tests pass.
- [x] `pnpm lint` clean
- [x] `tsc --noEmit` in `packages/cli` and `packages/core` — clean
- [x] Manual: `pnpm install --force` no longer emits the `Failed to create bin at .../node_modules/.bin/pax8` warning
- [x] Verified the compile-time mock-vs-real assertion fires by temporarily adding a `tempDriftMethod` to `CompaniesApi` — `tsc` flagged it; reverted before commit.

Closes #235, #236, #237, #258. Refs #257 (npm 404 piece resolved by #276; this closes the docs gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)