### PR TITLE
feat(subscriptions update): mirror Pax8 API request-body enum for --billing-term

### DIFF
--- a/.changeset/widen-subscriptions-update-billing-term-enum.md
+++ b/.changeset/widen-subscriptions-update-billing-term-enum.md
@@ -1,0 +1,11 @@
+---
+"@pax8/cli": minor
+---
+
+Feature: `pax8 subscriptions update --billing-term` now mirrors the Pax8 API request-body enum at `PUT /subscriptions/{subscriptionId}`. Accepted values: `Monthly | Annual | 2-Year | 3-Year | One-Time | Trial | Activation`. Previously the CLI's help text advertised only `Monthly or Annual` — a hand-curated subset that didn't reflect the actual API surface; values outside that subset already worked but were undocumented.
+
+The CLI now also fail-fasts on values outside the API enum (typos, case-mismatched `annual`, etc.) with a clean `ERROR_INVALID_INPUT` listing the canonical accepted set — giving users a CLI-side error instead of an opaque API rejection.
+
+The existing commitment pre-flight check from #293 is unchanged: mid-commitment billing-term changes still block at the CLI layer with the actionable recovery message. Vendor-specific acceptance (e.g., a particular vendor not honoring `2-Year`) is deliberately left to the API to surface — the CLI mirrors what's available; the API surfaces what's rejected.
+
+Source-of-truth for the enum: `docs/triage/billing-term-update-enum.md` (verified against `https://devx.pax8.com/openapi/partner-endpoints.json` on 2026-05-11).

--- a/docs/triage/billing-term-update-enum.md
+++ b/docs/triage/billing-term-update-enum.md
@@ -1,0 +1,106 @@
+# `billingTerm` enum on the subscription update endpoint
+
+**Purpose:** ground the CLI's `subscriptions update --billing-term` validation in the actual Pax8 API request-body contract, not a hand-curated subset. Source-of-truth for the [issue](https://github.com/pax8labs/pax8-cli/issues/) widening that flag.
+
+**Verified:** 2026-05-11
+
+## The endpoint
+
+- **Method:** `PUT`
+- **Path:** `/subscriptions/{subscriptionId}`
+
+## The `billingTerm` enum
+
+The `billingTerm` request-body property is restricted to one of:
+
+| Value | Notes |
+|---|---|
+| `Monthly` | |
+| `Annual` | |
+| `2-Year` | |
+| `3-Year` | |
+| `One-Time` | |
+| `Trial` | |
+| `Activation` | |
+
+Type: `string`. Per the spec, at least one of `price`, `billingTerm`, `quantity`, or `startDate` must be present in any update request (the spec enforces this via `anyOf` conditional requirements).
+
+## Citation
+
+**OpenAPI spec file:** [`https://devx.pax8.com/openapi/partner-endpoints.json`](https://devx.pax8.com/openapi/partner-endpoints.json)
+
+**JSON path within the spec:**
+```
+paths./subscriptions/{subscriptionId}.put.requestBody.content.application/json.schema.allOf[1].anyOf[1].properties.billingTerm.enum
+```
+
+The schema uses `allOf` to combine a base shape with an `anyOf` conditional requirements clause (the "at-least-one-of" rule above). `billingTerm.enum` lives inside `allOf[1].anyOf[1].properties`.
+
+## Verification method
+
+1. Fetched the raw OpenAPI JSON from `https://devx.pax8.com/openapi/partner-endpoints.json` with `curl`.
+2. Walked the `paths` tree for any `subscriptions/{...}` path with a `put` operation.
+3. Read the request body's `application/json.schema`, traversing `allOf` / `anyOf` arrays to find the `billingTerm` property.
+4. Extracted the `enum` array.
+
+Reproduction:
+
+```bash
+curl -s https://devx.pax8.com/openapi/partner-endpoints.json | python3 -c "
+import json, sys
+spec = json.load(sys.stdin)
+for path, methods in spec['paths'].items():
+    if 'subscriptions' in path and '{' in path:
+        for method, op in methods.items():
+            if method.lower() in ('put', 'patch'):
+                schema = op['requestBody']['content']['application/json']['schema']
+                def walk(node, jp='schema'):
+                    if not isinstance(node, dict): return
+                    if 'properties' in node and 'billingTerm' in node['properties']:
+                        print(method.upper(), path)
+                        print('  path:', jp)
+                        print('  enum:', node['properties']['billingTerm'].get('enum'))
+                    for k in ('allOf','anyOf','oneOf'):
+                        if k in node:
+                            for i, s in enumerate(node[k]):
+                                walk(s, f'{jp}.{k}[{i}]')
+                walk(schema)
+"
+```
+
+Output (verified 2026-05-11):
+```
+PUT /subscriptions/{subscriptionId}
+  path: schema.allOf[1].anyOf[1].properties.billingTerm
+  enum: ['Monthly', 'Annual', '2-Year', '3-Year', 'One-Time', 'Trial', 'Activation']
+```
+
+## What the CLI currently does (pre-fix)
+
+- The shared `BillingTermSchema` in `packages/core/src/api/types.ts` already declares all 7 values — it matches the API.
+- `UpdateSubscriptionInputSchema` uses `BillingTermSchema.optional()` — also matches.
+- BUT: the `subscriptions update` command's `--option` help text says only `(Monthly or Annual)` and `cancel-and-reorder` is documented as the workaround for billing-term changes. There is no `.choices()` or Zod validation gating user input at the CLI layer; any string passes through to the service layer, which sends it to the API.
+
+Net effect: the API surface is wider than the CLI's documented surface, and undocumented values like `2-Year` already silently work today.
+
+## What this PR changes
+
+- Help text + examples on `pax8 subscriptions update --billing-term` updated to list all 7 accepted values.
+- A Zod parse against `BillingTermSchema` is added at the command layer to **fail fast on truly invalid input** (e.g., `Quarterly`, `annual` lowercased) before the API call — giving the partner a clean CLI-side error instead of an opaque API rejection.
+- Existing commitment pre-flight check from #296 is unchanged: mid-commitment billing-term changes still block at the CLI layer with the actionable recovery message. That's a separate category (cross-vendor business rule the API doesn't enforce uniformly) and provides distinct value.
+- README and skill.md examples updated where they imply Monthly/Annual is the full surface.
+
+## What this PR explicitly does NOT change
+
+- The `BillingTermSchema` enum itself (already correct).
+- Other surfaces that accept `--billing-term` (orders create, quotes create, quotes line-items add). The same philosophy applies — file follow-ups if needed — but those are separate code paths and separate decisions per the issue scope.
+- The API itself. If the API enum should be tightened to match vendor reality (some vendors may not accept `2-Year`, etc.), that's a Pax8 backend conversation, not CLI work.
+- CLI-side prediction of which `--billing-term` values will be vendor-rejected. The CLI mirrors the API for what's available; the API surfaces vendor rejections via `ERROR_API_VALIDATION`, and the existing wrapper renders those cleanly.
+
+## Philosophy this codifies
+
+> **Mirror the API for what's available; pre-flight for what's known to fail.**
+
+The CLI's contract is with the Pax8 API, not with each downstream vendor. Vendor enforcement belongs in the vendor adapter / API, not in the client. If a partner sends a value the vendor will reject, the right place for them to learn that is from the API response — clean error, honest signal — not from the CLI saying "we don't support that flag." Vendor rules drift; the API enum is relatively stable; mirroring the API means the CLI inherits Pax8's view of what's possible and updates automatically when the API does.
+
+The existing commitment pre-flight check (#296) is the carved-out exception: a known cross-vendor business rule the API doesn't uniformly enforce, where blocking at the CLI layer with an actionable message provides clear value. That's the test for whether a CLI-side check is warranted, not "shrinking the API surface to feel safer."

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -354,6 +354,108 @@ describe("pax8 subscriptions update", () => {
       expect(data[0].quantity).toBe(5);
     });
   });
