### PR TITLE
docs(feedback-queue): fill in issue numbers for filed items

### DIFF
--- a/docs/Pre-publish reviewer feedback queue
+++ b/docs/Pre-publish reviewer feedback queue
@@ -4,7 +4,7 @@ Tracking domain-review reviewer comments through resolution. Updated as work lan
 
 **Owner:** Josh Dulberger
 **Status:** Publish held pending resolution of all unchecked items below.
-**Last updated:** [date]
+**Last updated:** 2026-05-11
 
 ## Tanner Horsey (Subscriptions & Renewals)
 
@@ -22,8 +22,9 @@ Tracking domain-review reviewer comments through resolution. Updated as work lan
 
 ## Fred Lintz (Orders & Quotes)
 
-- [x] `intentType` writability — resolved via read-only convention: <!-- #??? --> (codebase comment + regression test + README user-scope note)
-- [x] `quotes create` shorthand semantics — resolved via help-text clarification: <!-- #??? --> (also audits `line-items add` flag coverage)
+- [x] `intentType` writability — resolved via read-only convention: #304 (codebase comment + regression test + README user-scope note)
+- [x] `quotes create` shorthand semantics — resolved via help-text clarification: #305 (also audits `line-items add` flag coverage)
+- [ ] `quotes create --expiration-date` silent no-op — #306 (surfaced during the #305 audit; flag is declared and displayed in the confirm prompt but never sent to the API)
 - [ ] v2 surface scope (sections, attachments, access-list, take-ownership) — Q4 in re-review block, open for domain owner
 
 ## Franco Aurieme (Companies & Contacts)
@@ -35,7 +36,7 @@ Tracking domain-review reviewer comments through resolution. Updated as work lan
 ## Josh Hollander
 
 - [x] `originalSubscriptionId` exclusion — CI guard issue: <!-- #??? --> (permanently-excluded fields enforced via test)
-- [ ] `clients` rename — issue filed: <!-- #??? --> (rename command group with `companies` as deprecated alias; defer JSON field renames until Pax8 ships `/clients` endpoints)
+- [ ] `clients` rename — issue filed: #317 (rename command group with `companies` as deprecated alias; defer JSON field renames until Pax8 ships `/clients` endpoints)
 - [ ] Hollander re-reviews both items
 
 ## Audit findings (surfaced during reviewer-triggered investigation, not direct reviewer comments)


### PR DESCRIPTION
## Summary

- Replaces four \`<!-- #??? -->\` placeholders in \`docs/Pre-publish reviewer feedback queue\` with the actual issue numbers (#304, #305, #317) and adds the missing #306 item that was filed during the #305 audit but never logged in the doc.
- Bumps **Last updated** to today (2026-05-11).

## What's filled in

| Item | Issue | Reviewer |
|---|---|---|
| \`intentType\` writability | #304 | Fred / Orders & Quotes |
| \`quotes create\` shorthand semantics | #305 | Fred / Orders & Quotes |
| \`quotes create --expiration-date\` silent no-op | #306 (new line — was missing) | Fred / Orders & Quotes (surfaced during #305) |
| \`clients\` rename | #317 | Hollander |

## What's intentionally still empty

Four placeholders remain — no confident matches in the issue tracker:

- \`--billing-term\` enum scope (Fred / Subscriptions)
- \`provisioningDetails\` on subscriptions update (Fred / Subscriptions)
- \`companies create\` atomic endpoint / PAM-997 (Franco)
- \`originalSubscriptionId\` exclusion CI guard (Hollander)

Doc owner can fill these in once the underlying issues are filed.

## Test plan

- [ ] No code changed; doc-only.
- [ ] Renders correctly in GitHub's markdown preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)