### PR TITLE
fix(quotes): remove silent no-op --expiration-date from quotes create

### DIFF
--- a/.changeset/quotes-create-expiration-date-noop.md
+++ b/.changeset/quotes-create-expiration-date-noop.md
@@ -1,0 +1,9 @@
+---
+"@pax8/cli": patch
+---
+
+Fix: `pax8 quotes create --expiration-date <date>` is no longer a silent no-op. The flag previously appeared in `quotes create --help` and even rendered "Expires: <date>" in the confirmation prompt, but the value was never sent to the API — `CreateQuoteInputSchema` has no `expiresOn` field, because `POST /v2/quotes` accepts only `{ clientId, quoteRequestId? }` per the v2 quoting OpenAPI spec (see `docs/triage/quotes-api-version.md` §9.1). Setting an expiration on a brand-new quote is a two-step flow on the real API.
+
+Resolution (Option B from #306): the `--expiration-date` option has been removed from `pax8 quotes create`. The help footer now directs users at `pax8 quotes update <id> --expiration-date <YYYY-MM-DD>`, which has always wired the field through correctly via `UpdateQuoteInputSchema.expiresOn`. A regression test in `packages/cli/src/__tests__/quotes.create.test.ts` asserts the flag is absent from the create command's option list, so a future PR cannot silently re-introduce the no-op.
+
+Scope: standalone fix. The larger v2 rewrite of `quotes create` (companyId → clientId, lineItems-on-create removal, quote-request orchestration) is tracked under #311 and not pre-empted here.

--- a/packages/cli/src/__tests__/quotes.create.test.ts
+++ b/packages/cli/src/__tests__/quotes.create.test.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess } from "./test-utils.js";
+
+describe("pax8 quotes create", () => {
+  describe("--help", () => {
+    // Regression guard for #306: `--expiration-date` on `quotes create` was a
+    // silent no-op because `POST /v2/quotes` accepts only `{ clientId,
+    // quoteRequestId? }` — there is no place for `expiresOn` on the create
+    // body (see docs/triage/quotes-api-version.md §9.1). The flag was removed
+    // and users are now directed at `pax8 quotes update <id>
+    // --expiration-date <date>` for setting/changing expiration.
+    //
+    // If a future PR re-adds `--expiration-date` to `quotes create` without
+    // also wiring it through to the API, this test fails loudly. Do not
+    // delete this test just to make it pass — fix the create path properly
+    // (verify the API accepts the field, extend CreateQuoteInputSchema, send
+    // it through) or leave the flag off. #306.
+    it("does not declare a --expiration-date option (#306 regression guard)", async () => {
+      const result = await runCliExpectSuccess(["quotes", "create", "--help"]);
+      // The help block lists each option on its own line, e.g.
+      //   --quantity <number>     Quantity (default: "1")
+      // We assert the flag does not appear as a declared option. A free-form
+      // mention inside the "Setting an expiration date" help footer is fine —
+      // that's the intentional pointer to `quotes update`.
+      const optionsSection = result.stdout.split("Examples:")[0] ?? result.stdout;
+      expect(optionsSection).not.toContain("--expiration-date");
+    });
+
+    it("points users at `quotes update --expiration-date` for setting expiration", async () => {
+      const result = await runCliExpectSuccess(["quotes", "create", "--help"]);
+      expect(result.stdout).toContain("pax8 quotes update");
+      expect(result.stdout).toContain("--expiration-date");
+    });
+  });
+});

--- a/packages/cli/src/commands/quotes/create.ts
+++ b/packages/cli/src/commands/quotes/create.ts
@@ -22,14 +22,19 @@ export const quotesCreateCommand = new Command("create")
   .requiredOption("--product <id|name>", "Product ID or name (required)")
   .option("--quantity <number>", "Quantity", "1")
   .option("--billing-term <term>", "Billing term (Monthly or Annual)", "Monthly")
-  .option("--expiration-date <date>", "Quote expiration date (YYYY-MM-DD)")
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
     `
 Examples:
   pax8 quotes create --company "Summit Healthcare Partners" --product "Microsoft 365 E3" --quantity 10
-  pax8 quotes create --company a1b2c3d4 --product prod-m365-e3-0003 --quantity 5 --billing-term Annual`
+  pax8 quotes create --company a1b2c3d4 --product prod-m365-e3-0003 --quantity 5 --billing-term Annual
+
+Setting an expiration date:
+  The Pax8 v2 quotes API does not accept an expiration date on create
+  (POST /v2/quotes takes only { clientId, quoteRequestId? }). To set
+  or change a quote's expiration, use a follow-up update:
+    pax8 quotes update <id> --expiration-date <YYYY-MM-DD>`,
   )
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();
@@ -55,9 +60,6 @@ Examples:
       process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${product.name}\n`);
       process.stderr.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(quantity)}\n`);
       process.stderr.write(`  ${chalk.dim("Billing Term:".padEnd(18))}${options.billingTerm}\n`);
-      if (options.expirationDate) {
-        process.stderr.write(`  ${chalk.dim("Expires:".padEnd(18))}${options.expirationDate}\n`);
-      }
       process.stderr.write("\n");
 
       const ok = await confirm("Create this quote?", { default: true });


### PR DESCRIPTION
## Summary

- The `--expiration-date` flag on `pax8 quotes create` was a silent no-op: declared at `packages/cli/src/commands/quotes/create.ts:25`, rendered in the confirm prompt (`Expires: <date>`), then dropped on the floor — `CreateQuoteInputSchema` has no `expiresOn` field, because `POST /v2/quotes` accepts only `{ clientId, quoteRequestId? }` per the v2 quoting OpenAPI spec (see `docs/triage/quotes-api-version.md` §9.1).
- This PR applies **Option B** from #306: remove the flag from `quotes create` and point users at `pax8 quotes update <id> --expiration-date <YYYY-MM-DD>`, which has always wired the field through correctly via `UpdateQuoteInputSchema.expiresOn`.
- A regression test in `packages/cli/src/__tests__/quotes.create.test.ts` asserts the option is absent from the create command's help output, with an in-source comment citing #306 so a future PR cannot silently re-introduce the no-op.

**Scope discipline.** This is a small standalone fix. The larger v2 rewrite of `quotes create` (`companyId` → `clientId` rename, `lineItems` removed from the create body, two-call orchestration) is tracked under #311 (gated on #308) and is intentionally not pre-empted here — no changes to `CreateQuoteInputSchema`, the API client, the company/product resolution flow, or anything beyond removing this one flag.

## Files touched

- `packages/cli/src/commands/quotes/create.ts` — remove `--expiration-date` option + confirm-prompt row; rewrite the `addHelpText` footer to point at `quotes update`.
- `packages/cli/src/__tests__/quotes.create.test.ts` *(new)* — regression guard asserting the flag is absent and that the help text directs users at `quotes update --expiration-date`.
- `.changeset/quotes-create-expiration-date-noop.md` *(new)* — patch-level changeset for `@pax8/cli`.

## Test plan

- [x] `pnpm build` passes (core + cli)
- [x] `pnpm test` — 1586 passed / 8 skipped (105 files)
- [x] `pnpm lint` clean
- [x] New regression file: `pnpm test packages/cli/src/__tests__/quotes.create.test.ts` — 2/2 passing
- [x] Manual: `node packages/cli/dist/index.js quotes create --help` no longer lists `--expiration-date`; the footer points at `pax8 quotes update <id> --expiration-date <YYYY-MM-DD>`.
- [x] Conventional Commits subject + DCO sign-off

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)