### PR TITLE
chore(test): isolate vitest from developer's local ~/.pax8 config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,13 +11,23 @@ export default defineConfig({
     // every test worker (and every subprocess spawned by `runCli`) into
     // the explicit escape hatch. Production users without this var get
     // the strict default.
+    //
+    // The actual `PAX8_CONFIG_DIR` value is set by
+    // `vitest.test-isolation-setup.ts` (a globalSetup) to a fresh
+    // mkdtemp per run — this prevents a developer's local `~/.pax8/`
+    // (e.g. `demo: true` from a prior `pax8 config set` call) from
+    // leaking into unit tests like `context.test.ts > non-demo path …`.
+    // CI never saw this because runners are fresh; locally it was a
+    // paper-cut.
     env: {
       PAX8_ALLOW_NON_HOME_CONFIG: "1",
     },
-    // Sets NODE_V8_COVERAGE on the parent so child processes spawned by
-    // `runCli()` deposit their v8 profiles into a known directory, which the
-    // custom coverage provider then merges into the final report.
-    globalSetup: ["./vitest.coverage-setup.ts"],
+    // globalSetup order matters when scripts touch process.env: each runs
+    // in declaration order in the parent process, before workers fork.
+    globalSetup: [
+      "./vitest.test-isolation-setup.ts",
+      "./vitest.coverage-setup.ts",
+    ],
     coverage: {
       // Custom provider wraps the standard v8 provider and additionally
       // ingests subprocess coverage profiles. See vitest.coverage-provider.ts.

--- a/vitest.test-isolation-setup.ts
+++ b/vitest.test-isolation-setup.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Vitest globalSetup: isolates the test suite from the developer's local
+ * `~/.pax8/` config directory.
+ *
+ * Without this, a developer who has run `pax8 config set demo true` (or
+ * any other config write) gets unit-test failures that don't reproduce in
+ * CI — `buildContext` reads the on-disk config and takes whatever path
+ * the local config dictates, regardless of what the test set up. CI runs
+ * on fresh runners so it never sees this; locally it's a paper-cut.
+ *
+ * Sets `PAX8_CONFIG_DIR` to a fresh mkdtemp directory before workers
+ * spawn, then cleans up at teardown. Tests that need their own config
+ * dir (existing pattern in several `__tests__/` files using `os.tmpdir()`)
+ * still override `PAX8_CONFIG_DIR` for their own scope; they just no
+ * longer have to worry about whatever the developer happens to have in
+ * `~/.pax8/`.
+ *
+ * Pairs with the per-test mkdtemp `runCli` injection added by the e2e
+ * harness (#216) — that handles subprocess isolation; this handles
+ * unit-test isolation in the parent vitest process.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let isolatedConfigDir: string | undefined;
+
+export default function setup(): () => void {
+  isolatedConfigDir = mkdtempSync(join(tmpdir(), "pax8-vitest-config-"));
+  process.env.PAX8_CONFIG_DIR = isolatedConfigDir;
+  return () => {
+    if (isolatedConfigDir) {
+      try {
+        rmSync(isolatedConfigDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup; tmpdir gets reaped by the OS anyway.
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- A developer who has \`demo: true\` (or any other state) in their \`~/.pax8/config.yaml\` gets unit-test failures locally that don't reproduce in CI: \`buildContext\` reads the on-disk config and takes whatever path that dictates, regardless of what the test sets up.
- Adds \`vitest.test-isolation-setup.ts\` as a globalSetup that mkdtemps a fresh \`PAX8_CONFIG_DIR\` per test run, sets the env var before workers fork, and cleans up at teardown.

## Why now
Caught while running an e2e smoke pass through the CLI tonight. My local \`~/.pax8/config.yaml\` had \`demo: true\` from earlier session work, and 5 unit tests in \`context.test.ts\` and \`doctor.test.ts\` that exercise the non-demo path failed because the loaded config forced demo mode. Same paper-cut anyone iterating in a real \`PAX8_DEMO=1\` shell will hit.

## Tradeoffs
- Tests that explicitly set their own \`PAX8_CONFIG_DIR\` continue to override (existing pattern in several files using \`os.tmpdir()\` directly). This just changes the default from \"developer's home\" to \"isolated tmpdir.\"
- Pairs with the per-call \`PAX8_CONFIG_DIR\` mkdtemp added in #216 for the e2e harness — that handles subprocess isolation; this handles unit-test isolation in the parent vitest process.

## Test plan
- [x] \`pnpm test\` with \`~/.pax8/config.yaml\` containing \`demo: true\` → 1530 passed, 0 failed (was 5 failed before this change)
- [x] \`~/.pax8/config.yaml\` not touched after test run
- [x] \`/tmp/pax8-vitest-config-*\` dirs cleaned up after run
- [x] \`pnpm lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)