### PR TITLE
feat(renewals): add arrAtRisk companion + canonical MRR/ARR definitions (closes #295)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,19 @@ These are tracked, prioritized for v0.1.x, and not blockers for v0.1.0. Each lin
 - No update-notifier — the CLI doesn't tell you when a newer version exists ([#183](https://github.com/pax8labs/pax8-cli/issues/183)).
 - The scheduled API-drift watcher only filters `ERROR_API_VALIDATION` events; widening to `ERROR_API_TIMEOUT` / `ERROR_API_NOT_FOUND` / etc. is tracked separately ([#213](https://github.com/pax8labs/pax8-cli/issues/213)). Also note: the watcher is silent until `POSTHOG_PROJECT_API_KEY` is provisioned in repo secrets, and telemetry is opt-in by default.
 
+## Metric definitions
+
+The CLI surfaces MRR and ARR figures across `pax8 subscriptions renewals`, `pax8 report mrr`, and `pax8 report growth`. Definitions mirror Pax8's internal Unified Semantic Layer so partner-facing usage stays aligned with the dwh / Voyager Alliance / AMER Recurring Net Bookings methodology that internal teams rely on.
+
+MRR (Monthly Recurring Revenue): Monthly recurring revenue from active
+subscriptions. For monthly billing terms: price × quantity. For annual
+billing terms: (price × quantity) ÷ 12. Excludes one-time charges and
+prorated amounts. Equivalent to "Partner Gross MRR" in Pax8's internal
+metric taxonomy.
+
+ARR (Annual Recurring Revenue): MRR × 12. The yearly equivalent of MRR,
+used to measure long-term financial health.
+
 ## Documentation
 
 - [Credential Setup Guide](docs/credential-setup.md)

--- a/packages/cli/src/__tests__/report.test.ts
+++ b/packages/cli/src/__tests__/report.test.ts
@@ -44,6 +44,13 @@ describe("pax8 report", () => {
         expect(action).toHaveProperty("description");
       }
     });
+
+    it("--help shows canonical MRR/ARR definitions (#295)", async () => {
+      const result = await runCliExpectSuccess(["report", "mrr", "--help"]);
+      expect(result.stdout).toContain("Metric definitions:");
+      expect(result.stdout).toContain("MRR (Monthly Recurring Revenue)");
+      expect(result.stdout).toContain("ARR (Annual Recurring Revenue): MRR × 12");
+    });
   });
 
   describe("report growth", () => {
@@ -87,6 +94,13 @@ describe("pax8 report", () => {
         expect(action).toHaveProperty("command");
         expect(action).toHaveProperty("description");
       }
+    });
+
+    it("--help shows canonical MRR/ARR definitions (#295)", async () => {
+      const result = await runCliExpectSuccess(["report", "growth", "--help"]);
+      expect(result.stdout).toContain("Metric definitions:");
+      expect(result.stdout).toContain("MRR (Monthly Recurring Revenue)");
+      expect(result.stdout).toContain("ARR (Annual Recurring Revenue): MRR × 12");
     });
   });
 });

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -186,6 +186,38 @@ describe("pax8 subscriptions renewals", () => {
     expect(result.stdout).toContain("--within");
     expect(result.stdout).toContain("Examples:");
   });
