### PR TITLE
infra(client): per-API base URL mechanism in Pax8Client

### DIFF
--- a/.changeset/per-api-base-url.md
+++ b/.changeset/per-api-base-url.md
@@ -1,0 +1,13 @@
+---
+"@pax8/core": patch
+---
+
+Add a per-API base URL mechanism to `Pax8Client`. Each API class can now opt into a different base URL than the project-wide default by registering a key in `apiBaseOverrides` at construction time and passing `{ api: "<key>" }` in `RequestOpts`. This unblocks APIs that live on a different prefix entirely (e.g. Webhooks at `https://api.pax8.com/api/v2/...` — the per-call `apiVersion` substitution from #316 can swap version segments but cannot represent a different prefix).
+
+Three composition dimensions now compose cleanly:
+
+1. **Project-wide default** — `https://api.pax8.com/v1` (today's `FALLBACK_BASE_URL`); overridable via `PAX8_API_BASE` for staging.
+2. **Per-API override** — registered in `apiBaseOverrides`, opt-in per call via `RequestOpts.api`. Unaffected by `PAX8_API_BASE` so the staging-redirect pattern continues to work for the default base.
+3. **Per-call version segment** — existing `RequestOpts.apiVersion` from #316; applies on top of whichever base was selected.
+
+No wire behavior changes today for any existing API class. `QuotesApi` continues to use the per-call `apiVersion: "v2"` mechanism unchanged. `WebhooksApi` adoption ships separately under #322.

--- a/packages/core/src/api/client.test.ts
+++ b/packages/core/src/api/client.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Pax8Client, getDefaultBaseUrl, applyApiVersion } from "./client.js";
+import { Pax8Client, getDefaultBaseUrl, applyApiVersion, resolveBaseUrl } from "./client.js";
 import { ApiError, RateLimitError } from "./errors.js";
 import {
   Pax8SecurityError,
@@ -724,5 +724,291 @@ describe("Pax8Client debug error logging (#263)", () => {
     } finally {
       writeSpy.mockRestore();
     }
+  });
+});
+
+// #321 — pure URL-resolution helper. Pins the three-dimensional composition
+// (project-wide default × per-API override × per-call apiVersion) so that
+// future API classes can rely on a stable contract for where their requests
+// will land before any wire mocking is needed.
+describe("resolveBaseUrl (#321)", () => {
+  const DEFAULT = "https://api.pax8.com/v1";
+
+  it("returns the default base URL when no overrides apply", () => {
+    expect(resolveBaseUrl(DEFAULT, undefined, undefined, undefined)).toBe(DEFAULT);
+    expect(resolveBaseUrl(DEFAULT, {}, undefined, undefined)).toBe(DEFAULT);
+  });
+
+  it("returns the per-API override when api key is registered", () => {
+    expect(
+      resolveBaseUrl(
+        DEFAULT,
+        { webhooks: "https://api.pax8.com/api/v2" },
+        "webhooks",
+        undefined,
+      ),
+    ).toBe("https://api.pax8.com/api/v2");
+  });
+
+  it("silently falls back to default when api key is unknown", () => {
+    // Adding a new API class is a pure-addition change: a call passing an
+    // unknown key shouldn't crash, it should just use the default.
+    expect(
+      resolveBaseUrl(
+        DEFAULT,
+        { webhooks: "https://api.pax8.com/api/v2" },
+        "not-registered",
+        undefined,
+      ),
+    ).toBe(DEFAULT);
+  });
+
+  it("silently falls back to default when apiBaseOverrides is undefined", () => {
+    expect(resolveBaseUrl(DEFAULT, undefined, "webhooks", undefined)).toBe(DEFAULT);
+  });
+
+  it("applies apiVersion substitution to the default base when no api override", () => {
+    // The #316 / #307 mechanism still operates on the default base.
+    expect(resolveBaseUrl(DEFAULT, undefined, undefined, "v2")).toBe(
+      "https://api.pax8.com/v2",
+    );
+  });
+
+  it("applies apiVersion substitution to the per-API base, not the default", () => {
+    // The per-API override wins, then apiVersion substitutes its trailing
+    // version segment. Important: if a future API class lives at /v3 by
+    // default and a single call wants /v3.1, that combination must work.
+    expect(
+      resolveBaseUrl(
+        DEFAULT,
+        { future: "https://api.pax8.com/v3" },
+        "future",
+        "v3.1",
+      ),
+    ).toBe("https://api.pax8.com/v3.1");
+  });
+
+  it("apiVersion substitution against a per-API base that lacks a version segment throws loudly", () => {
+    // Symmetric with the default-base case (#307): if the partner overrides
+    // a per-API base to something without /vN suffix and a call still tries
+    // to substitute, fail loudly rather than producing a plausible-looking
+    // wrong URL. The Webhooks base `https://api.pax8.com/api/v2` ends in /v2
+    // so this only fires on misconfiguration.
+    expect(() =>
+      resolveBaseUrl(
+        DEFAULT,
+        { weird: "https://api.pax8.com/api" },
+        "weird",
+        "v2",
+      ),
+    ).toThrow(/must end with a version segment/);
+  });
+
+  it("per-API override does not affect calls that don't pass the api key", () => {
+    // A client configured with overrides for one API still routes everyone
+    // else through the default base — overrides are opt-in per call.
+    expect(
+      resolveBaseUrl(
+        DEFAULT,
+        { webhooks: "https://api.pax8.com/api/v2" },
+        undefined,
+        undefined,
+      ),
+    ).toBe(DEFAULT);
+  });
+
+  it("composes: per-API override + apiVersion substitution", () => {
+    // Future-proofing: if a v2-only API class needs a per-call /v3 override
+    // for an unreleased endpoint, the substitution still applies to the
+    // selected per-API base.
+    expect(
+      resolveBaseUrl(
+        DEFAULT,
+        { webhooks: "https://api.pax8.com/api/v2" },
+        "webhooks",
+        "v3",
+      ),
+    ).toBe("https://api.pax8.com/api/v3");
+  });
+});
+
+// #321 — wire-level integration: per-API base overrides actually change the
+// URL that `fetch` sees, compose correctly with `apiVersion` from #316, and
+// don't disturb the existing QuotesApi-style v1-base + v2-version-override
+// flow. These are the tests that would catch a regression where one
+// dimension silently swallowed another.
+describe("Pax8Client per-API base overrides (#321)", () => {
+  let originalFetch: typeof globalThis.fetch;
+  const originalApiBase = process.env.PAX8_API_BASE;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockTokenManager.getToken.mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    if (originalApiBase === undefined) delete process.env.PAX8_API_BASE;
+    else process.env.PAX8_API_BASE = originalApiBase;
+  });
+
+  it("routes a registered api-key call to its override base", async () => {
+    globalThis.fetch = mockFetchResponse(200, []);
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.pax8.com/v1",
+      apiBaseOverrides: {
+        webhooks: "https://api.pax8.com/api/v2",
+      },
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/webhooks", undefined, { api: "webhooks" });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toBe("https://api.pax8.com/api/v2/webhooks");
+  });
+
+  it("routes calls without an api key against the default base, even when overrides are configured", async () => {
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.pax8.com/v1",
+      apiBaseOverrides: {
+        webhooks: "https://api.pax8.com/api/v2",
+      },
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/companies/abc");
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toBe("https://api.pax8.com/v1/companies/abc");
+  });
+
+  it("falls back silently to the default base when api key is unknown", async () => {
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.pax8.com/v1",
+      apiBaseOverrides: { webhooks: "https://api.pax8.com/api/v2" },
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/something", undefined, { api: "not-registered" });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toBe("https://api.pax8.com/v1/something");
+  });
+
+  it("preserves the existing QuotesApi flow: default base + apiVersion override still routes to /v2", async () => {
+    // Regression guard: #316 must continue to work unchanged. A client with
+    // no apiBaseOverrides and a call passing only `{ apiVersion: "v2" }`
+    // resolves the URL exactly the way QuotesApi has always relied on.
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.pax8.com/v1",
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/quotes/abc", undefined, { apiVersion: "v2" });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toBe("https://api.pax8.com/v2/quotes/abc");
+  });
+
+  it("composes per-API base + per-call apiVersion: override base wins, version substitutes on top", async () => {
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.pax8.com/v1",
+      apiBaseOverrides: {
+        future: "https://api.pax8.com/api/v2",
+      },
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/widgets", undefined, { api: "future", apiVersion: "v3" });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toBe("https://api.pax8.com/api/v3/widgets");
+  });
+
+  it("PAX8_API_BASE overrides only the default; per-API override still applies on top", async () => {
+    // The staging/sandbox testing pattern: partners set PAX8_API_BASE to
+    // point at a non-prod environment. The per-API override (e.g. for
+    // webhooks) is independent — it's defined by the API class author, not
+    // the partner. So when PAX8_API_BASE is set, calls without an api key
+    // see the staging default, and calls with an api key see the registered
+    // override (which is unaffected by the env var).
+    process.env.PAX8_API_BASE = "https://api-staging.pax8.com/v1";
+    globalThis.fetch = mockFetchResponse(200, {});
+
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      apiBaseOverrides: {
+        webhooks: "https://api.pax8.com/api/v2",
+      },
+      cacheTtlMs: 0,
+    });
+
+    // A non-overridden call: hits staging.
+    await client.get("/companies");
+    const [defaultUrl] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(defaultUrl.toString()).toBe("https://api-staging.pax8.com/v1/companies");
+
+    // An overridden call: still hits the registered webhooks base, untouched
+    // by PAX8_API_BASE.
+    await client.get("/webhooks", undefined, { api: "webhooks" });
+    const [webhooksUrl] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(webhooksUrl.toString()).toBe("https://api.pax8.com/api/v2/webhooks");
+  });
+
+  it("POST/PUT/PATCH/DELETE all route through the per-API base override", async () => {
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.pax8.com/v1",
+      apiBaseOverrides: { webhooks: "https://api.pax8.com/api/v2" },
+      cacheTtlMs: 0,
+    });
+
+    await client.post("/webhooks", { url: "x" }, { api: "webhooks" });
+    let [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(url.toString()).toBe("https://api.pax8.com/api/v2/webhooks");
+
+    await client.put("/webhooks/123", { url: "y" }, { api: "webhooks" });
+    [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(url.toString()).toBe("https://api.pax8.com/api/v2/webhooks/123");
+
+    await client.patch("/webhooks/123", { url: "z" }, { api: "webhooks" });
+    [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(url.toString()).toBe("https://api.pax8.com/api/v2/webhooks/123");
+
+    // DELETE: use a 204 mock so the response path returns void cleanly.
+    globalThis.fetch = mockFetchResponse(204, undefined);
+    await client.delete("/webhooks/123", undefined, { api: "webhooks" });
+    [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(url.toString()).toBe("https://api.pax8.com/api/v2/webhooks/123");
+  });
+
+  it("strips trailing slashes from per-API override values", async () => {
+    globalThis.fetch = mockFetchResponse(200, {});
+    const client = new Pax8Client({
+      tokenManager: mockTokenManager,
+      baseUrl: "https://api.pax8.com/v1",
+      apiBaseOverrides: {
+        webhooks: "https://api.pax8.com/api/v2///",
+      },
+      cacheTtlMs: 0,
+    });
+
+    await client.get("/webhooks", undefined, { api: "webhooks" });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url.toString()).toBe("https://api.pax8.com/api/v2/webhooks");
+    expect(url.toString()).not.toContain("///");
   });
 });

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -15,6 +15,33 @@ export interface Pax8ClientOptions {
   debug?: boolean;
   /** Cache TTL in ms for GET requests. 0 disables caching. Default: 3600000 (1 hour). */
   cacheTtlMs?: number;
+  /**
+   * Per-API base URL overrides (#321). Maps an API-key (e.g. `"webhooks"`) to
+   * a fully-resolved base URL that replaces the project-wide default for
+   * requests that opt in via `RequestOpts.api`.
+   *
+   * Most of the Pax8 partner API lives under a single `/v1` base, but some
+   * surfaces live elsewhere — e.g. the Webhooks API is rooted at
+   * `https://api.pax8.com/api/v2`, a different *prefix* (not just a swapped
+   * version segment) that the per-call `apiVersion` substitution from #307
+   * cannot represent. An API class that needs to talk to a different base
+   * declares its key here and passes `{ api: "<key>" }` on every call; the
+   * client routes the request against the override instead of `baseUrl`.
+   *
+   * Composition rules:
+   * - `PAX8_API_BASE` overrides only the project-wide default (`baseUrl`).
+   *   Per-API overrides apply on top of whichever default is in play, and
+   *   are not affected by `PAX8_API_BASE`. Partners pointing at staging set
+   *   `PAX8_API_BASE` and trust the per-API override to coexist; if they need
+   *   to redirect a per-API override for staging, they can pass a custom
+   *   `apiBaseOverrides` map directly into the client constructor.
+   * - A request with `{ api: "<key>" }` resolves the base from this map; an
+   *   unknown key silently falls back to `baseUrl` (so adding a new API
+   *   class is a pure-addition change — old call sites won't crash).
+   * - The per-call `apiVersion` substitution from #307 then applies on top
+   *   of whichever base URL was selected.
+   */
+  apiBaseOverrides?: Record<string, string>;
 }
 
 /**
@@ -30,6 +57,18 @@ export interface RequestOpts {
    * and inherit the base URL's version segment unchanged. See #307.
    */
   apiVersion?: string;
