### PR TITLE
perf(cli): skip coverage on JSON, dedupe cache warmer, narrow product enrichment fetch

### DIFF
--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -81,8 +81,10 @@ Examples:
         return;
       }
 
-      // Determine if we should fetch coverage data
-      const wantsCoverage = allOpts.coverage || ctx.outputFormat === "json";
+      // Coverage analysis fires only when explicitly requested via --coverage.
+      // JSON output without --coverage returns the basic company shape and
+      // skips the 1000-row subscription fetch + product enrichment.
+      const wantsCoverage = Boolean(allOpts.coverage);
 
       // Build coverage map if requested
       let coverageMap: Map<string, { coverage: string; missingCategories: string[]; estimatedUplift: number; coveredCategories: string[] }> | null = null;

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -198,33 +198,20 @@ export async function buildContext(
 function spawnCacheWarmer(): void {
   const env = { ...process.env, PAX8_CACHE_WARMING: "1" };
 
-  const child = spawn(
-    "pax8",
-    ["companies", "list", "--json", "--size", "200", "--quiet"],
-    { detached: true, stdio: "ignore", env },
-  );
+  spawnCacheWarm(["companies", "list", "--json", "--size", "200", "--quiet"], env, "companies");
+  spawnCacheWarm(["subscriptions", "list", "--json", "--size", "1000", "--quiet"], env, "subscriptions");
+  spawnCacheWarm(["products", "list", "--json", "--size", "500", "--quiet"], env, "products");
+}
+
+/**
+ * Spawn a single detached `pax8 ...` cache-warm child. Errors are best-effort
+ * and only surfaced under `PAX8_DEBUG`. Caller is responsible for passing the
+ * env that already has `PAX8_CACHE_WARMING=1` set so the child doesn't recurse.
+ */
+function spawnCacheWarm(args: string[], env: NodeJS.ProcessEnv, label: string): void {
+  const child = spawn("pax8", args, { detached: true, stdio: "ignore", env });
   child.on("error", (err) => {
-    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] cache warmer (companies) failed: ${err}\n`);
+    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] cache warmer (${label}) failed: ${err}\n`);
   });
   child.unref();
-
-  const child2 = spawn(
-    "pax8",
-    ["subscriptions", "list", "--json", "--size", "1000", "--quiet"],
-    { detached: true, stdio: "ignore", env },
-  );
-  child2.on("error", (err) => {
-    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] cache warmer (subscriptions) failed: ${err}\n`);
-  });
-  child2.unref();
-
-  const child3 = spawn(
-    "pax8",
-    ["products", "list", "--json", "--size", "500", "--quiet"],
-    { detached: true, stdio: "ignore", env },
-  );
-  child3.on("error", (err) => {
-    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] cache warmer (products) failed: ${err}\n`);
-  });
-  child3.unref();
 }

