### PR TITLE
test: sandbox integration test pattern for wire-level URL verification

### DIFF
--- a/.changeset/integration-test-harness.md
+++ b/.changeset/integration-test-harness.md
@@ -1,0 +1,10 @@
+---
+"@pax8/cli": patch
+"@pax8/core": patch
+---
+
+Add wire-level integration test harness (#308) that hits the real Pax8 API and asserts every CLI call resolves to the URL documented by the relevant OpenAPI spec. Runs via `pnpm test:integration` and skips cleanly when `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` are absent — the default `pnpm test` never depends on credentials. Seed coverage hits one v1 resource (`companies list`) and one v2 resource (`quotes list`), proving both routing surfaces work against the real API.
+
+This closes the structural test gap that allowed the #307 quotes `v1`/`v2` regression to ship: unit tests mocked the client and only asserted relative paths; subprocess tests ran in demo mode against `MockPax8Client`. The new harness is the missing wire-level layer, with a documented extension pattern (`e2e/integration/harness.ts`, `CONTRIBUTING.md`) so any new API surface plugs in with one read-only smoke test. The harness unblocks the held quotes-v2 body-shape fixes (#311–#314 and the parallel audit's #323/#325/#326/#327/#328/#329/#331/#332).
+
+`@pax8/core` change: `Pax8Client` debug mode now also emits the resolved absolute URL alongside the existing relative-path log line, e.g. `[pax8] GET url=https://api.pax8.com/v2/quotes?page=0&size=50`. This is what the integration harness parses to verify version routing. Query strings carry no bearer tokens.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,66 @@
+name: Integration
+
+# Wire-level integration tests (#308). Runs `pnpm test:integration` against
+# the real Pax8 API using `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` repo
+# secrets. Job is informational — does NOT block PR merges — until the team
+# is ready to make it required. Forks and PRs from forks don't see the
+# secrets and the job will report a clean skip.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  integration:
+    name: Wire-level smoke tests
+    runs-on: ubuntu-latest
+    # `continue-on-error: true` keeps merges unblocked while the job is
+    # informational. Remove once the team agrees the suite is stable enough
+    # to gate merges on.
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Check for credentials
+        id: creds
+        # Fork PRs never see repo secrets — that's the GitHub default. This
+        # step decides whether to run the suite or skip with a clear log
+        # line. The `test:integration` runner ALSO skips internally when
+        # the env vars are absent, so the outer guard is defense-in-depth.
+        env:
+          PAX8_CLIENT_ID: ${{ secrets.PAX8_CLIENT_ID }}
+          PAX8_CLIENT_SECRET: ${{ secrets.PAX8_CLIENT_SECRET }}
+        run: |
+          if [ -n "$PAX8_CLIENT_ID" ] && [ -n "$PAX8_CLIENT_SECRET" ]; then
+            echo "have_creds=true" >> "$GITHUB_OUTPUT"
+            echo "Credentials present — running wire-level integration tests."
+          else
+            echo "have_creds=false" >> "$GITHUB_OUTPUT"
+            echo "PAX8_CLIENT_ID / PAX8_CLIENT_SECRET not configured as repo secrets — skipping. This is expected for fork PRs and forks of this repo."
+          fi
+
+      - name: Run integration tests
+        if: steps.creds.outputs.have_creds == 'true'
+        env:
+          PAX8_CLIENT_ID: ${{ secrets.PAX8_CLIENT_ID }}
+          PAX8_CLIENT_SECRET: ${{ secrets.PAX8_CLIENT_SECRET }}
+          NO_COLOR: "1"
+        run: pnpm test:integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,73 @@ packages/
 ## Testing
 
 ```bash
-pnpm test              # Run all tests
+pnpm test              # Run all tests (no credentials required)
 pnpm test:watch        # Watch mode
 pnpm test:coverage     # With coverage report
+pnpm test:integration  # Wire-level smoke tests against the real Pax8 API
 ```
 
 - Unit tests alongside source files (`*.test.ts`)
 - CLI integration tests in `packages/cli/src/__tests__/` (subprocess tests with `PAX8_DEMO=1`)
 - E2E flow tests in `e2e/`
+- Wire-level integration tests in `e2e/integration/` (real API; opt-in)
+
+### Wire-level integration tests (`pnpm test:integration`)
+
+A small, extensible suite that hits the real Pax8 API and asserts every
+call resolves to the URL documented by the relevant OpenAPI spec. Added in
+[#308](https://github.com/pax8labs/pax8-cli/issues/308) to close the gap
+that allowed the [#307](https://github.com/pax8labs/pax8-cli/issues/307)
+quotes `v1`/`v2` regression to ship — no test in the repo exercised a real
+wire URL.
+
+**Running locally with credentials:**
+
+```bash
+export PAX8_CLIENT_ID=...
+export PAX8_CLIENT_SECRET=...
+pnpm build              # the suite runs the built CLI, so build first
+pnpm test:integration
+```
+
+**Without credentials** the suite skips cleanly (exit 0) with a clear stderr
+message. The default `pnpm test` never depends on credentials — forks and
+local-only contributors are never blocked.
+
+**Adding a smoke test for a new resource:**
+
+1. Pick a read-only command for the resource (`list` is usually the right
+   shape). Writes against the real API are out of scope for this suite.
+2. Check `https://devx.pax8.com/openapi` for the spec that documents the
+   resource and note the version prefix (`/v1`, `/v2`, `/api/v2`, …).
+3. Add a file at `e2e/integration/<resource>.integration.test.ts`:
+
+   ```ts
+   import { it, expect } from "vitest";
+   import {
+     describeIntegration,
+     runCliVerbose,
+     expectExitZero,
+     expectWireUrl,
+   } from "./harness.js";
+
+   describeIntegration("widgets (v1)", () => {
+     it("widgets list hits /v1/widgets", async () => {
+       const result = await runCliVerbose(["widgets", "list", "--json"]);
+       expectExitZero(result);
+       expectWireUrl(result, {
+         method: "GET",
+         pathContains: "/v1/widgets",
+         version: "v1",
+       });
+     });
+   });
+   ```
+
+`describeIntegration` skips automatically when credentials are absent.
+`runCliVerbose` runs the built CLI with `--verbose` so `Pax8Client` emits
+the resolved URL on stderr; `expectWireUrl` parses that line and asserts
+the version segment. See `e2e/integration/harness.ts` for the full contract.
 
 ## Pull Requests
 

--- a/e2e/integration/companies.integration.test.ts
+++ b/e2e/integration/companies.integration.test.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Seed v1 smoke test (#308). Proves the default `/v1` routing reaches the
+ * real Pax8 partner API and returns a parseable response. See `harness.ts`
+ * for the extension pattern.
+ */
+
+import { it, expect } from "vitest";
+import {
+  describeIntegration,
+  runCliVerbose,
+  expectExitZero,
+  expectWireUrl,
+} from "./harness.js";
+
+describeIntegration("companies (v1)", () => {
+  it(
+    "companies list --json hits /v1/companies and returns an array",
+    async () => {
+      const result = await runCliVerbose(["companies", "list", "--json"]);
+
+      expectExitZero(result);
+      expectWireUrl(result, {
+        method: "GET",
+        pathContains: "/v1/companies",
+        version: "v1",
+      });
+
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      // Most real partner tenants have at least one company. Don't assert
+      // length > 0 — an empty-portfolio sandbox is still a valid v1 read.
+    },
+    60_000,
+  );
+});

--- a/e2e/integration/harness.ts
+++ b/e2e/integration/harness.ts
@@ -1,0 +1,241 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Sandbox integration test harness (#308).
+ *
+ * Hits the real Pax8 API using credentials from `PAX8_CLIENT_ID` /
+ * `PAX8_CLIENT_SECRET`. Skips cleanly when credentials are absent so local
+ * dev and credential-less CI both pass. Lives behind `pnpm test:integration`
+ * and is excluded from the default `pnpm test` — coupling the default test
+ * path to credentials would break forks and local-only contributors.
+ *
+ * # Why this exists
+ *
+ * The P0 bug in #307 (CLI quote calls resolving to `/v1/quotes` instead of
+ * `/v2/quotes`) shipped because no test in the repo exercised a real wire
+ * URL. Unit tests in `packages/core/src/api/*.test.ts` mock the client and
+ * only assert on relative path strings. Subprocess tests in
+ * `packages/cli/src/__tests__/` run with `PAX8_DEMO=1` against
+ * `MockPax8Client` — no wire calls at all. Both layers sit below the wire,
+ * so a version mismatch is invisible.
+ *
+ * This harness runs the built CLI with `--verbose` against the real API and
+ * asserts that the resolved URL hits the version documented by the relevant
+ * OpenAPI spec. If a future API class points at the wrong version segment,
+ * a wire smoke test here will catch it before the partner does.
+ *
+ * # How to add a smoke test for a new API surface
+ *
+ * 1. Decide which version the resource lives at by checking
+ *    `https://devx.pax8.com/openapi` for the relevant spec. Most resources
+ *    live at `/v1` (`partner-endpoints.json`); quotes live at `/v2`
+ *    (`quoting-endpoints.json`); webhooks live at `/api/v2`
+ *    (`webhooks-endpoints.json`); etc.
+ *
+ * 2. Pick a single read-only command for the resource — `list` is usually
+ *    the right shape (returns an array, exercises pagination, no required
+ *    inputs). Reads only: writes against the real API are out of scope for
+ *    this harness.
+ *
+ * 3. Add a `describe` block under `e2e/integration/`:
+ *
+ *    ```ts
+ *    describeIntegration("widgets (v1)", () => {
+ *      it("widgets list hits the documented v1 URL", async () => {
+ *        const result = await runCliVerbose(["widgets", "list", "--json"]);
+ *        expectExitZero(result);
+ *        expectWireUrl(result, {
+ *          method: "GET",
+ *          pathContains: "/v1/widgets",
+ *          version: "v1",
+ *        });
+ *      });
+ *    });
+ *    ```
+ *
+ *    `describeIntegration` skips cleanly when credentials are absent.
+ *
+ * 4. Keep each suite to **one read** per resource. The point is to catch
+ *    structural regressions (wrong version segment, broken auth, wrong
+ *    base URL) — not to re-test resource semantics, which subprocess tests
+ *    already cover under `PAX8_DEMO=1`.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe } from "vitest";
+
+const exec = promisify(execFile);
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const CLI_PATH = resolve(__dirname, "../../packages/cli/dist/index.js");
+
+/** Does the environment have credentials for the real Pax8 API? */
+export const HAS_CREDENTIALS =
+  !!process.env.PAX8_CLIENT_ID && !!process.env.PAX8_CLIENT_SECRET;
+
+// Surface the skip reason once per process so CI logs explain why every
+// suite is grey, without spamming on each file's import. Cheap, file-scoped.
+// Vitest forks a worker per file; the env-var marker propagates across
+// imports within a worker but each fresh worker prints once, which is fine.
+if (
+  !HAS_CREDENTIALS &&
+  !process.env.PAX8_INTEGRATION_QUIET &&
+  !process.env.__PAX8_INTEGRATION_SKIP_LOGGED__
+) {
+  process.env.__PAX8_INTEGRATION_SKIP_LOGGED__ = "1";
+  process.stderr.write(
+    "[integration] PAX8_CLIENT_ID / PAX8_CLIENT_SECRET not set — skipping wire-level integration tests. " +
+      "This is expected for forks, local dev, and credential-less CI runs.\n",
+  );
+}
+
+/**
+ * `describe`-style helper that skips the entire suite when credentials are
+ * absent. Use this as the outer block for every integration test file:
+ *
+ *   describeIntegration("quotes (v2)", () => { ... });
+ *
+ * When `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` are unset, the suite is
+ * registered with `describe.skip` so vitest exits 0 with a clean skip
+ * message instead of a false failure.
+ */
+export const describeIntegration: typeof describe = HAS_CREDENTIALS
+  ? describe
+  : describe.skip;
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Spawn the built CLI with `--verbose` so `Pax8Client.request` emits the
+ * resolved URL on stderr. `expectWireUrl` parses that line.
+ *
+ * Honors `PAX8_API_BASE` from the surrounding environment (e.g. sandbox
+ * pointing at `https://api-staging.pax8.com/v1`) — we never set it here.
+ */
+export async function runCliVerbose(args: string[]): Promise<CliResult> {
+  try {
+    const result = await exec("node", [CLI_PATH, "--verbose", ...args], {
+      env: { ...process.env, NO_COLOR: "1" },
+      timeout: 30_000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+      exitCode: typeof err.code === "number" ? err.code : 1,
+    };
+  }
+}
+
+/** Assert the CLI exited 0; if not, surface stdout + stderr in the failure message. */
+export function expectExitZero(result: CliResult): void {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Expected CLI to exit 0 but got ${result.exitCode}.\n` +
+        `--- stdout ---\n${result.stdout}\n` +
+        `--- stderr ---\n${result.stderr}`,
+    );
+  }
+}
+
+export interface WireUrlExpectation {
+  /** HTTP method the call should have used. */
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  /**
+   * Substring the resolved URL's pathname must contain — e.g. `"/v2/quotes"`.
+   * This is the load-bearing check: it catches wrong-version regressions like
+   * the #307 quotes bug (`/v1/quotes` when the spec only documents `/v2/quotes`).
+   */
+  pathContains: string;
+  /**
+   * Optional separate assertion on the version segment. If set, every
+   * matching call's URL must start with `<host>/<version>/...`. Mostly
+   * documentation — `pathContains` already covers the regression class —
+   * but useful for readability when the path substring doesn't pin version
+   * unambiguously.
+   */
+  version?: string;
+}
+
+/**
+ * Assert that the verbose-mode stderr trail contains at least one wire call
+ * matching `expected`. Parses lines emitted by `Pax8Client.request` of the
+ * form `[pax8] GET url=https://api.pax8.com/v2/quotes?page=0&size=50`.
+ *
+ * Throws a descriptive error if no matching call is observed, including the
+ * full list of URLs the run actually hit. This is intentionally noisy on
+ * failure: a wrong version segment is the exact class of bug we're catching.
+ */
+export function expectWireUrl(
+  result: CliResult,
+  expected: WireUrlExpectation,
+): void {
+  const calls = parseWireCalls(result.stderr);
+  if (calls.length === 0) {
+    throw new Error(
+      "No `[pax8] <METHOD> url=<URL>` lines found on stderr. " +
+        "Did you forget to pass `--verbose`? " +
+        "Did the CLI exit before any wire call was made?\n" +
+        `--- stderr ---\n${result.stderr}`,
+    );
+  }
+
+  const match = calls.find((call) => {
+    if (call.method !== expected.method) return false;
+    if (!call.url.pathname.includes(expected.pathContains)) return false;
+    if (expected.version) {
+      const versionRe = new RegExp(`^/${expected.version}(/|$)`);
+      if (!versionRe.test(call.url.pathname)) return false;
+    }
+    return true;
+  });
+
+  if (!match) {
+    const observed = calls
+      .map((c) => `  - ${c.method} ${c.url.toString()}`)
+      .join("\n");
+    const versionNote = expected.version
+      ? ` and starts with /${expected.version}/`
+      : "";
+    throw new Error(
+      `Expected at least one wire call where method=${expected.method} ` +
+        `and pathname contains "${expected.pathContains}"${versionNote}, ` +
+        `but observed:\n${observed}`,
+    );
+  }
+}
+
+interface WireCall {
+  method: string;
+  url: URL;
+}
+
+/**
+ * Parse `[pax8] <METHOD> url=<URL>` lines emitted by `Pax8Client` when
+ * `debug` is on. Lines without a parseable URL (or any other stderr noise:
+ * spinners, banners, ANSI) are silently skipped — this is a tolerant parser.
+ */
+function parseWireCalls(stderr: string): WireCall[] {
+  const lineRe = /\[pax8\]\s+(GET|POST|PUT|PATCH|DELETE)\s+url=(\S+)/g;
+  const calls: WireCall[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = lineRe.exec(stderr)) !== null) {
+    try {
+      calls.push({ method: match[1]!, url: new URL(match[2]!) });
+    } catch {
+      // ignore malformed URLs — the parser is best-effort
+    }
+  }
+  return calls;
+}

--- a/e2e/integration/quotes.integration.test.ts
+++ b/e2e/integration/quotes.integration.test.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Seed v2 smoke test (#308). Proves the post-#316 `/v2` routing for quotes
+ * reaches the real Pax8 quoting API. This is the test that would have
+ * failed for #307 (quote calls hitting `/v1/quotes` instead of `/v2/quotes`)
+ * if it had existed before #266 shipped. See `harness.ts` for the extension
+ * pattern.
+ */
+
+import { it, expect } from "vitest";
+import {
+  describeIntegration,
+  runCliVerbose,
+  expectExitZero,
+  expectWireUrl,
+} from "./harness.js";
+
+describeIntegration("quotes (v2)", () => {
+  it(
+    "quotes list --json hits /v2/quotes and returns a paginated result",
+    async () => {
+      const result = await runCliVerbose(["quotes", "list", "--json"]);
+
+      expectExitZero(result);
+      expectWireUrl(result, {
+        method: "GET",
+        pathContains: "/v2/quotes",
+        version: "v2",
+      });
+
+      const data = JSON.parse(result.stdout);
+      // `quotes list` outputs the paginated `content` array directly.
+      // Empty-portfolio sandboxes are valid here; the load-bearing assertion
+      // is the wire URL above.
+      expect(Array.isArray(data) || typeof data === "object").toBe(true);
+    },
+    60_000,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint packages/*/src/**/*.ts",
     "format": "prettier --write .",
     "dev": "pnpm --filter @pax8/cli dev",
-    "test:real": "vitest run e2e/real-api.test.ts"
+    "test:real": "vitest run e2e/real-api.test.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -235,6 +235,12 @@ export class Pax8Client {
         try {
           if (this.debug) {
             process.stderr.write(`[pax8] ${method} ${path}\n`);
+            // #308: emit the resolved absolute URL so wire-level integration
+            // tests can assert which API version each call actually hits. The
+            // relative `path` above is preserved as the human-readable summary;
+            // the `url=` line is the machine-parseable form. Query strings are
+            // safe here (no bearer tokens are ever placed in URL params).
+            process.stderr.write(`[pax8] ${method} url=${url.toString()}\n`);
           }
 
           const response = await fetch(url.toString(), init);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["packages/*/src/**/*.test.ts", "e2e/**/*.test.ts"],
+    // #308: wire-level integration tests under `e2e/integration/` hit the
+    // real Pax8 API and require credentials. They live behind their own
+    // runner (`pnpm test:integration` → `vitest.integration.config.ts`).
+    // Keeping them out of the default `pnpm test` is a hard contract: it
+    // means forks, credential-less CI, and local dev never break because
+    // of missing secrets.
+    exclude: ["**/node_modules/**", "e2e/integration/**"],
     // #262: tests routinely point PAX8_CONFIG_DIR at `os.tmpdir()` (which
     // resolves outside `os.homedir()` on macOS / Linux) for isolation. The
     // new validateConfigDir() guard would reject those by default, so opt

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from "vitest/config";
+
+/**
+ * Integration test config (#308).
+ *
+ * Runs only the wire-level smoke tests under `e2e/integration/`. These tests
+ * hit the real Pax8 API using credentials from `PAX8_CLIENT_ID` /
+ * `PAX8_CLIENT_SECRET` and skip cleanly when credentials are absent (see
+ * `e2e/integration/harness.ts`).
+ *
+ * Kept separate from `vitest.config.ts` because:
+ * - Default `pnpm test` must never depend on credentials (forks, local dev).
+ * - Per-test timeouts are larger here — real network calls vs. mocked fetch.
+ * - No coverage / no isolation-setup needed for this suite.
+ *
+ * Run with `pnpm test:integration`.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["e2e/integration/**/*.test.ts"],
+    env: {
+      // Match the production-test escape hatch from vitest.config.ts so that
+      // any helper that resolves PAX8_CONFIG_DIR doesn't reject a non-home
+      // path (e.g. on hosted CI where $HOME is unusual).
+      PAX8_ALLOW_NON_HOME_CONFIG: "1",
+    },
+    // No globalSetup — these tests don't need a temp config dir; they read
+    // credentials directly from the environment. Per-test timeout is bumped
+    // because real network round-trips can be slow.
+    testTimeout: 60_000,
+    hookTimeout: 30_000,
+    passWithNoTests: true,
+    // Run files serially — the real API has per-key rate limits and we don't
+    // want to burn through them on a credential-less skip run, let alone a
+    // real run. Cheap insurance against accidental concurrency.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary

Builds the reusable wire-level integration test harness from #308. Hits the real Pax8 API using `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` and asserts every CLI call resolves to the URL documented by the relevant OpenAPI spec. Skips cleanly when credentials are absent — the default `pnpm test` never depends on credentials, so forks and local-only contributors are never blocked.

- New `pnpm test:integration` runner backed by `vitest.integration.config.ts`. Default `pnpm test` is unchanged and stays credential-free (hard contract from #308).
- Seed coverage: one v1 read (`companies list`) and one v2 read (`quotes list`) — the harness would have caught #307 (quotes `/v1` vs `/v2`) and will catch #322 (webhooks `/v1` vs `/api/v2`) once that fix lands.
- `Pax8Client` debug mode now also emits the resolved absolute URL on stderr (`[pax8] GET url=https://api.pax8.com/v2/quotes`). The harness parses that line; query strings carry no bearer tokens. Existing relative-path debug log is preserved.
- Documented extension pattern in `e2e/integration/harness.ts` and a new "Wire-level integration tests" section in `CONTRIBUTING.md` — any new API surface plugs in with one read-only smoke test.
- New `.github/workflows/integration.yml` runs `pnpm test:integration` only when `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` repo secrets are present. `continue-on-error: true` so the job is **informational and does NOT block PR merges**. Remove that flag once the team agrees the suite is stable enough to gate merges on.

## Unblocks

This was the prerequisite for the body-shape fixes that were held until wire-level test coverage existed:

- #311, #312, #313, #314 (per-operation quote write body shapes)
- Parallel audit follow-ups: #323, #325, #326, #327, #328, #329, #331, #332

Each of those fixes can now plug in by adding a single read-only smoke test under `e2e/integration/` following the documented pattern.

## Test plan

- [x] `pnpm build && pnpm test` — default suite passes unchanged (1584 passed, 8 skipped — same as main)
- [x] `pnpm lint` — clean
- [x] `pnpm test:integration` without credentials — exits 0 with a clear stderr skip line, no false failures
- [ ] `pnpm test:integration` with real `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` set — both seed tests pass and assert the expected `/v1/companies` and `/v2/quotes` wire URLs (reviewer to verify locally before flipping `continue-on-error` to false in a follow-up)
- [ ] CI `Integration` job runs on this PR — should report "skipped" since fork PRs / unconfigured secrets don't see credentials. Once secrets are added to the repo, the job will run for real.

## Notes for reviewers

- The CI workflow is intentionally non-blocking. Flip `continue-on-error: false` (and optionally add it to a required-checks list) in a follow-up PR once the team agrees the seed suite is stable.
- The harness deliberately does not intercept `fetch` globally — that would defeat the purpose of a wire test. It parses the existing `--verbose` stderr trail instead, which keeps the test honest about what the real CLI does.
- Reads only; writes against the real API are out of scope per #308.

Closes #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)