### PR TITLE
fix(subscriptions): commitment-aware update pre-flight (closes #293)

### DIFF
--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -209,6 +209,101 @@ describe("pax8 subscriptions update", () => {
     const combined = result.stdout + result.stderr;
     expect(combined).toMatch(/[Nn]o changes/);
   });
+
+  // ─── Commitment-aware pre-flight (#293) ───────────────────────────────────
+  // The Pax8 marketplace API blocks quantity decreases and billing-term
+  // changes during the commitment term. The CLI catches both pre-flight so
+  // the user gets actionable guidance instead of an opaque API rejection.
+  // `sub-summit-m365bp-001` is on a 1-Year commitment that ends 3 days from
+  // now (current quantity 85, billing term Annual) — a stable mid-commitment
+  // fixture. `sub-redwood-acronis-007` and `sub-bright-m365bb-001` are
+  // monthly with no commitment. `sub-acme-aad-003` carries a commitment whose
+  // endDate is in the past (added in #293 specifically for this branch).
+  describe("commitment-aware pre-flight", () => {
+    it("blocks quantity DECREASE on a sub with active commitment", async () => {
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "update",
+        "sub-summit-m365bp-001",
+        "--quantity",
+        "5",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Quantity decreases are not permitted/);
+    });
+
+    it("blocks quantity DECREASE before any API call (--json envelope code)", async () => {
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "update",
+        "sub-summit-m365bp-001",
+        "--quantity",
+        "5",
+        "--yes",
+        "--json",
+      ]);
+      expect(result.stderr).toContain("ERROR_API_VALIDATION");
+    });
+
+    it("blocks BILLING-TERM change on a sub with active commitment", async () => {
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "update",
+        "sub-summit-m365bp-001",
+        "--billing-term",
+        "Monthly",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Billing-term changes are not permitted/);
+    });
+
+    it("allows quantity INCREASE on a sub with active commitment", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "update",
+        "sub-summit-m365bp-001",
+        "--quantity",
+        "100",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0].quantity).toBe(100);
+    });
+
+    it("allows update on a sub with NO commitment (monthly billing)", async () => {
+      // Monthly sub, no commitment — quantity decrease should pass through.
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "update",
+        "sub-redwood-acronis-007",
+        "--quantity",
+        "10",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0].quantity).toBe(10);
+    });
+
+    it("allows update on a sub with PAST commitment endDate", async () => {
+      // Past commitment → treat as post-commitment; updates pass through.
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "update",
+        "sub-acme-aad-003",
+        "--quantity",
+        "5",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0].quantity).toBe(5);
+    });
+  });
 });
 
 describe("pax8 subscriptions cancel", () => {

--- a/packages/cli/src/commands/subscriptions/update.ts
+++ b/packages/cli/src/commands/subscriptions/update.ts
@@ -6,11 +6,51 @@ import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
-import { handleCommandError } from "../../lib/errors.js";
-import { confirmWithChange } from "../../lib/confirm.js";
+import { handleCommandError, CliError, extractErrorDetail } from "../../lib/errors.js";
+import { confirmWithChange, replCmd } from "../../lib/confirm.js";
 import { formatQuantity, formatCurrency, formatStatus } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
+import { ApiError, ERROR_API_VALIDATION } from "@pax8/core";
+import type { Subscription } from "@pax8/core";
+
+/**
+ * Format an ISO date string for human display (e.g. "2026-05-11").
+ * Falls back to the raw value if parsing fails.
+ */
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Whole-day delta from `now` until `iso`. Returns 0 for past or same-day.
+ */
+function daysUntil(iso: string, now: Date = new Date()): number {
+  const target = new Date(iso);
+  if (isNaN(target.getTime())) return 0;
+  const ms = target.getTime() - now.getTime();
+  return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
+}
+
+/**
+ * Decide whether the subscription is mid-commitment. Returns the endDate when
+ * the commitment is active (in the future), otherwise `null`.
+ *
+ * The Pax8 marketplace API treats absent / past `commitment.endDate` as
+ * "monthly billing or post-commitment" — those subs accept arbitrary updates,
+ * so we let the API handle them as before. Only active commitments need
+ * pre-flight protection.
+ */
+function activeCommitmentEndDate(sub: Subscription): string | null {
+  const endDate = sub.commitment?.endDate ?? sub.commitmentTermEndDate ?? null;
+  if (!endDate) return null;
+  const parsed = new Date(endDate);
+  if (isNaN(parsed.getTime())) return null;
+  if (parsed.getTime() <= Date.now()) return null;
+  return endDate;
+}
 
 export const subscriptionsUpdateCommand = new Command("update")
   .description("Update a subscription")
@@ -35,6 +75,67 @@ Examples:
       const spinner = createSpinner("Fetching subscription...").start();
       const sub = await ctx.api.subscriptions.get(id);
       spinner.stop();
+
+      // ── Commitment-aware pre-flight ────────────────────────────────────────
+      //
+      // The Pax8 marketplace API governs mid-commitment subscription updates:
+      // quantity decreases are blocked, billing-term changes are essentially
+      // impossible (PFR-86 documents $250K+ in credits from failed attempts;
+      // the only documented workaround is cancel-and-reorder), and
+      // commitment-term changes are admin-only. The CLI previously let users
+      // attempt any of these and surfaced a flat opaque API rejection
+      // post-confirm — same anti-pattern as orders create pre-#230.
+      //
+      // Quantity INCREASES are permitted (each gets its own vendor-specific
+      // cancel window, but those windows are scattered across internal-only
+      // VPM wiki pages — Rovo confirmed this — so we don't try to mirror them
+      // here; we let increases pass through to the API.
+      const commitEnd = activeCommitmentEndDate(sub);
+      if (commitEnd) {
+        const endLabel = formatDate(commitEnd);
+        const days = daysUntil(commitEnd);
+
+        // Quantity decrease — not permitted mid-commitment.
+        if (options.quantity !== undefined) {
+          const newQty = parseInt(options.quantity, 10);
+          if (!Number.isNaN(newQty) && newQty < sub.quantity) {
+            throw new CliError(
+              `Can't decrease quantity on "${sub.productName ?? id}" mid-commitment`,
+              [
+                "Quantity decreases are not permitted during the commitment term",
+                `Commitment ends ${endLabel} (${days} days from now)`,
+              ],
+              [
+                `Wait until ${endLabel} to decrease quantity`,
+                "Or use the Pax8 portal for early changes (may incur fees)",
+              ],
+              undefined,
+              ERROR_API_VALIDATION,
+            );
+          }
+        }
+
+        // Billing-term change — not permitted mid-commitment.
+        if (
+          options.billingTerm !== undefined &&
+          sub.billingTerm !== undefined &&
+          options.billingTerm !== sub.billingTerm
+        ) {
+          throw new CliError(
+            `Can't change billing term on "${sub.productName ?? id}" mid-commitment`,
+            [
+              "Billing-term changes are not permitted during the commitment term",
+              "The current path requires cancel-and-reorder; this CLI does not automate that flow",
+            ],
+            [
+              `Wait until commitment ends (${endLabel}) to change billing term`,
+              "Or use the Pax8 portal for cancel-and-reorder workflow",
+            ],
+            undefined,
+            ERROR_API_VALIDATION,
+          );
+        }
+      }
 
       const updateData: Record<string, unknown> = {};
 
@@ -96,6 +197,33 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Price:".padEnd(18))}${formatCurrency(updated.price ?? 0)}\n`);
       process.stdout.write("\n");
     } catch (error) {
+      // Wrap opaque API rejections (post-confirm) with a generic
+      // commitment-restriction hint. We deliberately do NOT pattern-match the
+      // flat `errors[]` string — Rovo confirmed it isn't a stable contract,
+      // and brittle string matching has bitten the CLI before. The hint
+      // simply points the user at `subscriptions show` so they can see the
+      // commitment shape and decide.
+      if (error instanceof ApiError && error.statusCode >= 400 && error.statusCode < 500) {
+        const detail = extractErrorDetail(error.responseBody);
+        const causes: string[] = [];
+        if (detail) causes.push(detail);
+        causes.push("This may be a commitment-term restriction");
+
+        await handleCommandError(
+          new CliError(
+            `Can't update subscription "${id}"`,
+            causes,
+            [
+              `Run \`${replCmd("pax8 subscriptions show")} ${id}\` to see commitment details`,
+              "Quantity decreases and billing-term changes are blocked during the commitment term",
+            ],
+            undefined,
+            ERROR_API_VALIDATION,
+          ),
+        );
+        return;
+      }
+
       await handleCommandError(error, undefined, "Failed to update subscription");
     }
   });

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -1006,6 +1006,28 @@ export const subscriptions: Subscription[] = [
     provisioningStatus: "Provisioned",
     companyName: "Acme Corp",
   },