+
+  // ─── #295: arrAtRisk companion + canonical MRR/ARR definitions ────────────
+  it("includes arrAtRisk = mrrAtRisk * 12 for every renewal in --json", async () => {
+    const result = await runCliExpectSuccess([
+      "subscriptions",
+      "renewals",
+      "--within",
+      "365d",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThan(0);
+    for (const item of data) {
+      expect(item).toHaveProperty("mrrAtRisk");
+      expect(item).toHaveProperty("arrAtRisk");
+      // JSON output rounds to 2dp; allow a tiny rounding delta.
+      expect(item.arrAtRisk).toBeCloseTo(item.mrrAtRisk * 12, 1);
+    }
+  });
+
+  it("renewals --help shows canonical MRR/ARR definitions", async () => {
+    const result = await runCliExpectSuccess([
+      "subscriptions",
+      "renewals",
+      "--help",
+    ]);
+    expect(result.stdout).toContain("Metric definitions:");
+    expect(result.stdout).toContain("MRR (Monthly Recurring Revenue)");
+    expect(result.stdout).toContain("ARR (Annual Recurring Revenue): MRR × 12");
+    expect(result.stdout).toContain("Partner Gross MRR");
+  });
 });
 
 describe("pax8 subscriptions update", () => {

--- a/packages/cli/src/commands/report/growth.ts
+++ b/packages/cli/src/commands/report/growth.ts
@@ -18,7 +18,17 @@ Examples:
   pax8 report growth
   pax8 report growth --months 12
   pax8 report growth --json
-  pax8 report growth --csv`)
+  pax8 report growth --csv
+
+Metric definitions:
+  MRR (Monthly Recurring Revenue): Monthly recurring revenue from active
+  subscriptions. For monthly billing terms: price × quantity. For annual
+  billing terms: (price × quantity) ÷ 12. Excludes one-time charges and
+  prorated amounts. Equivalent to "Partner Gross MRR" in Pax8's internal
+  metric taxonomy.
+
+  ARR (Annual Recurring Revenue): MRR × 12. The yearly equivalent of MRR,
+  used to measure long-term financial health.`)
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();
     const ctx = await buildContext(globalOpts);

--- a/packages/cli/src/commands/report/mrr.ts
+++ b/packages/cli/src/commands/report/mrr.ts
@@ -17,7 +17,17 @@ export const reportMrrCommand = new Command("mrr")
 Examples:
   pax8 report mrr
   pax8 report mrr --json
-  pax8 report mrr --csv`)
+  pax8 report mrr --csv
+
+Metric definitions:
+  MRR (Monthly Recurring Revenue): Monthly recurring revenue from active
+  subscriptions. For monthly billing terms: price × quantity. For annual
+  billing terms: (price × quantity) ÷ 12. Excludes one-time charges and
+  prorated amounts. Equivalent to "Partner Gross MRR" in Pax8's internal
+  metric taxonomy.
+
+  ARR (Annual Recurring Revenue): MRR × 12. The yearly equivalent of MRR,
+  used to measure long-term financial health.`)
   .action(async (_options, command) => {
     const globalOpts = command.optsWithGlobals();
     const ctx = await buildContext(globalOpts);

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -54,7 +54,17 @@ Examples:
   pax8 subscriptions renewals
   pax8 subscriptions renewals --within 7d
   pax8 subscriptions renewals --company "Summit Healthcare"
-  pax8 subscriptions renewals --json`
+  pax8 subscriptions renewals --json
+
+Metric definitions:
+  MRR (Monthly Recurring Revenue): Monthly recurring revenue from active
+  subscriptions. For monthly billing terms: price × quantity. For annual
+  billing terms: (price × quantity) ÷ 12. Excludes one-time charges and
+  prorated amounts. Equivalent to "Partner Gross MRR" in Pax8's internal
+  metric taxonomy.
+
+  ARR (Annual Recurring Revenue): MRR × 12. The yearly equivalent of MRR,
+  used to measure long-term financial health.`
   )
   .action(async (options, cmd) => {
     const allOpts = cmd.optsWithGlobals();
@@ -90,6 +100,7 @@ Examples:
         const renewalItems = report.items.map((item) => ({
           ...item,
           mrrAtRisk: Number(item.mrrAtRisk.toFixed(2)),
+          arrAtRisk: Number(item.arrAtRisk.toFixed(2)),
           renewalDate: item.renewalDate.toISOString().split("T")[0],
         }));
         if (options.withActions) {
@@ -134,9 +145,15 @@ Examples:
 
       output(report.items, { format: "table", columns });
 
+      // Header keeps MRR primary (Pax8's canonical operational unit per the
+      // Unified Semantic Layer / Voyager Alliance / dwh fact tables), with
+      // ARR as a parallel companion. The per-row table stays MRR-only to
+      // avoid clutter; ARR lives in the JSON for consumers who want it.
+      // See #295 — PFR-86 escalations frame risk as "ARR at risk", so QBR /
+      // strategic conversations get the right unit too.
       process.stdout.write(
         chalk.dim(
-          `\n  ${report.items.length} renewals within ${withinDays} days — ${formatCurrency(report.totalMrrAtRisk)} estimated MRR at risk\n`
+          `\n  ${report.items.length} renewals within ${withinDays} days — ${formatCurrency(report.totalMrrAtRisk)}/mo MRR · ${formatCurrency(report.totalArrAtRisk)}/yr ARR at risk\n`
         )
       );
 

--- a/packages/core/src/services/renewal-tracker.test.ts
+++ b/packages/core/src/services/renewal-tracker.test.ts
@@ -232,4 +232,55 @@ describe("getUpcomingRenewals", () => {
     expect(report.items[0].mrrAtRisk).toBe(0);
     expect(report.totalMrrAtRisk).toBe(0);
   });
+
+  // ─── ARR companion field (#295) ────────────────────────────────────────────
+  // ARR is the derived board/investor metric — PFR-86 escalations frame risk
+  // as "$12M ARR partner" — while MRR stays the canonical operational unit.
+  // Pax8 internal convention is `÷ 12` annual amortization for MRR, so ARR =
+  // MRR × 12 falls out cleanly.
+  it("should compute arrAtRisk = mrrAtRisk * 12 for monthly subscriptions", () => {
+    const subs = [
+      makeSub({ id: "s1", price: 10, quantity: 5, billingTerm: "Monthly", commitmentTermEndDate: daysFromNow(5) }),
+    ];
+
+    const report = getUpcomingRenewals(subs, 30);
+    expect(report.items[0].mrrAtRisk).toBe(50);
+    expect(report.items[0].arrAtRisk).toBe(600); // 50 * 12
+  });
+
+  it("should compute arrAtRisk = mrrAtRisk * 12 for annual subscriptions", () => {
+    // Annual contracts get amortized to MRR via `÷ 12`, then ARR is MRR × 12 —
+    // so ARR equals annual contract value (price × qty) in this case.
+    const subs = [
+      makeSub({ id: "s1", price: 120, quantity: 1, billingTerm: "Annual", commitmentTermEndDate: daysFromNow(5) }),
+    ];
+
+    const report = getUpcomingRenewals(subs, 30);
+    expect(report.items[0].mrrAtRisk).toBe(10);
+    expect(report.items[0].arrAtRisk).toBe(120);
+  });
+
+  it("should compute totalArrAtRisk = totalMrrAtRisk * 12 across mixed billing terms", () => {
+    const subs = [
+      makeSub({ id: "s1", price: 10, quantity: 5, billingTerm: "Monthly", commitmentTermEndDate: daysFromNow(5) }), // MRR 50
+      makeSub({ id: "s2", price: 120, quantity: 1, billingTerm: "Annual", commitmentTermEndDate: daysFromNow(7) }), // MRR 10
+    ];
+
+    const report = getUpcomingRenewals(subs, 30);
+    expect(report.totalMrrAtRisk).toBe(60);
+    expect(report.totalArrAtRisk).toBe(720); // 60 * 12
+  });
+
+  it("arrAtRisk equals mrrAtRisk * 12 for every item in a real-shaped report", () => {
+    const subs = [
+      makeSub({ id: "s1", price: 10, quantity: 5, billingTerm: "Monthly", commitmentTermEndDate: daysFromNow(2) }),
+      makeSub({ id: "s2", price: 120, quantity: 1, billingTerm: "Annual", commitmentTermEndDate: daysFromNow(7) }),
+      makeSub({ id: "s3", price: 0, quantity: 10, billingTerm: "Monthly", commitmentTermEndDate: daysFromNow(10) }),
+    ];
+
+    const report = getUpcomingRenewals(subs, 30);
+    for (const item of report.items) {
+      expect(item.arrAtRisk).toBe(item.mrrAtRisk * 12);
+    }
+  });
 });

--- a/packages/core/src/services/renewal-tracker.ts
+++ b/packages/core/src/services/renewal-tracker.ts
@@ -19,13 +19,30 @@ export interface RenewalItem {
   renewalDate: Date;
   billingTerm: string;
   price: number;
+  /**
+   * Monthly Recurring Revenue exposure for this renewal. Per Pax8's canonical
+   * convention (Unified Semantic Layer, Voyager Alliance partner tiering, dwh
+   * fact_transaction_monthly, AMER Recurring Net Bookings methodology):
+   *   - Monthly billing: price × quantity
+   *   - Annual billing: (price × quantity) ÷ 12
+   * Equivalent to "Partner Gross MRR" in Pax8's internal metric taxonomy.
+   */
   mrrAtRisk: number;
+  /**
+   * ARR companion field added in #295 — `mrrAtRisk × 12`. ARR is the derived
+   * board/investor metric (PFR-86 escalations frame risk as "$12M ARR
+   * partner"); operational surfaces still use MRR. Both fields are emitted so
+   * partners can pick whichever unit matches their conversation.
+   */
+  arrAtRisk: number;
   daysUntilRenewal: number;
 }
 
 export interface RenewalReport {
   items: RenewalItem[];
   totalMrrAtRisk: number;
+  /** Aggregate ARR at risk — `totalMrrAtRisk × 12`. See #295. */
+  totalArrAtRisk: number;
   annualCount: number;
   monthlyCount: number;
   urgentCount: number; // within 14 days
@@ -64,6 +81,7 @@ export function getUpcomingRenewals(subscriptions: RenewalSubscriptionInput[], w
     const price: number = sub.price ?? 0;
     const quantity: number = sub.quantity ?? 0;
 
+    const mrrAtRisk = computeMrrAtRisk(price, quantity, billingTerm);
     items.push({
       subscriptionId: sub.id ?? sub.subscriptionId ?? "",
       companyId: sub.companyId ?? "",
@@ -73,7 +91,8 @@ export function getUpcomingRenewals(subscriptions: RenewalSubscriptionInput[], w
       renewalDate,
       billingTerm,
       price,
-      mrrAtRisk: computeMrrAtRisk(price, quantity, billingTerm),
+      mrrAtRisk,
+      arrAtRisk: mrrAtRisk * 12,
       daysUntilRenewal,
     });
   }
@@ -82,6 +101,7 @@ export function getUpcomingRenewals(subscriptions: RenewalSubscriptionInput[], w
   items.sort((a, b) => a.daysUntilRenewal - b.daysUntilRenewal);
 
   const totalMrrAtRisk = items.reduce((sum, item) => sum + item.mrrAtRisk, 0);
+  const totalArrAtRisk = totalMrrAtRisk * 12;
   const annualCount = items.filter(
     (i) => i.billingTerm.toLowerCase().includes("annual") || i.billingTerm.toLowerCase().includes("yearly"),
   ).length;
@@ -91,6 +111,7 @@ export function getUpcomingRenewals(subscriptions: RenewalSubscriptionInput[], w
   return {
     items,
     totalMrrAtRisk,
+    totalArrAtRisk,
     annualCount,
     monthlyCount,
     urgentCount,


### PR DESCRIPTION
## Summary
- Adds `arrAtRisk` (= `mrrAtRisk × 12`) per renewal entry and `totalArrAtRisk` to the aggregate
- MRR stays primary (partners are MRR-native, dwh + Semantic Layer + Voyager partner tiering all use it)
- ARR companion gives board/escalation views the right unit (PFR-86: "\$12M ARR partner at churn risk")
- Adds canonical MRR/ARR definitions verbatim to `subscriptions renewals` / `report mrr` / `report growth` help text + a new "## Metric definitions" README section. The CLI becomes a de facto Pax8 partner-facing metric definition since none exists; the wording mirrors the internal Unified Semantic Layer.

## Background
Pax8-internal research (Rovo across 12+ docs) confirmed:
- MRR is Pax8's canonical operational unit (GMRR / NMRR / VMRR everywhere internal)
- `÷ 12` annual amortization is standard convention (Voyager Alliance partner tiering, dwh fact tables, AMER Recurring Net Bookings)
- ARR is the derived board/investor metric (PFR-86 escalations)
- No partner-facing Pax8 metrics dictionary exists today

## Out of scope
- Replacing MRR with contract value (would be inconsistent with Pax8 conventions)
- Reframing `pax8 report mrr` itself to ARR (separate, broader conversation)
- Rounding / display polish on the new field

## Follow-up
Worth flagging to Tanner Horsey / the Partner Analytics Center team that the CLI is the first place "MRR/ARR at risk" exists as an aggregate. When the Partner Analytics Center ships its renewal view (P3 post-MVP per the latest PRD), there could be vocabulary alignment work.

Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)