### PR TITLE
fix(test): match pax8 version output with semver regex instead of pinning literal

### DIFF
--- a/packages/cli/src/__tests__/version.test.ts
+++ b/packages/cli/src/__tests__/version.test.ts
@@ -8,7 +8,10 @@ describe("pax8 version", () => {
   it("prints version number", async () => {
     const result = await runCliExpectSuccess(["version"]);
     expect(result.stdout).toContain("pax8-cli");
-    expect(result.stdout).toContain("0.1.0");
+    // Match any semver-shaped string instead of pinning a specific version
+    // — `chore: release` bumps the package version regularly and the test
+    // shouldn't break every release.
+    expect(result.stdout).toMatch(/\d+\.\d+\.\d+/);
   });
 
   it("prints node version", async () => {


### PR DESCRIPTION
## Why

`packages/cli/src/__tests__/version.test.ts` asserted that `stdout` contained the literal string `'0.1.0'`. When `chore: release (#276)` bumped the package version to `0.2.0`, the test broke. Main has been red on this test since that release; PR #281 (welcome refresh) merged through it because the failure was pre-existing.

## Fix

Match `\d+\.\d+\.\d+` instead of a literal version. Future `chore: release` PRs won't regress CI on this test.

## Test plan

`pnpm test packages/cli/src/__tests__/version.test.ts` — all 3 tests pass locally.