### PR TITLE
refactor(types): loosen z.string().uuid() to z.string() on ID fields; complete demo-data invariant test

### DIFF
--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -64,8 +64,11 @@ describe("CompanySchema", () => {
     expect(() => CompanySchema.parse({ name: "Acme Corp" })).toThrow();
   });
 
-  it("rejects invalid uuid", () => {
-    expect(() => CompanySchema.parse({ id: "not-a-uuid", name: "Acme" })).toThrow();
+  it("rejects non-string id", () => {
+    // ID schema is `z.string()` (loosened from `.uuid()` in #289 follow-up so
+    // human-readable demo IDs like `prod-m365-biz-prem-0001` parse cleanly).
+    // Format isn't enforced at the schema layer; the type still must be a string.
+    expect(() => CompanySchema.parse({ id: 12345, name: "Acme" })).toThrow();
   });
 
   it("rejects missing name", () => {
@@ -196,8 +199,10 @@ describe("ProductSchema", () => {
     expect(() => ProductSchema.parse({ id: uuid })).toThrow();
   });
 
-  it("rejects non-uuid id", () => {
-    expect(() => ProductSchema.parse({ id: "abc", name: "Product" })).toThrow();
+  it("rejects non-string id", () => {
+    // ID schema is `z.string()` (loosened from `.uuid()` so human-readable
+    // demo IDs parse cleanly); the type still must be a string.
+    expect(() => ProductSchema.parse({ id: 42, name: "Product" })).toThrow();
   });
 });
 
@@ -784,10 +789,13 @@ describe("PaginatedResponseSchema", () => {
 
   it("rejects invalid items in content", () => {
     const schema = PaginatedResponseSchema(CompanySchema);
+    // CompanySchema.id is `z.string()` (UUID format isn't enforced); the
+    // content item must still satisfy the rest of the shape (e.g. `name`
+    // is required, types must match).
     expect(() =>
       schema.parse({
         page: { size: 10, totalElements: 1, totalPages: 1, number: 0 },
-        content: [{ id: "not-a-uuid", name: "Bad Company" }],
+        content: [{ id: uuid /* missing name */ }],
       }),
     ).toThrow();
   });

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -65,7 +65,7 @@ export type Address = z.infer<typeof AddressSchema>;
 // ─── Company ─────────────────────────────────────────────────────────────────
 
 export const CompanySchema = z.object({
-  id: z.string().uuid(),
+  id: z.string(),
   name: z.string(),
   address: AddressSchema.optional(),
   phone: z.string().optional(),
@@ -112,12 +112,12 @@ export type UpdateCompanyInput = z.infer<typeof UpdateCompanyInputSchema>;
 // ─── Contact ─────────────────────────────────────────────────────────────────
 
 export const ContactSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string(),
   firstName: z.string(),
   lastName: z.string(),
   email: z.string().email(),
   phone: z.string().optional(),
-  companyId: z.string().uuid(),
+  companyId: z.string(),
   types: z.array(ContactTypeSchema),
 });
 export type Contact = z.infer<typeof ContactSchema>;
@@ -127,7 +127,7 @@ export const CreateContactInputSchema = z.object({
   lastName: z.string().min(1),
   email: z.string().email(),
   phone: z.string().optional(),
-  companyId: z.string().uuid(),
+  companyId: z.string(),
   types: z.array(ContactTypeSchema).min(1),
 });
 export type CreateContactInput = z.infer<typeof CreateContactInputSchema>;
@@ -144,7 +144,7 @@ export type UpdateContactInput = z.infer<typeof UpdateContactInputSchema>;
 // ─── Product ─────────────────────────────────────────────────────────────────
 
 export const ProductSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string(),
   name: z.string(),
   // The public Pax8 API exposes vendor identity as `vendorName`. Earlier CLI
   // versions also carried a duplicate `vendor` field for the same concept;
@@ -168,7 +168,7 @@ export const ProductPricingRateSchema = z.object({
 export type ProductPricingRate = z.infer<typeof ProductPricingRateSchema>;
 
 export const ProductPricingPlanSchema = z.object({
-  productId: z.string().uuid(),
+  productId: z.string(),
   productName: z.string().optional(),
   billingTerm: z.string(),
   commitmentTerm: z.string().optional(),
@@ -199,7 +199,7 @@ export const ProvisioningFieldSchema = z.object({
 export type ProvisioningField = z.infer<typeof ProvisioningFieldSchema>;
 
 export const ProvisioningDetailSchema = z.object({
-  productId: z.string().uuid(),
+  productId: z.string(),
   vendorPrerequisites: z.string().optional(),
   fields: z.array(ProvisioningFieldSchema).optional(),
 });
@@ -217,18 +217,18 @@ export const CommitmentTermSchema = z.enum([
 export type CommitmentTerm = z.infer<typeof CommitmentTermSchema>;
 
 export const OrderLineItemInputSchema = z.object({
-  productId: z.string().uuid(),
+  productId: z.string(),
   quantity: z.number().int().min(1),
   billingTerm: BillingTermSchema.optional(),
-  commitmentTermId: z.string().uuid().optional(),
+  commitmentTermId: z.string().optional(),
   provisioningDetails: OrderLineItemProvisioningSchema.optional(),
 });
 export type OrderLineItemInput = z.infer<typeof OrderLineItemInputSchema>;
 
 export const OrderLineItemSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string(),
   offerId: z.string().optional(),
-  productId: z.string().uuid(),
+  productId: z.string(),
   /** Denormalized product name (demo data convenience). */
   productName: z.string().optional(),
   /** Optional billing term (demo data convenience). */
@@ -240,8 +240,8 @@ export const OrderLineItemSchema = z.object({
 export type OrderLineItem = z.infer<typeof OrderLineItemSchema>;
 
 export const OrderSchema = z.object({
-  id: z.string().uuid(),
-  companyId: z.string().uuid(),
+  id: z.string(),
+  companyId: z.string(),
   /** Denormalized company name. Returned by the demo client; the real API
    * doesn't include it directly but the CLI populates it after lookup. */
   companyName: z.string().optional(),
@@ -255,7 +255,7 @@ export const OrderSchema = z.object({
 export type Order = z.infer<typeof OrderSchema>;
 
 export const CreateOrderInputSchema = z.object({
-  companyId: z.string().uuid(),
+  companyId: z.string(),
   lineItems: z.array(OrderLineItemInputSchema).min(1),
 });
 export type CreateOrderInput = z.infer<typeof CreateOrderInputSchema>;
@@ -263,7 +263,7 @@ export type CreateOrderInput = z.infer<typeof CreateOrderInputSchema>;
 // ─── Subscription ────────────────────────────────────────────────────────────
 
 export const CommitmentSchema = z.object({
-  id: z.string().uuid().optional(),
+  id: z.string().optional(),
   term: z.string().optional(),
   endDate: z.string().optional(),
 });
@@ -295,9 +295,9 @@ export type Commitment = z.infer<typeof CommitmentSchema>;
  * tracked separately.
  */
 export const SubscriptionSchema = z.object({
-  id: z.string().uuid(),
-  companyId: z.string().uuid(),
-  productId: z.string().uuid(),
+  id: z.string(),
+  companyId: z.string(),
+  productId: z.string(),
   quantity: z.number(),
   startDate: z.string(),
   endDate: z.string().optional(),
@@ -330,7 +330,7 @@ export type UpdateSubscriptionInput = z.infer<typeof UpdateSubscriptionInputSche
 // ─── Subscription History ────────────────────────────────────────────────────
 
 export const SubscriptionHistorySchema = z.object({
-  id: z.string().uuid(),
+  id: z.string(),
   action: z.string(),
   date: z.string(),
   quantity: z.number(),
@@ -341,8 +341,8 @@ export type SubscriptionHistory = z.infer<typeof SubscriptionHistorySchema>;
 // ─── Invoice ─────────────────────────────────────────────────────────────────
 
 export const InvoiceSchema = z.object({
-  id: z.string().uuid(),
-  companyId: z.string().uuid(),
+  id: z.string(),
+  companyId: z.string(),
   invoiceDate: z.string(),
   dueDate: z.string(),
   // Optional defensively: the public OpenAPI Invoice properties block does
@@ -359,10 +359,10 @@ export type Invoice = z.infer<typeof InvoiceSchema>;
 // ─── Invoice Item ────────────────────────────────────────────────────────────
 
 export const InvoiceItemSchema = z.object({
-  id: z.string().uuid(),
-  invoiceId: z.string().uuid(),
-  productId: z.string().uuid(),
-  subscriptionId: z.string().uuid().optional(),
+  id: z.string(),
+  invoiceId: z.string(),
+  productId: z.string(),
+  subscriptionId: z.string().optional(),
   quantity: z.number(),
   // Field names mirror the public Pax8 API: `price` (per-unit) and `subTotal`
   // (line subtotal). Earlier CLI versions exposed these as `unitPrice` and
@@ -370,7 +370,7 @@ export const InvoiceItemSchema = z.object({
   // upstream contract so partners reading both surfaces don't have to translate.
   price: z.number(),
   subTotal: z.number(),
-  companyId: z.string().uuid().optional(),
+  companyId: z.string().optional(),
   productName: z.string().optional(),
   companyName: z.string().optional(),
 });
@@ -379,9 +379,9 @@ export type InvoiceItem = z.infer<typeof InvoiceItemSchema>;
 // ─── Usage Summary ───────────────────────────────────────────────────────────
 
 export const UsageSummarySchema = z.object({
-  id: z.string().uuid(),
-  companyId: z.string().uuid(),
-  productId: z.string().uuid(),
+  id: z.string(),
+  companyId: z.string(),
+  productId: z.string(),
   date: z.string(),
   quantity: z.number(),
   unitPrice: z.number(),
@@ -395,8 +395,8 @@ export type UsageSummary = z.infer<typeof UsageSummarySchema>;
 // ─── Usage Line ──────────────────────────────────────────────────────────────
 
 export const UsageLineSchema = z.object({
-  id: z.string().uuid(),
-  usageSummaryId: z.string().uuid(),
+  id: z.string(),
+  usageSummaryId: z.string(),
   quantity: z.number(),
   unitPrice: z.number(),
   subtotal: z.number(),
@@ -415,7 +415,7 @@ export const QuoteLineItemSchema = z.object({
    * Demo data populates it.
    */
   id: z.string().optional(),
-  productId: z.string().uuid(),
+  productId: z.string(),
   quantity: z.number(),
   billingTerm: BillingTermSchema.optional(),
   unitPrice: z.number().optional(),
@@ -449,8 +449,8 @@ export type QuoteRespondedBy = z.infer<typeof QuoteRespondedBySchema>;
  * statuses is also a goal.
  */
 export const QuoteSchema = z.object({
-  id: z.string().uuid(),
-  companyId: z.string().uuid(),
+  id: z.string(),
+  companyId: z.string(),
   // Field names mirror the public quoting v2 API: `createdOn` and `expiresOn`.
   // Earlier CLI versions exposed these as `createdDate` and `expirationDate`;
   // renamed in #273 (fixes #8) to align `--json` output with the upstream
@@ -477,7 +477,7 @@ export type Quote = z.infer<typeof QuoteSchema>;
 // ─── Webhook ─────────────────────────────────────────────────────────────────
 
 export const WebhookSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string(),
   url: z.string().url(),
   topics: z.array(z.string()),
   status: WebhookStatusSchema,
@@ -534,8 +534,8 @@ export type UpdateWebhookConfigurationInput = z.infer<typeof UpdateWebhookConfig
 // ─── Webhook Log ─────────────────────────────────────────────────────────────
 
 export const WebhookLogSchema = z.object({
-  id: z.string().uuid(),
-  webhookId: z.string().uuid(),
+  id: z.string(),
+  webhookId: z.string(),
   topic: z.string(),
   responseCode: z.number(),
   responseBody: z.string().optional(),
@@ -590,9 +590,9 @@ export type PaginatedResponse<T> = {
 // ─── Quote Input Types ──────────────────────────────────────────────────────
 
 export const CreateQuoteInputSchema = z.object({
-  companyId: z.string().uuid(),
+  companyId: z.string(),
   lineItems: z.array(z.object({
-    productId: z.string().uuid(),
+    productId: z.string(),
     quantity: z.number().int().positive(),
     billingTerm: BillingTermSchema.optional(),
     provisioningDetails: z.record(z.string(), z.unknown()).optional(),
@@ -602,7 +602,7 @@ export type CreateQuoteInput = z.infer<typeof CreateQuoteInputSchema>;
 
 export const UpdateQuoteInputSchema = z.object({
   lineItems: z.array(z.object({
-    productId: z.string().uuid(),
+    productId: z.string(),
     quantity: z.number().int().positive(),
     billingTerm: BillingTermSchema.optional(),
     provisioningDetails: z.record(z.string(), z.unknown()).optional(),
@@ -619,7 +619,7 @@ export type UpdateQuoteInput = z.infer<typeof UpdateQuoteInputSchema>;
  * `--quantity`, and `--billing-term`.
  */
 export const AddQuoteLineItemInputSchema = z.object({
-  productId: z.string().uuid(),
+  productId: z.string(),
   quantity: z.number().int().positive(),
   billingTerm: BillingTermSchema.optional(),
 });
@@ -648,9 +648,9 @@ export const PageSchema = PageInfoSchema;
 // ─── Product Dependency ─────────────────────────────────────────────────────
 
 export const ProductDependencySchema = z.object({
-  id: z.string().uuid(),
-  productId: z.string().uuid(),
-  dependsOnProductId: z.string().uuid(),
+  id: z.string(),
+  productId: z.string(),
+  dependsOnProductId: z.string(),
   dependencyType: z.string(),
   description: z.string().nullable().optional(),
 });

--- a/packages/core/src/mock/demo-data.invariant.test.ts
+++ b/packages/core/src/mock/demo-data.invariant.test.ts
@@ -15,34 +15,46 @@
  * MUST `safeParse` cleanly. If a collection has no corresponding schema (e.g.
  * internal helper data), it's skipped explicitly with a comment.
  *
- * NOTE — known-incomplete coverage:
- * Only the four collections covered below (`companies`, `webhooks`,
- * `webhookLogs`, `webhookTopicDefinitions`) parse against their public
- * schemas today. The remaining demo collections — `subscriptions`, `products`,
- * `invoices`, `invoiceItems`, `orders`, `contacts`, `usageSummaries`,
- * `usageLines`, `quotes` — fail because every demo seed uses
- * human-readable IDs (e.g. `prod-m365-...`, `sub-summit-...`, `inv-summit-...`)
- * while the schemas declare `id: z.string().uuid()` (and similarly on every
- * cross-reference: `productId`, `companyId`, etc.). The two surfaces were
- * never reconciled because the mock client bypasses Zod on read paths, so
- * the conflict was invisible until this invariant was attempted.
- *
- * Resolving it is a design call (loosen the schemas to `z.string()` on IDs to
- * match the upstream OpenAPI spec, OR migrate demo IDs to UUIDs and keep
- * readable names in the existing `*Name` fields). That's a separate PR; this
- * file ships only what passes today and grows as the conflict is resolved.
+ * History: prior to this PR, only `companies`, `webhooks`, `webhookLogs`, and
+ * `webhookTopicDefinitions` parsed cleanly. The other 9 collections failed
+ * because demo seeds use human-readable IDs (e.g. `prod-m365-...`,
+ * `sub-summit-...`, `inv-summit-...`) while the schemas declared
+ * `id: z.string().uuid()` on every primary and foreign key. The mock client
+ * bypasses Zod on read paths, so the conflict was invisible until this
+ * invariant was attempted. Resolved by loosening the ID schemas to
+ * `z.string()` (the OpenAPI `format: uuid` annotation is upstream metadata
+ * the CLI doesn't depend on; debuggable demo IDs are worth more than
+ * format checks the API client never reaches for).
  */
 
 import { describe, it, expect } from "vitest";
 import type { z } from "zod";
 import {
   CompanySchema,
+  ContactSchema,
+  InvoiceItemSchema,
+  InvoiceSchema,
+  OrderSchema,
+  ProductSchema,
+  QuoteSchema,
+  SubscriptionSchema,
   TopicDefinitionSchema,
+  UsageLineSchema,
+  UsageSummarySchema,
   WebhookLogSchema,
   WebhookSchema,
 } from "../api/types.js";
 import {
   companies,
+  contacts,
+  invoiceItems,
+  invoices,
+  orders,
+  products,
+  quotes,
+  subscriptions,
+  usageLines,
+  usageSummaries,
   webhookLogs,
   webhookTopicDefinitions,
   webhooks,
@@ -82,6 +94,49 @@ function expectAllParse<T>(
 describe("demo-data — Zod schema invariant", () => {
   it("companies parse against CompanySchema", () => {
     expectAllParse(companies, CompanySchema, "companies");
+  });
+
+  it("contacts parse against ContactSchema", () => {
+    expectAllParse(contacts, ContactSchema, "contacts");
+  });
+
+  it("products parse against ProductSchema", () => {
+    expectAllParse(products, ProductSchema, "products");
+  });
+
+  it("subscriptions parse against SubscriptionSchema", () => {
+    expectAllParse(subscriptions, SubscriptionSchema, "subscriptions");
+  });
+
+  // SEPARATE DRIFT (not UUID-related): `OrderLineItemSchema.id` is required,
+  // but demo orders' `lineItems` entries omit the per-line `id`. This isn't
+  // an ID-format issue — it's a missing required field. Tracking as a
+  // follow-up (either populate `id` on demo line items, or make line-item
+  // `id` optional like `QuoteLineItemSchema.id` already is, since the API
+  // returns an opaque per-line id that consumers rarely refer to). Out of
+  // scope for the UUID-loosening PR.
+  it.skip("orders parse against OrderSchema", () => {
+    expectAllParse(orders, OrderSchema, "orders");
+  });
+
+  it("invoices parse against InvoiceSchema", () => {
+    expectAllParse(invoices, InvoiceSchema, "invoices");
+  });
+
+  it("invoiceItems parse against InvoiceItemSchema", () => {
+    expectAllParse(invoiceItems, InvoiceItemSchema, "invoiceItems");
+  });
+
+  it("usageSummaries parse against UsageSummarySchema", () => {
+    expectAllParse(usageSummaries, UsageSummarySchema, "usageSummaries");
+  });
+
+  it("usageLines parse against UsageLineSchema", () => {
+    expectAllParse(usageLines, UsageLineSchema, "usageLines");
+  });
+
+  it("quotes parse against QuoteSchema", () => {
+    expectAllParse(quotes, QuoteSchema, "quotes");
   });
 
   it("webhooks parse against WebhookSchema", () => {


### PR DESCRIPTION
## Summary

Resolves the schema-vs-data conflict surfaced in #289 via **option (a): loosen the schemas, keep the human-readable demo IDs**. Every primary and foreign-key field in `packages/core/src/api/types.ts` was declared `z.string().uuid()`, but the demo fixtures in `packages/core/src/mock/demo-data.ts` use human-readable IDs like `prod-m365-biz-prem-0001` and `sub-summit-m365bp-001`. The mock client bypasses Zod on read paths, so the conflict was invisible until #289's invariant exposed it (4 of 13 collections passed).

UUID format is an upstream OpenAPI annotation (`format: uuid`) the CLI doesn't depend on; debuggable demo IDs are worth more than a format check the API client never reaches for.

## Schema fields loosened (`z.string().uuid()` → `z.string()`)

- `CompanySchema.id`
- `ContactSchema.id`, `ContactSchema.companyId`
- `CreateContactInputSchema.companyId`
- `ProductSchema.id`
- `ProductPricingPlanSchema.productId`
- `ProvisioningDetailSchema.productId`
- `OrderLineItemInputSchema.productId`, `.commitmentTermId`
- `OrderLineItemSchema.id`, `.productId`
- `OrderSchema.id`, `.companyId`
- `CreateOrderInputSchema.companyId`
- `CommitmentSchema.id`
- `SubscriptionSchema.id`, `.companyId`, `.productId`
- `SubscriptionHistorySchema.id`
- `InvoiceSchema.id`, `.companyId`
- `InvoiceItemSchema.id`, `.invoiceId`, `.productId`, `.subscriptionId`, `.companyId`
- `UsageSummarySchema.id`, `.companyId`, `.productId`
- `UsageLineSchema.id`, `.usageSummaryId`
- `QuoteLineItemSchema.productId`
- `QuoteSchema.id`, `.companyId`
- `WebhookSchema.id`
- `WebhookLogSchema.id`, `.webhookId`
- `CreateQuoteInputSchema.companyId`, `.lineItems[].productId`
- `UpdateQuoteInputSchema.lineItems[].productId`
- `AddQuoteLineItemInputSchema.productId`
- `ProductDependencySchema.id`, `.productId`, `.dependsOnProductId`

## Invariant test coverage

Extended `packages/core/src/mock/demo-data.invariant.test.ts` from 4 → 13 collections. Now covers `companies`, `contacts`, `products`, `subscriptions`, `invoices`, `invoiceItems`, `usageSummaries`, `usageLines`, `quotes`, `webhooks`, `webhookLogs`, `webhookTopicDefinitions` — all parse cleanly.

The `orders` block is `it.skip`-ped with a comment because it surfaces a **separate, non-UUID drift**: `OrderLineItemSchema.id` is required but demo orders' line items omit it. That's a different fix (either populate `id` on demo line items, or make line-item `id` optional like `QuoteLineItemSchema.id` already is). Out of scope for this PR — tracking as follow-up.

## Tests touched

- Replaced two `types.test.ts` cases that asserted UUID-format rejection (`"not-a-uuid"`, `"abc"`) with non-string-rejection cases. `z.string()` still rejects wrong types — the constraint is just looser.
- Updated `PaginatedResponseSchema` "rejects invalid items in content" test similarly: now asserts a missing required `name` instead of an invalid UUID.

## What was NOT changed

- Demo data — human-readable IDs preserved as designed.
- `idempotency.ts` UUID-or-identifier regex validation — separate layer, intentionally untouched (the brief: `--idempotency-key` accepts UUIDs OR 8-128 char identifiers).
- API client — `Pax8Client` Zod-parses but doesn't care about UUID-ness specifically.
- Adding a Zod boundary at the live API client — separate scope, follow-up if needed.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` — 1544 passed, 9 skipped (1 newly skipped: `orders` invariant, separate drift)
- [x] `pnpm lint` clean
- [x] All 13 demo collections except `orders` parse against their schemas
- [x] `types.test.ts` UUID-rejection cases replaced with type-rejection cases

Refs: #289