### PR TITLE
docs: audit of write-side API version + body-shape findings (no code changes)

### DIFF
--- a/docs/triage/api-version-audit/README.md
+++ b/docs/triage/api-version-audit/README.md
@@ -1,0 +1,191 @@
+# API-version audit — CLI write operations
+
+Read-only audit triggered by the Quotes finding (`docs/triage/quotes-api-version.md`): CLI quote commands hit `/v1/quotes/...` while the public OpenAPI documents quotes only at `/v2/quotes/...`, AND several quote writes send body shapes that don't match the spec's `requestBody`. The original quotes audit initially missed the body-shape problems because it only verified URLs. This audit is the follow-up sweep across every other write-heavy CLI surface, with both URL and body checks done independently — per the lesson logged in §10 of the quotes triage.
+
+**Scope:** writes only (create / update / delete / cancel / status transitions / anything that sends a request body). Reads, quotes, computed surfaces (renewals, audit, recommendations, report mrr, cost sim), and the recommendations engine are out of scope.
+
+**Per-domain reports:** [subscriptions.md](subscriptions.md), [orders.md](orders.md), [companies.md](companies.md), [contacts.md](contacts.md), [webhooks.md](webhooks.md), [invoices.md](invoices.md).
+
+---
+
+## 1. Totals
+
+**15 write operations audited across 6 domains.** Of those, 14 make an HTTP write call; 1 (`invoices dispute`) is draft-only by design and makes no wire write — see §4 (case F).
+
+Counting against the 14 wire-write operations:
+
+| Bucket | Count | Operations |
+|---|---|---|
+| **Wire-clean and body-clean** | 1 | `subscriptions update` |
+| **Wire-clean, minor body/query-format deviation** | 1 | `subscriptions cancel` (`cancelDate` date-only vs spec's `format: date-time`) |
+| **Wire-clean, body broken** | 2 | `orders create`, `companies create` |
+| **Wire broken, body clean (or no body)** | 6 | `contacts delete`, `webhooks update`, `webhooks enable`, `webhooks disable`, `webhooks delete`, `webhooks logs retry` |
+| **Wire broken AND body broken** | 4 | `companies update` (verb is PUT, spec is PATCH; address shape latent), `contacts create`, `contacts update`, `webhooks create` |
+
+Counted on each dimension independently:
+
+- **Wire issues (URL, prefix, or HTTP verb wrong):** 10 / 14 operations (71%).
+- **Body-shape issues (missing required, extra fields, wrong type, wrong name):** 7 / 14 operations (50%), plus 1 latent (companies update — address fields don't surface yet because no address flags are wired into `companies update`).
+- **Truly clean on both axes:** 1 / 14 (`subscriptions update`).
+
+Two distinct wire-bug classes were found:
+
+1. **Base-URL split.** The Pax8 webhooks API lives at `https://api.pax8.com/api/v2/...` per `webhooks-api.json servers[0].url`, but `Pax8Client` is hard-pinned to `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` (`packages/core/src/api/client.ts:20`). Every webhook write resolves to `/v1/webhooks/...` instead of `/api/v2/webhooks/...`. Same shape as the quotes `/v1` vs `/v2` bug, with a different (more unusual) prefix.
+2. **Path-nesting mismatch.** The spec only documents contacts under `/companies/{companyId}/contacts[/{contactId}]`. The CLI hits flat `/contacts/{id}` paths that **do not exist in the spec at all** — verified via `jq '.paths | keys[] | select(test("contact"; "i"))' /tmp/partner-endpoints.json` returning only the nested forms.
+
+And one verb-level bug: `companies update` issues PUT, but `partner-endpoints.json paths."/companies/{companyId}"` declares only `get` and `patch` (no PUT).
+
+---
+
+## 2. Per-operation verdict table
+
+| # | Domain | Operation | Wire | Body | Verdict | Recommendation |
+|---|---|---|---|---|---|---|
+| 1 | subscriptions | `update` (`PUT /v1/subscriptions/{id}`) | ✅ | ✅ | **A — clean** | none |
+| 2 | subscriptions | `cancel` (`DELETE /v1/subscriptions/{id}?cancelDate=...`) | ✅ | minor B' | **B' (minor)** — spec types `cancelDate` as `format: date-time`, CLI sends date-only | confirm with marketplace API team; align spec or CLI |
+| 3 | orders | `create` (`POST /v1/orders`) | ✅ | ❌ | **B'** — missing required `lineItemNumber`; latent `provisioningDetails` shape mismatch | populate `lineItemNumber` (1-based index); fix `OrderLineItemInputSchema.provisioningDetails` to `Array<{key, values[]}>` before any feature uses it |
+| 4 | companies | `create` (`POST /v1/companies`) | ✅ | ❌ | **B'** — `address.state`/`address.zip` instead of `stateOrProvince`/`postalCode`; 3 required booleans (`billOnBehalfOfEnabled`, `selfServiceAllowed`, `orderApprovalRequired`) never sent; always-present empty `address` object | rename address fields in `AddressSchema`; stop sending empty `address`; add flags (or explicit defaults) for the 3 required booleans |
+| 5 | companies | `update` (`PUT /v1/companies/{id}`) | ❌ (verb) | latent ❌ | **B + B'** — CLI uses PUT, spec is **PATCH-only**; address-field-name mismatch is latent (no address flags on update today) | change `CompaniesApi.update` from `client.put` → `client.patch`; partial body is then correct; also fix `AddressSchema` names |
+| 6 | contacts | `create` (`POST /v1/contacts`) | ❌ | ❌ | **wire + body** — flat path doesn't exist in spec (spec: `POST /v1/companies/{companyId}/contacts`); body carries `companyId` (not in spec body); `types` is `string[]` but spec wants `Array<{type, primary}>`; `phone` optional in CLI but spec marks required | thread `companyId` into the URL path; drop `companyId` from body; reshape `types`; make `--phone` required |
+| 7 | contacts | `update` (`PUT /v1/contacts/{id}`) | ❌ | ❌ | **wire + body** — flat path doesn't exist in spec; spec PUT body requires `firstName, lastName, email, phone` but CLI sends partial without fetch-then-merge; `types` shape wrong | thread `companyId` into URL; fetch-then-merge using the `get(id)` result the handler already fetches; reshape `types` |
+| 8 | contacts | `delete` (`DELETE /v1/contacts/{id}`) | ❌ | n/a | **wire-only** — flat path doesn't exist in spec (`DELETE /v1/companies/{companyId}/contacts/{contactId}`); pre-delete `get(id)` already returns `companyId` to thread | thread `companyId` into URL |
+| 9 | webhooks | `create` (`POST /v1/webhooks`) | ❌ (base) | ❌ | **wire + body** — `/v1` vs spec's `/api/v2`; missing required `displayName`; CLI sends `topics: string[]` but spec wants `webhookTopics: Array<{topic, filters}>` | fix base URL (see §3); add `--display-name`; restructure topic input; surface optional flags |
+| 10 | webhooks | `update` (`POST /v1/webhooks/{id}/configuration`) | ❌ (base) | ✅ | **wire-only** — `/v1` vs `/api/v2`; sub-resource path is correct | fix base URL only |
+| 11 | webhooks | `enable` (`POST /v1/webhooks/{id}/status`, body `{active:true}`) | ❌ (base) | ✅ | **wire-only** — `/v1` vs `/api/v2` | fix base URL only |
+| 12 | webhooks | `disable` (same path, `{active:false}`) | ❌ (base) | ✅ | **wire-only** — `/v1` vs `/api/v2` | fix base URL only |
+| 13 | webhooks | `delete` (`DELETE /v1/webhooks/{id}`) | ❌ (base) | n/a | **wire-only** — `/v1` vs `/api/v2` | fix base URL only |
+| 14 | webhooks | `logs retry` (`POST /v1/webhooks/{webhookId}/logs/{logId}/retry`) | ❌ (base) | ✅ | **wire-only** — `/v1` vs `/api/v2` | fix base URL only |
+| 15 | invoices | `dispute` | n/a | n/a | **case F** — no wire call by design; writes a local draft + portal template; spec exposes no dispute endpoint | flag as deliberate divergence; no code change |
+
+---
+
+## 3. Prioritized follow-up issues
+
+Recommend filing as separate GitHub issues. Ordered by blast radius × user impact.
+
+**P0 — broken at the wire today (likely 404 on real API):**
+
+1. **fix(webhooks): all writes hit `/v1/webhooks/...` but spec lives at `/api/v2/webhooks/...`.** Affects 6 write ops + every webhook read. Same class as the quotes `/v1` vs `/v2` bug. **Cannot** be fixed by changing `Pax8Client`'s single `baseUrl` — every non-webhooks API (companies, subscriptions, orders, invoices, contacts, products, usage) genuinely lives at `/v1`. Needs per-API base override or per-call absolute URL support in `Pax8Client`. See `docs/triage/api-version-audit/webhooks.md §"Sub-resource routing observations"`. Also delete dead helpers `WebhooksApi.update` (`PUT /webhooks/{id}` — not in spec) and `WebhooksApi.updateStatus` (`PATCH /webhooks/{id}` — not in spec) at `packages/core/src/api/webhooks.ts:36-44`.
+
+2. **fix(contacts): CLI uses flat `/v1/contacts/*` paths, spec only documents nested `/v1/companies/{companyId}/contacts/*`.** Affects 3 ops (create / update / delete). Thread `companyId` into `ContactsApi.create/update/delete`; for `update` and `delete` the company id is already obtainable from the pre-write `get(id)` response (the read schema includes `companyId`). See `contacts.md`.
+
+3. **fix(webhooks/create): missing required `displayName`; `topics: string[]` should be `webhookTopics: Array<{topic, filters}>`.** Required-field violation per `webhooks-api.json components.schemas.CreateWebhook.required`. Pair with the base-URL fix in #1. See `webhooks.md §"Operation: webhooks create"`.
+
+**P1 — wire-correct but body wrong; would 4xx today against a strict implementation:**
+
+4. **fix(contacts/create): `types: string[]` should be `Array<{type, primary}>`; `companyId` belongs in the path, not the body; `--phone` should be required.** Per `partner-endpoints.json components.schemas.Contact` (required: `firstName, lastName, email, phone`) and `components.schemas.ContactType` (object with `type` and `primary`). See `contacts.md`.
+
+5. **fix(contacts/update): partial PUT body doesn't satisfy spec's `Contact` required-field set; no fetch-then-merge.** The handler at `packages/cli/src/commands/contacts/update.ts:94` already calls `get(id)` for the preview but never merges the result into the outgoing body. Same `types` shape fix as #4. See `contacts.md`.
+
+6. **fix(companies/create): address field names + missing required booleans.** `AddressSchema` uses `state`/`zip` (`packages/core/src/api/types.ts:56-62`) but spec is `stateOrProvince`/`postalCode`. Three required booleans (`billOnBehalfOfEnabled`, `selfServiceAllowed`, `orderApprovalRequired`) are omitted entirely. CLI also always sends an empty `address` object even when no flags are passed. See `companies.md`.
+
+7. **fix(companies/update): wrong HTTP method (PUT vs PATCH).** `CompaniesApi.update` at `packages/core/src/api/companies.ts:34-37` issues `client.put`; spec documents only `PATCH /companies/{companyId}`. `Pax8Client.patch` already exists. Partial-body approach is correct *for PATCH* — only the verb needs to change. See `companies.md`.
+
+8. **fix(orders/create): missing required `lineItemNumber`; latent `provisioningDetails` shape mismatch.** Spec's `CreateLineItem.required` includes `lineItemNumber` (a writeOnly number used for parent/child line-item references). CLI never sends it. Separately, `OrderLineItemInputSchema.provisioningDetails` is typed as `Record<string, unknown>` (`packages/core/src/api/types.ts:224`) but the spec requires `Array<{key, values[]}>` — latent today because `orders create` never populates it, but a foot-gun for any future feature that wires through provisioning. See `orders.md`.
+
+**P2 — minor / unverified:**
+
+9. **verify(subscriptions/cancel): `cancelDate` query-param format.** Spec types `cancelDate` as `format: date-time` with offset example; CLI emits `YYYY-MM-DD` and the source comment at `packages/cli/src/commands/subscriptions/cancel.ts:44-45` explicitly asserts the API "treats `cancelDate` as a date (not a timestamp)." Two readings (spec wrong vs CLI wrong) — confirm with marketplace API team via sandbox.
+
+10. **verify(orders/create): three spec ambiguities.** (a) `CreateLineItem.required` lists `companyId` but the schema declares no such property and the canonical example omits it — almost certainly a spec bug. (b) The example uses `commitmentTermID` (capital ID) where the schema uses `commitmentTermId`. (c) `lineItemNumber` required by schema, absent from example. Confirm with Pax8 before patching. See `orders.md §"Spec ambiguities"`.
+
+**P3 — cleanup / coverage debt:**
+
+11. **chore(core): delete dead webhooks helpers and their input schemas.** `WebhooksApi.update`, `WebhooksApi.updateStatus`, `UpdateWebhookInputSchema` (`packages/core/src/api/types.ts:516-521`). They target endpoints the spec does not document and would 404 (or worse, hit a legacy alias) for any embedded `@pax8/core` consumer that picks them up. See `webhooks.md §"Sub-resource routing observations"`.
+
+12. **note(read-side): out-of-scope but worth tracking — `CompanySchema` and the contacts `types` shape also affect reads.** `packages/core/src/api/types.ts:56-62` has the same wrong `state`/`zip` field names on the read schema, so the CLI is likely silently dropping those fields when displaying companies today (Zod's non-strict mode strips). Same for contacts `types` on read. Not in this audit's scope but the schema fixes from P1 #4 and #6 should land together with the read-side fix.
+
+13. **coverage: webhooks topic sub-resources.** Spec defines `POST/PUT /webhooks/{id}/topics`, `DELETE /webhooks/{id}/topics/{topicId}`, `PUT /webhooks/{id}/topics/{topicId}/configuration`, `POST /webhooks/{id}/topics/{topic}/test`. CLI exposes none. Out of scope for "fix what exists," tracked as backlog.
+
+14. **doc(invoices/dispute): flag case F in user-facing audit summary.** `pax8 invoices dispute` honestly presents itself as a local draft generator, but consumers of this audit pack shouldn't have to re-derive that "invoices write" means "local file write." See `invoices.md`.
+
+---
+
+## 4. Reconciliation cases used
+
+Extending the quotes audit's case set (A–E) with two new cases this audit needed:
+
+- **A — deliberate-and-correct.** Wire URL, HTTP method, body shape, and required-field coverage all match the spec. Example: `subscriptions update`.
+- **B — wire-bug-by-accident.** Wrong base URL, wrong path prefix, wrong path nesting, or wrong HTTP verb. The CLI's intent matches the spec but the call doesn't resolve to the documented endpoint. Examples: `companies update` (PUT vs PATCH), `contacts create/update/delete` (flat vs nested), all webhook writes (`/v1` vs `/api/v2`).
+- **B' — body-shape-only deviation** (new label; introduced in the quotes addendum). Wire URL correct, body diverges from `requestBody.content."application/json".schema`: missing required fields, extra fields, wrong type, wrong key name, wrong nesting. Examples: `orders create` (missing `lineItemNumber`), `companies create` (address field names + missing booleans), `subscriptions cancel` (`cancelDate` format).
+- **B + B'** — both. Wire and body both diverge. Examples: `companies update`, `contacts create`, `contacts update`, `webhooks create`.
+- **C — silent wire mismatch.** CLI on wrong wire path but the path coincidentally works because of legacy aliasing or back-compat routing. Not confirmed for any operation in this audit (would require sandbox verification), but flagged as the "best-case" interpretation for the contacts flat-path bug — *if* `/v1/contacts/*` is a legacy alias still served by a Pax8 gateway, the contacts ops might be working today despite being off-spec. Whether this is true is unverified.
+- **D — v1/v2 functionally equivalent.** Ruled out for every webhook op by spec: the webhooks endpoints exist only at `/api/v2` per `webhooks-api.json paths.*`; nothing in `partner-endpoints.json` documents `/v1/webhooks*`.
+- **E — routing override I missed.** Ruled out by inspection of `Pax8Client.buildUrl` (`packages/core/src/api/client.ts:267-278`) — it's a plain concat with no per-resource routing, no version rewriter, no per-call base override. Verified across all 6 domains.
+- **F — draft-only by design, no API surface exists** (new; first use). The command performs a "write" from the partner's perspective (materializes durable state, prompts, takes an idempotency key, marks a write-in-flight) but the durable state is local-only. The CLI is transparent about it in `--help` and inline output, and the public spec confirms no API endpoint exists. Example: `invoices dispute`.
+
+---
+
+## 5. Methodology — what evidence we used
+
+Each domain audit verified four things, in this order:
+
+1. **Wire URL resolution.** Traced from the command handler → core API method → relative path → `Pax8Client.buildUrl()` and the resolved URL on the default base. The CLI claims are cited with `packages/...:lineno` paths. The resolution chain is: `Pax8Client` constructor at `packages/core/src/api/client.ts:53` sets `this.baseUrl = (options.baseUrl ?? getDefaultBaseUrl()).replace(/\/+$/, "")`; `getDefaultBaseUrl()` returns `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` (`client.ts:20, 37-41`) unless `PAX8_API_BASE` is set; `buildUrl` (`client.ts:267-278`) does `new URL(${baseUrl}${path})` with no version munging or per-resource routing.
+
+2. **Spec presence and version.** Confirmed via `jq '.paths | keys'` against the public OpenAPI specs (downloaded from `https://devx.pax8.com/openapi`):
+   - `/tmp/partner-endpoints.json` (title "PARTNER ENDPOINTS", `info.version 1.0.0`, `servers[0].url https://api.pax8.com/v1`) — companies, subscriptions, orders, contacts, invoices, products, usage.
+   - `/tmp/webhooks-api.json` (title "Webhooks Api", `info.version 1.0.0`, `servers[0].url https://api.pax8.com/api/v2`) — all webhook endpoints.
+   - `/tmp/quoting-endpoints.json` (out of scope here; covered by `quotes-api-version.md`).
+
+3. **Request body shape.** Verified from the spec's `paths.X.<method>.requestBody.content."application/json".schema`, resolving `$ref`s through `components.schemas.*`. **Response schemas were never used to infer request bodies** — a mistake the quotes audit made the first pass.
+
+4. **Required-field coverage.** Read the spec's `required` arrays explicitly and cross-checked field-by-field against the CLI's outgoing body. For PUT operations: also checked whether the spec is PUT-full-replace or PATCH-partial-merge, and whether the CLI fetch-then-merges accordingly.
+
+**Evidence inputs per claim:**
+
+- CLI behavior: source code only (`packages/cli/src/commands/...`, `packages/core/src/api/...`). No subprocess runs against `PAX8_DEMO=1`, no sandbox API calls. `MockPax8Client` was not consulted — it accepts whatever shape the CLI sends and would mask wire mismatches.
+- Spec behavior: the public OpenAPI JSON only. The spec is treated as the published contract: if the CLI's source comments contradict the spec (as they do for `subscriptions cancel`'s `cancelDate` typing), the audit flags both and reports — it does not infer one is right.
+- Ambiguity: where the spec is silent, contradicts its own example, or where the spec required-field list contains a property that isn't declared on the schema (`orders create`'s per-line `companyId`), the audit reports the ambiguity and stops. No imputation.
+
+**What this audit deliberately did NOT do:**
+
+- Run live sandbox API calls. Would require credentials and is outside the scope of a paper audit.
+- Test whether legacy aliases work. The CLI may be calling off-spec paths that work today by accident; this audit cites the spec as authority.
+- Examine internal Pax8 routes (e.g., anything not in the public OpenAPI). The public contract is the only fact set used.
+- Audit reads, computed surfaces, the recommendations engine, or the Quotes domain.
+
+---
+
+## 6. Why these problems weren't caught before
+
+Same structural test gap as the quotes audit (`quotes-api-version.md §10`):
+
+- **Subprocess CLI tests run in `PAX8_DEMO=1`** and exercise `MockPax8Client`, which accepts whatever shape the CLI builds. The wire URL and the body shape are invisible to demo tests.
+- **Core API unit tests** (`packages/core/src/api/*.test.ts`) mock `Pax8Client.get/post/put/delete` with `vi.fn()` and assert on **relative path strings**. `buildUrl()` and `fetch()` are never invoked. The resolved wire URL is invisible.
+- **No sandbox integration test** exists for any resource — verified for webhooks, contacts, companies, subscriptions, orders. Every layer of the test pyramid is below the wire, so a wrong base URL, a wrong path prefix, a missing required body field, or a wrong field name produces zero test failures.
+
+Until a sandbox smoke test exists (even one read-only call per resource), every audit like this one has to be paper-only — and paper-only audits will keep missing problems the spec is precise about and the comments are vague about.
+
+---
+
+## 7. Methodology lessons (for the next audit)
+
+Refined from the quotes audit retrospective and exercised across all six domains here:
+
+1. **URL audit and body audit are separate verification tracks.** Finishing one is not finishing the other. The quotes audit's first pass verified URLs and stopped; the second pass found 5 of 10 quote operations had body-shape bugs too. This audit ran both passes for every operation from the start, and the body axis flagged independent problems on 5 of 14 wire-write operations that a URL-only audit would have missed.
+
+2. **Code comments and Zod schema names are hypotheses, not evidence.** A schema labeled "Input for `POST /v2/quotes/...`" is not proof the schema matches what `POST /v2/quotes/...` accepts. The companies audit found `AddressSchema` claiming to model an address while using field names (`state`, `zip`) that no Pax8 spec uses anywhere. Comments are hypotheses; the spec's `requestBody` is the ground truth.
+
+3. **Response-shape alignment ≠ request-shape alignment.** They're authored separately even within the same resource. The webhooks audit found `WebhookSchema` (read) is broadly aligned with the spec while `CreateWebhookInputSchema` (write) is structurally wrong (missing `displayName`, wrong topics shape). Same pattern likely exists in other domains; verify both directions when auditing any resource.
+
+4. **Spec examples can contradict spec schemas.** The orders audit found three contradictions within `partner-endpoints.json` itself: `CreateLineItem.required` lists a property not declared on the schema; the canonical example uses different casing for `commitmentTermID`; and the example omits a schema-required `lineItemNumber`. When schema and example disagree, the schema is authoritative for contract verification, but the disagreement itself is worth reporting upstream.
+
+5. **Read the `required` arrays carefully.** Multiple ops here are sending bodies that omit fields the spec lists as required (`companies create` missing 3 booleans; `webhooks create` missing `displayName`; `orders create` missing `lineItemNumber`; `contacts create` sending `phone` as optional when spec marks it required). Required-field omissions are 4xx contract violations, not warnings.
+
+6. **Verbs matter.** `companies update` is the clearest example: the body is fine (true partial), the path is fine, the only thing wrong is the HTTP method (PUT vs spec's PATCH-only). A URL+body audit would still miss this if the verb axis isn't checked separately.
+
+7. **`servers[0].url` is part of the wire URL.** Multi-spec APIs can use different base URLs per spec — `partner-endpoints.json` is `/v1`, `webhooks-api.json` is `/api/v2`, `quoting-endpoints.json` is unversioned with `/v2/...` paths. A single-baseUrl client (`Pax8Client`) cannot represent this; per-API or per-call base override is needed.
+
+8. **`PAX8_DEMO=1` is a productivity feature, not a correctness check.** Demo mode swaps in `MockPax8Client`, which accepts whatever shape the CLI sends and returns synthetic data shaped however the CLI's *read* schemas define. It will pass every write-shape mistake silently. Don't rely on `pnpm test` as a wire-correctness signal.
+
+---
+
+## 8. Constraints honored
+
+- **Read-only audit.** No source files (`packages/...`) were modified. The only files written by this audit are the seven markdown files under `docs/triage/api-version-audit/`.
+- **No live sandbox API calls.** All evidence is from static source reads (CLI and core packages) and `jq` queries against the locally-downloaded public OpenAPI specs.
+- **Every CLI claim cites a file path and line number.**
+- **Every spec claim cites the OpenAPI path** (e.g., `partner-endpoints.json paths."/companies".post.requestBody.content."application/json".schema`).
+- **Request bodies were verified from `requestBody` schemas only**, resolving `$ref`s explicitly. Response schemas were not used to infer request shapes.
+- **Spec ambiguities are reported, not inferred away.** Where the spec is silent or self-contradicting, the report calls that out and stops.
+- **Worktree isolation.** The audit ran in `/tmp/pax8-cli-api-audit` (branch `audit/write-api-versions` based on `origin/main`); the user's primary working checkout at `/Users/jdulberger/Documents/pax8-cli` (`fix/quotes-v2-wire-path`) was not touched.

--- a/docs/triage/api-version-audit/companies.md
+++ b/docs/triage/api-version-audit/companies.md
@@ -1,0 +1,189 @@
+# Companies write API audit
+
+**TL;DR:** Both write operations hit URLs that exist on the Pax8 v1 API, so the URL story is clean (this is **not** the quotes-style v1-vs-v2 problem). But both operations send a **request body that does not match the OpenAPI schema** — the `address` sub-object uses CLI-invented field names (`state`, `zip`) instead of the spec's `stateOrProvince`, `postalCode`. In addition, `companies update` calls `PUT /companies/{id}` while the spec only documents `PATCH /companies/{companyId}`, and `companies create` always sends an `address` object even when the user supplies no address flags. Verdicts: `create` = **case B' (body-shape bug, address field names)**; `update` = **case B+B' (wrong HTTP method AND body-shape bug)**.
+
+## Operations audited
+
+| Operation | CLI command | CLI wire | Spec path | Spec method | Verdict |
+|---|---|---|---|---|---|
+| Create company | `pax8 companies create` | `POST {baseUrl}/companies` | `/companies` | `post` | B' — URL correct, body shape wrong (`state`/`zip` vs `stateOrProvince`/`postalCode`; always sends `address` even when empty) |
+| Update company | `pax8 companies update <id\|name>` | `PUT {baseUrl}/companies/{id}` | `/companies/{companyId}` | `patch` | B + B' — wrong HTTP method (PUT vs PATCH) AND body shape wrong (address field names) |
+
+`{baseUrl}` resolves to `https://api.pax8.com/v1` by default (`packages/core/src/api/client.ts:20`, `getDefaultBaseUrl()` at lines 37–41). `PAX8_API_BASE` can override but must validate as `https://` (or localhost http) per `validateBaseUrl`.
+
+## Operation: companies create
+
+### Wire path
+
+1. CLI handler: `packages/cli/src/commands/companies/create.ts:59–70` calls `ctx.api.companies.create({ name, phone, website, address: {...} })`.
+2. Core method: `packages/core/src/api/companies.ts:29–32` — `create(data)` calls `this.client.post<unknown>("/companies", data)`.
+3. HTTP client: `packages/core/src/api/client.ts:91–93` — `post(path, body)` → `request("POST", path, body)`. `buildUrl` at lines 267–278 builds `new URL(\`${this.baseUrl}${path}\`)`, with `baseUrl` defaulting to `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` (line 20).
+4. **Resolved wire URL:** `POST https://api.pax8.com/v1/companies`.
+
+### Public spec location
+
+- Path: `paths."/companies"` exists in `/tmp/partner-endpoints.json`.
+- Method: `post` (operationId `createCompany`, tags `Companies`).
+- Server: `servers[0].url = "https://api.pax8.com/v1"` (info.version `1.0.0`).
+- **The URL is correct.** No v1-vs-v2 problem here.
+
+### Request body shape
+
+**CLI sends** (`packages/cli/src/commands/companies/create.ts:59–70`):
+
+```jsonc
+{
+  "name": "<--name>",
+  "phone": "<--phone or ''>",
+  "website": "<--website or ''>",
+  "address": {
+    "street": "",                              // always empty string — no --street flag
+    "city":    "<--city or ''>",
+    "state":   "<--state or ''>",              // !! CLI invented field name
+    "zip":     "<--zip or ''>",                // !! CLI invented field name
+    "country": "<--country or 'US'>"
+  }
+}
+```
+
+The Zod input schema enforcing this shape is `AddressSchema` / `CreateCompanyInputSchema` at `packages/core/src/api/types.ts:56–99`.
+
+**Spec requires** (`paths."/companies".post.requestBody.content."application/json".schema` → `$ref components.schemas.Company`):
+
+- `required`: `["name", "address", "phone", "website", "billOnBehalfOfEnabled", "selfServiceAllowed", "orderApprovalRequired"]`.
+- `address` is `$ref components.schemas.Address` with properties: `street`, `street2`, `city`, **`stateOrProvince`**, **`postalCode`**, `country` (ISO 3166-1 alpha-2, regex `^[A-Z]{2}$`).
+- Spec example payload (`components.examples.company-post`):
+  ```json
+  {
+    "name": "VFC Network, Inc",
+    "address": {
+      "street": "48918 Liberty Lane Ave",
+      "city": "Denver",
+      "postalCode": "80210",
+      "country": "US",
+      "stateOrProvince": "Colorado"
+    },
+    "phone": "123-456-5555",
+    "website": "vfc-network-inc-liberty.com",
+    "externalId": "A123",
+    "selfServiceAllowed": false,
+    "billOnBehalfOfEnabled": false,
+    "orderApprovalRequired": false,
+    "contacts": [ ... ]
+  }
+  ```
+
+**Mismatches:**
+
+1. **Address field-name mismatch (B'):** CLI sends `address.state` and `address.zip`; spec defines `address.stateOrProvince` and `address.postalCode`. Same nesting (both flat-under-`address`), but the leaf names disagree. The API will either reject as 422 or silently discard those fields and store the company with an empty state/zip — neither is acceptable.
+2. **Always-present empty address (likely B'):** The handler unconditionally sends an `address` object with all fields defaulting to `""` (lines 63–69). Even when the user supplies no `--city`/`--state`/`--zip`, the body has `address: { street: "", city: "", state: "", zip: "", country: "US" }`. The spec marks `address` as a required parent, but its leaf properties have no `pattern`/`minLength` declared — except `country` (`^[A-Z]{2}$`) which the `"US"` default satisfies. So this is more of a quality concern than a hard 422, but it makes the CLI ship dummy address data on every create.
+3. **Missing required boolean fields (B'):** Spec marks `billOnBehalfOfEnabled`, `selfServiceAllowed`, `orderApprovalRequired` as **required**. The CLI exposes no flags for them and never sends them. The Zod `CreateCompanyInputSchema` lists them as `.optional()` (`packages/core/src/api/types.ts:95–97`), confirming the omission is by design. The API may default these server-side (the partner UI lets you create a company without them), but per the spec contract they should be in the request body.
+4. **No `--street` / `--street2` / `--external-id` flags:** Spec accepts `street`, `street2`, `externalId`; CLI hard-codes `street: ""` and omits the others. Not a "wrong" finding per se (extras are optional) but it's coverage debt.
+
+### Required field coverage
+
+For create, the spec's `required` list is `[name, address, phone, website, billOnBehalfOfEnabled, selfServiceAllowed, orderApprovalRequired]`.
+
+| Spec required | CLI sends? | Notes |
+|---|---|---|
+| `name` | yes (required flag) | OK |
+| `address` | yes (always — empty object even when no flags) | Present-but-degenerate |
+| `phone` | yes (defaults to `""` if `--phone` omitted) | Empty string |
+| `website` | yes (defaults to `""`) | Empty string |
+| `billOnBehalfOfEnabled` | **no** | No CLI flag |
+| `selfServiceAllowed` | **no** | No CLI flag |
+| `orderApprovalRequired` | **no** | No CLI flag |
+
+Three required-by-spec boolean fields are silently omitted.
+
+### Reconciliation case (A–E, or B'/B+B')
+
+**Case B' (body-shape bug).** The URL is correct (v1 path, no version drift), but the request body diverges from the OpenAPI request schema in three ways:
+
+- Address field names: `state`/`zip` instead of `stateOrProvince`/`postalCode`.
+- Three required boolean fields (`billOnBehalfOfEnabled`, `selfServiceAllowed`, `orderApprovalRequired`) are never sent.
+- A dummy empty `address` object is always sent even when the user supplies no address flags.
+
+Borderline B+B' if you consider the missing required fields a structural omission rather than a shape mismatch. Either label points at the same fix.
+
+### Recommendation
+
+1. Rename `AddressSchema` fields in `packages/core/src/api/types.ts:56–62` to match the spec: `street`, `street2?`, `city`, `stateOrProvince`, `postalCode`, `country`. Update `companies create` flags accordingly (`--state` → still UX-fine but maps to `stateOrProvince` on the wire; `--zip` → maps to `postalCode`).
+2. Stop unconditionally building an `address` object when no address flags were supplied (`packages/cli/src/commands/companies/create.ts:63–69`). Omit `address` from the body in that case, or fail-fast with an `ERROR_INVALID_INPUT` since the spec marks `address` required.
+3. Add CLI flags for the three required booleans (e.g. `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required`) with sensible defaults, OR send them as `false` defaults explicitly. The current "rely on server defaults" approach is invisible to operators and not contractually safe.
+4. (Nice-to-have) Add `--external-id`, `--street`, `--street2` flags so partners using PSA-bridging can do create-with-`externalId` from the CLI, matching the `externalId` field already in `CompanySchema` (`packages/core/src/api/types.ts:84`).
+
+## Operation: companies update
+
+### Wire path
+
+1. CLI handler: `packages/cli/src/commands/companies/update.ts:30–74`. Builds `updates: Record<string, unknown>` containing only the user-supplied flags (`name`, `phone`, `website`) at lines 36–39, then calls `ctx.api.companies.update(resolved.id, updates)` at line 71.
+2. Core method: `packages/core/src/api/companies.ts:34–37` — `update(id, data)` calls `this.client.put<unknown>(\`/companies/${id}\`, data)`. **Note the verb: PUT.**
+3. HTTP client: `packages/core/src/api/client.ts:95–97` — `put(path, body)` → `request("PUT", path, body)`. Same `buildUrl` machinery as create.
+4. **Resolved wire URL:** `PUT https://api.pax8.com/v1/companies/{id}`.
+
+Test confirms verb is PUT: `packages/core/src/api/companies.test.ts:82` asserts `client.put` is invoked.
+
+### Public spec location
+
+- Path: `paths."/companies/{companyId}"` exists.
+- Methods documented: `get`, **`patch`** (operationId `updateCompany`, summary "Update Company"). **No `put`.**
+- Spec description for PATCH: "Updates an existing Company. ATTENTION - at least one parameter has to be modified."
+
+### Request body shape
+
+**CLI sends** (`packages/cli/src/commands/companies/update.ts:36–39, 71`):
+
+```jsonc
+// Only keys whose flags were passed:
+{
+  "name":    "<--name>",     // if --name passed
+  "phone":   "<--phone>",    // if --phone passed
+  "website": "<--website>"   // if --website passed
+}
+```
+
+There is **no fetch-then-merge**. `resolveCompany` (`packages/cli/src/lib/resolve-company.ts`) returns the full Company for ID/name lookup, but the handler only consults `resolved.id` (line 71) and `resolved.name` (line 54, display only). The existing field values are never spliced into the request body.
+
+**Spec defines** (`paths."/companies/{companyId}".patch.requestBody.content."application/json".schema` → `$ref components.schemas.CompanyUpdate`):
+
+- `type: object`, **no `required` list** (genuine partial-update schema).
+- Properties: `id` (readOnly), `name`, `address` (`$ref Address`), `phone`, `website`, `externalId`, `billOnBehalfOfEnabled`, `selfServiceAllowed`, `orderApprovalRequired`, `status` (readOnly).
+- `Address` properties: `street`, `street2`, `city`, **`stateOrProvince`**, **`postalCode`**, `country`.
+
+**Mismatches:**
+
+1. **HTTP method (B):** CLI uses **PUT**, spec documents **PATCH**. This is a verb-level wire mismatch. Per typical Pax8 routing, the API may either reject PUT with 405 Method Not Allowed, or accept it as an alias — unverified, but the public contract is PATCH-only.
+2. **Address field-name mismatch (B'):** Same issue as create — though `companies update` exposes no address flags today (only `--name`, `--phone`, `--website`), so the address divergence is dormant. The moment someone adds `--state`/`--zip` flags, it would manifest the same `state` vs `stateOrProvince` problem.
+3. **Body-direction is fine:** The CLI sends a true partial body (only modified fields), which matches the PATCH semantics declared in the spec ("at least one parameter has to be modified"). If the API really is PATCH, then partial-send is correct and a fetch-then-merge would actually be *wrong*. So if the verb is fixed to PATCH, the partial-body approach is right; if the API only accepts PUT-with-full-replace, then both the verb AND the missing-field merge are bugs. The spec says PATCH, so I'm treating the verb as the primary fault.
+
+### Required field coverage
+
+- Spec method is **PATCH**, not PUT. `CompanyUpdate` schema declares **no required fields** (it's a partial-update schema, properties only).
+- The only spec-imposed constraint is "at least one parameter has to be modified" — the CLI enforces this at the handler level (lines 41–49), throwing `ERROR_INVALID_INPUT` if no flags were passed. Good.
+- The CLI does **not** fetch-then-merge. It sends only the user-supplied fields. That matches PATCH semantics. It would be wrong for PUT (full-replace).
+
+So: **partial body is correct iff the verb is PATCH.** Since the spec says PATCH, the partial-body approach is fine; the verb is the bug.
+
+### Reconciliation case (A–E, or B'/B+B')
+
+**Case B + B' (wrong HTTP method, plus body-shape bug latent in address).**
+
+- B (wrong wire-level method): the CLI hits `PUT /companies/{id}`, the spec documents `PATCH /companies/{companyId}` only. URL path is right; verb is wrong.
+- B' (body shape): the `AddressSchema` field names (`state`, `zip` vs spec `stateOrProvince`, `postalCode`) are wrong, but currently dormant because the update command exposes no address flags. As soon as address flags are added, this becomes active.
+
+### Recommendation
+
+1. Change `CompaniesApi.update` (`packages/core/src/api/companies.ts:34–36`) from `this.client.put(...)` to `this.client.patch(...)`. The PATCH method already exists on `Pax8Client` (`packages/core/src/api/client.ts:99–101`).
+2. Update the companies test (`packages/core/src/api/companies.test.ts:82`) to assert `client.patch` instead of `client.put`. Keep the partial-body assertion.
+3. Fix the `AddressSchema` field names in `packages/core/src/api/types.ts:56–62` (same change as for create) so future `--state-or-province` / `--postal-code` (or remapped `--state`/`--zip`) flags will serialize correctly.
+4. Keep the partial-update approach in the CLI handler. Do **not** introduce a fetch-then-merge — the spec is PATCH, partial is correct.
+
+## Constraints honored
+
+- READ-ONLY audit: no source-tree files in `packages/` were modified. Only `docs/triage/api-version-audit/companies.md` was written.
+- All CLI claims cite worktree-relative file paths and line numbers (e.g. `packages/cli/src/commands/companies/update.ts:71`).
+- All API claims cite the OpenAPI spec by JSON path (e.g. `paths."/companies/{companyId}".patch`) or `components.schemas.{Company,CompanyUpdate,Address}` / `components.examples.{company-post, company-update-post}`.
+- Request body shapes derived from `requestBody.content."application/json".schema` (resolved through `$ref`s), not from response examples. (Response examples were consulted only as cross-check confirmation; they happen to use the same `Address` field names.)
+- No live API calls were made.
+- Worktree path used throughout: `/tmp/pax8-cli-api-audit/`. Did not touch `/Users/jdulberger/Documents/pax8-cli`.

--- a/docs/triage/api-version-audit/contacts.md
+++ b/docs/triage/api-version-audit/contacts.md
@@ -1,0 +1,194 @@
+# Contacts write API audit
+
+**TL;DR:** All three contact write commands hit the **wrong wire URL** — the CLI uses flat `/contacts/...` paths but the public spec only documents the nested `/companies/{companyId}/contacts/...` form (no flat path exists in `partner-endpoints.json`). `contacts create` POSTs to `/v1/contacts` (spec: `POST /v1/companies/{companyId}/contacts`) and additionally carries the `companyId` in the body instead of the URL — a body field the spec does not declare. `contacts update` PUTs to `/v1/contacts/{id}` (spec: `PUT /v1/companies/{companyId}/contacts/{contactId}`) and sends a partial body; the spec's PUT request body has four required scalars (`firstName`, `lastName`, `email`, `phone`), so a partial PUT would 422 against a strict implementation, and the spec does not document PATCH. `contacts delete` DELETEs `/v1/contacts/{id}` (spec: `DELETE /v1/companies/{companyId}/contacts/{contactId}`). The **most-surprising and load-bearing body finding**: the spec types each `types` element as an **object** `{type: "Admin"|"Billing"|"Technical", primary: boolean}`, but the CLI sends a flat array of strings (`types: ["Admin", "Billing"]`). This is a structural body-shape mismatch that a URL-only audit would have missed.
+
+## Operations audited
+
+| Command | Source file:lines | CLI-resolved URL | Spec-documented URL | HTTP method |
+|---|---|---|---|---|
+| `pax8 contacts create` | `packages/cli/src/commands/contacts/create.ts:107` → `packages/core/src/api/contacts.ts:32-35` | `POST https://api.pax8.com/v1/contacts` | `POST https://api.pax8.com/v1/companies/{companyId}/contacts` | `POST` |
+| `pax8 contacts update <id>` | `packages/cli/src/commands/contacts/update.ts:117` → `packages/core/src/api/contacts.ts:37-40` | `PUT https://api.pax8.com/v1/contacts/{id}` | `PUT https://api.pax8.com/v1/companies/{companyId}/contacts/{contactId}` | `PUT` (spec is PUT, no PATCH variant) |
+| `pax8 contacts delete <id>` | `packages/cli/src/commands/contacts/delete.ts:55` → `packages/core/src/api/contacts.ts:42-44` | `DELETE https://api.pax8.com/v1/contacts/{id}` | `DELETE https://api.pax8.com/v1/companies/{companyId}/contacts/{contactId}` | `DELETE` |
+
+Wire-URL trace (shared):
+- `Pax8Client` constructor sets `this.baseUrl = (options.baseUrl ?? getDefaultBaseUrl()).replace(/\/+$/, "")` at `packages/core/src/api/client.ts:53`.
+- `getDefaultBaseUrl()` returns `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` when `PAX8_API_BASE` is unset (`packages/core/src/api/client.ts:20`, `37-41`).
+- `buildUrl(path, params)` concatenates `${this.baseUrl}${normalizedPath}` (`packages/core/src/api/client.ts:267-278`) — no path rewriting, no version override.
+- `ContactsApi` passes literal relative paths beginning with `/contacts` to `client.post/put/delete` (`packages/core/src/api/contacts.ts:33, 38, 43`). It never templates `companyId` into the path.
+
+Spec server: `partner-endpoints.json .servers[0].url = "https://api.pax8.com/v1"` (so the spec is unambiguously talking about `/v1`).
+
+Spec paths (full enumeration of contact endpoints — there are no flat sibling paths):
+```
+$ jq '.paths | keys[] | select(test("contact"; "i"))' /tmp/partner-endpoints.json
+"/companies/{companyId}/contacts"
+"/companies/{companyId}/contacts/{contactId}"
+```
+
+---
+
+## Operation: contacts create
+
+### Wire path
+CLI hits `POST https://api.pax8.com/v1/contacts`.
+- Command handler calls `ctx.api.contacts.create(input)` at `packages/cli/src/commands/contacts/create.ts:107`.
+- `ContactsApi.create` calls `this.client.post<unknown>("/contacts", data)` at `packages/core/src/api/contacts.ts:33`.
+- `client.post` issues `POST` to `buildUrl("/contacts")` → `https://api.pax8.com/v1/contacts` (`packages/core/src/api/client.ts:91-93`, `267-278`).
+
+### Public spec location
+The spec documents creation at `partner-endpoints.json paths."/companies/{companyId}/contacts".post` (summary: "Create Contact"). It declares `companyId` as a **required path parameter** (`type: string, format: uuid`). There is no flat `/contacts` POST in the spec — confirmed by the path-key enumeration above.
+
+### Request body shape
+CLI body construction (`packages/cli/src/commands/contacts/create.ts:94-101`):
+```
+const input: CreateContactInput = {
+  firstName: options.firstName,
+  lastName:  options.lastName,
+  email:     options.email,
+  companyId: company.id,         // <-- companyId carried in body
+  types,                         // <-- string[]: e.g. ["Admin", "Billing"]
+  ...(options.phone ? { phone: options.phone } : {}),
+};
+```
+Zod input contract (`packages/core/src/api/types.ts:125-133`):
+```
+export const CreateContactInputSchema = z.object({
+  firstName: z.string().min(1),
+  lastName:  z.string().min(1),
+  email:     z.string().email(),
+  phone:     z.string().optional(),
+  companyId: z.string(),
+  types:     z.array(ContactTypeSchema).min(1),   // ContactTypeSchema = z.enum(["Admin","Billing","Technical"])
+});
+```
+The spec's `requestBody.content."application/json".schema` resolves via `$ref` to `#/components/schemas/Contact` (`partner-endpoints.json paths."/companies/{companyId}/contacts".post.requestBody`). The resolved `Contact` schema (`partner-endpoints.json .components.schemas.Contact`):
+```
+required: [firstName, lastName, email, phone]
+properties:
+  id:          string, format uuid, readOnly
+  firstName:   string
+  lastName:    string
+  email:       string, format email
+  phone:       string, format phone
+  createdDate: string, readOnly
+  types:       array of components.schemas.ContactType
+```
+And `ContactType` (`partner-endpoints.json .components.schemas.ContactType`):
+```
+type: object
+properties:
+  type:    string, enum [Admin, Billing, Technical]
+  primary: boolean
+```
+
+Body-shape deltas vs spec:
+- **`companyId` in body — not in spec.** Spec carries `companyId` in the path. CLI carries it in the body and uses no `companyId` in the URL. The server (if it follows the spec) would ignore the body field and have no path-level company to attach the new contact to.
+- **`types` is the wrong shape.** Spec: `types: Array<{type: enum, primary: boolean}>`. CLI: `types: Array<"Admin" | "Billing" | "Technical">` (flat enum strings). A spec-strict server would reject this with 422 ("Invalid contact create" per the spec's documented error).
+- **`phone` is required by spec, optional in CLI input.** Spec marks `phone` in the `Contact.required` array; the CLI command has `--phone` as `.option()` (not `.requiredOption()`) at `packages/cli/src/commands/contacts/create.ts:38`, and the Zod schema marks `phone` as `.optional()` (`packages/core/src/api/types.ts:129`).
+- **No `primary` flag concept in CLI.** The spec's `ContactType.primary` indicates which contact is primary for a given type; the CLI cannot express this at all.
+
+### Required field coverage
+N/A for create — but the spec's required-field set (`firstName`, `lastName`, `email`, `phone`) is not enforced by the CLI's input contract (phone is optional). The CLI also defaults `--type` to `"Admin"` (`packages/cli/src/commands/contacts/create.ts:39`), so the `types` array is always populated client-side; but the shape it sends is wrong (see above).
+
+### Reconciliation case
+There are two reads of how the production API actually behaves; the spec is one source, observed behavior may differ:
+1. **Spec-strict**: API rejects `POST /v1/contacts` with 404 (no such route) — write never lands.
+2. **Undocumented compatibility route**: API accepts `POST /v1/contacts` and reads `companyId` from the body. In that case the `types` body field still doesn't match the spec's `Array<{type, primary}>` shape, so even with a friendly route, the `types` portion is unlikely to round-trip correctly. The CLI's `MockPax8Client` will of course accept whatever shape the CLI sends, so demo-mode tests don't catch any of this.
+
+### Recommendation
+Change `ContactsApi.create` to take `companyId` separately and build the path `/companies/${companyId}/contacts`; drop `companyId` from the JSON body. Reshape `types` to `Array<{type, primary}>` (with `primary` either user-controlled via new flag or defaulted false). Promote `--phone` to `requiredOption` and tighten `CreateContactInputSchema.phone` to `z.string().min(1)`.
+
+---
+
+## Operation: contacts update
+
+### Wire path
+CLI hits `PUT https://api.pax8.com/v1/contacts/{id}`.
+- Command handler calls `ctx.api.contacts.update(id, data)` at `packages/cli/src/commands/contacts/update.ts:117`.
+- `ContactsApi.update` calls `this.client.put<unknown>(\`/contacts/${id}\`, data)` at `packages/core/src/api/contacts.ts:38`.
+- `client.put` issues `PUT` to `buildUrl("/contacts/${id}")` → `https://api.pax8.com/v1/contacts/{id}` (`packages/core/src/api/client.ts:95-97`, `267-278`).
+
+The CLI never resolves a `companyId` for the update flow — it only takes the contact id as an argument (`packages/cli/src/commands/contacts/update.ts:33`) and the pre-update `get(id)` call uses the same flat path (`packages/core/src/api/contacts.ts:28`).
+
+### Public spec location
+Spec documents update at `partner-endpoints.json paths."/companies/{companyId}/contacts/{contactId}".put` (summary: "Update Contact"; `requestBody.required: true`). The spec defines **only `put`** for this path — there is no `patch` operation. Both `companyId` and `contactId` are required path params (`type: string, format: uuid`).
+
+### Request body shape
+CLI body construction (`packages/cli/src/commands/contacts/update.ts:54-81`):
+```
+const data: UpdateContactInput = {};
+if (options.firstName) data.firstName = options.firstName;
+if (options.lastName)  data.lastName  = options.lastName;
+if (options.email)     data.email     = options.email;
+if (options.phone)     data.phone     = options.phone;
+if (options.type !== undefined) data.types = parsed as ContactType[];
+```
+Zod contract (`packages/core/src/api/types.ts:135-142`):
+```
+export const UpdateContactInputSchema = z.object({
+  firstName: z.string().min(1).optional(),
+  lastName:  z.string().min(1).optional(),
+  email:     z.string().email().optional(),
+  phone:     z.string().optional(),
+  types:     z.array(ContactTypeSchema).optional(),
+});
+```
+Spec requestBody is the same `Contact` schema as create (`partner-endpoints.json paths."/companies/{companyId}/contacts/{contactId}".put.requestBody.content."application/json".schema` → `#/components/schemas/Contact`), with the same four required scalars (`firstName`, `lastName`, `email`, `phone`) and the same nested `types: Array<{type, primary}>` shape.
+
+Body-shape deltas vs spec:
+- **Partial PUT body.** The CLI emits only the fields the user supplied on the CLI. The spec's PUT body inherits the `Contact` schema's required set (`firstName`, `lastName`, `email`, `phone`), so e.g. `pax8 contacts update <id> --email new@example.com` produces `{email: "new@example.com"}` — a body that fails the spec's required-properties contract.
+- **Same `types` shape mismatch as create** — CLI sends string array, spec wants `Array<{type, primary}>`.
+- **No fetch-then-merge.** The handler does call `ctx.api.contacts.get(id)` (`packages/cli/src/commands/contacts/update.ts:94`), but only to render the preview ("Current: First Last <email>") on stderr. The fetched `current` is **not merged** into the outgoing `data`. So a partial PUT is sent on the wire even though the CLI has the full prior state in memory.
+
+### Required field coverage for update
+Spec: **PUT, not PATCH** (no `.patch` key exists at `paths."/companies/{companyId}/contacts/{contactId}"`). With PUT and a required-fields body schema, the spec expects a full replacement document. The CLI does not fetch-then-merge before sending; partial bodies will fail the spec contract.
+
+### Reconciliation case
+Same two-readings frame as create:
+1. **Spec-strict**: API rejects `PUT /v1/contacts/{id}` with 404 (no such route). Even if it did route there, a partial body would 422 on missing required fields.
+2. **Undocumented compatibility route + partial PUT tolerated**: API might accept `PUT /v1/contacts/{id}` with a merge-patch semantic. The CLI ships as if this is true, but the `types` shape mismatch still bites.
+
+### Recommendation
+Three independent fixes are needed:
+1. Path: thread `companyId` through `ContactsApi.update` (either via a new arg, or by resolving the contact's company via the prior `get(id)` response) and target `/companies/${companyId}/contacts/${contactId}`.
+2. Body completeness: fetch-then-merge using the result of `ctx.api.contacts.get(id)` (which the handler already calls) so the PUT body satisfies the spec's required-fields invariant. Alternatively, request that Pax8 add a `PATCH` to the spec.
+3. `types` shape: reshape to `Array<{type, primary}>`, identical to the create fix.
+
+---
+
+## Operation: contacts delete
+
+### Wire path
+CLI hits `DELETE https://api.pax8.com/v1/contacts/{id}`.
+- Command handler calls `ctx.api.contacts.delete(id)` at `packages/cli/src/commands/contacts/delete.ts:55`.
+- `ContactsApi.delete` calls `this.client.delete(\`/contacts/${id}\`)` at `packages/core/src/api/contacts.ts:43`.
+- `client.delete` issues `DELETE` to `buildUrl("/contacts/${id}")` → `https://api.pax8.com/v1/contacts/{id}` (`packages/core/src/api/client.ts:103-105`, `267-278`).
+
+### Public spec location
+Spec documents deletion at `partner-endpoints.json paths."/companies/{companyId}/contacts/{contactId}".delete` (summary: "Delete Contact"; success: `204` with empty body). Both `companyId` and `contactId` are required path params. No flat `/contacts/{id}` DELETE exists in the spec.
+
+### Request body shape
+DELETE has no body (the CLI sends none — `client.delete` calls `request("DELETE", path, undefined, params)` at `packages/core/src/api/client.ts:104`). No body deltas to flag.
+
+### Required field coverage
+N/A for delete.
+
+### Reconciliation case
+1. **Spec-strict**: API rejects `DELETE /v1/contacts/{id}` with 404 — deletion never happens.
+2. **Undocumented compatibility route**: API may accept the flat form and resolve the contact's company server-side, in which case behavior matches the user's intent.
+
+The user-facing risk for delete is lower than for create/update (no body to silently corrupt), but the URL is still off-spec.
+
+### Recommendation
+Thread `companyId` through `ContactsApi.delete` and target `/companies/${companyId}/contacts/${contactId}`. The pre-delete `ctx.api.contacts.get(id)` call at `packages/cli/src/commands/contacts/delete.ts:31` already returns a `Contact` with a `companyId` field (`Contact.companyId` per `packages/core/src/api/types.ts:120`), so the handler can resolve the company id without changing its public flag surface.
+
+---
+
+## Constraints honored
+
+- Read-only audit — no source files were modified.
+- Every CLI claim is cited with `package/file/line` paths inside the worktree at `/tmp/pax8-cli-api-audit`.
+- Every spec claim is cited by `partner-endpoints.json` path + JSON-pointer location, resolving `$ref`s explicitly.
+- Request body shapes were read from `paths.*.<method>.requestBody.content."application/json".schema` (and resolved `$ref`s under `.components.schemas`), never inferred from response schemas.
+- No live API calls were made.
+- Worktree-relative paths used throughout.

--- a/docs/triage/api-version-audit/invoices.md
+++ b/docs/triage/api-version-audit/invoices.md
@@ -1,0 +1,137 @@
+# Invoices write API audit
+
+**TL;DR:** `pax8 invoices dispute` **does not make any HTTP write call**. It is a deliberately local, draft-only command: it runs the read-only `auditInvoices` pipeline (which itself only issues GET requests to `/invoices`, `/invoices/{id}/items`, and `/subscriptions`) to locate a discrepancy, then writes a JSON dispute draft to `~/.pax8/disputes/<id>.json` (or `$PAX8_DISPUTES_DIR`) and prints a markdown support-ticket template. The CLI's own source explicitly documents the rationale (`packages/cli/src/commands/invoices/dispute.ts:21-32`): the Pax8 v1 API does not expose a public dispute / write-off / credit endpoint, so Pax8 billing disputes are handled out-of-band via the partner portal and support, and this command "closes the loop locally." The public OpenAPI spec (`/tmp/partner-endpoints.json`) confirms the absence — there is no `/invoices/{id}/dispute`, `/disputes`, `/credits`, `/adjustments`, or any non-GET verb on any `/invoices*` path. The command is honest about this in `--help` output and in the inline note at `dispute.ts:252-254`. **No API contract exists to verify.**
+
+## Operations audited
+
+| Command | Source file:lines | HTTP write call? | What it writes |
+|---|---|---|---|
+| `pax8 invoices dispute` | `packages/cli/src/commands/invoices/dispute.ts:226-449` | **No** | `~/.pax8/disputes/<draft-id>.json` (local file, mode `0o600`) |
+
+---
+
+## Operation: invoices dispute
+
+### Does it make a wire call?
+
+**No.** There is no `client.post/put/patch/delete` anywhere in `dispute.ts`. The only `ctx.api.*` calls in the command are reads, all inside the `findDiscrepancy()` helper, used to *locate* the discrepancy the user wants to dispute:
+
+- `ctx.api.invoices.list({ month, companyId, size: 200 })` — `dispute.ts:137`
+- `ctx.api.subscriptions.list({ companyId, size: ALL_SUBS_PAGE_SIZE })` — `dispute.ts:138`
+- `ctx.api.invoices.listItems(inv.id, { size: 500 })` — `dispute.ts:143`
+
+All three of those route through `Pax8Client.get` (`packages/core/src/api/invoices.ts:34, 63-66, 89-92`) and hit GET-only documented endpoints.
+
+The `InvoicesApi` class in `packages/core/src/api/invoices.ts:17-120` exposes exactly four methods — `list`, `get`, `listItems`, `listDraftItems` — and every one of them is `client.get(...)`. **There is no `dispute()`, `post()`, or any other write-capable method on `InvoicesApi`.** The CLI's inline note at `dispute.ts:31-32` calls this out: "If/when Pax8 ships a real endpoint, the local-storage path can be replaced with `ctx.api.invoices.dispute(...)` without changing the CLI surface."
+
+The dispute.test.ts test file corroborates that no API write happens:
+
+- The happy-path test (`dispute.test.ts:24-52`) overrides `PAX8_DISPUTES_DIR` to a `mkdtemp`'d directory and asserts the draft lands on disk (`dispute.test.ts:50-51`). The recorded artifact is a local file, not an API response.
+- The idempotency-replay test (`dispute.test.ts:71-104`) asserts that a second invocation with the same `--idempotency-key` produces a byte-for-byte identical `stdout` *and* does **not** create a second file on disk (`dispute.test.ts:101-103`) — i.e. the entire "write" is a file write, and replay is enforced purely by the local idempotency cache (`PAX8_IDEMPOTENCY_DIR`), with no network round-trip.
+- All tests run in `PAX8_DEMO=1` mode (the default for the subprocess test harness). No `nock`/`msw` server is started for `dispute` — unlike the subscription write tests — because there is no HTTP traffic to intercept.
+
+### What does it do instead?
+
+Both a file write **and** stdout/stderr output. Specifically:
+
+1. **Locates the discrepancy** via a read-only audit pass (`findDiscrepancy`, `dispute.ts:130-224`). The discrepancy ID is a SHA-1 hash of `companyId|productName|type|month`, truncated to 12 hex chars and prefixed `disc-` (`dispute.ts:45-53`). This is the same hash function `invoices audit` uses to stamp its output — see "Cross-reference" below.
+2. **Prompts for confirmation** (`dispute.ts:363-369`), respecting `--yes` / `PAX8_YES=1` per the project's read-vs-write contract.
+3. **Writes a draft file** atomically via `writeDraft()` (`dispute.ts:109-117`): `fs.writeFile(tmp, ..., { mode: 0o600 })` then `fs.rename(tmp, fp)`. Path = `${PAX8_DISPUTES_DIR ?? ~/.pax8/disputes}/disp-<8 hex>.json` (`dispute.ts:37-39, 372, 385`). The file contains the full `DisputeDraft` record (`dispute.ts:55-71`) including a pre-rendered `portalTemplate` — a markdown-ish support-ticket body produced by `buildPortalTemplate()` (`dispute.ts:73-107`).
+4. **Prints output**: in `--json` mode the draft plus `filePath` and `nextActions` go to stdout (`dispute.ts:392-409`); in human mode the draft ID, save path, and the portal-ready template go to stdout, and the "next steps" hint goes to stderr (`dispute.ts:415-426`).
+5. **Honors idempotency**: the whole operation is wrapped in `withIdempotency` (`dispute.ts:290-430`) keyed by `--idempotency-key` + `hashArgs({discrepancy, company, product, month, reason})`. `markWriteInFlight("invoices", undefined, idempotencyKey)` (`dispute.ts:382`) registers the SIGINT cleanup — the same convention real wire-write commands use, even though here the only thing in flight is an `fs.rename`.
+
+Where does the `--discrepancy` ID come from? From a previous `pax8 invoices audit --json` run (the audit command's `nextActions[].command` field hands the partner the exact `pax8 invoices dispute --discrepancy disc-<id>` invocation). See "Cross-reference" below.
+
+### Wire path (if applicable)
+
+N/A — there is no wire write.
+
+For completeness, the reads issued during `findDiscrepancy` resolve to:
+
+- `GET https://api.pax8.com/v1/invoices?...`
+- `GET https://api.pax8.com/v1/invoices/{id}/items?...`
+- `GET https://api.pax8.com/v1/subscriptions?...`
+
+(via `Pax8Client.baseUrl` defaulting to `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` at `packages/core/src/api/client.ts:20, 37-41, 267-278`). Those reads are out of scope for this audit.
+
+### Public spec location
+
+**Absent by design.** `jq '.paths | keys' /tmp/partner-endpoints.json | grep -i invoice` returns exactly four endpoints:
+
+```
+"/invoices",
+"/invoices/draftItems",
+"/invoices/{invoiceId}",
+"/invoices/{invoiceId}/items",
+```
+
+Every one of them exposes **only `get`** (verified individually via `jq '.paths."<path>" | keys'` — all four return `["get"]`). `jq '.paths | keys[]' /tmp/partner-endpoints.json | grep -iE "dispute|credit|adjustment|writeoff|write-off"` returns no matches. There is no documented public endpoint for filing a billing dispute, requesting a credit memo, or otherwise writing back to an invoice.
+
+The CLI's behavior is consistent with that absence: rather than POST to a speculative or undocumented internal endpoint, it writes locally and renders a portal template the user can paste into the partner portal. This is the right choice given the spec.
+
+### Request body shape (if applicable)
+
+N/A — no body sent over the wire. For reference, the locally-written `DisputeDraft` JSON shape is defined at `dispute.ts:55-71`:
+
+```
+{
+  id: "disp-<8 hex>",
+  discrepancyId: "disc-<12 hex>",
+  status: "draft",
+  createdAt: ISO-8601,
+  month?: "YYYY-MM",
+  companyId, companyName, productName,
+  type: "overcharge" | "undercharge" | "missing" | "unexpected",
+  invoicedQuantity, activeQuantity, delta, dollarImpact,
+  reason?,
+  portalTemplate: <multi-line string>,
+}
+```
+
+This shape is internal to the CLI; there is no Zod input schema in `packages/core/src/api/types.ts` for a dispute payload (and there shouldn't be — no API consumes it).
+
+### Reconciliation case
+
+**Unique case: F — draft-only by design, no API surface exists.** This doesn't fit the A–E cases used for subscriptions (those all assume *some* wire call). The CLI is transparent about it: the file-header comment (`dispute.ts:20-33`), the `--help` epilog (`dispute.ts:252-254`), and the absence of any `InvoicesApi.dispute(...)` method all converge on the same story. The closest analog is "deliberate divergence with explicit user-facing disclosure" — the command performs a `write` from the partner's perspective (it materializes durable state, prompts, takes an idempotency key, marks a write-in-flight, exits 130 on SIGINT) but the durable state is local-only.
+
+**Is the UX misleading?** Mostly no:
+
+- The `--help` text at `dispute.ts:252-254` says, verbatim, "The Pax8 v1 API does not expose a public dispute endpoint, so this command files a local draft and produces a support ticket template you can paste into the Pax8 portal."
+- Human-mode output explicitly prints "Saved to: `<filePath>`" (`dispute.ts:417`), shows the portal template, and tells the user to paste it into the portal (`dispute.ts:425`).
+- The draft's `status: "draft"` field and the spinner text "Filing dispute..." (`dispute.ts:381`) could read as "filing with Pax8" to a skim-reader, but the surrounding output (file path, portal template, "paste into Pax8 portal" hint) corrects that impression in the same render.
+
+One small UX risk: the `nextActions[0]` in `--json` output (`dispute.ts:396-400`) suggests `cat "<filePath>"` — a hint that the artifact is local — but doesn't include an action like `open https://app.pax8.com/...` that walks the user to the portal. Not a wire issue, just a closed-loop suggestion.
+
+### Recommendation
+
+**No code change needed; flag as deliberate divergence (case F).** The command honestly presents itself as a draft generator, the public spec confirms no dispute endpoint exists, and the seam (`ctx.api.invoices.dispute(...)`) is pre-cut for the day Pax8 ships one. Optional documentation polish: surface this in the audit-suite TL;DR so consumers of the audit pack don't have to re-derive that "invoices write" means "local file write."
+
+---
+
+## Cross-reference: where does the discrepancy data come from?
+
+The closed loop between `invoices audit` and `invoices dispute` is fully in-process — no API state is involved on either side. Specifically:
+
+- `dispute.ts:45-53` defines and exports `discrepancyId({companyId, productName, type, month})` as `"disc-" + sha1(companyId|productName|type|month).slice(0,12)`.
+- `audit.ts:13` imports that **same function** from `./dispute.js` and uses it at `audit.ts:97-105` to stamp every discrepancy in its output with a `discrepancyId` field.
+- `audit.ts:109-114` emits `nextActions[].command` strings of the form `pax8 invoices dispute --discrepancy <id> [--month YYYY-MM]`, handing the partner (or an agent) the exact replay invocation.
+- When `dispute` runs with `--discrepancy <id>`, it re-executes `auditInvoices` over the same reads and uses the same `discrepancyId(...)` hash to match (`dispute.ts:165-182`). Same inputs → same hash → match.
+
+This means the end-to-end "expected path" is:
+
+1. `pax8 invoices audit --json` → reads `/invoices`, `/invoices/{id}/items`, `/subscriptions` (GET-only), computes discrepancies, stamps IDs.
+2. Partner/agent picks an ID from `nextActions`.
+3. `pax8 invoices dispute --discrepancy <id>` → re-runs the same reads (no caching across commands), re-derives the same ID, locates the matching discrepancy, writes a draft to disk, prints the portal template.
+4. Partner pastes the template into the Pax8 portal billing-support flow (out-of-band; not automated by the CLI).
+5. Optionally `pax8 invoices audit --month <m>` again later to confirm resolution — this is suggested in `nextActions[1]` at `dispute.ts:401-404`.
+
+The IDs are not stored on any Pax8 server. They are a content hash of the discrepancy's identity columns, and they round-trip between the two commands purely because both commands compute the same hash from the same inputs. If the underlying invoice/subscription data changes between the audit run and the dispute run, the hash will still match (assuming `companyId|productName|type|month` is unchanged), but the discrepancy itself may have resolved — at which point `dispute` would throw `ERROR_INVALID_INPUT` with "No discrepancy matches ID …" (`dispute.ts:170-180`).
+
+## Constraints honored
+
+- **READ-ONLY** — no source files were modified. Only `docs/triage/api-version-audit/invoices.md` was created.
+- **File-and-line citations** — every CLI claim is anchored to `dispute.ts`, `dispute.test.ts`, `audit.ts`, or `invoices.ts` with explicit line numbers.
+- **Spec citations** — the absence of a dispute endpoint is documented via the four `jq '.paths | keys'` results on `/tmp/partner-endpoints.json` and the per-path `keys` verification showing each invoice endpoint is `get`-only.
+- **No speculation** — the audit does not claim Pax8 "probably has" a dispute endpoint elsewhere; it cites the public spec's `paths | keys` output and stops there.
+- **No live API calls** — no `pax8 …` commands were executed during this audit; all evidence is from static source reads and `jq` queries against the local OpenAPI file.
+- **Worktree-relative paths** — all CLI/spec citations use paths rooted at `/tmp/pax8-cli-api-audit/...` or the spec file `/tmp/partner-endpoints.json`.

--- a/docs/triage/api-version-audit/orders.md
+++ b/docs/triage/api-version-audit/orders.md
@@ -1,0 +1,121 @@
+# Orders write API audit
+
+**TL;DR:** `pax8 orders create` hits `POST https://api.pax8.com/v1/orders` — the wire URL matches the public OpenAPI spec exactly. The request **body**, however, has two discrepancies with the spec: (1) the CLI omits `lineItemNumber` on every line item even though `CreateLineItem` lists it as required; (2) the typed contract for `provisioningDetails` (a free-form `Record<string, unknown>`) doesn't match the spec's array-of-`{key, values[]}` shape — this is latent because the create command never populates it. The required-field gap is the load-bearing problem; everything else lines up.
+
+## Operations audited
+
+| Command | Source file:lines | Resolved URL | HTTP method |
+|---|---|---|---|
+| `pax8 orders create` (real) | `packages/cli/src/commands/orders/create.ts:574` → `packages/core/src/api/orders.ts:45-46` → `packages/core/src/api/client.ts:267-278` | `https://api.pax8.com/v1/orders` | `POST` |
+| `pax8 orders create --dry-run` | same call site, `opts.isMock=true` | `https://api.pax8.com/v1/orders?isMock=true` | `POST` |
+| `pax8 recommendations act` (constructs the same payload) | `packages/cli/src/commands/recommendations/act.ts:70-78` → same `OrdersApi.create()` | `https://api.pax8.com/v1/orders` | `POST` |
+
+## Operation: orders create
+
+### Wire path
+
+- Command handler invokes the API at `packages/cli/src/commands/orders/create.ts:574`:
+  `order = await ctx.api.orders.create(orderInput, { isMock: dryRun });`
+- `OrdersApi.create()` builds the relative path at `packages/core/src/api/orders.ts:45-46`:
+  `const path = opts?.isMock ? "/orders?isMock=true" : "/orders"; await this.client.post<unknown>(path, data);`
+- `Pax8Client.post` delegates to `request("POST", path, body)` at `packages/core/src/api/client.ts:91-93`, which calls `buildUrl(path)` at `packages/core/src/api/client.ts:141`.
+- `buildUrl` (`packages/core/src/api/client.ts:267-278`) concatenates `this.baseUrl` and a leading-slash-normalized path with no version munging.
+- `baseUrl` is set in the constructor at `packages/core/src/api/client.ts:53` from `getDefaultBaseUrl()` which returns `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` (`packages/core/src/api/client.ts:20, 37-41`) unless `PAX8_API_BASE` is set.
+- **Resolved URL on default base:** `https://api.pax8.com/v1/orders` (real) or `https://api.pax8.com/v1/orders?isMock=true` (`--dry-run`). Note: the CLI inlines the query string into the path; `buildUrl` does `new URL(${baseUrl}${path})`, so `?isMock=true` is preserved verbatim into the URL's query string.
+
+### Public spec location
+
+- Spec file: `/tmp/partner-endpoints.json`
+- `servers[0].url = "https://api.pax8.com/v1"` (no `/v2` server is declared).
+- `paths."/orders".post` is documented with `operationId: createOrder`, request body `$ref: #/components/schemas/CreateOrder`, and a single query parameter `isMock` (boolean, optional). Match on URL is **clean**.
+
+### Request body shape
+
+CLI builds the body at `packages/cli/src/commands/orders/create.ts:554-564`:
+
+```ts
+const lineItems: OrderLineItemInput[] = resolvedLines.map((line, idx) => ({
+  productId: line.productId,
+  quantity: confirmedQuantities[idx],
+  billingTerm: line.billingTerm as BillingTerm,
+  ...(line.commitmentTermId ? { commitmentTermId: line.commitmentTermId } : {}),
+}));
+const orderInput: CreateOrderInput = { companyId: resolvedCompanyId, lineItems };
+```
+
+Zod typing for `OrderLineItemInput` is at `packages/core/src/api/types.ts:219-225`:
+- `productId: z.string()`
+- `quantity: z.number().int().min(1)`
+- `billingTerm: BillingTermSchema.optional()` (enum matches spec)
+- `commitmentTermId: z.string().optional()`
+- `provisioningDetails: z.record(z.string(), z.unknown()).optional()`
+
+Spec `CreateOrder` (resolved from `paths."/orders".post.requestBody.content."application/json".schema.$ref` → `components.schemas.CreateOrder`):
+- `companyId` (uuid, required)
+- `lineItems[]` of `CreateLineItem` (required)
+- Top-level extras allowed/permitted by spec but not required: `orderedBy` (enum), `orderedByUserEmail`.
+
+Spec `CreateLineItem` (`components.schemas.CreateLineItem`):
+- `productId` (uuid) — **required**
+- `companyId` (uuid) — **required** per `required` array (likely a spec bug; not in the example; nesting `companyId` inside each line item is inconsistent with the top-level body and with the canonical example. See "spec ambiguities" below.)
+- `lineItemNumber` (number) — **required**, marked `writeOnly`. Description: "Required. Number used as a reference to the line item for parent line items."
+- `quantity` (number) — **required**
+- `billingTerm` (enum) — **required**
+- Optional: `commitmentTermId`, `provisionStartDate`, `parentSubscriptionId`, `parentLineItemNumber`, `provisioningDetails` (array of `ProvisioningDetail`)
+
+**Field-by-field diff (top-level body):**
+
+| Field | CLI sends | Spec requires | Verdict |
+|---|---|---|---|
+| `companyId` | yes (UUID resolved from `--company`) | required | match |
+| `lineItems` | yes, array with ≥1 | required | match |
+| `orderedBy` | no | optional | n/a |
+| `orderedByUserEmail` | no | optional | n/a |
+
+**Field-by-field diff (per line item):**
+
+| Field | CLI sends | Spec requires | Verdict |
+|---|---|---|---|
+| `productId` | yes | required | match |
+| `quantity` | yes (positive int) | required | match |
+| `billingTerm` | yes (Monthly default) | required | match |
+| `lineItemNumber` | **NO** | **required** | **MISSING** |
+| `companyId` (per-line) | no | required per `required` array | spec ambiguity (see below) |
+| `commitmentTermId` | conditional (only when resolved) | optional (but required when product `requiresCommitment`) | match |
+| `provisioningDetails` | not sent by `orders create`; typed as `z.record(string, unknown)` in `OrderLineItemInputSchema` | array of `{key, values[], …}` | latent shape mismatch (never exercised by the create command) |
+| `provisionStartDate`, `parentSubscriptionId`, `parentLineItemNumber` | no | optional | n/a |
+
+The CLI body is fundamentally well-shaped (flat list of line items, no rogue nesting), but it is **missing the required `lineItemNumber`** on every line item.
+
+### Required field coverage
+
+Spec `CreateLineItem.required = ["productId", "companyId", "lineItemNumber", "quantity", "billingTerm"]`. CLI satisfies `productId`, `quantity`, `billingTerm`. CLI does NOT send `lineItemNumber`. Per-line `companyId` is in the required list but absent from the spec's own canonical example — see ambiguities.
+
+Spec `CreateOrder.required = ["companyId", "lineItems"]`. CLI satisfies both.
+
+### Reconciliation case
+
+**B' (body-shape-only).** Wire URL is correct on `/v1`. Body is missing a spec-required line-item field (`lineItemNumber`), and there is a latent type-shape mismatch on `provisioningDetails` that isn't exercised by the CLI today. No URL-version issue.
+
+### Recommendation
+
+Populate `lineItemNumber` on each outgoing line item (sequential 1-based index, matching the spec's `parentLineItemNumber` referencing model), and reconcile `OrderLineItemInputSchema.provisioningDetails` with the spec's `Array<ProvisioningDetail>` shape (`{key: string, values: string[]}[]`) before any feature begins sending it; either fix the typing and convert at the wire, or accept the spec shape directly in CLI input.
+
+## Other notes
+
+- **Idempotency at the wire.** The CLI accepts `--idempotency-key <uuid>` but the explicit `TODO` at `packages/cli/src/commands/orders/create.ts:566-570` confirms the key is **not** sent to the API as a header or in the body — deduplication is purely local via the file cache in `withIdempotency`. The spec's `POST /orders` defines no `Idempotency-Key` header parameter, so this is consistent with the documented API (but means retries that bypass the local cache could double-create).
+- **Recommendation acceptance path.** `pax8 recommendations act` at `packages/cli/src/commands/recommendations/act.ts:70-78` builds the same body shape — `{companyId, lineItems: [{productId, quantity, billingTerm, commitmentTermId?}]}` — through `ctx.api.orders.create()`. Same missing `lineItemNumber`, same wire URL. No divergence.
+- **Demo vs real branching.** `buildContext()` at `packages/cli/src/lib/context.ts:135-142` swaps in `MockPax8Client` when `PAX8_DEMO=1` or no credentials are set. Demo mode never calls `Pax8Client.post`, so the request body never reaches the wire under `PAX8_DEMO=1`. The command code is unbranched on `PAX8_DEMO` (per the convention in `CLAUDE.md`); the same `orderInput` is what would be POSTed in real mode.
+- **`isMock` placement.** The CLI puts `isMock=true` into the path string before passing to `client.post`. `buildUrl` parses this via `new URL()`, which preserves the query string, so it lands as a real URL query parameter — matching the spec's `parameters[].in: "query"`. Correct, just an unusual idiom (most other paths use the `params` argument).
+- **Spec ambiguities (unresolved):**
+  1. `CreateLineItem.required` lists `companyId`, but `companyId` is not declared as a property of `CreateLineItem` and is absent from the spec's own `microsoft-office-365-e3-order` example. Almost certainly a spec bug; the CLI's behavior (only top-level `companyId`) matches the example.
+  2. The example uses `commitmentTermID` (capital ID) where the schema declares `commitmentTermId`. The schema name is authoritative; the example is likely a typo. CLI uses the lowercase form.
+  3. `lineItemNumber` is marked required in the schema but is absent from the example. Hard to say which is canonical; safer interpretation is that the schema is authoritative since at least one provisioning-heavy or parent/child order will need it. Worth confirming with Pax8 platform before patching.
+
+## Constraints honored
+
+- READ-ONLY (no source files modified).
+- All CLI claims cite worktree-relative file paths and line numbers.
+- All spec claims cite specific OpenAPI paths under `/tmp/partner-endpoints.json`.
+- Request body shape verified from `requestBody.content.application/json.schema` and `components.schemas.CreateOrder`/`CreateLineItem`, not from response schemas.
+- No live API calls.

--- a/docs/triage/api-version-audit/subscriptions.md
+++ b/docs/triage/api-version-audit/subscriptions.md
@@ -1,0 +1,132 @@
+# Subscriptions write API audit
+
+**TL;DR:** Both subscription write operations hit the **correct wire URL** at the version the public spec documents (`/v1/subscriptions/{id}`). `subscriptions update` is **wire-clean and body-clean** — it sends a partial `{quantity?, billingTerm?}` body via `PUT`, which conforms to the spec's `anyOf` requirement that "at least one of {price, billingTerm, quantity, startDate}" be present. `subscriptions cancel` is **wire-clean** but has a **minor body/query format deviation (B')**: the CLI sends `cancelDate=YYYY-MM-DD` (date-only) while the spec types `cancelDate` as `string, format: date-time` with an offset example (`2000-10-31T01:30:00.000-05:00`). Whether the API accepts the shorter form is empirically unverified — flagged for confirmation, not a confirmed bug.
+
+## Operations audited
+
+| Command | Source file:lines | Resolved URL (default base) | HTTP method |
+|---|---|---|---|
+| `pax8 subscriptions update <id>` | `packages/cli/src/commands/subscriptions/update.ts:177` → `packages/core/src/api/subscriptions.ts:41-44` | `https://api.pax8.com/v1/subscriptions/{id}` | `PUT` |
+| `pax8 subscriptions cancel <id>` | `packages/cli/src/commands/subscriptions/cancel.ts:246-249` → `packages/core/src/api/subscriptions.ts:51-54` | `https://api.pax8.com/v1/subscriptions/{id}?cancelDate=<date>` (query optional) | `DELETE` |
+
+Wire-URL trace (shared):
+- `Pax8Client` constructor sets `this.baseUrl = (options.baseUrl ?? getDefaultBaseUrl()).replace(/\/+$/, "")` at `packages/core/src/api/client.ts:53`.
+- `getDefaultBaseUrl()` returns `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` when `PAX8_API_BASE` is unset (`packages/core/src/api/client.ts:20`, `37-41`).
+- `buildUrl(path, params)` concatenates `${this.baseUrl}${normalizedPath}` (`packages/core/src/api/client.ts:267-278`) — no version override, no rewriting.
+- `SubscriptionsApi.update` passes the literal path `/subscriptions/${id}` to `client.put` (`packages/core/src/api/subscriptions.ts:42`).
+- `SubscriptionsApi.delete` passes `/subscriptions/${id}` to `client.delete` with the `cancelDate` query param (`packages/core/src/api/subscriptions.ts:51-54`).
+
+---
+
+## Operation: subscriptions update
+
+### Wire path
+`PUT https://api.pax8.com/v1/subscriptions/{id}`.
+- CLI handler calls `ctx.api.subscriptions.update(id, updateData)` at `packages/cli/src/commands/subscriptions/update.ts:177`.
+- `SubscriptionsApi.update` calls `this.client.put<unknown>(\`/subscriptions/${id}\`, data)` at `packages/core/src/api/subscriptions.ts:42`.
+- `client.put` issues `PUT` to `buildUrl("/subscriptions/${id}")` → `https://api.pax8.com/v1/subscriptions/{id}` (see shared trace above).
+
+### Public spec location
+Documented at `partner-endpoints.json paths."/subscriptions/{subscriptionId}".put` with `operationId: updateSubscription`. The spec's `servers[0].url` is `https://api.pax8.com/v1`, so the spec endpoint resolves to the same URL the CLI hits. No `v2` alternative exists in this spec (`jq '.paths | keys[] | select(test("subscription"; "i"))' /tmp/partner-endpoints.json` returns only `/subscriptions`, `/subscriptions/{subscriptionId}`, `/subscriptions/{subscriptionId}/history`, and `/subscriptions/{subscriptionId}/usage-summaries`).
+
+### Request body shape
+CLI body construction (`packages/cli/src/commands/subscriptions/update.ts:140-164`):
+```
+const updateData: Record<string, unknown> = {};
+if (options.quantity !== undefined)    updateData.quantity = newQty;       // number
+if (options.billingTerm)               updateData.billingTerm = options.billingTerm;  // string
+```
+Zod input contract at `packages/core/src/api/types.ts:324-328`:
+```
+UpdateSubscriptionInputSchema = z.object({
+  quantity: z.number().int().min(1).optional(),
+  billingTerm: BillingTermSchema.optional(),
+});
+```
+
+Spec request body at `partner-endpoints.json paths."/subscriptions/{subscriptionId}".put.requestBody.content."application/json".schema`:
+```
+allOf: [
+  { $ref: "#/components/schemas/Subscription" },          // all properties optional in the schema itself
+  { anyOf: [
+      { required: ["price"],       properties: { price: number } },
+      { required: ["billingTerm"], properties: { billingTerm: enum } },
+      { required: ["quantity"],    properties: { quantity: number } },
+      { required: ["startDate"],   properties: { startDate: date-time } }
+  ]}
+]
+```
+Spec description: "Updates a subscription... At least one of the following fields are required: Price, BillingTerm, Quantity, StartDate".
+
+**Diff:** The CLI sends `quantity` and/or `billingTerm` — both are members of the spec's `anyOf` block. Field names match (`quantity`, `billingTerm`); types match (number, enum); the `BillingTermSchema` in `packages/core/src/api/types.ts:25-33` enumerates exactly the seven values the spec lists. No extra fields, no nesting mismatch. The CLI guards against the empty case at `update.ts:166-171` ("No changes specified. Use --quantity or --billing-term."), so it never sends an empty body that would violate the `anyOf`.
+
+### Required field coverage
+- The Subscription branch of `allOf` has **no `required` array** at the top level; all referenced subscription fields are optional. So the `Subscription` allOf member does not, by itself, require any field.
+- The `anyOf` block requires at least one of `{price, billingTerm, quantity, startDate}`. The CLI's quantity/billingTerm flags both satisfy this.
+- The CLI does **not** fetch-then-merge — it sends only the changed field(s). This is correct given the spec's `anyOf` requirement (partial bodies are explicitly supported). No "PUT-as-full-replace" risk because the schema's other top-level fields are not in any `required` set.
+- Commitment-aware pre-flight (`update.ts:79-138`) is a CLI-side guardrail (quantity decreases blocked, billing-term changes blocked when an active commitment is present). This never hits the API; it just short-circuits with `CliError(ERROR_API_VALIDATION)` before constructing the body. Not a spec-conformance issue.
+
+### Reconciliation case (A–E)
+**A — deliberate-and-correct.** Wire URL matches; body shape conforms to the `anyOf` requirement; field names and types align with the spec. The commitment pre-flight is a deliberate UX layer in front of an API the spec doesn't constrain, and it never alters the wire body.
+
+### Recommendation
+**Clean.** No wire or body fix needed. The fetch-then-merge question doesn't apply because the spec explicitly supports partial updates via the `anyOf` block.
+
+---
+
+## Operation: subscriptions cancel
+
+### Wire path
+`DELETE https://api.pax8.com/v1/subscriptions/{id}` with optional `?cancelDate=<date>` query.
+- CLI handler calls `ctx.api.subscriptions.delete(id, effectiveCancelDate ? { cancelDate: effectiveCancelDate } : undefined)` at `packages/cli/src/commands/subscriptions/cancel.ts:246-249`.
+- `SubscriptionsApi.delete` forwards as `await this.client.delete(\`/subscriptions/${id}\`, query)` at `packages/core/src/api/subscriptions.ts:51-54`.
+- `client.delete` calls `request("DELETE", path, undefined, params)` at `packages/core/src/api/client.ts:103-105`, which feeds `params` through `buildUrl` and emits each entry as `url.searchParams.set(key, String(value))` (`client.ts:270-275`). Resolved URL: `https://api.pax8.com/v1/subscriptions/{id}?cancelDate=2026-12-31` (when scheduled).
+
+### Public spec location
+Documented at `partner-endpoints.json paths."/subscriptions/{subscriptionId}".delete` with summary `"Cancel Subscription"` (no `operationId` listed in the spec block). Spec confirms there is **no separate `/cancel` sub-endpoint** — cancellation rides the DELETE verb with an optional `cancelDate` query parameter. The CLI's wire path is structurally correct.
+
+### Request body shape
+DELETE has **no request body** in the spec (no `requestBody` key under the delete operation). The CLI also sends no body — `client.delete` only ever calls `request("DELETE", path, undefined, params)` with `body` undefined (`client.ts:103-105`, and `init.body` is only set when `body !== undefined` per `client.ts:155-157`). The relevant payload surface is the `cancelDate` query parameter.
+
+Spec definition of `cancelDate` (`partner-endpoints.json paths."/subscriptions/{subscriptionId}".delete.parameters[1]`):
+```
+{
+  name: "cancelDate",
+  in: "query",
+  required: false,
+  schema: { type: "string", format: "date-time", example: "2000-10-31T01:30:00.000-05:00" }
+}
+```
+
+CLI emits `cancelDate` in `YYYY-MM-DD` form (date-only). The CLI flag validator (`cancel.ts:45-78`, `parseCancelDate`) enforces the strict shape `^\d{4}-\d{2}-\d{2}$`, rejects timestamps explicitly, and round-trips through `new Date()` for semantic validity. The value passes through `client.delete → buildUrl` verbatim as the query string value.
+
+**Diff:**
+- Spec format: `string, format: date-time` (RFC 3339 / ISO 8601 timestamp with offset, per the spec's example).
+- CLI format: `string` matching `YYYY-MM-DD` (calendar date, no time, no zone).
+- Field name (`cancelDate`) matches; location (query param) matches; presence requirement (optional) matches.
+
+The CLI source comments at `cancel.ts:44-45` claim "the Pax8 API treats `cancelDate` as a date (not a timestamp), and accepting timestamps would silently drop the time portion." That assertion contradicts the public spec's `format: date-time` typing. Either:
+- The spec is wrong and the API actually treats it as a date (the CLI's documented assumption); or
+- The spec is right and the API accepts a date-time, in which case the CLI's date-only string may be accepted leniently (most JSON-Schema `date-time` consumers do) or may be rejected by stricter parsers.
+
+This is unverified from spec alone — the spec is the published contract and types it as `date-time`; the CLI ships against the opposite assumption.
+
+### Required field coverage
+Not applicable for DELETE in this spec — there is no `requestBody`, and the only parameter that could carry payload data (`cancelDate`) is explicitly `required: false`. The CLI honors that: immediate cancellation sends no query param at all (`cancel.ts:248`, conditional `effectiveCancelDate ? {...} : undefined`).
+
+No fetch-then-merge needed; there is no body to merge. The pre-flight `subscriptions.get(id)` at `cancel.ts:126` is purely for the commitment-aware preview block and is not used to populate any payload field.
+
+### Reconciliation case (A–E)
+**B' — body-shape-only deviation (query-param format).** Wire URL and HTTP method are correct, and DELETE has no JSON body so there's no "body" in the strict sense — but the published spec types `cancelDate` as `date-time` and the CLI sends `date`. The deviation is mild (most APIs accept the shorter form leniently) but it is a documented contract mismatch, so it's not pure A.
+
+### Recommendation
+**Needs body-shape confirmation.** Either (a) the CLI's `parseCancelDate` should also accept full ISO `date-time` strings and forward them through to align with the spec, or (b) the spec should be updated to `format: date` if the CLI's comment is correct and the API actually rejects timestamps. The wire URL itself is clean. Confirming with the marketplace API team (e.g., via sandbox test of both forms) is the cheapest path to resolution.
+
+---
+
+## Constraints honored
+- Read-only audit: no code edits, no `pax8` commands executed, no sandbox API calls.
+- Every CLI claim cites `packages/...` paths with line numbers (e.g., `packages/cli/src/commands/subscriptions/cancel.ts:246-249`, `packages/core/src/api/client.ts:53`, `packages/core/src/api/types.ts:324-328`).
+- Every spec claim cites the OpenAPI path inside `partner-endpoints.json` (e.g., `paths."/subscriptions/{subscriptionId}".put.requestBody.content."application/json".schema`, `paths."/subscriptions/{subscriptionId}".delete.parameters[1]`).
+- Body shapes were resolved from the OpenAPI **request body** schemas (and the spec's DELETE `parameters[1]` for the cancel query) — not inferred from response schemas.
+- Where the spec is ambiguous (date-only vs date-time tolerance on cancel), the ambiguity is reported, not inferred away.

--- a/docs/triage/api-version-audit/webhooks.md
+++ b/docs/triage/api-version-audit/webhooks.md
@@ -1,0 +1,198 @@
+# Webhooks write API audit
+
+**TL;DR:** Every CLI webhooks write operation appears to hit the wrong wire URL. The public webhooks OpenAPI spec (title `Webhooks Api`, `info.version 1.0.0`) declares `servers[0].url: https://api.pax8.com/api/v2`, but `Pax8Client` is hard-pinned to `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` (`packages/core/src/api/client.ts:20`) and `WebhooksApi` sends only relative paths like `/webhooks` and `/webhooks/{id}/status` — so every call lands at `https://api.pax8.com/v1/webhooks/...` instead of `https://api.pax8.com/api/v2/webhooks/...`. This is the same class of bug as the Quotes `/v1` vs `/v2` finding, but with the more unusual `/api/v2` prefix. **In addition**, three operations have body-shape and HTTP-method mismatches that would still be wrong even after the base URL is corrected:
+
+1. `webhooks create` sends `{ url, topics: string[] }`, but the spec's `CreateWebhook` schema requires `displayName` (mandatory), accepts `url` as optional, and expects `webhookTopics: Array<{ topic, filters }>` rather than a flat string array.
+2. `webhooks update` issues `PUT /webhooks/{id}` with `{ displayName?, url?, authorization?, contactEmail?, errorThreshold? }`, but the spec has **no `PUT` (or `PATCH`) on `/webhooks/{id}` at all** — configuration changes live at `POST /webhooks/{id}/configuration`. (Confusingly, the core helper `WebhooksApi.updateConfiguration` already targets the correct path — but `webhooks update` calls `updateConfiguration` ✓, while `WebhooksApi.update` (`PUT /webhooks/{id}`) is dead-end wrong and still callable.)
+3. `webhooks enable` / `webhooks disable` body shape is correct (`{ active: boolean }`) and the relative path is correct (`/webhooks/{id}/status`), but on top of the base-URL mismatch there is a stale `WebhooksApi.updateStatus` helper that issues `PATCH /webhooks/{id}` with `{ status }` — not what enable/disable call, but a latent foot-gun.
+
+Net effect: even after a `/v1` → `/api/v2` base-path correction, `create` and the dead `update`/`updateStatus` helpers would still fail server-side validation. `delete`, `setStatus` (`enable`/`disable`), and `retryLog` (`logs retry`) are wire-clean modulo the base-URL prefix.
+
+## Operations audited
+
+| Command | Source file:lines | Resolved URL (default base, today) | HTTP method | Spec path (`https://api.pax8.com/api/v2`) |
+|---|---|---|---|---|
+| `pax8 webhooks create` | `packages/cli/src/commands/webhooks/create.ts:142` → `packages/core/src/api/webhooks.ts:26-29` | `https://api.pax8.com/v1/webhooks` | `POST` | `paths."/webhooks".post` |
+| `pax8 webhooks update <id>` | `packages/cli/src/commands/webhooks/update.ts:170` → `packages/core/src/api/webhooks.ts:51-60` (`updateConfiguration`) | `https://api.pax8.com/v1/webhooks/{id}/configuration` | `POST` | `paths."/webhooks/{id}/configuration".post` |
+| `pax8 webhooks enable <id>` | `packages/cli/src/commands/webhooks/enable.ts:69` → `packages/core/src/api/webhooks.ts:67-70` (`setStatus`) | `https://api.pax8.com/v1/webhooks/{id}/status` | `POST` | `paths."/webhooks/{id}/status".post` |
+| `pax8 webhooks disable <id>` | `packages/cli/src/commands/webhooks/disable.ts:70` → `packages/core/src/api/webhooks.ts:67-70` (`setStatus`) | `https://api.pax8.com/v1/webhooks/{id}/status` | `POST` | `paths."/webhooks/{id}/status".post` |
+| `pax8 webhooks delete <id>` | `packages/cli/src/commands/webhooks/delete.ts:56` → `packages/core/src/api/webhooks.ts:72-74` | `https://api.pax8.com/v1/webhooks/{id}` | `DELETE` | `paths."/webhooks/{id}".delete` |
+| `pax8 webhooks logs retry <log-id>` | `packages/cli/src/commands/webhooks/logs.ts:328` → `packages/core/src/api/webhooks.ts:99-101` | `https://api.pax8.com/v1/webhooks/{webhookId}/logs/{logId}/retry` | `POST` | `paths."/webhooks/{webhookId}/logs/{logId}/retry".post` |
+
+### Shared wire-URL trace
+
+- `Pax8Client` constructor: `this.baseUrl = (options.baseUrl ?? getDefaultBaseUrl()).replace(/\/+$/, "")` (`packages/core/src/api/client.ts:53`).
+- `getDefaultBaseUrl()` returns `FALLBACK_BASE_URL = "https://api.pax8.com/v1"` when `PAX8_API_BASE` is unset (`packages/core/src/api/client.ts:20`, `37-41`).
+- `buildUrl(path, params)` concatenates `${this.baseUrl}${normalizedPath}` (`packages/core/src/api/client.ts:267-278`). **No per-call base override or version rewriter exists** — every `WebhooksApi.*` relative path inherits the shared `/v1` prefix.
+- The webhooks spec at `webhooks-api.json servers[0].url` is `https://api.pax8.com/api/v2`. Resolution mismatch: CLI hits `/v1/webhooks/...`, spec documents `/api/v2/webhooks/...`. **Same class of bug as Quotes `/v1` vs `/v2`, with a different (more unusual) prefix.**
+
+---
+
+## Per-operation findings
+
+### Operation: webhooks create
+
+**Wire path.** CLI handler at `packages/cli/src/commands/webhooks/create.ts:142` calls `ctx.api.webhooks.create({ url, topics })`. `WebhooksApi.create` at `packages/core/src/api/webhooks.ts:26-29` issues `POST` to the literal relative path `/webhooks`. Resolved against the default base, this becomes `POST https://api.pax8.com/v1/webhooks`.
+
+**Public spec location.** `webhooks-api.json paths."/webhooks".post` (`operationId: Webhooks_create`). Per `servers[0].url`, the canonical resolved endpoint is `POST https://api.pax8.com/api/v2/webhooks` — the CLI is sending to the wrong base prefix.
+
+**Request body shape.** CLI sends:
+```json
+{ "url": "https://example.com/hook", "topics": ["subscription.created", "invoice.paid"] }
+```
+Zod input contract at `packages/core/src/api/types.ts:510-514`:
+```ts
+CreateWebhookInputSchema = z.object({
+  url: z.string().url(),
+  topics: z.array(z.string()).min(1),
+});
+```
+
+Spec request body at `webhooks-api.json paths."/webhooks".post.requestBody.content."application/json".schema.$ref = "#/components/schemas/CreateWebhook"`:
+```jsonc
+{
+  "type": "object",
+  "required": ["displayName"],
+  "properties": {
+    "displayName":    { "type": "string" },                       // REQUIRED
+    "url":            { "type": "string" },                       // optional
+    "authorization":  { "type": "string" },
+    "active":         { "type": "boolean", "default": false },
+    "contactEmail":   { "type": "string" },
+    "errorThreshold": { "type": "integer", "maximum": 20, "default": 3 },
+    "integrationId":  { "type": "string", "format": "uuid" },
+    "webhookTopics":  { "type": "array", "items": { "$ref": "#/components/schemas/AddWebhookTopic" }, "default": [] }
+  }
+}
+```
+Where `AddWebhookTopic` (`webhooks-api.json components.schemas.AddWebhookTopic`) requires both `topic: string` and `filters: Array<UpdateWebhookFilter>`.
+
+Reconciliation: **wrong wire path AND wrong body** (case ≈ A+B+C):
+- `displayName` is required by the spec; CLI never sends it. Surprising the command works at all today against the real API — most likely the `/v1/webhooks` path is being served by a legacy gateway that still accepts the older `{url, topics}` shape, which is why nobody has noticed.
+- The CLI uses `topics: string[]`. Spec wants `webhookTopics: Array<{ topic, filters }>` — both the key name and the array element shape are different, and `filters` is required on each topic.
+- The CLI doesn't expose `displayName`, `authorization`, `active`, `contactEmail`, `errorThreshold`, or `integrationId` at all on `create`.
+
+**Recommendation.** Two compounding problems. First, fix the base URL (see "Sub-resource routing observations" below). Second, redesign `webhooks create` to match the spec: add a `--display-name` required flag, change `--topics` from `comma-separated-string` to a structured representation (or default each topic to `filters: []`), and surface the optional spec-side flags. Coordinate this with the read-path `WebhookSchema` (which already mirrors the spec's `displayName`, `errorThreshold`, etc., and uses `topics` as a synthesized string-array — see `packages/core/src/api/types.ts:479-507`, where the read schema diverges from the spec by parsing `topics: string[]` instead of `webhookTopics: Array<WebhookTopic>`). Likely needs an upstream verification call against staging — flag for confirmation, not silent fix.
+
+---
+
+### Operation: webhooks update
+
+**Wire path.** CLI handler at `packages/cli/src/commands/webhooks/update.ts:170` calls `ctx.api.webhooks.updateConfiguration(id, data)`. `WebhooksApi.updateConfiguration` at `packages/core/src/api/webhooks.ts:51-60` issues `POST` to `/webhooks/${id}/configuration`. Resolved: `POST https://api.pax8.com/v1/webhooks/{id}/configuration`.
+
+**Public spec location.** `webhooks-api.json paths."/webhooks/{id}/configuration".post` (`operationId: updateConfiguration`). Canonical resolved endpoint: `POST https://api.pax8.com/api/v2/webhooks/{id}/configuration`. CLI uses correct method, correct sub-resource path — **only the base-URL prefix is wrong**.
+
+**Request body shape.** CLI sends a partial subset of:
+```ts
+// Zod input contract — packages/core/src/api/types.ts:529-535
+UpdateWebhookConfigurationInputSchema = z.object({
+  displayName:    z.string().min(1).optional(),
+  url:            z.string().url().optional(),
+  authorization:  z.string().optional(),
+  contactEmail:   z.string().email().optional(),
+  errorThreshold: z.number().int().min(1).max(20).optional(),
+});
+```
+Spec body at `webhooks-api.json components.schemas.UpdateWebhookConfiguration` — same five properties (`displayName`, `url`, `authorization`, `contactEmail`, `errorThreshold`), all optional, with `errorThreshold` capped at 20. **Body shapes match exactly.**
+
+**Required field coverage.** Spec marks no field as required on this endpoint. CLI enforces "at least one provided" client-side (`update.ts:111-124`) and fetches the current record before posting the diff (`update.ts:128-130`) — defensive merge isn't needed because the spec body shape is a partial.
+
+**Reconciliation case.** **A** (wire path wrong: `/v1` vs `/api/v2` prefix). Body shape and method are clean.
+
+**Recommendation.** Fix the base URL globally (see below); no other change required for this op.
+
+**Latent foot-gun:** `WebhooksApi.update(id, data)` at `packages/core/src/api/webhooks.ts:36-39` still exists and would issue `PUT /webhooks/{id}` with an `UpdateWebhookInput` body — but the spec defines **no `PUT` (or `PATCH`) on `/webhooks/{id}`** (only `get` and `delete`; verified via `jq '.paths."/webhooks/{id}" | keys'` → `["delete","get"]`). Nothing in the CLI command tree calls `WebhooksApi.update` today, but the helper is exported on the public `@pax8/core` surface. Recommend deleting both `WebhooksApi.update` and `WebhooksApi.updateStatus` (the latter does `PATCH /webhooks/{id}` with `{status}` — also unsupported by the spec) along with their Zod schema `UpdateWebhookInputSchema` (`packages/core/src/api/types.ts:516-521`).
+
+---
+
+### Operation: webhooks enable
+
+**Wire path.** CLI handler at `packages/cli/src/commands/webhooks/enable.ts:69` calls `ctx.api.webhooks.setStatus(id, true)`. `WebhooksApi.setStatus` at `packages/core/src/api/webhooks.ts:67-70` issues `POST` to `/webhooks/${id}/status`. Resolved: `POST https://api.pax8.com/v1/webhooks/{id}/status`.
+
+**Public spec location.** `webhooks-api.json paths."/webhooks/{id}/status".post` (`operationId: updateStatus`). Canonical resolved endpoint: `POST https://api.pax8.com/api/v2/webhooks/{id}/status`. Method ✓, sub-resource path ✓, base prefix ✗.
+
+**Request body shape.** CLI sends `{ active: true }` (literal at `webhooks.ts:68`). Spec body at `webhooks-api.json components.schemas.UpdateWebhookStatus`:
+```json
+{ "type": "object", "required": ["active"], "properties": { "active": { "type": "boolean" } } }
+```
+**Body matches exactly.**
+
+**Reconciliation case.** **A** (wire path wrong: `/v1` vs `/api/v2`). Body, method, and required-field coverage are clean.
+
+**Recommendation.** Fix the base URL globally; no other change.
+
+---
+
+### Operation: webhooks disable
+
+**Wire path.** CLI handler at `packages/cli/src/commands/webhooks/disable.ts:70` calls `ctx.api.webhooks.setStatus(id, false)`. Same `WebhooksApi.setStatus` path as `enable`. Resolved: `POST https://api.pax8.com/v1/webhooks/{id}/status`.
+
+**Public spec location.** Same as `enable` — `webhooks-api.json paths."/webhooks/{id}/status".post`.
+
+**Request body shape.** CLI sends `{ active: false }`. Spec body `UpdateWebhookStatus` requires `{ active: boolean }`. **Body matches.**
+
+**Reconciliation case.** **A** (wire path wrong: `/v1` vs `/api/v2`).
+
+**Recommendation.** Same as `enable`.
+
+---
+
+### Operation: webhooks delete
+
+**Wire path.** CLI handler at `packages/cli/src/commands/webhooks/delete.ts:56` calls `ctx.api.webhooks.delete(id)`. `WebhooksApi.delete` at `packages/core/src/api/webhooks.ts:72-74` issues `DELETE` to `/webhooks/${id}`. Resolved: `DELETE https://api.pax8.com/v1/webhooks/{id}`.
+
+**Public spec location.** `webhooks-api.json paths."/webhooks/{id}".delete` (`operationId: Webhooks_delete`). Canonical resolved endpoint: `DELETE https://api.pax8.com/api/v2/webhooks/{id}`.
+
+**Request body shape.** Empty body (`DELETE` with no payload). Spec defines no `requestBody` on this op — clean.
+
+**Reconciliation case.** **A** (wire path wrong: `/v1` vs `/api/v2`).
+
+**Recommendation.** Fix the base URL globally; no other change.
+
+---
+
+### Operation: webhooks logs retry
+
+**Wire path.** CLI handler at `packages/cli/src/commands/webhooks/logs.ts:328` calls `ctx.api.webhooks.retryLog(webhookId, logId)`. `WebhooksApi.retryLog` at `packages/core/src/api/webhooks.ts:99-101` issues `POST` to `/webhooks/${id}/logs/${logId}/retry` with an empty `{}` body. Resolved: `POST https://api.pax8.com/v1/webhooks/{webhookId}/logs/{logId}/retry`.
+
+**Public spec location.** `webhooks-api.json paths."/webhooks/{webhookId}/logs/{logId}/retry".post` (`operationId: retryWebhookDelivery`, tag `Webhook Logs`). Canonical resolved endpoint: `POST https://api.pax8.com/api/v2/webhooks/{webhookId}/logs/{logId}/retry`.
+
+**Request body shape.** CLI sends `{}`. Spec defines no `requestBody` for this op (only path parameters `webhookId` and `logId`). Sending `{}` is harmless. Response is `202 Accepted` with no content.
+
+**Reconciliation case.** **A** (wire path wrong: `/v1` vs `/api/v2`). Method, params, body all clean.
+
+**Note on resolution path:** when the user invokes `pax8 webhooks logs retry <log-id>` without `--webhook`, the CLI walks `WebhooksApi.list()` → `getLogs(wh.id)` to find the owning webhook (`logs.ts:260-282`). Those are read-path calls — same `/v1` base-URL bug applies, but flagged separately as it affects every webhook read too.
+
+**Recommendation.** Fix the base URL globally; no other change.
+
+---
+
+## Sub-resource routing observations
+
+The CLI **does** use the spec's sub-resource structure correctly for `update` (→ `/configuration`), `enable`/`disable` (→ `/status`), and the retry endpoint. No "everything goes through one giant `PUT /webhooks/{id}`" anti-pattern in the live command tree — the routing is on the right shape, just at the wrong base URL.
+
+However, the core API surface still carries two stale helpers that target endpoints **the spec does not document**:
+
+- `WebhooksApi.update(id, data): client.put(/webhooks/${id}, data)` — `packages/core/src/api/webhooks.ts:36-39`. Spec has no `PUT /webhooks/{id}`.
+- `WebhooksApi.updateStatus(id, status): client.patch(/webhooks/${id}, { status })` — `packages/core/src/api/webhooks.ts:41-44`. Spec has no `PATCH /webhooks/{id}`. Note also that this helper sends `{ status: string }` while the actual spec endpoint (`/status`, POST) wants `{ active: boolean }` — body shape mismatch on top of the wrong endpoint.
+
+Neither is called from any CLI command, but they're exported on `@pax8/core` and would silently 404 (or worse, route to a legacy handler) for any embedded consumer who picks them up.
+
+Sub-resources the spec defines but the CLI does **not** expose at all:
+- `POST /webhooks/{id}/topics` (`addWebhookTopic`) — add a single topic to an existing webhook.
+- `PUT /webhooks/{id}/topics` (`replaceWebhookTopics`) — replace the full topic list.
+- `DELETE /webhooks/{id}/topics/{topicId}` — remove one topic.
+- `PUT /webhooks/{id}/topics/{topicId}/configuration` — reconfigure a single topic's filters.
+- `POST /webhooks/{id}/topics/{topic}/test` — topic-specific test ping (the `testTopic` core helper at `packages/core/src/api/webhooks.ts:87-92` knows about this but no CLI command surfaces it).
+
+This is a feature-coverage gap, not a wire-mismatch — flagged for completeness but out of scope for "fix the writes that already exist."
+
+The headline fix — pointing the webhooks calls at `https://api.pax8.com/api/v2` instead of `https://api.pax8.com/v1` — is **not** safely done at the `Pax8Client` level, because every non-webhooks API in the codebase (`companies`, `subscriptions`, `orders`, `invoices`, `products`, etc.) genuinely lives at `/v1`. The clean fix is per-API base override: either let `WebhooksApi` carry its own base URL, or refactor `Pax8Client` to accept a per-call `baseUrl` override the way it would for any other split-versioned API. The current single `FALLBACK_BASE_URL` + single-baseUrl client model cannot represent the actual deployment split.
+
+## Constraints honored
+
+- READ-ONLY: no source files modified outside of writing this report to `docs/triage/api-version-audit/`.
+- All CLI claims cite file paths and line numbers in the worktree.
+- All spec claims cite `webhooks-api.json` paths in the format `webhooks-api.json paths.X.method` or `components.schemas.Y`.
+- Request bodies were verified against `paths.X.method.requestBody.content."application/json".schema` (resolving `$ref` into `components.schemas.*`) — not inferred from response schemas.
+- No live API calls were made.


### PR DESCRIPTION
## Summary

Read-only audit triggered by the Quotes finding (#307/#316). Covers every write-heavy CLI surface except quotes: subscriptions update/cancel, orders create, companies create/update, contacts create/update/delete, webhooks create/update/enable/disable/delete + logs retry, and invoices dispute.

Per the §10 lesson in `docs/triage/quotes-api-version.md`, both URL and request-body shape were verified independently for every write operation.

## Headline counts

- **15 write operations** audited across 6 domains.
- **1 fully clean** (`subscriptions update`).
- **10 wire bugs** (71%) across two distinct classes:
  - Webhooks (6 ops) — every webhook write hits `/v1/webhooks/...` but the spec is at `https://api.pax8.com/api/v2/webhooks/...`.
  - Contacts (3 ops) — every contact write hits flat `/v1/contacts/*` paths that don't exist in the spec; the spec is nested under `/v1/companies/{companyId}/contacts/*`.
  - Plus 1 verb-level bug: `companies update` uses PUT but the spec is PATCH-only.
- **7 body-shape bugs** (50%): `orders create` (missing required `lineItemNumber`), `companies create` (wrong address field names + missing required booleans), `contacts create/update` (`types` shape, missing `companyId` in path), `webhooks create` (missing `displayName`, wrong topics shape), `subscriptions cancel` (minor `cancelDate` format).
- **1 case F** (new): `invoices dispute` is draft-only by design — no wire call, no API surface in the spec. CLI is honest about it in `--help`.

## What's in this PR

- `docs/triage/api-version-audit/README.md` — totals, prioritized issue list, methodology, lessons.
- `docs/triage/api-version-audit/{subscriptions,orders,companies,contacts,webhooks,invoices}.md` — per-domain audits with operation-level verdicts, file:line citations, and OpenAPI path citations.

## Read-only

No source files under `packages/` were modified. Per-finding follow-up issues are filed under the `pre-publish-write-fix` label.

## Methodology — why these problems weren't caught before

Same structural test gap as the quotes audit: subprocess CLI tests run in `PAX8_DEMO=1` against `MockPax8Client` (which accepts anything); core API unit tests mock `Pax8Client.get/post/...` and only assert on relative path strings — `buildUrl()` and `fetch()` are never invoked. Every layer of the test pyramid is below the wire. Sandbox integration tests (#308) would close the gap.

## Related issues

- Triggered by: #307, #316
- Held quotes body-shape work this audit parallels: #311, #312, #313, #314
- Blocker for every fix this audit recommends: #308 (sandbox integration test pattern)
- Follow-up issues filed: see `pre-publish-write-fix` label

## Test plan

- [ ] Documentation-only PR; no test execution required.
- [ ] Reviewer: confirm cited file paths and line numbers resolve correctly against current `main`.
- [ ] Reviewer: confirm spec citations (`partner-endpoints.json`, `webhooks-api.json`) are accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)