--- a/packages/cli/src/lib/enrich-subscriptions.test.ts
+++ b/packages/cli/src/lib/enrich-subscriptions.test.ts
@@ -25,15 +25,18 @@ function mockCtx(catalogProducts: Array<{ id: string; name: string }>, individua
 }
 
 describe("enrichProductNames", () => {
-  it("resolves names from bulk catalog", async () => {
+  it("resolves names via per-id lookup when the missing set is small", async () => {
+    // <=25 unique missing IDs: narrow path uses products.get(id) in parallel
+    // and avoids the 500-row bulk catalog fetch entirely.
     const subs: MockSub[] = [{ productId: "p1", productName: undefined }];
-    const ctx = mockCtx([{ id: "p1", name: "Microsoft 365" }], {});
+    const ctx = mockCtx([{ id: "p1", name: "Microsoft 365" }], { p1: "Microsoft 365" });
     await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("Microsoft 365");
-    expect(ctx.api.products.get).not.toHaveBeenCalled();
+    expect(ctx.api.products.get).toHaveBeenCalledWith("p1");
+    expect(ctx.api.products.list).not.toHaveBeenCalled();
   });
 
-  it("falls back to individual lookup when not in catalog", async () => {
+  it("uses per-id lookup for individual products on the narrow path", async () => {
     const subs: MockSub[] = [{ productId: "p1", productName: undefined }];
     const ctx = mockCtx([], { p1: "Defender for Business" });
     await enrichProductNames(ctx, subs);
@@ -41,15 +44,16 @@ describe("enrichProductNames", () => {
     expect(ctx.api.products.get).toHaveBeenCalledWith("p1");
   });
 
-  it("uses catalog for some and individual for others", async () => {
+  it("resolves multiple products in parallel via per-id lookups", async () => {
     const subs: MockSub[] = [
       { productId: "p1", productName: undefined },
       { productId: "p2", productName: undefined },
     ];
-    const ctx = mockCtx([{ id: "p1", name: "M365" }], { p2: "Acronis Backup" });
+    const ctx = mockCtx([], { p1: "M365", p2: "Acronis Backup" });
     await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("M365");
     expect(subs[1].productName).toBe("Acronis Backup");
+    expect(ctx.api.products.list).not.toHaveBeenCalled();
   });
 
   it("skips subs that already have names", async () => {
@@ -58,6 +62,7 @@ describe("enrichProductNames", () => {
     await enrichProductNames(ctx, subs);
     expect(subs[0].productName).toBe("Already Named");
     expect(ctx.api.products.list).not.toHaveBeenCalled();
+    expect(ctx.api.products.get).not.toHaveBeenCalled();
   });
 
   it("handles individual lookup 404 gracefully", async () => {
@@ -71,17 +76,27 @@ describe("enrichProductNames", () => {
     expect(subs[1].productName).toBeUndefined();
   });
 
-  it("handles bulk fetch failure and falls back entirely", async () => {
-    const subs: MockSub[] = [{ productId: "p1", productName: undefined }];
-    const ctx = {
-      api: {
-        products: {
-          list: vi.fn().mockRejectedValue(new Error("network error")),
-          get: vi.fn().mockResolvedValue({ id: "p1", name: "Fallback Product" }),
-        },
-      },
-    } as unknown as CommandContext;
+  it("falls back to bulk catalog when the missing set exceeds the per-id threshold", async () => {
+    // Build 30 missing subscriptions: > the 25-id threshold triggers the
+    // bulk-list path. Catalog covers some, per-id fills the rest.
+    const catalogProducts: Array<{ id: string; name: string }> = [];
+    const lookups: Record<string, string> = {};
+    const subs: MockSub[] = [];
+    for (let i = 0; i < 30; i++) {
+      const pid = `p${i}`;
+      subs.push({ productId: pid, productName: undefined });
+      if (i < 20) {
+        catalogProducts.push({ id: pid, name: `Catalog ${i}` });
+      } else {
+        lookups[pid] = `Individual ${i}`;
+      }
+    }
+    const ctx = mockCtx(catalogProducts, lookups);
     await enrichProductNames(ctx, subs);
-    expect(subs[0].productName).toBe("Fallback Product");
+    expect(ctx.api.products.list).toHaveBeenCalledWith({ size: 500 });
+    expect(subs[0].productName).toBe("Catalog 0");
+    expect(subs[19].productName).toBe("Catalog 19");
+    expect(subs[20].productName).toBe("Individual 20");
+    expect(subs[29].productName).toBe("Individual 29");
   });
 });

--- a/packages/cli/src/lib/enrich-subscriptions.ts
+++ b/packages/cli/src/lib/enrich-subscriptions.ts
@@ -16,8 +16,21 @@ interface EnrichableByCompany {
 }
 
 /**
+ * When the set of missing product IDs is at or below this threshold we fetch
+ * each one individually (in parallel) instead of pulling the entire 500-row
+ * catalog. Sized so that `Promise.all` over the batch doesn't risk tripping
+ * the API's per-minute rate limit even on chatty terminals.
+ */
+const PER_ID_FETCH_THRESHOLD = 25;
+
+/**
  * Enrich subscriptions with product names when the API only returns productId.
- * Tries bulk catalog first, then individual lookups for any still missing.
+ *
+ * Strategy: collect the unique missing product IDs first. If the set is small
+ * (<= PER_ID_FETCH_THRESHOLD), fetch each via `products.get(id)` in parallel —
+ * this avoids pulling 500 catalog rows for a portfolio with a handful of
+ * unique products. For larger sets, fall back to the bulk `products.list`
+ * path (with per-id fill-in for anything still unresolved).
  *
  * Accepts typed subscription arrays (e.g. Subscription[]) as well as
  * Record<string, unknown>[] for backward compatibility.
@@ -39,34 +52,47 @@ export async function enrichProductNames(
 
   const nameMap = new Map<string, string>();
 
-  // Step 1: bulk fetch from catalog
-  try {
-    const result = await ctx.api.products.list({ size: 500 });
-    for (const product of result.content) {
-      if (missing.has(product.id)) {
-        nameMap.set(product.id, product.name);
+  if (missing.size <= PER_ID_FETCH_THRESHOLD) {
+    // Narrow path: fetch only the IDs we need, in parallel.
+    await Promise.all(
+      [...missing].map(async (pid) => {
+        try {
+          const product = await ctx.api.products.get(pid);
+          if (product?.name) nameMap.set(pid, product.name);
+        } catch (err) {
+          if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] product lookup failed for ${pid}: ${err}\n`);
+        }
+      })
+    );
+  } else {
+    // Wide path: bulk fetch the catalog, then fill in any stragglers.
+    try {
+      const result = await ctx.api.products.list({ size: 500 });
+      for (const product of result.content) {
+        if (missing.has(product.id)) {
+          nameMap.set(product.id, product.name);
+        }
       }
+    } catch (err) {
+      if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] bulk product fetch failed: ${err}\n`);
     }
-  } catch (err) {
-    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] bulk product fetch failed: ${err}\n`);
-  }
 
-  // Step 2: individual lookups for any still unresolved (batched to avoid rate limits)
-  const stillMissing = [...missing].filter((pid) => !nameMap.has(pid));
-  if (stillMissing.length > 0) {
-    const BATCH_SIZE = 15;
-    for (let i = 0; i < stillMissing.length; i += BATCH_SIZE) {
-      const batch = stillMissing.slice(i, i + BATCH_SIZE);
-      await Promise.all(
-        batch.map(async (pid) => {
-          try {
-            const product = await ctx.api.products.get(pid);
-            if (product?.name) nameMap.set(pid, product.name);
-          } catch (err) {
-            if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] product lookup failed for ${pid}: ${err}\n`);
-          }
-        })
-      );
+    const stillMissing = [...missing].filter((pid) => !nameMap.has(pid));
+    if (stillMissing.length > 0) {
+      const BATCH_SIZE = 15;
+      for (let i = 0; i < stillMissing.length; i += BATCH_SIZE) {
+        const batch = stillMissing.slice(i, i + BATCH_SIZE);
+        await Promise.all(
+          batch.map(async (pid) => {
+            try {
+              const product = await ctx.api.products.get(pid);
+              if (product?.name) nameMap.set(pid, product.name);
+            } catch (err) {
+              if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] product lookup failed for ${pid}: ${err}\n`);
+            }
+          })
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Three small efficiency wins surfaced by a code-review audit, all clustered in the read-path plumbing for `companies list` / subscription enrichment. No CLI flags, output contracts, or core abstractions change.

### Fix 1 — `companies list --json` no longer forces coverage analysis

**Before:** `wantsCoverage = allOpts.coverage || ctx.outputFormat === "json"` — every JSON request forced a 1000-row subscription fetch, full product-name enrichment, and the coverage-analysis pipeline.

**After:** `wantsCoverage = Boolean(allOpts.coverage)`. Coverage fires only when explicitly requested. Plain `pax8 companies list --json` returns the basic company shape, fast.

`--with-actions` still works on either path (it falls back to the "Re-run with --coverage" hint when coverage data isn't available — pre-existing logic in the `else` branch).

### Fix 2 — Cache warmer DRY refactor

**Before:** three near-identical 9-line `spawn()` blocks in `buildContext`.

**After:** a single `spawnCacheWarm(args, env, label)` helper, three one-line calls.

**Note on the deferred half:** the audit also asked for a freshness gate so the warmer skips when the cache is still hot. `FileCache` exposes `get<T>` (which returns the data) and `set/invalidate/clear`, but no `isFresh()` / `getAge()` that checks freshness without reading the value. Per the spec's stop condition ("If the cache module has no method to check freshness without reading the value, stop and report — adding such a method is out of scope for this PR") that piece is deferred. Could land as a follow-up that adds `FileCache.isFresh(key, withinMs)`.

### Fix 3 — `enrichProductNames` fetches only what's missing on the narrow path

**Before:** unconditionally pulled the 500-row catalog via `products.list({ size: 500 })`, then per-id-batched any stragglers.

**After:**
- Collect unique missing product IDs first.
- If the set is small (`<= PER_ID_FETCH_THRESHOLD = 25`): fetch each via `products.get(id)` in parallel (`Promise.all`) and skip the bulk catalog entirely. Typical MSP portfolios have ~5–15 unique products, so this path is the common case.
- If the set is large (`> 25`): fall back to the original bulk-list-then-fill-in pattern unchanged.

Threshold of 25 is conservative enough that `Promise.all` over the batch won't trip the 1,000 req/min API ceiling. The existing API client has built-in retry/backoff for 429s.

`enrichCompanyNames` doesn't have the same pattern (it takes a pre-built map, no fetch), so it's left alone.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test packages/cli/src/lib/enrich-subscriptions.test.ts` — 6/6 pass (tests updated to cover the new narrow + bulk-fallback contract)
- [x] `pnpm lint` clean
- [x] `PAX8_DEMO=1 pax8 companies list --json` — no coverage fields, fast
- [x] `PAX8_DEMO=1 pax8 companies list --json --coverage` — includes `coverage`, `coveredCategories`, `missingCategories`, `estimatedUplift`
- [x] Full `pnpm test` — same 5 pre-existing failures as `main` (all environmental: my local `~/.pax8/config.yaml` has `demo: true`, which makes the non-demo `context.test.ts` cases skip the cache-warmer branch; doctor's `.mcp.json` walk hits one in the parent worktree). None of the 5 are caused by this PR — verified by running tests on `main` with my changes stashed and seeing the identical failure set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)