+  /**
+   * Per-API base URL override key (#321). When set, the client looks up the
+   * fully-resolved base URL in the `apiBaseOverrides` map passed at
+   * construction time and routes this call against it instead of the
+   * project-wide default. The `apiVersion` substitution (if any) is applied
+   * on top of whichever base URL was selected.
+   *
+   * If the key isn't registered in `apiBaseOverrides`, the call silently
+   * falls back to the default `baseUrl` — adding a new API class is a
+   * pure-addition change.
+   */
+  api?: string;
 }
 
 const FALLBACK_BASE_URL = "https://api.pax8.com/v1";
@@ -73,6 +112,35 @@ export function applyApiVersion(baseUrl: string, apiVersion?: string): string {
 }
 
 /**
+ * Pure URL-resolution helper for the per-API base URL mechanism (#321).
+ *
+ * Resolution order:
+ *   1. If `api` is set AND `apiBaseOverrides` has an entry for that key, use
+ *      the override as the base. Otherwise, fall back to `defaultBaseUrl`.
+ *   2. Apply `applyApiVersion(base, apiVersion)` on top — the per-call version
+ *      substitution from #307 operates on whichever base URL was selected.
+ *
+ * An unknown `api` key silently falls back to `defaultBaseUrl` rather than
+ * throwing. Rationale: API classes are added incrementally and registering
+ * the override is the API class author's responsibility; downstream embedders
+ * shouldn't crash if they instantiate `Pax8Client` without all overrides
+ * configured (the default for most APIs is the project-wide base anyway).
+ *
+ * Exported so the resolution rule is unit-testable independent of the
+ * surrounding request plumbing.
+ */
+export function resolveBaseUrl(
+  defaultBaseUrl: string,
+  apiBaseOverrides: Record<string, string> | undefined,
+  api: string | undefined,
+  apiVersion: string | undefined,
+): string {
+  const override = api && apiBaseOverrides ? apiBaseOverrides[api] : undefined;
+  const base = override ?? defaultBaseUrl;
+  return applyApiVersion(base, apiVersion);
+}
+
+/**
  * Resolve the API base URL. Honors `PAX8_API_BASE` so partners can point at
  * a non-prod environment without code changes; falls back to production.
  * Exported so the CLI can surface it in `pax8 doctor`.
@@ -94,6 +162,7 @@ export function getDefaultBaseUrl(): string {
 export class Pax8Client {
   private readonly tokenManager: { getToken(): Promise<string> };
   private readonly baseUrl: string;
+  private readonly apiBaseOverrides: Record<string, string> | undefined;
   private readonly timeout: number;
   private readonly debug: boolean;
   private readonly cache: FileCache | null;
@@ -102,6 +171,18 @@ export class Pax8Client {
   constructor(options: Pax8ClientOptions) {
     this.tokenManager = options.tokenManager;
     this.baseUrl = (options.baseUrl ?? getDefaultBaseUrl()).replace(/\/+$/, "");
+    // Normalize per-API overrides the same way as the default baseUrl so the
+    // composition is symmetric — trailing slashes don't leak through to
+    // `buildUrl`, regardless of which dimension supplied the base.
+    if (options.apiBaseOverrides) {
+      const normalized: Record<string, string> = {};
+      for (const [key, value] of Object.entries(options.apiBaseOverrides)) {
+        normalized[key] = value.replace(/\/+$/, "");
+      }
+      this.apiBaseOverrides = normalized;
+    } else {
+      this.apiBaseOverrides = undefined;
+    }
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT;
     this.debug = options.debug ?? false;
     this.cacheTtlMs = options.cacheTtlMs ?? 3_600_000; // 1 hour default
@@ -114,7 +195,7 @@ export class Pax8Client {
     opts?: RequestOpts,
   ): Promise<T> {
     if (this.cache) {
-      const cacheKey = this.buildCacheKey(path, params, opts?.apiVersion);
+      const cacheKey = this.buildCacheKey(path, params, opts?.apiVersion, opts?.api);
       const cached = await this.cache.get<T>(cacheKey);
       if (cached !== null) {
         if (this.debug) {
@@ -135,6 +216,7 @@ export class Pax8Client {
     path: string,
     params?: Record<string, string | number | undefined>,
     apiVersion?: string,
+    api?: string,
   ): string {
     const normalized = path.replace(/^\/+/, "");
     const paramStr = params
@@ -144,8 +226,12 @@ export class Pax8Client {
           .map(([k, v]) => `${k}=${v}`)
           .join("&")
       : "";
+    // Per-API base and per-call apiVersion both shift the resolved wire URL,
+    // so cache entries must be partitioned by both — otherwise a `/v1/foo`
+    // response could be served to a `/v2/foo` or `/api/v2/foo` caller (#321).
+    const apiPrefix = api ? `${api}:` : "";
     const versionPrefix = apiVersion ? `${apiVersion}:` : "";
-    return `${versionPrefix}${normalized}${paramStr ? "_" + paramStr : ""}`;
+    return `${apiPrefix}${versionPrefix}${normalized}${paramStr ? "_" + paramStr : ""}`;
   }
 
   async post<T>(path: string, body: unknown, opts?: RequestOpts): Promise<T> {
@@ -205,7 +291,7 @@ export class Pax8Client {
     params?: Record<string, string | number | undefined>,
     opts?: RequestOpts,
   ): Promise<T> {
-    const url = this.buildUrl(path, params, opts?.apiVersion);
+    const url = this.buildUrl(path, params, opts?.apiVersion, opts?.api);
     const token = await this.tokenManager.getToken();
 
     const headers: Record<string, string> = {
@@ -335,8 +421,9 @@ export class Pax8Client {
     path: string,
     params?: Record<string, string | number | undefined>,
     apiVersion?: string,
+    api?: string,
   ): URL {
-    const base = applyApiVersion(this.baseUrl, apiVersion);
+    const base = resolveBaseUrl(this.baseUrl, this.apiBaseOverrides, api, apiVersion);
     const normalizedPath = path.startsWith("/") ? path : `/${path}`;
     const url = new URL(`${base}${normalizedPath}`);
     if (params) {

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,7 +1,13 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export { Pax8Client, applyApiVersion, type Pax8ClientOptions, type RequestOpts } from "./client.js";
+export {
+  Pax8Client,
+  applyApiVersion,
+  resolveBaseUrl,
+  type Pax8ClientOptions,
+  type RequestOpts,
+} from "./client.js";
 export { CompaniesApi } from "./companies.js";
 export { ContactsApi } from "./contacts.js";
 export { ProductsApi } from "./products.js";


### PR DESCRIPTION
## Summary

Adds a per-API base URL mechanism to `Pax8Client` so each API class can opt out of the project-wide `/v1` default. Unblocks the webhooks `/api/v2/webhooks/...` wire-path fix (#322) and any future v2-only API that lives on a different prefix than the per-call `apiVersion` substitution from #316 can represent.

Two new optional fields wire the mechanism through:

- `Pax8ClientOptions.apiBaseOverrides?: Record<string, string>` — map of API-key to fully-resolved base URL, registered at construction time.
- `RequestOpts.api?: string` — per-call key naming which override applies, threaded alongside the existing `apiVersion`.

A new pure helper `resolveBaseUrl(defaultBaseUrl, apiBaseOverrides, api, apiVersion)` is exported so the resolution rule is unit-testable independent of the surrounding request plumbing. Cache keys for GET requests now partition by both `api` and `apiVersion` to prevent cross-base collisions.

**Three composition dimensions** compose cleanly:

1. **Project-wide default** — `https://api.pax8.com/v1` (today's `FALLBACK_BASE_URL`); overridable via `PAX8_API_BASE` for staging.
2. **Per-API override** — new; opt-in per call via `RequestOpts.api`. Unaffected by `PAX8_API_BASE` so the staging-redirect pattern continues to work for the default base. An unknown key silently falls back to the default — adding a new API class is a pure-addition change.
3. **Per-call version segment** — existing from #316. `applyApiVersion` applies on top of whichever base was selected in step 2. Throw-on-missing-version-segment behavior is preserved and now fires symmetrically against misconfigured per-API overrides.

**No wire behavior changes** for any existing API class today. `QuotesApi`'s #316 `apiVersion: "v2"` mechanism is preserved unchanged; its tests pass without modification. `WebhooksApi` adoption ships separately under #322.

Design comment posted on the issue before the code landed: https://github.com/pax8labs/pax8-cli/issues/321#issuecomment-4422198493

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` — 1601 passed / 8 skipped (104 test files)
- [x] `pnpm lint` — clean
- [x] `resolveBaseUrl` unit tests pin every composition combination (default-only, per-API override, unknown-key fallback, apiVersion alone, apiVersion against per-API base, misconfigured per-API + apiVersion throws)
- [x] Wire-level mocked-`fetch` tests: per-API override hits the right URL on GET/POST/PUT/PATCH/DELETE; QuotesApi's v1-base + v2-version-override flow still works; combined per-API + apiVersion composes correctly; `PAX8_API_BASE` interaction with per-API overrides verified; trailing-slash normalization on per-API overrides
- [x] All existing `QuotesApi` tests (#316) pass with no changes

## Out of scope

- **WebhooksApi adoption** — tracked as #322 follow-up. That PR will declare `WebhooksApi`'s per-API base as `https://api.pax8.com/api/v2`, delete the dead `update` / `updateStatus` helpers, and pin the resolved URL for every webhook method.
- **QuotesApi rework** — the #316 `apiVersion` mechanism is left exactly as-is.
- **Larger redesign** ("base URL has no version segment; every API class names its own prefix") — explicitly out of scope per the issue.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)