### PR TITLE
docs(readme): lead Quick Start with run-from-source, mark npm as coming soon

### DIFF
--- a/.changeset/readme-source-install.md
+++ b/.changeset/readme-source-install.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+Docs: README Quick Start now leads with a working run-from-source path (`git clone` + `pnpm install` + `pnpm build` + `node packages/cli/dist/index.js`) and clearly marks `npm install -g @pax8/cli` as the post-v0.1.0 install path. Previously the documented Quick Start started with `npm install -g @pax8/cli`, which 404s because `@pax8/cli` is not yet published — every first-time visitor hit a dead-end on the first command. The README Status section now carries a pre-release callout linking to the source-install steps. Closes #257.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An open-source CLI for managing Pax8 cloud marketplace operations. Built for MSP
 
 This is an early-stage open-source experiment. We're using engagement signals (installs, issues, command usage) to learn which capabilities are worth investing in further. Feedback, issues, and PRs are welcome.
 
+> **Pre-release.** `@pax8/cli` is not yet published to npm — `npm install -g @pax8/cli` will work once v0.1.0 ships. Until then, install from source: see [Quick Start → Running from source](#running-from-source).
+
 ## Highlights
 
 - **Answers the API doesn't** — renewals, invoice audit, upsell recommendations, MRR analytics computed locally from raw Pax8 data
@@ -32,10 +34,35 @@ Pax8 publishes a hosted MCP server at `mcp.pax8.com` for AI assistants — see t
 
 ## Quick Start
 
-Tested on macOS, Linux, and Windows under PowerShell.
+Tested on macOS, Linux, and Windows under PowerShell. Requires Node.js 20+ and [pnpm](https://pnpm.io/installation) 9+.
+
+### Running from source
+
+Until `@pax8/cli` is published to npm, install from source — copy-pasteable, under 5 minutes on a fresh checkout:
 
 ```bash
-# Install
+git clone https://github.com/pax8labs/pax8-cli
+cd pax8-cli
+pnpm install
+pnpm build
+
+# Try it without credentials (demo data, no API calls)
+PAX8_DEMO=1 node packages/cli/dist/index.js dashboard
+
+# Or expose `pax8` globally from your checkout so every example in this
+# README works as-is (the REPL and cache-warmer also need `pax8` on PATH)
+cd packages/cli && npm link
+PAX8_DEMO=1 pax8 dashboard
+```
+
+For watch mode, tests, and the rest of the contributor workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### From npm (coming soon)
+
+Once v0.1.0 ships, the documented path will be:
+
+```bash
+# Install (not yet published — tracked in repo Status section above)
 npm install -g @pax8/cli
 
 # Authenticate
@@ -47,26 +74,6 @@ pax8 dashboard
 # Or try with demo data (no credentials needed)
 PAX8_DEMO=1 pax8 dashboard
 ```
-
-### Running from source (contributors / unmerged branches)
-
-If you're contributing to the CLI or trying it before it's published:
-
-```bash
-git clone https://github.com/pax8labs/pax8-cli
-cd pax8-cli
-pnpm install
-pnpm build
-
-# Use directly:
-node packages/cli/dist/index.js status
-
-# Or symlink for global use:
-cd packages/cli && npm link
-pax8 status
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full dev workflow.
 
 ## Demo Flow (90 seconds)
 

--- a/docs/credential-setup.md
+++ b/docs/credential-setup.md
@@ -6,7 +6,7 @@ This guide walks you through getting API credentials from Pax8 and configuring t
 
 - A Pax8 partner account
 - API access enabled on your account (contact your Pax8 account manager if unsure)
-- Node.js 18+ and the CLI installed (`npm install -g @pax8/cli`)
+- Node.js 20+ and the CLI installed — `npm install -g @pax8/cli` once v0.1.0 ships, or build from source per the [README Quick Start](../README.md#running-from-source) until then
 
 ## Step 1: Get your API credentials
 


### PR DESCRIPTION
## Summary

- README's primary Quick Start CTA was `npm install -g @pax8/cli`, but `@pax8/cli` is not yet published — every cold visitor 404s on the first command. Reorder Quick Start so a working `git clone` + `pnpm install` + `pnpm build` + `node packages/cli/dist/index.js dashboard` path leads, with `npm link` shown as the optional "expose pax8 globally" step.
- Keep the npm install as a sibling "From npm (coming soon)" section so the post-publish path is already documented in place. Add a pre-release callout to §Status that links to the source-install steps.
- Update `docs/credential-setup.md` prerequisite line to match (was also pointing at the unpublished npm install).
- Add `@pax8/cli` patch changeset entry.

Closes #257.

## Test plan

- [x] Verified `pnpm install && pnpm build` succeed on a fresh checkout of this branch (the same steps the README now documents).
- [x] Confirmed `packages/cli/dist/index.js` is built with a `#!/usr/bin/env node` shebang and registered as the `bin` entry in `packages/cli/package.json` — `node packages/cli/dist/index.js dashboard` is the correct invocation.
- [x] `pnpm test` — 1584 passed, 8 skipped, 0 failed.
- [x] `pnpm lint` — clean.
- [x] Inspected the rendered README locally — anchor link `#running-from-source` resolves to the new subsection, and §Status pre-release callout points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)