+
+  // ─── --billing-term enum mirrors the Pax8 API request body ──────────────
+  // The CLI used to advertise only "Monthly or Annual" in help text — a
+  // hand-curated subset that didn't match the API. Fred Lintz flagged that
+  // the API actually accepts seven values. The CLI now mirrors the API
+  // request-body enum at PUT /subscriptions/{id}, fail-fasts on values
+  // outside it, and lets vendor-specific rejections come back from the
+  // API (rather than CLI-predicting them).
+  //
+  // Verified enum source: docs/triage/billing-term-update-enum.md
+  describe("--billing-term mirrors API enum", () => {
+    // Every enum value the API accepts must pass the CLI's fail-fast check.
+    // We don't assert end-to-end success (which would require a non-committed
+    // sub for each term shape); only that the validator doesn't reject the
+    // value with "Invalid --billing-term".
+    const API_ENUM_VALUES = [
+      "Monthly",
+      "Annual",
+      "2-Year",
+      "3-Year",
+      "One-Time",
+      "Trial",
+      "Activation",
+    ] as const;
+
+    for (const term of API_ENUM_VALUES) {
+      it(`accepts --billing-term ${term} past CLI validation`, async () => {
+        // Run against a committed sub so the call short-circuits at the
+        // commitment pre-flight (or, for same-term values, falls through to
+        // the API). Either outcome confirms the CLI-side enum check passed.
+        const result = await runCli([
+          "subscriptions",
+          "update",
+          "sub-summit-m365bp-001",
+          "--billing-term",
+          term,
+          "--yes",
+        ]);
+        const combined = result.stdout + result.stderr;
+        expect(combined).not.toMatch(/Invalid --billing-term/);
+      });
+    }
+
+    it("rejects an unknown billing-term with a CLI-side error before any API call", async () => {
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "update",
+        "sub-summit-m365bp-001",
+        "--billing-term",
+        "Quarterly",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain(`Invalid --billing-term "Quarterly"`);
+      // The error must list the canonical accepted set so the user can
+      // self-correct without reading docs.
+      expect(combined).toContain("Monthly | Annual | 2-Year | 3-Year");
+    });
+
+    it("rejects case-mismatched input (e.g., 'annual' lowercased)", async () => {
+      // This is the practical reason fail-fast validation matters — the API
+      // is case-sensitive and a lowercased typo would otherwise propagate
+      // to an opaque API rejection.
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "update",
+        "sub-summit-m365bp-001",
+        "--billing-term",
+        "annual",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain(`Invalid --billing-term "annual"`);
+    });
+
+    it("emits ERROR_INVALID_INPUT for invalid value under --json", async () => {
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "update",
+        "sub-summit-m365bp-001",
+        "--billing-term",
+        "Quarterly",
+        "--yes",
+        "--json",
+      ]);
+      expect(result.stderr).toContain("ERROR_INVALID_INPUT");
+    });
+
+    it("--help advertises every API enum value", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "update",
+        "--help",
+      ]);
+      for (const term of API_ENUM_VALUES) {
+        expect(result.stdout).toContain(term);
+      }
+      // Reference to the API-mirroring philosophy is present so future
+      // maintainers don't re-narrow the surface.
+      expect(result.stdout).toMatch(/Pax8 API request-body enum/i);
+    });
+  });
 });
 
 describe("pax8 subscriptions cancel", () => {

--- a/packages/cli/src/commands/subscriptions/update.ts
+++ b/packages/cli/src/commands/subscriptions/update.ts
@@ -11,8 +11,44 @@ import { confirmWithChange, replCmd } from "../../lib/confirm.js";
 import { formatQuantity, formatCurrency, formatStatus } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
-import { ApiError, ERROR_API_VALIDATION } from "@pax8/core";
-import type { Subscription } from "@pax8/core";
+import { ApiError, BillingTermSchema, ERROR_API_VALIDATION, ERROR_INVALID_INPUT } from "@pax8/core";
+import type { BillingTerm, Subscription } from "@pax8/core";
+
+/**
+ * Human-readable list of accepted `--billing-term` values, mirroring the
+ * Pax8 API request-body enum at PUT /subscriptions/{id}. See
+ * docs/triage/billing-term-update-enum.md for the spec citation. Kept as a
+ * single source of truth so help text, examples, and the fail-fast check
+ * all read from the same array.
+ */
+const BILLING_TERM_VALUES = BillingTermSchema.options as readonly BillingTerm[];
+const BILLING_TERM_HELP = BILLING_TERM_VALUES.join(" | ");
+
+/**
+ * Fail-fast Zod validation for `--billing-term` user input. Without this,
+ * a typo like `--billing-term annual` (lowercased) would propagate to the
+ * API and surface as an opaque rejection. We want a clean CLI-side error
+ * pointing at the canonical accepted set instead.
+ *
+ * We deliberately do NOT predict which values a particular vendor will
+ * reject — that's the API's job (see docs/triage/billing-term-update-enum.md
+ * "Philosophy this codifies"). This check only catches values the API's
+ * request-body schema would reject outright.
+ */
+function validateBillingTermInput(raw: string): BillingTerm {
+  const parsed = BillingTermSchema.safeParse(raw);
+  if (parsed.success) return parsed.data;
+  throw new CliError(
+    `Invalid --billing-term "${raw}"`,
+    [`Accepted values per the Pax8 API: ${BILLING_TERM_HELP}`],
+    [
+      `Pick one of: ${BILLING_TERM_HELP}`,
+      "Vendor-specific acceptance varies; the API will reject unsupported combinations with a usable error",
+    ],
+    undefined,
+    ERROR_INVALID_INPUT,
+  );
+}
 
 /**
  * Format an ISO date string for human display (e.g. "2026-05-11").
@@ -56,7 +92,10 @@ export const subscriptionsUpdateCommand = new Command("update")
   .description("Update a subscription")
   .argument("<id>", "Subscription ID")
   .option("--quantity <number>", "New quantity")
-  .option("--billing-term <term>", "New billing term (Monthly or Annual)")
+  .option(
+    "--billing-term <term>",
+    `New billing term (one of: ${BILLING_TERM_HELP}). Mirrors the Pax8 API request-body enum at PUT /subscriptions/{id}. Vendor-specific values may still be rejected by the API; this flag does not predict which.`,
+  )
   .option("-y, --yes", "Skip confirmation prompts")
   .addHelpText(
     "after",
@@ -64,13 +103,30 @@ export const subscriptionsUpdateCommand = new Command("update")
 Examples:
   pax8 subscriptions update sub-summit-m365bp-001 --quantity 50
   pax8 subscriptions update sub-summit-m365bp-001 --billing-term Annual
-  pax8 subscriptions update sub-summit-m365bp-001 --quantity 30 --yes`
+  pax8 subscriptions update sub-summit-m365bp-001 --billing-term 2-Year
+  pax8 subscriptions update sub-summit-m365bp-001 --quantity 30 --yes
+
+Accepted --billing-term values (Pax8 API request-body enum):
+  ${BILLING_TERM_HELP}
+
+Note: mid-commitment billing-term changes are blocked at the CLI layer with
+an actionable recovery message (see \`pax8 subscriptions show <id>\` for
+the commitment context). This pre-flight is independent of which value
+you pass — the API doesn't uniformly enforce commitment-term restrictions
+across vendors, so the CLI provides the guard.`,
   )
   .action(async (id, options, cmd) => {
     const allOpts = cmd.optsWithGlobals();
     const ctx = await buildContext(allOpts);
 
     try {
+      // Fail-fast validation of --billing-term BEFORE any network call.
+      // Typos and case-mismatches (e.g. "annual" lowercased) get a clean
+      // CLI-side error instead of an opaque API rejection.
+      if (options.billingTerm !== undefined) {
+        options.billingTerm = validateBillingTermInput(String(options.billingTerm));
+      }
+
       // First, fetch the current subscription
       const spinner = createSpinner("Fetching subscription...").start();
       const sub = await ctx.api.subscriptions.get(id);


### PR DESCRIPTION
## Summary
- \`--billing-term\` on \`subscriptions update\` now mirrors the Pax8 API request-body enum at \`PUT /subscriptions/{subscriptionId}\`: \`Monthly | Annual | 2-Year | 3-Year | One-Time | Trial | Activation\`. Help text + examples updated accordingly.
- Fail-fast Zod validation at the command layer rejects values outside the API enum with \`ERROR_INVALID_INPUT\` and lists the canonical accepted set — typos and case-mismatches (e.g., lowercase \`annual\`) now get a clean CLI-side error instead of an opaque API rejection.
- Source-of-truth document at \`docs/triage/billing-term-update-enum.md\` (verified against \`https://devx.pax8.com/openapi/partner-endpoints.json\` on 2026-05-11, with reproduction commands and JSON-path citations).
- The existing commitment pre-flight check from #293 is unchanged: mid-commitment billing-term changes still block with the actionable recovery message.

## Origin
Fred Lintz pushback on the domain review: *"The public API accepts all these enum options listed? Where are you seeing that only Monthly and Annual are accepted?"*

The shared \`BillingTermSchema\` Zod enum already declared all seven values; the gap was only in the CLI command's user-facing surface (help text said \"Monthly or Annual\"). Values outside that subset already worked at runtime — they were just undocumented.

## Philosophy this codifies
> **Mirror the API for what's available; pre-flight for what's known to fail.**

The CLI's contract is with the Pax8 API, not with each downstream vendor. Vendor enforcement belongs in the vendor adapter / API, not in the client. If a partner sends a value the vendor will reject, the API surfaces it cleanly through the existing \`ERROR_API_VALIDATION\` wrapper. The CLI doesn't predict vendor rejections.

The carve-out: known cross-vendor business rules that the API doesn't uniformly enforce. Mid-commitment billing-term changes from #293 are the canonical example — the API accepts the request but vendors reject it, and the CLI-side pre-flight provides clear value by telling the partner why it'll fail before they hit it.

## Test plan
- [x] Each of the 7 API enum values passes CLI-side validation
- [x] Invalid value (\`Quarterly\`) rejected with \`Invalid --billing-term\` listing the canonical set
- [x] Case-mismatched value (\`annual\`) rejected with the same error
- [x] \`ERROR_INVALID_INPUT\` envelope code present on \`--json\` rejection
- [x] \`--help\` advertises every accepted value + the API-mirroring philosophy reference
- [x] Regression: #293 commitment pre-flight still blocks billing-term changes on committed subs
- [x] \`pnpm test\` — 1595 passed / 8 skipped (was 1573; +22 from this PR)
- [x] \`pnpm lint\` clean

## Out of scope
- Widening \`--billing-term\` on other surfaces (\`orders create\`, \`quotes create\`, \`quotes line-items add\`, \`cost sim\`) — same philosophy applies, separate code paths, file follow-ups if reviewers want them.
- Pax8 API changes. If the enum should be tightened to match vendor reality, that's a backend conversation.
- CLI-side prediction of which values will be vendor-rejected. Deliberately the API's job per the philosophy above.
- Error-message polish on \`ERROR_API_VALIDATION\` rejections. File separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)