### PR TITLE
fix(mock): populate per-line id on demo Order line items

### DIFF
--- a/packages/core/src/mock/demo-data.invariant.test.ts
+++ b/packages/core/src/mock/demo-data.invariant.test.ts
@@ -108,14 +108,7 @@ describe("demo-data — Zod schema invariant", () => {
     expectAllParse(subscriptions, SubscriptionSchema, "subscriptions");
   });
 
-  // SEPARATE DRIFT (not UUID-related): `OrderLineItemSchema.id` is required,
-  // but demo orders' `lineItems` entries omit the per-line `id`. This isn't
-  // an ID-format issue — it's a missing required field. Tracking as a
-  // follow-up (either populate `id` on demo line items, or make line-item
-  // `id` optional like `QuoteLineItemSchema.id` already is, since the API
-  // returns an opaque per-line id that consumers rarely refer to). Out of
-  // scope for the UUID-loosening PR.
-  it.skip("orders parse against OrderSchema", () => {
+  it("orders parse against OrderSchema", () => {
     expectAllParse(orders, OrderSchema, "orders");
   });
 

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -1458,6 +1458,7 @@ export const orders: Order[] = [
     status: "Completed",
     lineItems: [
       {
+        id: "oli-summit-001-a",
         productId: "prod-s1-singularity-0010",
         productName: "CrowdStrike MSSP Complete Defend",
         quantity: 85,
@@ -1475,6 +1476,7 @@ export const orders: Order[] = [
     status: "Completed",
     lineItems: [
       {
+        id: "oli-redwood-001-a",
         productId: "prod-acronis-backup-0009",
         productName: "AvePoint Cloud Backup for Microsoft 365",
         quantity: 30,
@@ -1492,12 +1494,14 @@ export const orders: Order[] = [
     status: "Processing",
     lineItems: [
       {
+        id: "oli-pinnacle-001-a",
         productId: "prod-m365-biz-prem-0001",
         productName: "Microsoft 365 Business Premium [New Commerce Experience]",
         quantity: 5,
         billingTerm: "Annual",
       },
       {
+        id: "oli-pinnacle-001-b",
         productId: "prod-defender-biz-0007",
         productName: "Microsoft Defender for Office 365 (Plan 1) [New Commerce Experience]",
         quantity: 5,
@@ -1515,12 +1519,14 @@ export const orders: Order[] = [
     status: "Completed",
     lineItems: [
       {
+        id: "oli-coastline-001-a",
         productId: "prod-m365-e3-0003",
         productName: "Microsoft 365 E3 [New Commerce Experience]",
         quantity: 40,
         billingTerm: "Annual",
       },
       {
+        id: "oli-coastline-001-b",
         productId: "prod-exo-plan2-0006",
         productName: "Exchange Online (Plan 2) [New Commerce Experience]",
         quantity: 40,
@@ -1538,6 +1544,7 @@ export const orders: Order[] = [
     status: "Completed",
     lineItems: [
       {
+        id: "oli-bright-001-a",
         productId: "prod-m365-biz-basic-0002",
         productName: "Microsoft 365 Business Basic [New Commerce Experience]",
         quantity: 25,


### PR DESCRIPTION
## Summary

Follow-up to #290. The UUID-loosening PR resolved 12 of 13 demo invariants but flagged a separate drift on orders: \`OrderLineItemSchema.id\` is required (matching what the real API returns), but every demo \`OrderLineItem\` was missing the field.

## Fix

Populated \`id\` on all 7 demo order line items using the same \`oli-<order>-<index>\` pattern already used on quote line items (\`li-<quote>-<index>\`). Un-skipped the \`orders\` block in \`demo-data.invariant.test.ts\`.

## Why this direction (not loosening the schema)

The real API returns \`id\` on every fetched OrderLineItem — it's the canonical handle for the line. Making the schema field optional would weaken validation against real responses. Demo data should match real API shape.

## Test plan

- \`pnpm test packages/core/src/mock/demo-data.invariant.test.ts\` — 13/13 invariants pass.
- Full \`pnpm test\` — 1545 passed / 8 skipped, no regressions.