### PR TITLE
feat(subscriptions): commitment-aware cancel preview (closes #294)

### DIFF
--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -436,6 +436,107 @@ describe("pax8 subscriptions cancel", () => {
       cancelDate: "2026-12-31",
     });
   });
+
+  // Regression for #294: commitment-aware preview + safe-path defaults.
+  describe("commitment-aware behavior (#294)", () => {
+    // sub-summit-m365bp-001 is a 1-Year committed sub in demo data — its
+    // commitment.endDate is in the future.
+    const COMMITTED_SUB = "sub-summit-m365bp-001";
+
+    it("defaults to commitment term end date on a committed sub (no flag)", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "cancel",
+        COMMITTED_SUB,
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      // Safe-path default: cancelDate is set to a real future date (the
+      // commitment term end date), NOT undefined (which would be cancel-today).
+      expect(data[0]).toMatchObject({
+        id: COMMITTED_SUB,
+        status: "Cancelled",
+      });
+      expect(typeof data[0].cancelDate).toBe("string");
+      expect(data[0].cancelDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("--immediately overrides the safe-path default", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "cancel",
+        COMMITTED_SUB,
+        "--immediately",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      // cancel-today: no cancelDate field in the output.
+      expect(data[0]).toMatchObject({
+        id: COMMITTED_SUB,
+        status: "Cancelled",
+      });
+      expect(data[0].cancelDate).toBeUndefined();
+    });
+
+    it("respects --cancel-date over both default and --immediately", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "cancel",
+        COMMITTED_SUB,
+        "--cancel-date",
+        "2027-01-15",
+        "--immediately", // explicit --cancel-date should win
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0].cancelDate).toBe("2027-01-15");
+    });
+
+    // Vocabulary discipline: per Pax8 TOS + canonical macros, the consequence
+    // is "fees paid are nonrefundable" (billing continues), not an
+    // early-termination fee. The CLI must NOT use ETF / "early termination" /
+    // "fee" / "penalty" framing on the cancel surface — those misrepresent
+    // how the system works.
+    it("never uses ETF / fee / penalty vocabulary in output", async () => {
+      // Run without --json so the human preview block surfaces too. We can't
+      // force TTY in the subprocess (matrix limitation), but we capture all
+      // output streams and assert vocabulary discipline across stderr + stdout.
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "cancel",
+        COMMITTED_SUB,
+        "--yes",
+      ]);
+      const combined = result.stdout + "\n" + result.stderr;
+      // Each forbidden token represents a vocabulary mismatch with Pax8
+      // canonical phrasing; a regression here means we drifted back toward
+      // the ETF framing that the TOS doesn't support.
+      expect(combined).not.toMatch(/\bETF\b/);
+      expect(combined).not.toMatch(/early[- ]termination/i);
+      expect(combined).not.toMatch(/\bpenalty\b/i);
+      // "fee" appears in phrases like "no early-termination FEE" — guard
+      // against the term in any negative-financial context. The intentional
+      // word is "billing" (which continues per the TOS).
+      expect(combined).not.toMatch(/cancellation[- ]fee/i);
+    });
+
+    it("--help documents the safe-path default and --immediately escape hatch", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "cancel",
+        "--help",
+      ]);
+      expect(result.stdout).toContain("--immediately");
+      expect(result.stdout).toContain("commitment term end date");
+      // Make sure the help doesn't reintroduce ETF vocabulary either.
+      expect(result.stdout).not.toMatch(/\bETF\b/);
+      expect(result.stdout).not.toMatch(/early[- ]termination[- ]fee/i);
+    });
+  });
 });
 
 describe("pax8 subscriptions", () => {

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -3,7 +3,7 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
-import { ERROR_INVALID_INPUT } from "@pax8/core";
+import { ApiError, ERROR_API_VALIDATION, ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
@@ -13,6 +13,27 @@ import { formatCurrency, formatQuantity, calculateMrr } from "../../lib/formatte
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { replCmd } from "../../lib/confirm.js";
 import { markWriteInFlight } from "../../lib/signals.js";
+
+/**
+ * Active-commitment summary for the preview block. `null` when the sub has
+ * no commitment or the commitment endDate is in the past.
+ */
+function summarizeActiveCommitment(
+  commitmentEndIso: string | null | undefined,
+  now: Date = new Date(),
+): { endIso: string; daysRemaining: number; monthsRemaining: number } | null {
+  if (!commitmentEndIso) return null;
+  const endDate = new Date(`${commitmentEndIso}T23:59:59Z`);
+  if (Number.isNaN(endDate.getTime())) return null;
+  const msRemaining = endDate.getTime() - now.getTime();
+  if (msRemaining <= 0) return null;
+  const daysRemaining = Math.ceil(msRemaining / (1000 * 60 * 60 * 24));
+  // Whole months, rounded UP — partial months still incur full billing per the
+  // Pax8 TOS ("all fees paid are nonrefundable"). Underestimating would
+  // mislead partners about the cost-through-term-end.
+  const monthsRemaining = Math.max(1, Math.ceil(daysRemaining / 30));
+  return { endIso: commitmentEndIso, daysRemaining, monthsRemaining };
+}
 
 /**
  * Validate a `YYYY-MM-DD` cancel date. Returns the normalized string on
@@ -60,6 +81,10 @@ export const subscriptionsCancelCommand = new Command("cancel")
   .description("Cancel a subscription")
   .argument("<id>", "Subscription ID")
   .option("--cancel-date <YYYY-MM-DD>", "Schedule cancellation for a future date (ISO YYYY-MM-DD)")
+  .option(
+    "--immediately",
+    "Cancel today (overrides the default safe-path of scheduling for the commitment term end date on committed subscriptions). Without this flag, committed subs default to cancellation at the commitment term end date.",
+  )
   .option("-y, --yes", "Skip confirmation prompts")
   .addHelpText(
     "after",
@@ -67,37 +92,133 @@ export const subscriptionsCancelCommand = new Command("cancel")
 Examples:
   pax8 subscriptions cancel sub-summit-m365bp-001
   pax8 subscriptions cancel sub-summit-m365bp-001 --yes
-  pax8 subscriptions cancel sub-summit-m365bp-001 --cancel-date 2026-12-31`
+  pax8 subscriptions cancel sub-summit-m365bp-001 --immediately --yes
+  pax8 subscriptions cancel sub-summit-m365bp-001 --cancel-date 2026-12-31
+
+Behavior on committed subscriptions:
+  When the subscription has an active commitment term, cancellation defaults
+  to the commitment term end date — the canonical Pax8 safe path. Cancelling
+  before the commitment term end date will not stop billing: per the Pax8
+  Direct User Agreement, fees paid for the unused portion of the term are
+  nonrefundable. Use --immediately to make a cancel-today intent explicit, or
+  --cancel-date <YYYY-MM-DD> to schedule a different date.
+
+  Vendor-specific cancellation rules (Microsoft NCE 7-day window, Adobe
+  renewal-only window, Azure Savings Plan finality, etc.) are governed by
+  Pax8 marketplace policy and the vendor; see the Pax8 portal for
+  vendor-coordinated cancellation flows when the API rejects.`,
   )
   .action(async (id, options, cmd) => {
     const allOpts = cmd.optsWithGlobals();
     const ctx = await buildContext(allOpts);
 
+    let companyName: string | undefined;
+    let productName: string | undefined;
+
     try {
-      const cancelDate = allOpts.cancelDate
+      const explicitCancelDate = allOpts.cancelDate
         ? parseCancelDate(String(allOpts.cancelDate))
         : undefined;
+      const cancelImmediately = !!allOpts.immediately;
 
-      // Fetch subscription details to show what will be cancelled
+      // Fetch subscription details to inspect commitment context + show preview
       const spinner = createSpinner("Fetching subscription...").start();
       const sub = await ctx.api.subscriptions.get(id);
       spinner.stop();
 
-      // Calculate estimated MRR impact
-      const mrr = calculateMrr(sub.price ?? 0, sub.quantity, String(sub.billingTerm ?? "Monthly"));
+      companyName = sub.companyName ?? sub.companyId;
+      productName = sub.productName ?? sub.productId;
+
+      const commitmentEndIso =
+        sub.commitment?.endDate ?? sub.commitmentTermEndDate ?? null;
+      const activeCommitment = summarizeActiveCommitment(commitmentEndIso);
+
+      // Effective cancel-date resolution:
+      //   1. --cancel-date wins (explicit user override, existing #256 contract)
+      //   2. --immediately forces cancel-today (overrides commitment-aware default)
+      //   3. Active commitment + no flag → default to commitment term end date
+      //      (the canonical Pax8 safe path)
+      //   4. No commitment / past commitment → cancel today (existing behavior)
+      let effectiveCancelDate: string | undefined;
+      let usedSafePath = false;
+      if (explicitCancelDate) {
+        effectiveCancelDate = explicitCancelDate;
+      } else if (cancelImmediately) {
+        effectiveCancelDate = undefined;
+      } else if (activeCommitment) {
+        effectiveCancelDate = activeCommitment.endIso;
+        usedSafePath = true;
+      } else {
+        effectiveCancelDate = undefined;
+      }
+
+      const mrr = calculateMrr(
+        sub.price ?? 0,
+        sub.quantity,
+        String(sub.billingTerm ?? "Monthly"),
+      );
 
       if (ctx.outputFormat === "table") {
-        // Table format only: humans see the preview block.
-        // In --json/--csv/--quiet, stdout is reserved for the data envelope.
-        const heading = cancelDate
-          ? `\n  Subscription to be cancelled on ${cancelDate}:\n\n`
-          : "\n  Subscription to be cancelled:\n\n";
+        // Commitment-aware preview block. Vocabulary follows Pax8 canonical
+        // phrasing: "commitment term end date" (not "renewal date" — they
+        // can differ); "Cancelling now will not stop billing" (Pax8 has no
+        // early-termination fee per the Direct User Agreement — the
+        // consequence is "fees paid are nonrefundable", i.e. billing
+        // continues, not a separate penalty). See the canonical Rovo
+        // research grounding for #294.
+        if (activeCommitment) {
+          const estimatedCost =
+            (sub.price ?? 0) * sub.quantity * activeCommitment.monthsRemaining;
+          process.stdout.write(chalk.yellow.bold("\n  ⚠ COMMITMENT ACTIVE\n\n"));
+          process.stdout.write(
+            `  ${chalk.bold("Product")}            ${productName}\n`,
+          );
+          process.stdout.write(
+            `  ${chalk.bold("Commitment term")}    ${sub.commitment?.term ?? "—"} (ends ${activeCommitment.endIso})\n`,
+          );
+          process.stdout.write(
+            `  ${chalk.bold("Days remaining")}     ${activeCommitment.daysRemaining}\n`,
+          );
+          process.stdout.write(
+            `  ${chalk.bold("Estimated cost through term end")}   ${formatCurrency(estimatedCost)}\n`,
+          );
+          process.stdout.write(
+            chalk.dim(
+              "    (price × quantity × remaining months — estimated, not guaranteed)\n\n",
+            ),
+          );
+          if (cancelImmediately) {
+            process.stdout.write(
+              chalk.yellow(
+                `  --immediately: cancelling today. Cancelling now will not stop billing\n  for the remaining commitment term through ${activeCommitment.endIso}.\n\n`,
+              ),
+            );
+          } else if (explicitCancelDate && explicitCancelDate < activeCommitment.endIso) {
+            process.stdout.write(
+              chalk.yellow(
+                `  --cancel-date ${explicitCancelDate} is before the commitment term end date.\n  Cancelling on that date will not stop billing for the remaining commitment\n  term through ${activeCommitment.endIso}.\n\n`,
+              ),
+            );
+          } else {
+            process.stdout.write(
+              chalk.dim(
+                `  Defaulting to schedule cancellation for the commitment term end date.\n  Use --immediately to cancel today, or --cancel-date <YYYY-MM-DD> to schedule a different date.\n\n`,
+              ),
+            );
+          }
+        }
+
+        const heading = effectiveCancelDate
+          ? `  Subscription to be cancelled on ${effectiveCancelDate}:\n\n`
+          : "  Subscription to be cancelled:\n\n";
         process.stdout.write(chalk.red.bold(heading));
         process.stdout.write(`  ${chalk.bold("Company")}      ${sub.companyName ?? sub.companyId}\n`);
-        process.stdout.write(`  ${chalk.bold("Product")}      ${sub.productName}\n`);
+        process.stdout.write(`  ${chalk.bold("Product")}      ${productName}\n`);
         process.stdout.write(`  ${chalk.bold("Quantity")}     ${formatQuantity(sub.quantity)}\n`);
-        if (cancelDate) {
-          process.stdout.write(`  ${chalk.bold("Cancel Date")}  ${cancelDate}\n`);
+        if (effectiveCancelDate) {
+          process.stdout.write(
+            `  ${chalk.bold("Cancel Date")}  ${effectiveCancelDate}${usedSafePath ? chalk.dim(" (commitment term end)") : ""}\n`,
+          );
         }
         process.stdout.write(`  ${chalk.bold("Est. MRR Impact")}   ${chalk.red("-" + formatCurrency(mrr))}\n`);
         process.stdout.write("\n");
@@ -105,12 +226,10 @@ Examples:
 
       // Destructive confirmation — surface the scheduled date so the user
       // doesn't conflate scheduled with immediate cancellation.
-      const confirmed = await confirmDestructive(
-        cancelDate
-          ? `This will schedule cancellation for ${cancelDate}. This action cannot be undone.`
-          : "This action cannot be undone.",
-        "cancel"
-      );
+      const confirmMessage = effectiveCancelDate
+        ? `This will schedule cancellation for ${effectiveCancelDate}. This action cannot be undone.`
+        : "This action cannot be undone.";
+      const confirmed = await confirmDestructive(confirmMessage, "cancel");
 
       if (!confirmed) {
         process.stderr.write(chalk.yellow("\n  Cancellation aborted.\n\n"));
@@ -118,24 +237,31 @@ Examples:
       }
 
       const cancelSpinner = createSpinner(
-        cancelDate ? `Scheduling cancellation for ${cancelDate}...` : "Cancelling subscription...",
+        effectiveCancelDate
+          ? `Scheduling cancellation for ${effectiveCancelDate}...`
+          : "Cancelling subscription...",
       ).start();
       const doneCancel = markWriteInFlight("subscriptions");
       try {
-        await ctx.api.subscriptions.delete(id, cancelDate ? { cancelDate } : undefined);
+        await ctx.api.subscriptions.delete(
+          id,
+          effectiveCancelDate ? { cancelDate: effectiveCancelDate } : undefined,
+        );
       } finally {
         doneCancel();
       }
       await invalidateCacheAfterWrite();
       cancelSpinner.succeed(
-        cancelDate ? `Cancellation scheduled for ${cancelDate}` : "Subscription cancelled",
+        effectiveCancelDate
+          ? `Cancellation scheduled for ${effectiveCancelDate}`
+          : "Subscription cancelled",
       );
 
       if (ctx.outputFormat === "json") {
         output(
           [
-            cancelDate
-              ? { id: sub.id, status: "Cancelled", cancelDate }
+            effectiveCancelDate
+              ? { id: sub.id, status: "Cancelled", cancelDate: effectiveCancelDate }
               : { id: sub.id, status: "Cancelled" },
           ],
           { format: "json" },
@@ -149,6 +275,34 @@ Examples:
       process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders create --company "${coName}" --product <name>`))}  ${chalk.dim("order a replacement")}\n`);
       process.stderr.write("\n");
     } catch (error) {
+      // Wrap API rejections (vendor-specific commitment enforcement: NCE
+      // 7-day window, Adobe renewal-only window, Azure Savings Plan
+      // finality, vendor-coordinated cancellations like Sophos / INKY)
+      // with an actionable message that points partners at the portal.
+      // Per Rovo research, the cancel API returns 204/404 with no
+      // structured body — pattern-matching the error string is fragile,
+      // so the wrapper is generic.
+      if (error instanceof ApiError && error.statusCode !== 404) {
+        const display = productName
+          ? `"${productName}"${companyName ? ` for ${companyName}` : ""}`
+          : "subscription";
+        await handleCommandError(
+          new CliError(
+            `Pax8 marketplace rejected the cancellation of ${display}`,
+            [
+              "This may be vendor-specific commitment enforcement",
+              "Some vendors block mid-commitment cancellation entirely (e.g., Microsoft NCE outside the 7-day window, Adobe outside the 14-day renewal window, Azure Savings Plans)",
+            ],
+            [
+              `Run ${replCmd("pax8 subscriptions show")} ${id} to see the commitment term`,
+              "Use --cancel-date <YYYY-MM-DD> to schedule cancellation for the commitment term end date",
+              "Use the Pax8 portal for vendor-coordinated cancellation flows",
+            ],
+            undefined,
+            ERROR_API_VALIDATION,
+          ),
+        );
+      }
       await handleCommandError(error, undefined, "Failed to cancel subscription");
     }
   });


### PR DESCRIPTION
## Summary
- Pre-cancel preview detects an active commitment and surfaces commitment context (term, end date, days remaining, estimated cost through term end).
- Committed subs default to scheduling cancellation for the commitment term end date (the canonical Pax8 safe path).
- New \`--immediately\` flag makes \"cancel today\" intent explicit.
- Existing \`--cancel-date\` contract (#256) preserved and takes precedence.
- API rejections wrapped in \`CliError(ERROR_API_VALIDATION)\` with a generic \"may be vendor-specific enforcement\" hint pointing at the Pax8 portal.

## Vocabulary discipline (regression-tested)
Per Pax8-internal Rovo research across the TOS, NCE policy macros, AOS-G order rules, 10+ vendor integration pages, NCT meeting notes, the WHMCS integration behavior, and 80+ supporting docs:

- ✓ \"commitment term end date\" (not \"renewal date\" — they can differ)
- ✓ \"Cancelling now will not stop billing\" (Pax8 has NO early-termination fee per the Direct User Agreement; the consequence is fees-paid-are-nonrefundable, i.e. billing continues)
- ❌ \"ETF\" / \"early-termination fee\" / \"penalty\" / \"cancellation fee\" — never used; new test asserts none of these appear in cancel output or help text

## Why this is the right shape
- Vendor enforcement varies enormously: Microsoft NCE 7-day window, AOS-G 14/60/180-day windows, Azure Savings Plans never-cancellable, Adobe 14-day renewal-only window, Sophos vendor-coordinated escalation, etc. CLI doesn't decode these — they're scattered across internal-only Pax8 docs.
- Public API is bare: \`DELETE /subscriptions/{id}?cancelDate=…\` returns 204 or 404 with no preview support, no \`cancelableDate\` field, no financial-impact endpoint.
- Portal partially supports NCE only — the CLI gets to be ahead with a uniform UX matching the WHMCS integration's out-of-window auto-schedule behavior.

## Test plan
- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 1571 passed / 8 skipped (5 new tests)
- [x] \`pnpm lint\` clean
- [x] Manual: committed sub default → cancelDate set to commitment term end
- [x] Manual: \`--immediately --yes\` → cancel today, no cancelDate
- [x] Manual: \`--cancel-date\` overrides both default and \`--immediately\`
- [x] Vocabulary regression test: ETF / early-termination / penalty / cancellation-fee NEVER appear

Closes #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)