### PR TITLE
security(webhooks): redact secret on show/list/logs (closes #300)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,30 @@ Vulnerabilities in the Pax8 API itself should be reported to Pax8 directly at ht
 
 Pax8 API credentials carry the full set of permissions associated with the issuing partner account — there is currently no per-scope or read-only credential type at the API level. Treat them as account-equivalent and store them only on machines you trust. To revoke credentials, see <https://app.pax8.com> (Integrations Hub → API Credentials).
 
+## Bulk-export aggregation
+
+Read commands return individual records that are individually low-to-medium
+sensitivity, but bulk iteration (e.g., `contacts list` × `companies list`,
+`invoices items` × `orders show` across the partner's full book) can compose
+a higher-sensitivity dataset (Tier 3 PII + Tier 2 transaction history). This
+is inherent to the public Pax8 API, not a CLI-specific concern, but partners
+aggregating output should treat stored CLI output (logs, scripts, dashboards)
+accordingly.
+
+## Webhook secrets
+
+The webhook HMAC signing secret (`secret` field, `whsec_…` prefix) is the
+key partners use to verify the authenticity of incoming webhook payloads.
+It is classified Tier 0 (Existential) under Pax8's Marketplace & Platform
+Data Risk Tiering standard.
+
+Following the industry-standard pattern (Stripe, GitHub, Twilio), the CLI
+displays the secret **exactly once**, on `pax8 webhooks create`, accompanied
+by a "save this now" warning. Read-path commands (`webhooks show`,
+`webhooks list`, `webhooks logs`) strip the field from output even if the
+upstream API returns it. Partners who lose the secret should rotate via the
+webhook update flow rather than relying on the read path.
+
 ## Claude skill data flow
 
 When a partner uses [`@pax8/claude-skill`](packages/claude-skill) via Claude Code, command output flows to Anthropic via Claude Code as part of the agent loop — i.e. whatever the CLI prints in response to a tool invocation becomes part of the model's context for that turn. This is the normal Claude Code data flow and is governed by Anthropic's policies. Pax8 does not receive or store skill conversations and is not involved in that data path.

--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -613,6 +613,18 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     },
     demo: { forbiddenFragments: ["undefined"] },
     jsonContract: { objectRequiredFields: ["id", "url"] },
+    // Regression-gated invariant for #300: the HMAC signing secret
+    // (Tier 0) MUST NOT appear in `webhooks show` human output. Pattern
+    // matches Stripe / GitHub / Twilio — show once on create, never on
+    // read. If this assertion ever fires, the read-path redaction in
+    // packages/cli/src/commands/webhooks/show.ts has regressed.
+    customAssertions: (out) => {
+      if (/whsec_/.test(out)) {
+        throw new Error(
+          "webhooks show leaked an HMAC secret (whsec_*) — Tier 0 regression (#300)",
+        );
+      }
+    },
   },
   {
     command: ["webhooks", "topics", "list"],

--- a/packages/cli/src/__tests__/webhooks.show.test.ts
+++ b/packages/cli/src/__tests__/webhooks.show.test.ts
@@ -76,4 +76,69 @@ describe("pax8 webhooks show", () => {
     expect(result.stdout).toContain("enable");
     expect(result.stdout).toContain("disable");
   });
+
+  // ─── Tier 0 secret redaction (#300) ──────────────────────────────────────
+  //
+  // The webhook `secret` is the HMAC signing key — Tier 0 (Existential) per
+  // Pax8 Data Risk Tiering. Industry-standard pattern (Stripe / GitHub /
+  // Twilio): show once on create, never on read. The CLI strips the field
+  // from every read-path command (show / list / logs) even if the API
+  // returns it.
+  describe("redacts the HMAC `secret` (Tier 0) on read paths", () => {
+    it("`webhooks show <id> --json` does NOT include the secret value", async () => {
+      const result = await runCliExpectSuccess([
+        "webhooks",
+        "show",
+        ACTIVE_WEBHOOK_ID,
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).not.toHaveProperty("secret");
+      expect(result.stdout).not.toMatch(/whsec_/);
+      expect(result.stdout).not.toMatch(/"secret"\s*:/);
+    });
+
+    it("`webhooks show <id>` (human render) does NOT include the secret value", async () => {
+      const result = await runCliExpectSuccess([
+        "webhooks",
+        "show",
+        ACTIVE_WEBHOOK_ID,
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).not.toMatch(/whsec_/);
+      // Human render shouldn't print a "Secret:" label either.
+      expect(combined).not.toMatch(/Secret:/i);
+    });
+
+    it("`webhooks list --json` does NOT include any secret field", async () => {
+      const result = await runCliExpectSuccess(["webhooks", "list", "--json"]);
+      const data = JSON.parse(result.stdout);
+      const items: Array<Record<string, unknown>> = Array.isArray(data)
+        ? data
+        : ((data as { webhooks?: Array<Record<string, unknown>> }).webhooks ?? []);
+      expect(items.length).toBeGreaterThan(0);
+      for (const item of items) {
+        expect(item).not.toHaveProperty("secret");
+      }
+      expect(result.stdout).not.toMatch(/whsec_/);
+    });
+
+    it("`webhooks logs <id> --json` does NOT include any secret field", async () => {
+      const result = await runCliExpectSuccess([
+        "webhooks",
+        "logs",
+        ACTIVE_WEBHOOK_ID,
+        "--json",
+      ]);
+      // Tolerate either a flat array or { logs, nextActions } envelope.
+      const parsed = JSON.parse(result.stdout);
+      const logs: Array<Record<string, unknown>> = Array.isArray(parsed)
+        ? parsed
+        : ((parsed as { logs?: Array<Record<string, unknown>> }).logs ?? []);
+      for (const entry of logs) {
+        expect(entry).not.toHaveProperty("secret");
+      }
+      expect(result.stdout).not.toMatch(/whsec_/);
+    });
+  });
 });

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -170,6 +170,21 @@ Note: --events is a deprecated alias for --topics; it still works but will be re
       process.stdout.write(`  ${chalk.dim("Events:".padEnd(10))}${webhook.topics.join(", ")}\n`);
       if (webhook.secret) {
         process.stdout.write(`  ${chalk.dim("Secret:".padEnd(10))}${webhook.secret}\n`);
+        // Tier 0 credential warning (#300). Pattern matches Stripe / GitHub /
+        // Twilio: the secret is shown exactly once, on creation, and never
+        // surfaced again on `webhooks show` / `list` / `logs`. Partners must
+        // capture it now or rotate via `pax8 webhooks update` if lost.
+        process.stdout.write("\n");
+        process.stdout.write(
+          chalk.yellow(
+            "  ⚠ Save this secret now — it will not be shown again.\n",
+          ),
+        );
+        process.stdout.write(
+          chalk.dim(
+            "    Use it to verify HMAC signatures on incoming webhook payloads.\n",
+          ),
+        );
       }
       process.stdout.write("\n");
 

--- a/packages/cli/src/commands/webhooks/list.ts
+++ b/packages/cli/src/commands/webhooks/list.ts
@@ -30,8 +30,18 @@ Examples:
 
     try {
       spinner.start();
-      const webhooks = await ctx.api.webhooks.list();
+      const webhooksRaw = await ctx.api.webhooks.list();
       spinner.stop();
+
+      // Tier 0 credential redaction (#300): defensively strip `secret` (HMAC
+      // signing key) from every record. The API list endpoint should never
+      // return it, but trust nothing — redact at the read path so any
+      // current/future API behavior change can't surface it via this CLI.
+      const webhooks = webhooksRaw.map((w) => {
+        const { secret: _redactedSecret, ...rest } = w;
+        void _redactedSecret;
+        return rest;
+      });
 
       if (globalOpts.idsOnly) {
         for (const wh of webhooks) {

--- a/packages/cli/src/commands/webhooks/logs.ts
+++ b/packages/cli/src/commands/webhooks/logs.ts
@@ -69,6 +69,19 @@ async function runLogsList(
       }
     }
 
+    // Tier 0 credential redaction (#300): defensively strip any `secret`
+    // field that might appear in a log entry. WebhookLogSchema does not
+    // declare one, but trust nothing — redact at the read path.
+    allLogs = allLogs.map((entry) => {
+      const e = entry as unknown as Record<string, unknown>;
+      if ("secret" in e) {
+        const { secret: _redactedSecret, ...rest } = e;
+        void _redactedSecret;
+        return rest as unknown as (typeof allLogs)[number];
+      }
+      return entry;
+    });
+
     // Newest first
     allLogs.sort(
       (a, b) => new Date(b.sentAt).getTime() - new Date(a.sentAt).getTime(),

--- a/packages/cli/src/commands/webhooks/show.ts
+++ b/packages/cli/src/commands/webhooks/show.ts
@@ -26,8 +26,16 @@ Examples:
     try {
       const ctx = await buildContext(allOpts);
       spinner.start();
-      const webhook = await ctx.api.webhooks.get(id);
+      const webhookRaw = await ctx.api.webhooks.get(id);
       spinner.stop();
+
+      // Tier 0 credential redaction (#300): strip `secret` (HMAC signing key)
+      // from any read-path output. The API may still return it; we never do.
+      // Partners must save the secret at create time — see `webhooks create`.
+      // Industry-standard pattern: show once on create, never on read
+      // (Stripe, GitHub, Twilio).
+      const { secret: _redactedSecret, ...webhook } = webhookRaw;
+      void _redactedSecret;
 
       if (ctx.outputFormat === "json") {
         process.stdout.write(JSON.stringify(webhook, null, 2) + "\n");

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -483,11 +483,15 @@ export const WebhookSchema = z.object({
   status: WebhookStatusSchema,
   createdDate: z.string(),
   /**
-   * HMAC signing secret for verifying delivery payloads. Surfaced by the API
-   * on the create (POST) response so subscribers can capture it once; not
-   * documented in the public webhooks OpenAPI spec and not guaranteed to be
-   * returned on subsequent GET calls. Optional for that reason — consumers
-   * should record it at create time. See issue #241.
+   * HMAC signing secret. Tier 0 (Existential) per Pax8 Data Risk Tiering.
+   * Returned by the API only on POST create (and possibly on rotation);
+   * the CLI redacts/omits this field on read paths (show / list / logs).
+   * Partners who need the secret should save it on creation; if lost,
+   * rotate via the webhook update flow.
+   *
+   * Optional in the schema because the API may include or omit it; the
+   * CLI's read-path commands strip it defensively before any output
+   * (#300). See issue #241 for the original create-time-only contract.
    */
   secret: z.string().optional(),
   /** Human-friendly label for the webhook (Pax8 v2.1+). */


### PR DESCRIPTION
## Summary
- Webhook `secret` is HMAC-signing-key material — Tier 0 per Pax8's Data Risk Tiering. Was exposed cleartext on `webhooks show`.
- Industry-standard pattern: show once on create, never on read. Implemented across show / list / logs.
- `webhooks create` keeps the create-time display with a strengthened "save this now" warning.
- Zod schema comment marks the field Tier 0 with the omitted-on-read contract.
- SECURITY.md gains a short aggregation-principle paragraph.

## Why this is v0.1.0 ship-blocker
Tier 0 credential exposure shouldn't reach public OSS. The CLI's existing pattern was script-leak-prone: any consumer piping `webhooks show --json` to a log file or monitoring tool published the HMAC key.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test` green (with new redaction assertions)
- [x] `pnpm lint` clean
- [x] Manual: `webhooks show --json` no longer contains `whsec_*` or `"secret"`
- [x] Manual: `webhooks list --json` no longer contains `whsec_*`
- [x] Manual: `webhooks create` still displays secret once with warning
- [x] Per-command matrix gains a regression assertion that no `whsec_*` appears in webhooks show human output

Closes #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)