+
+  // ── Past-commitment fixture (for #293 commitment-aware update tests) ──
+  // Same partner, same product family, but the original 1-Year commitment
+  // has rolled past. Lets the CLI exercise the "past commitment → updates
+  // pass through" branch without manufacturing a date in the test suite.
+  {
+    id: "sub-acme-aad-003",
+    companyId: ACME_ID,
+    productId: "prod-aad-p1-0008",
+    productName: "Microsoft Entra ID P1 [New Commerce Experience]",
+    quantity: 25,
+    startDate: "2024-01-15",
+    createdDate: "2024-01-10",
+    billingStart: "2024-01-15",
+    status: "Active",
+    price: 6.0,
+    billingTerm: "Annual",
+    commitment: { id: "cterm-0006-0001-0001-000000000003", term: "1-Year", endDate: daysFromNow(-30) },
+    commitmentTermEndDate: daysFromNow(-30),
+    provisioningStatus: "Provisioned",
+    companyName: "Acme Corp",
+  },
 ];
 
 // ─── Invoices ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Pre-flight detects `commitment.endDate` in the future and blocks the two restricted change classes BEFORE the API call:
  - Quantity decreases (not permitted mid-commitment per Pax8 marketplace rules)
  - Billing-term changes (the documented workaround is cancel-and-reorder; not automated by the CLI)
- Quantity increases pass through unchanged (vendor-specific cancel-window rules aren't decoded — Rovo research confirmed they're scattered across internal-only Pax8 docs)
- API rejections that slip through get wrapped in CliError with generic "may be commitment-restriction" hint

## Background
Pax8-internal research (Rovo across the API reference, NCE FAQ, partner-facing docs, PFR-86, and 60+ other sources) confirmed:
- Quantity decreases mid-commitment: blocked
- Billing-term changes mid-commitment: blocked (PFR-86: \$250K+ in credits from failed attempts)
- No scheduled-update API exists (so `--at-renewal` is out of scope; could be a future CLI-side reminder feature)
- Error shape is `{ errors: [string] }` — flat, no codes; pattern-matching is fragile

## Test plan
- [x] Pre-flight blocks quantity decrease with actionable message
- [x] Pre-flight blocks billing-term change with cancel-and-reorder hint
- [x] Quantity increase passes through unchanged
- [x] No-commitment / past-commitment subs unaffected

Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)