### PR TITLE
docs(feedback-queue): mark #305 superseded by #311

### DIFF
--- a/docs/Pre-publish reviewer feedback queue
+++ b/docs/Pre-publish reviewer feedback queue
@@ -23,7 +23,7 @@ Tracking domain-review reviewer comments through resolution. Updated as work lan
 ## Fred Lintz (Orders & Quotes)
 
 - [x] `intentType` writability — resolved via read-only convention: #304 (codebase comment + regression test + README user-scope note)
-- [x] `quotes create` shorthand semantics — resolved via help-text clarification: #305 (also audits `line-items add` flag coverage)
+- [x] `quotes create` shorthand semantics — superseded by #311 (decision preserved in domain review; implementation rolls into v2 rewrite)
 - [ ] `quotes create --expiration-date` silent no-op — #306 (surfaced during the #305 audit; flag is declared and displayed in the confirm prompt but never sent to the API)
 - [ ] v2 surface scope (sections, attachments, access-list, take-ownership) — Q4 in re-review block, open for domain owner
 


### PR DESCRIPTION
One-line update to the feedback queue: #305 (quotes create shorthand semantics) is closed as superseded by #311.

- Design decision preserved in the domain review's Orders & Quotes section.
- Help-text implementation rolls into #311's v2 rewrite of \`quotes create\` to avoid PR ordering churn on the same surface.
- Line-items add flag coverage audit rolls into #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)