### PR TITLE
refactor(cli): rename status to dashboard with deprecation alias

### DIFF
--- a/.changeset/status-to-dashboard-rename.md
+++ b/.changeset/status-to-dashboard-rename.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+`pax8 status` renamed to `pax8 dashboard` for clarity. The previous name collided semantically with `pax8 auth status` (an auth-credential check) and was generically named for what is actually a portfolio dashboard (top customers by MRR, urgent renewals, top recommendations). `pax8 status` is preserved as a deprecated alias that still functions identically but prints a one-line deprecation notice on stderr (`warning: \`status\` is deprecated; use \`dashboard\`. Will be removed in v1.0.`); it is hidden from `pax8 --help` so the canonical name is the only one advertised. No-change for scripts already calling `pax8 status`; new scripts and docs should prefer `pax8 dashboard`. Mirrors the parallel `--events` → `--topics` deprecation shipped on `pax8 webhooks create`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "containerEnv": {
     "PAX8_DEMO": "1"
   },
-  "postStartCommand": "echo '\n  ✨ Pax8 CLI is ready in demo mode!\n\n  Try these commands:\n    pax8 status\n    pax8 companies list\n    pax8 subscriptions list\n    pax8 recommendations list\n    pax8 status --all\n'",
+  "postStartCommand": "echo '\n  ✨ Pax8 CLI is ready in demo mode!\n\n  Try these commands:\n    pax8 dashboard\n    pax8 companies list\n    pax8 subscriptions list\n    pax8 recommendations list\n    pax8 dashboard --all\n'",
   "customizations": {
     "vscode": {
       "settings": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ When asked anything about Pax8 data, your first action should be a shell call. N
 
 | Question | Run this |
 |---|---|
-| overview / status / how am I doing | `pax8 status --json 2>/dev/null` |
+| overview / status / how am I doing | `pax8 dashboard --json 2>/dev/null` |
 | companies / customers | `pax8 companies list --json 2>/dev/null` |
 | subscriptions | `pax8 subscriptions list --json --size 1000 2>/dev/null` (add `--status Active` or `--company <name>` as needed) |
 | renewals | `pax8 subscriptions renewals --json --within 30d 2>/dev/null` |
@@ -57,7 +57,7 @@ These never mutate state. Run them freely, in parallel, and as often as needed.
 - `pax8 invoices items` — line items for an invoice
 - `pax8 invoices audit` — read-only computation, no writes
 - `pax8 cost sim` — what-if pricing simulation, no writes
-- `pax8 status`, `pax8 status --all|--renewals|--growth|--customers`
+- `pax8 dashboard`, `pax8 dashboard --all|--renewals|--growth|--customers`
 - `pax8 doctor` — diagnostics only
 - `pax8 webhooks logs <id>` — delivery history (read-only)
 
@@ -91,7 +91,7 @@ If unsure whether a command counts as a write, default to confirming. Better one
 | `--csv` | When the operator asks for a spreadsheet, export, or PSA import. |
 | `--quiet` | Suppress output entirely (rare; mostly for write commands you're chaining). |
 | `--ids-only` | Pipe one command's output into another's `--company` filter. |
-| `--with-actions` | Wrap list-command JSON as `{ items, nextActions }` so suggested next commands ride along. Available on `recommendations list`, `subscriptions renewals`, `webhooks list`, `webhooks logs`. Single-object commands (`status`, `report mrr/growth`, `invoices audit`) always include `nextActions` inline. |
+| `--with-actions` | Wrap list-command JSON as `{ items, nextActions }` so suggested next commands ride along. Available on `recommendations list`, `subscriptions renewals`, `webhooks list`, `webhooks logs`. Single-object commands (`dashboard`, `report mrr/growth`, `invoices audit`) always include `nextActions` inline. |
 
 ## Result size
 
@@ -170,6 +170,6 @@ The CLI is self-describing — agents that want to enumerate their own surface s
 - `pax8 --help` — top-level resource and command listing.
 - `pax8 <resource> --help` and `pax8 <resource> <action> --help` — per-command flag and argument detail.
 - `pax8 doctor --json` — environment, auth, API reachability, cache, and telemetry state in a single structured payload. Use it as a one-shot health check, not a per-call probe.
-- `pax8 status --json` — portfolio snapshot (MRR, renewals, recs, trials) with `nextActions` inline.
+- `pax8 dashboard --json` — portfolio snapshot (MRR, renewals, recs, trials) with `nextActions` inline.
 
 A first-class `pax8 agents` command — emitting a machine-readable inventory of every command, flag, error code, and read/write classification — is planned for v0.2.x as part of the canonical-source-of-truth refactor (#164). Until that lands, parse `--help` output or read this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Deprecated
 
 - **`pax8 webhooks create --events`** renamed to `--topics` to match the API field name (`webhookTopics`) and the CLI's own `Webhook.topics[]` output. `--events` continues to function as a deprecated alias and prints a one-line deprecation notice on stderr; it will be removed in v1.0. Passing both `--topics` and `--events` is rejected with `ERROR_INVALID_INPUT` (#273).
+- **`pax8 status`** renamed to `pax8 dashboard`. The previous name collided semantically with `pax8 auth status` (an auth-credential check) and was generically named for what is actually a portfolio dashboard. `pax8 status` continues to function as a deprecated alias and prints a one-line deprecation notice on stderr (`warning: \`status\` is deprecated; use \`dashboard\`. Will be removed in v1.0.`); it is hidden from `pax8 --help`. Same deprecation pattern as the `--events` → `--topics` rename above; will be removed in v1.0.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ When the user asks ANYTHING about Pax8 data (companies, subscriptions, MRR, reco
 
 | User asks about | Run this |
 |---|---|
-| overview / status / how am I doing | `pax8 status --json 2>/dev/null` |
+| overview / status / how am I doing | `pax8 dashboard --json 2>/dev/null` |
 | companies / customers | `pax8 companies list --json 2>/dev/null` |
 | subscriptions | `pax8 subscriptions list --json --size 1000 2>/dev/null` (add `--status Active` or `--company <name>` as needed) |
 | renewals | `pax8 subscriptions renewals --json --within 30d 2>/dev/null` |

--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ npm install -g @pax8/cli
 pax8 auth login
 
 # See how your business is doing
-pax8 status
+pax8 dashboard
 
 # Or try with demo data (no credentials needed)
-PAX8_DEMO=1 pax8 status
+PAX8_DEMO=1 pax8 dashboard
 ```
 
 ## Demo Flow (90 seconds)
 
 ```bash
-pax8 status                              # estimated MRR, renewals, growth opportunities
+pax8 dashboard                           # estimated MRR, renewals, growth opportunities
 pax8 recommendations list                # Cross-sell and seat gap opportunities
 pax8 recommendations act                 # Multi-select picker → batch order
 pax8 companies list                      # Browse customers (type # to drill in)
@@ -63,10 +63,10 @@ pax8 companies more "Acme Corp"          # Full customer summary
 ### Dashboard
 
 ```bash
-pax8 status                    # Quick snapshot: estimated MRR, renewals, recs, trials
-pax8 status --all              # Full dashboard with top customers and details
-pax8 status --renewals         # Focus on upcoming renewals
-pax8 status --growth           # Focus on growth opportunities
+pax8 dashboard                 # Quick snapshot: estimated MRR, renewals, recs, trials
+pax8 dashboard --all           # Full dashboard with top customers and details
+pax8 dashboard --renewals      # Focus on upcoming renewals
+pax8 dashboard --growth        # Focus on growth opportunities
 ```
 
 ### Companies
@@ -199,7 +199,7 @@ By default, the CLI talks to `https://api.pax8.com/v1`. Partners testing against
 
 ```bash
 export PAX8_API_BASE=https://staging-api.pax8.com/v1/
-pax8 status
+pax8 dashboard
 pax8 doctor   # confirms the active API base in its output
 ```
 
@@ -210,7 +210,7 @@ pax8 doctor   # confirms the active API base in its output
 Try everything without API credentials:
 
 ```bash
-PAX8_DEMO=1 pax8 status
+PAX8_DEMO=1 pax8 dashboard
 PAX8_DEMO=1 pax8 recommendations act
 ```
 

--- a/docs/credential-setup.md
+++ b/docs/credential-setup.md
@@ -43,7 +43,7 @@ Then run any command normally:
 
 ```bash
 pax8 auth login    # validates and saves
-pax8 status        # works directly — env vars are checked first
+pax8 dashboard     # works directly — env vars are checked first
 ```
 
 Environment variables take priority over the stored credentials file, so you can use them to temporarily override saved credentials. A copy-pasteable starter for these (and the optional `PAX8_API_BASE` / `PAX8_DEMO` toggles) is in [`.env.example`](../.env.example) at the repo root.
@@ -60,7 +60,7 @@ pax8 doctor   # surfaces the active API base in its output
 ```powershell
 $env:PAX8_CLIENT_ID = "your-client-id"
 $env:PAX8_CLIENT_SECRET = "your-client-secret"
-pax8 status
+pax8 dashboard
 ```
 
 ### Option C: Direct file (advanced)

--- a/docs/domain-review.md
+++ b/docs/domain-review.md
@@ -460,7 +460,7 @@ API `Webhook` fields: `id, accountId, displayName, url, authorization, active, c
 |---|---|---|---|
 | `pax8 report mrr` | (none) | | **Computed** |
 | `pax8 report growth` | `--months <number>` | months=6 | **Computed** |
-| `pax8 status` | (none) | | **Computed — portfolio overview** |
+| `pax8 dashboard` | (none) | | **Computed — portfolio overview** (legacy alias `pax8 status` retained until v1.0) |
 | `pax8 cost sim` | `--company`, `--product`, `--quantity`, `--from`, `--from-quantity`, `--billing-term` | qty=1, billing=Annual | **Computed — what-if simulator** |
 | `pax8 doctor` | (none) | | Diagnostics |
 
@@ -474,13 +474,13 @@ There are no `/report`, `/mrr`, `/growth`, or `/cost` endpoints in the public AP
 |---|---|---|---|---|
 | `report mrr` | All active subscriptions | For each: `monthly = price × quantity`; `annual term = price × quantity ÷ 12`. Group by `companyId`, `productName`, `vendorName`. | `{ totalMrr, byCompany[], byProduct[], byVendor[] }` | API has no MRR endpoint. |
 | `report growth` | All invoices for the partner | Group invoice totals by `YYYY-MM`, take last N months, compute MoM `delta` and `growthPercent`, plus `averageGrowth`. **Note: this is invoiced revenue, not MRR.** | `{ months[], averageGrowth }` | API has no growth/trend endpoint. |
-| `status` | All companies, all subscriptions, all products, all orders, plus the `recommendations list` output and the `subscriptions renewals` output | Computes top customers by MRR, total seats, urgent renewals (≤14d), top recommendations. | Portfolio-level dashboard JSON or formatted table. | Single-call landing page for "how is my business doing." |
+| `dashboard` (alias `status`) | All companies, all subscriptions, all products, all orders, plus the `recommendations list` output and the `subscriptions renewals` output | Computes top customers by MRR, total seats, urgent renewals (≤14d), top recommendations. | Portfolio-level dashboard JSON or formatted table. | Single-call landing page for "how is my business doing." |
 | `cost sim` | Target company + proposed product, optional `--from` (current product), pricing plans for the proposed product | Resolve current subscription via company × product (or via `--from`); look up proposed pricing plan by billing term; pick volume tier (largest `startQuantityRange` ≤ proposed quantity); compute `monthly = subscriptionMrr(unitPrice, quantity, billingTerm)`, `annual = monthly × 12`, deltas, and per-seat delta. Emit notes for tier selection, default-Annual fallback, billing-term swap. | `{ current: {...} \| null, proposed: {unitPrice, quantity, monthly, annual, productName, billingTerm}, delta: {monthly, annual, perSeat}, notes[] }` | What-if pricing without placing the order. |
 
 ### Naming Drift Flags
 
 - `report growth` is computed from invoiced revenue, but the field is named `mrr` and the percent is `growthPercent`. Partners reading "MRR growth" may assume it's recurring revenue trended forward, not invoice totals trended backward. Worth a label change.
-- `status` mixes computed surfaces (renewals, recommendations) into one response. Any contract change in those flows through `status`.
+- `dashboard` mixes computed surfaces (renewals, recommendations) into one response. Any contract change in those flows through `dashboard`. (The legacy `status` name is retained as a deprecated alias until v1.0; it semantically collided with `auth status`.)
 - `cost sim` does not call any documented Pax8 simulation endpoint. The volume-tier rule (largest `startQuantityRange` ≤ qty) is the CLI's interpretation.
 
 ### Questions for Domain Owner

--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -820,14 +820,28 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
   },
   // ── root-level ────────────────────────────────────────────────────────────
   {
-    command: ["status"],
+    command: ["dashboard"],
     group: "root",
     type: "diagnostic",
     demo: {
       expectedFragments: [/MRR|customers|renewals/i],
       forbiddenFragments: ["undefined"],
     },
-    jsonContract: { skip: { reason: "status dashboard freeform" } },
+    jsonContract: { skip: { reason: "dashboard freeform" } },
+  },
+  {
+    // Deprecated alias for `dashboard`. Hidden from `pax8 --help` and prints
+    // a one-line stderr deprecation notice on every invocation. Kept here so
+    // the per-command matrix continues to exercise the alias path until v1.0.
+    command: ["status"],
+    label: "status (deprecated alias)",
+    group: "root",
+    type: "diagnostic",
+    demo: {
+      expectedFragments: [/MRR|customers|renewals/i],
+      forbiddenFragments: ["undefined"],
+    },
+    jsonContract: { skip: { reason: "alias for dashboard; same freeform output" } },
   },
   {
     command: ["doctor"],

--- a/e2e/per-command.test.ts
+++ b/e2e/per-command.test.ts
@@ -368,7 +368,7 @@ function stripValueArgs(args: string[]): string[] {
     }
     // Skip free-form positionals (likely an ID/name like "Acme Corp")
     // ONLY if we already have a subcommand. Top-level commands like
-    // "status" / "doctor" are positional too but ARE the command.
+    // "dashboard" / "doctor" are positional too but ARE the command.
     if (out.length >= 2) continue; // group + subcommand already captured
     out.push(a);
   }

--- a/e2e/real-api.test.ts
+++ b/e2e/real-api.test.ts
@@ -133,13 +133,13 @@ describeReal("Real API integration tests", () => {
   );
 
   it(
-    "status --json returns dashboard data",
+    "dashboard --json returns dashboard data",
     async () => {
-      const result = await runRealExpectSuccess(["status", "--json"]);
+      const result = await runRealExpectSuccess(["dashboard", "--json"]);
       const data = JSON.parse(result.stdout);
       expect(data).toBeTruthy();
       expect(typeof data).toBe("object");
-      // Status should have some known keys
+      // Dashboard should have some known keys
       expect(data).toHaveProperty("totalCompanies");
       expect(data).toHaveProperty("activeSubscriptions");
     },

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -22,7 +22,7 @@ These never mutate state. Run them freely, in parallel, and as often as needed.
 - `pax8 invoices items` — line items for an invoice
 - `pax8 invoices audit` — read-only computation, no writes
 - `pax8 cost sim` — what-if pricing simulation, no writes
-- `pax8 status`, `pax8 status --all|--renewals|--growth`
+- `pax8 dashboard`, `pax8 dashboard --all|--renewals|--growth`
 - `pax8 doctor` — diagnostics only
 - `pax8 webhooks logs <id>` — delivery history (read-only)
 
@@ -67,14 +67,14 @@ If you're unsure whether a command counts as a write, default to confirming. Bet
 | `--csv` | User asks for a spreadsheet, export, or PSA import. |
 | `--quiet` | Suppress output entirely (rare; mostly for write commands you're chaining). |
 | `--ids-only` | Pipe one command's output into another's `--company` filter. |
-| `--with-actions` | Wrap list-command JSON as `{ items, nextActions }` so suggested next commands ride along. Available on `recommendations list`, `subscriptions renewals`, `webhooks list`, `webhooks logs`. Single-object commands (`status`, `report mrr/growth`, `invoices audit`) always include `nextActions` inline. |
+| `--with-actions` | Wrap list-command JSON as `{ items, nextActions }` so suggested next commands ride along. Available on `recommendations list`, `subscriptions renewals`, `webhooks list`, `webhooks logs`. Single-object commands (`dashboard`, `report mrr/growth`, `invoices audit`) always include `nextActions` inline. |
 
 Result size: list commands default to `--size 25`. For portfolio-wide analysis (MRR, audits, recommendations) use `--size 1000`. Don't fetch 1000 if the user asked for "top 5."
 
 ## Commands
 
 ```
-pax8 status [--all|--customers|--renewals|--growth] --json
+pax8 dashboard [--all|--customers|--renewals|--growth] --json
 pax8 companies list --json
 pax8 companies show <id|name> --json
 pax8 companies more <name>                                  # rich summary, table only
@@ -96,7 +96,7 @@ pax8 doctor                                                  # diagnostics, not 
 
 ## MRR math
 
-The CLI computes MRR for you in `pax8 status`, `pax8 report mrr`, and `pax8 companies more`. Prefer those over hand-rolling it. If you must compute from `subscriptions list`:
+The CLI computes MRR for you in `pax8 dashboard`, `pax8 report mrr`, and `pax8 companies more`. Prefer those over hand-rolling it. If you must compute from `subscriptions list`:
 
 - Monthly billing term → `price × quantity`
 - Annual billing term → `price × quantity ÷ 12`

--- a/packages/cli/src/__tests__/dashboard.test.ts
+++ b/packages/cli/src/__tests__/dashboard.test.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess } from "./test-utils.js";
+
+const DEPRECATION_NOTICE =
+  "warning: `status` is deprecated; use `dashboard`. Will be removed in v1.0.";
+
+describe("pax8 dashboard (canonical)", () => {
+  it("--json returns the portfolio snapshot under the new name", async () => {
+    const result = await runCliExpectSuccess(["dashboard", "--json"]);
+    const data = JSON.parse(result.stdout);
+    expect(data).toHaveProperty("totalCompanies");
+    expect(data).toHaveProperty("activeSubscriptions");
+    expect(data).toHaveProperty("mrr");
+    // Deprecation notice MUST NOT fire for the canonical name.
+    expect(result.stderr).not.toContain(DEPRECATION_NOTICE);
+  });
+
+  it("--help mentions the dashboard command name", async () => {
+    const result = await runCliExpectSuccess(["dashboard", "--help"]);
+    expect(result.stdout).toContain("dashboard");
+    expect(result.stdout.toLowerCase()).toContain("snapshot");
+    expect(result.stderr).not.toContain(DEPRECATION_NOTICE);
+  });
+
+  it("is listed in `pax8 --help` (canonical command surfaces in top-level help)", async () => {
+    const result = await runCliExpectSuccess(["--help"]);
+    expect(result.stdout).toContain("dashboard");
+  });
+});
+
+describe("pax8 status (deprecated alias)", () => {
+  it("--json returns the same payload shape as `pax8 dashboard --json`", async () => {
+    const dash = await runCliExpectSuccess(["dashboard", "--json"]);
+    const status = await runCliExpectSuccess(["status", "--json"]);
+
+    const dashData = JSON.parse(dash.stdout);
+    const statusData = JSON.parse(status.stdout);
+
+    // Same keys → same surface (values may drift across calls if the demo
+    // mock is non-deterministic, but the contract is identical).
+    expect(Object.keys(statusData).sort()).toEqual(Object.keys(dashData).sort());
+    expect(statusData).toHaveProperty("totalCompanies");
+    expect(statusData).toHaveProperty("activeSubscriptions");
+  });
+
+  it("emits the one-line deprecation notice on stderr", async () => {
+    const result = await runCliExpectSuccess(["status", "--json"]);
+    expect(result.stderr).toContain(DEPRECATION_NOTICE);
+    // Stderr-only — never leaks into the JSON payload that consumers parse.
+    expect(result.stdout).not.toContain(DEPRECATION_NOTICE);
+  });
+
+  it("is hidden from `pax8 --help` (still works, but not advertised)", async () => {
+    const result = await runCliExpectSuccess(["--help"]);
+    // The legacy alias must not appear as its own line in the top-level
+    // command list. (The substring "status" still occurs inside other
+    // help phrases — e.g. `--status <status>` filter examples — so we
+    // assert on the leading-whitespace-then-"status" command-listing
+    // shape Commander uses, which would only be present if the alias
+    // were *not* hidden.)
+    expect(result.stdout).not.toMatch(/^\s+status\b/m);
+  });
+
+  it("--help still works on the alias and emits the deprecation notice on stderr", async () => {
+    const result = await runCliExpectSuccess(["status", "--help"]);
+    // The alias --help can render either the dashboard help or the alias's
+    // own help; either is acceptable. What matters is that invoking the
+    // alias still surfaces the deprecation notice.
+    expect(result.stderr).toContain(DEPRECATION_NOTICE);
+  });
+});

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -157,20 +157,12 @@ function renderGrowthSection(
 
 // ── Command ──────────────────────────────────────────────────────────────────
 
-export const statusCommand = new Command("status")
-  .description("Quick snapshot of your Pax8 business")
-  .option("--all", "Show full dashboard with all sections")
-  .option("--customers", "Show top customers by estimated MRR")
-  .option("--renewals", "Show upcoming renewal details")
-  .option("--growth", "Show growth opportunities")
-  .addHelpText("after", `
-Examples:
-  pax8 status
-  pax8 status --all
-  pax8 status --customers
-  pax8 status --renewals --growth
-  pax8 status --json`)
-  .action(async (options, cmd) => {
+// The dashboard handler is extracted so the canonical `dashboard` command and
+// the deprecated `status` alias share the same implementation; the alias is
+// just a thin wrapper that prints a stderr deprecation notice before invoking
+// `runDashboard()`. Will be removed in v1.0 (mirrors the `--events` → `--topics`
+// deprecation in `pax8 webhooks create`).
+async function runDashboard(options: { all?: boolean; customers?: boolean; renewals?: boolean; growth?: boolean }, cmd: Command): Promise<void> {
     const allOpts = cmd.optsWithGlobals();
     const ctx = await buildContext(allOpts);
     const spinner = createSpinner("Loading dashboard...").start();
@@ -500,6 +492,56 @@ Examples:
 
       out.write("\n");
     } catch (error) {
-      await handleCommandError(error, spinner, "Failed to load status");
+      await handleCommandError(error, spinner, "Failed to load dashboard");
     }
-  });
+}
+
+// One-line stderr deprecation notice for the legacy `status` alias. Mirrors
+// the `--events`/`--topics` deprecation pattern (#274). Will be removed in v1.0.
+const STATUS_DEPRECATION_NOTICE =
+  "warning: `status` is deprecated; use `dashboard`. Will be removed in v1.0.\n";
+
+function buildDashboardCommand(name: "dashboard" | "status"): Command {
+  const cmd = new Command(name)
+    .description("Quick snapshot of your Pax8 business")
+    .option("--all", "Show full dashboard with all sections")
+    .option("--customers", "Show top customers by estimated MRR")
+    .option("--renewals", "Show upcoming renewal details")
+    .option("--growth", "Show growth opportunities")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  pax8 ${name}
+  pax8 ${name} --all
+  pax8 ${name} --customers
+  pax8 ${name} --renewals --growth
+  pax8 ${name} --json`,
+    )
+    .action(async (options: { all?: boolean; customers?: boolean; renewals?: boolean; growth?: boolean }, c: Command) => {
+      if (name === "status") {
+        process.stderr.write(STATUS_DEPRECATION_NOTICE);
+      }
+      await runDashboard(options, c);
+    });
+
+  if (name === "status") {
+    // Commander short-circuits `--help` before running .action(), so the
+    // deprecation notice is also emitted as a beforeAll help-text hook so
+    // `pax8 status --help` still surfaces the notice on stderr. The hook
+    // returns "" (no extra help-text content) — its sole purpose is the
+    // side-effect of writing to stderr.
+    cmd.addHelpText("beforeAll", () => {
+      process.stderr.write(STATUS_DEPRECATION_NOTICE);
+      return "";
+    });
+  }
+
+  return cmd;
+}
+
+export const dashboardCommand = buildDashboardCommand("dashboard");
+
+// Deprecated alias. Registered with `{ hidden: true }` in src/index.ts so it
+// does not appear in `pax8 --help`. Removal tracked for v1.0.
+export const statusCommand = buildDashboardCommand("status");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,7 +20,7 @@ import { registerWebhooksCommands } from "./commands/webhooks/index.js";
 import { registerContactsCommands } from "./commands/contacts/index.js";
 import { registerQuotesCommands } from "./commands/quotes/index.js";
 import { registerCostCommands } from "./commands/cost/index.js";
-import { statusCommand } from "./commands/status.js";
+import { dashboardCommand, statusCommand } from "./commands/dashboard.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { completionsCommand } from "./commands/completions.js";
 import { versionCommand } from "./commands/version.js";
@@ -109,7 +109,11 @@ export function createProgram(): Command {
   registerContactsCommands(program);
   registerQuotesCommands(program);
   registerCostCommands(program);
-  program.addCommand(statusCommand);
+  program.addCommand(dashboardCommand);
+  // Deprecated alias for `dashboard`. Hidden from --help; emits a one-line
+  // stderr deprecation notice when invoked. Will be removed in v1.0. Same
+  // pattern as the `--events` → `--topics` deprecation on `webhooks create`.
+  program.addCommand(statusCommand, { hidden: true });
   program.addCommand(initCommand);
   program.addCommand(doctorCommand);
   program.addCommand(completionsCommand);

--- a/packages/cli/src/lib/welcome.test.ts
+++ b/packages/cli/src/lib/welcome.test.ts
@@ -83,7 +83,7 @@ describe("showWelcomeScreen", () => {
     await showWelcomeScreen();
 
     expect(captured).toContain("Common commands:");
-    expect(captured).toContain("status");
+    expect(captured).toContain("dashboard");
     expect(captured).toContain("subscriptions renewals");
     expect(captured).toContain("recommendations");
     expect(captured).toContain("invoices audit");

--- a/packages/cli/src/lib/welcome.ts
+++ b/packages/cli/src/lib/welcome.ts
@@ -61,7 +61,7 @@ export async function showWelcomeScreen(): Promise<void> {
   const commandBlock = authed
     ? [
         `  ${chalk.dim("Common commands:")}`,
-        `    ${cmd("status")}${chalk.dim("Portfolio at a glance")}`,
+        `    ${cmd("dashboard")}${chalk.dim("Portfolio at a glance")}`,
         `    ${cmd("subscriptions renewals")}${chalk.dim("What's renewing in 30 days")}`,
         `    ${cmd("recommendations")}${chalk.dim("Upsell opportunities")}`,
         `    ${cmd("invoices audit")}${chalk.dim("Reconcile invoices vs subscriptions")}`,


### PR DESCRIPTION
## Why

`pax8 status` collided semantically with `pax8 auth status` (an auth-credential check) and was generically named for what is actually a portfolio dashboard — top customers by MRR, urgent renewals, top recommendations. New users encountering `pax8 status` reasonably expect a credential check; partners scripting against the surface have to keep two unrelated `status` commands straight.

This rename gives the dashboard a name that matches what it does. The same approach was used for `pax8 webhooks create --events` → `--topics` in #274: keep the old name as a deprecated alias that prints a one-line stderr notice but still functions identically, hidden from `--help`. Removal is tracked for v1.0; this PR is a patch-level changeset (deprecation, not breaking).

## What changes

- `packages/cli/src/commands/status.ts` → `packages/cli/src/commands/dashboard.ts`. The action handler is extracted into a shared `runDashboard()` so the alias is a thin wrapper around the same logic, not a copy.
- Both commands are constructed via the same `buildDashboardCommand(name)` factory — same options, same examples (rendered with the right name), same handler.
- `dashboardCommand` is registered as the canonical command. `statusCommand` is registered with `{ hidden: true }` so it does not appear in `pax8 --help`.
- The deprecation notice (`warning: \`status\` is deprecated; use \`dashboard\`. Will be removed in v1.0.`) fires from two places: the `.action()` handler (for normal invocations) and an `addHelpText("beforeAll")` hook (so `pax8 status --help` also surfaces the notice — Commander short-circuits `--help` past `.action()`).

## How both paths look

```
$ pax8 dashboard --json
{ "totalCompanies": …, "activeSubscriptions": …, … }       # stdout
                                                            # stderr clean

$ pax8 status --json
warning: \`status\` is deprecated; use \`dashboard\`. Will be removed in v1.0.   # stderr
{ "totalCompanies": …, "activeSubscriptions": …, … }                              # stdout (identical to dashboard --json)

$ pax8 --help
…
  dashboard         Quick snapshot of your Pax8 business
  …
                                                            # `status` is hidden
```

## Audited consumers

- `CLAUDE.md`, `AGENTS.md` — `pax8 status --json` row in the act-first table, `--with-actions` description, read-only commands list, discovery section
- `README.md` — quick-start, demo flow, dashboard subsection, sandbox/staging snippet, demo-mode example
- `packages/claude-skill/skill.md` — read-only commands list, output-flags table, command grammar, MRR-math callout
- `docs/credential-setup.md` — env-var verification examples (bash + PowerShell)
- `docs/domain-review.md` — Reporting & Analytics CLI surface table, computed-layer description, naming-drift flag
- `e2e/command-inventory.ts` — canonical `dashboard` entry plus a hidden/aliased `status` entry so the matrix continues to exercise both paths until v1.0
- `e2e/per-command.test.ts` — comment update only (top-level positional example)
- `e2e/real-api.test.ts` — `["status", "--json"]` → `["dashboard", "--json"]`
- `.devcontainer/devcontainer.json` — postStartCommand hint
- `packages/cli/src/lib/welcome.ts` + `welcome.test.ts` — the welcome PR (#281) had just landed; updated the authenticated layout's `status` row to `dashboard` and adjusted the matching test assertion (per section 2 of the worklog)

## New test coverage

`packages/cli/src/__tests__/dashboard.test.ts` (7 cases) covers:

- `pax8 dashboard --json` returns the snapshot, no deprecation notice on stderr
- `pax8 dashboard --help` works and is mentioned by name
- `dashboard` appears in `pax8 --help`
- `pax8 status --json` returns the same payload shape as `pax8 dashboard --json`
- `pax8 status --json` emits the deprecation notice on stderr (and never on stdout — agent JSON contract)
- `status` does NOT appear in `pax8 --help` (hidden)
- `pax8 status --help` works AND emits the deprecation notice on stderr

## Changeset / CHANGELOG

- New changeset entry: `.changeset/status-to-dashboard-rename.md` (`@pax8/cli`: patch).
- `CHANGELOG.md` Unreleased → Deprecated: new entry under the existing `--events` → `--topics` deprecation, with the same "removed in v1.0" cadence.

## Test plan

- [ ] `pnpm build && pnpm test && pnpm lint` clean (subprocess test for both names + welcome test passing locally; full suite ran under disk-pressure on my environment but the targeted layers all pass — please re-run on a clean CI host)
- [ ] `PAX8_DEMO=1 pax8 dashboard --json` returns the dashboard payload, stderr clean
- [ ] `PAX8_DEMO=1 pax8 status --json` returns the same payload, with the deprecation notice on stderr only (never on stdout)
- [ ] `pax8 --help` lists `dashboard` and does NOT list `status`
- [ ] `pax8 dashboard --help` and `pax8 status --help` both work; only the latter emits the deprecation notice
- [ ] Welcome screen (`pax8` with no args, authenticated layout) shows `dashboard` in the Common commands list

## Out of scope / what NOT to do

- `pax8 auth status` (auth-credential subcommand) is intentionally untouched — it's a different concept under a different command group.
- No new flags, no refactor of dashboard logic itself — pure rename + alias.
- Removal of the alias is a v1.0 task; this PR is patch-level.

## Coordination note

The welcome PR #281 (`feat/welcome-auth-aware`) had merged on `origin/main` by the time this PR's rebase completed, so `packages/cli/src/lib/welcome.ts` is updated here directly (not deferred). The welcome test (`welcome.test.ts`) was updated to assert `dashboard` instead of `status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)