### PR TITLE
test(version): read version from package.json instead of hardcoded "0.1.0"

### DIFF
--- a/packages/cli/src/__tests__/version.test.ts
+++ b/packages/cli/src/__tests__/version.test.ts
@@ -2,13 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join as pathJoin } from "node:path";
 import { runCliExpectSuccess } from "./test-utils.js";
+
+// Read the @pax8/cli package version dynamically so this test doesn't
+// silently break every time changesets bumps the version. Previously
+// hardcoded as "0.1.0"; the bump to 0.2.0 in #276 broke main CI because
+// the changesets release PR didn't run CI to catch this.
+const PKG_PATH = pathJoin(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "package.json",
+);
+const PKG_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf-8")).version as string;
 
 describe("pax8 version", () => {
   it("prints version number", async () => {
     const result = await runCliExpectSuccess(["version"]);
     expect(result.stdout).toContain("pax8-cli");
-    expect(result.stdout).toContain("0.1.0");
+    expect(result.stdout).toContain(PKG_VERSION);
   });
 
   it("prints node version", async () => {


### PR DESCRIPTION
## Summary
- Version test asserted \`stdout\` contains literal "0.1.0"; #276's changesets bump to 0.2.0 broke that assertion.
- Reads from \`packages/cli/package.json\` dynamically instead.
- The release PR (#276) didn't run CI before merge (changesets-bot quirk we've noticed before — empty checks array on its PRs), so this slipped past pre-merge gating.

## Why this matters now
- Main is currently red on the CI workflow (commit 0b6cce6, 4/4 cells failing on this one assertion).
- Every PR opening against main inherits the failure until this lands.
- #282 (Phase 1 Cassie wins) is currently blocked on the same failure.

## Test plan
- [x] \`pnpm exec vitest run packages/cli/src/__tests__/version.test.ts\` — 3/3 pass
- [x] Reads "0.2.0" correctly from package.json
- [x] Will stay green across future changesets bumps (the failure mode that hit us this round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)