### PR TITLE
fix(output): union-of-keys column inference; test(mock): Zod invariant on demo data

### DIFF
--- a/packages/cli/src/__tests__/table-output.test.ts
+++ b/packages/cli/src/__tests__/table-output.test.ts
@@ -97,13 +97,12 @@ describe("table output — TTY-aware rendering", () => {
       expect(result.exitCode).toBe(0);
       const data = JSON.parse(result.stdout);
       expect(data.length).toBeGreaterThan(0);
-      // Verify all rows have consistent keys
-      const keys = Object.keys(data[0]);
-      for (const row of data) {
-        for (const key of keys) {
-          expect(row).toHaveProperty(key);
-        }
-      }
+      // No per-row key-presence assertion here. The original assertion took
+      // `Object.keys(data[0])` and required every other row to carry the same
+      // keys, which forced uniform population of optional fields and bit us in
+      // PR #277. Optional-field sparseness is *expected* in real `--json`
+      // output; the table renderer's column inference (now union-of-keys) is
+      // tested directly in `lib/output-extended.test.ts`.
     });
 
     it("CSV output has no ANSI codes", async () => {

--- a/packages/cli/src/lib/output-extended.test.ts
+++ b/packages/cli/src/lib/output-extended.test.ts
@@ -51,10 +51,38 @@ describe("output — extended coverage", () => {
       expect(lines[1]).toBe("1,Acme,Active");
     });
 
+    it("infers columns from the union of keys across all rows", () => {
+      // First row has {a, b}; second has {a, c}. The brittle pre-fix
+      // implementation only saw `a, b` because it read `Object.keys(rows[0])`.
+      // The fix collects keys in first-encounter order: a, b, c.
+      const data = [
+        { a: 1, b: 2 },
+        { a: 3, c: 4 },
+      ];
+      output(data, { format: "csv" });
+
+      const written = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+      const lines = written.trim().split("\n");
+      expect(lines[0]).toBe("a,b,c");
+      // Row 1: a=1, b=2, c=(absent → empty cell)
+      expect(lines[1]).toBe("1,2,");
+      // Row 2: a=3, b=(absent → empty cell), c=4
+      expect(lines[2]).toBe("3,,4");
+    });
+
     it("produces no output when data is empty and no columns", () => {
       output([], { format: "csv" });
 
       // No columns to infer, so nothing should be output
+      expect(stdoutWrite).not.toHaveBeenCalled();
+    });
+
+    it("produces no output when data is empty and no columns (no rows[0] access)", () => {
+      // Regression guard: the brittle implementation indexed `rows[0]` before
+      // the length check, which would crash on an empty array if reordered.
+      // The fix walks all rows; with zero rows, the inferred-column list is
+      // empty and we short-circuit cleanly.
+      expect(() => output([], { format: "csv" })).not.toThrow();
       expect(stdoutWrite).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -125,6 +125,32 @@ function formatCSV(data: readonly Record<string, unknown>[], columns: Column[]):
 }
 
 /**
+ * Build a `Column[]` by walking every row and collecting unique keys in
+ * first-encounter order.
+ *
+ * Earlier code inferred columns from `Object.keys(rows[0])`, which assumes
+ * the first row is canonical. With realistic data (some entries populating
+ * optional fields, others not), that meant the column set could flicker
+ * based on sort order. Walking the union closes the gap without imposing
+ * uniformity on the underlying records.
+ *
+ * Returns an empty array when `rows` is empty.
+ */
+function inferColumns(rows: readonly Record<string, unknown>[]): Column[] {
+  const seen = new Set<string>();
+  const orderedKeys: string[] = [];
+  for (const row of rows) {
+    for (const k of Object.keys(row)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        orderedKeys.push(k);
+      }
+    }
+  }
+  return orderedKeys.map((key) => ({ key, header: key }));
+}
+
+/**
  * Render `data` to stdout in the format selected by `options`.
  *
  * The parameter type is intentionally widened to `readonly object[]` so that
@@ -153,12 +179,12 @@ export function output(data: readonly object[], options: OutputOptions): void {
       // Fallback: show as JSON if no columns defined
       formatJSON(rows);
     } else if (format === "csv") {
-      // Infer columns from first item
-      if (rows.length > 0) {
-        const inferred: Column[] = Object.keys(rows[0]).map((key) => ({
-          key,
-          header: key,
-        }));
+      // Infer columns from the union of keys across all rows, in
+      // first-encounter order. Walking the union (rather than `rows[0]`)
+      // means rows with sparsely populated optional fields don't cause the
+      // column list to flicker based on which row sorts first.
+      const inferred = inferColumns(rows);
+      if (inferred.length > 0) {
         formatCSV(rows, inferred);
       }
     }

--- a/packages/core/src/mock/demo-data.invariant.test.ts
+++ b/packages/core/src/mock/demo-data.invariant.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Drift insurance for the demo fixtures.
+ *
+ * The mock client returns objects from `demo-data.ts` directly — it doesn't
+ * Zod-parse them on the way out. If a public schema in `api/types.ts` adds a
+ * required field or tightens a type, the demo data silently goes stale (we
+ * hit this on PR #277 when the demo `Company` type didn't reflect a schema
+ * change). This test parses every demo entry against its public schema so any
+ * such drift fails CI immediately.
+ *
+ * Invariant: every entry in every demo collection that has a public Zod schema
+ * MUST `safeParse` cleanly. If a collection has no corresponding schema (e.g.
+ * internal helper data), it's skipped explicitly with a comment.
+ *
+ * NOTE — known-incomplete coverage:
+ * Only the four collections covered below (`companies`, `webhooks`,
+ * `webhookLogs`, `webhookTopicDefinitions`) parse against their public
+ * schemas today. The remaining demo collections — `subscriptions`, `products`,
+ * `invoices`, `invoiceItems`, `orders`, `contacts`, `usageSummaries`,
+ * `usageLines`, `quotes` — fail because every demo seed uses
+ * human-readable IDs (e.g. `prod-m365-...`, `sub-summit-...`, `inv-summit-...`)
+ * while the schemas declare `id: z.string().uuid()` (and similarly on every
+ * cross-reference: `productId`, `companyId`, etc.). The two surfaces were
+ * never reconciled because the mock client bypasses Zod on read paths, so
+ * the conflict was invisible until this invariant was attempted.
+ *
+ * Resolving it is a design call (loosen the schemas to `z.string()` on IDs to
+ * match the upstream OpenAPI spec, OR migrate demo IDs to UUIDs and keep
+ * readable names in the existing `*Name` fields). That's a separate PR; this
+ * file ships only what passes today and grows as the conflict is resolved.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { z } from "zod";
+import {
+  CompanySchema,
+  TopicDefinitionSchema,
+  WebhookLogSchema,
+  WebhookSchema,
+} from "../api/types.js";
+import {
+  companies,
+  webhookLogs,
+  webhookTopicDefinitions,
+  webhooks,
+} from "./demo-data.js";
+
+/**
+ * Walk every entry in `collection`, Zod-parse it, and assert success. On
+ * failure, surface the entry index, its `id` if any, and the Zod error paths
+ * so the diagnostic isn't a wall of stringified noise.
+ */
+function expectAllParse<T>(
+  collection: readonly T[],
+  schema: z.ZodTypeAny,
+  collectionName: string,
+): void {
+  const failures: string[] = [];
+  for (let i = 0; i < collection.length; i++) {
+    const entry = collection[i];
+    const result = schema.safeParse(entry);
+    if (!result.success) {
+      const id =
+        entry && typeof entry === "object" && "id" in entry
+          ? String((entry as { id: unknown }).id)
+          : `<index ${i}>`;
+      const issues = result.error.issues
+        .map((iss) => `    - ${iss.path.join(".") || "<root>"}: ${iss.message}`)
+        .join("\n");
+      failures.push(`  [${i}] ${id}:\n${issues}`);
+    }
+  }
+  expect(
+    failures,
+    `${collectionName}: ${failures.length}/${collection.length} entries failed Zod validation:\n${failures.join("\n")}`,
+  ).toEqual([]);
+}
+
+describe("demo-data — Zod schema invariant", () => {
+  it("companies parse against CompanySchema", () => {
+    expectAllParse(companies, CompanySchema, "companies");
+  });
+
+  it("webhooks parse against WebhookSchema", () => {
+    expectAllParse(webhooks, WebhookSchema, "webhooks");
+  });
+
+  it("webhookLogs parse against WebhookLogSchema", () => {
+    expectAllParse(webhookLogs, WebhookLogSchema, "webhookLogs");
+  });
+
+  it("webhookTopicDefinitions parse against TopicDefinitionSchema", () => {
+    expectAllParse(
+      webhookTopicDefinitions,
+      TopicDefinitionSchema,
+      "webhookTopicDefinitions",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes from the same code-review thread, bounded to the audit's scope. Both motivated by the brittle `Object.keys(rows[0])` pattern that bit us in #277.

### Fix A — Zod invariant on demo data (drift insurance)

`MockPax8Client` returns objects from `packages/core/src/mock/demo-data.ts` without Zod-parsing them, so a schema tightening in `packages/core/src/api/types.ts` silently goes stale (#277 was the precipitating incident — the demo `Company` type didn't reflect a public schema change). New `packages/core/src/mock/demo-data.invariant.test.ts` `safeParse`s every demo entry against its public schema and surfaces the entry id + Zod error path on failure.

**Known-incomplete coverage.** The new file covers `companies`, `webhooks`, `webhookLogs`, and `webhookTopicDefinitions` today. The remaining demo collections — `subscriptions`, `products`, `invoices`, `invoiceItems`, `orders`, `contacts`, `usageSummaries`, `usageLines`, `quotes` — fail the invariant because every demo seed uses human-readable IDs (e.g. `prod-m365-...`, `sub-summit-...`, `inv-summit-...`) while the schemas declare `id: z.string().uuid()` and similarly require UUIDs on every cross-reference. The mock client bypasses Zod on read paths, so the conflict was invisible until this invariant was attempted.

Resolving the conflict is a design call (loosen the schemas to `z.string()` on IDs to match the upstream OpenAPI contract, OR migrate demo IDs to deterministic UUIDs and keep readable names in the existing `*Name` fields). That's a separate PR. The `demo-data.invariant.test.ts` header documents the conflict and the resolution options. Per the audit's stop conditions, this PR ships only the harness + the collections that pass today, rather than picking a direction unilaterally.

### Fix B — union-of-keys column inference in `lib/output.ts`

Two sites assumed `rows[0]` was canonical. Both were addressed:

- **`packages/cli/src/lib/output.ts`** — the CSV-without-explicit-columns fallback used `Object.keys(rows[0]).map(...)` to infer the column set. With sparsely-populated optional fields, that meant the column list could flicker based on sort order. New `inferColumns()` helper walks every row and collects keys in first-encounter order. Empty-input case is handled without indexing `rows[0]`.
- **`packages/cli/src/__tests__/table-output.test.ts`** — the `for (const key of keys) { expect(row).toHaveProperty(key); }` block (where `keys = Object.keys(data[0])`) is dropped. That assertion was the contract that forced demo-data uniformity in #277, and the semantic invariant it claimed to check ("well-formed table") doesn't actually exist for `--json` output where optional-field sparseness is *expected*. The renderer's column-inference behavior is now tested directly in `output-extended.test.ts`.

Demo-data uniformity from #277 (e.g. every Company carrying `externalId`) is intentionally **not** undone here — that's a separate cosmetic cleanup. Post-merge, the demo data is free to vary again.

### Coordination

- Bounded to `lib/output.ts`, `output-extended.test.ts`, `__tests__/table-output.test.ts`, and the new invariant test file.
- Does **not** touch `lib/context.ts`, `lib/enrich-subscriptions.ts`, or `commands/companies/list.ts` (in-flight sibling PR `perf/json-coverage-cache-warmer-enrichment`).
- No schema changes. No demo-data structural refactor. No runtime Zod step in the mock client. No new abstractions beyond the union-of-keys helper.
- Test-infra + internal-helper change → no changeset.

## Test plan

- [ ] `pnpm test packages/core/src/mock/demo-data.invariant.test.ts` — 4 invariants pass.
- [ ] `pnpm test packages/cli/src/lib/output-extended.test.ts` — the new union-of-keys test asserts headers `a,b,c` (in that order) for `[{a,b},{a,c}]` and the empty-input case doesn't crash.
- [ ] `pnpm test packages/cli/src/__tests__/table-output.test.ts` — passes; the per-row `toHaveProperty(key)` assertion is gone.
- [ ] `pnpm build && pnpm lint` — clean.
- [ ] Spot-check `PAX8_DEMO=1 pax8 companies list --csv` and `subscriptions list --csv` (both pass an explicit `Column[]`, so they exercise the non-inferred CSV path; behavior unchanged).