### PR TITLE
fix(quotes): line-items add sends required effectiveDate and price (closes #312)

### DIFF
--- a/.changeset/quotes-line-items-add-effective-date-price.md
+++ b/.changeset/quotes-line-items-add-effective-date-price.md
@@ -1,0 +1,12 @@
+---
+"@pax8/core": patch
+"@pax8/cli": patch
+---
+
+Fix: `pax8 quotes line-items add` now sends the `effectiveDate` and `price` fields that the v2 `POST /v2/quotes/{quoteId}/line-items` Standard payload requires. Before this fix the call had the right URL (post-#316) but a 4xx-eliciting body — the v2 `AddStandardLineItemPayload` schema marks both fields required, and the CLI sent neither.
+
+`effectiveDate` defaults to today (UTC), normalized to ISO 8601 (`YYYY-MM-DDT00:00:00Z`); `price` defaults to the product's list price (`suggestedRetailPrice`) for the chosen billing term, resolved via `products getPricing` and cached per command run. Both are overridable via new flags: `--effective-date <YYYY-MM-DD>` (strict format) and `--price <number>` (non-negative). The Standard payload is the only shape exposed — Custom and UsageBased remain out of scope (separate scope decision per #310).
+
+Schema change: `AddQuoteLineItemInputSchema` in `@pax8/core` now requires `effectiveDate: z.string()` and `price: z.number()`. Downstream callers constructing `AddQuoteLineItemInput` directly must supply both.
+
+Closes #312.

--- a/docs/triage/quotes-api-version.md
+++ b/docs/triage/quotes-api-version.md
@@ -154,7 +154,7 @@ Five of the ten quote operations need body-shape work in addition to the wire-pa
 | `POST /v2/quotes` (create) | `{ companyId, lineItems[] }` | `{ clientId }` (required) + `quoteRequestId` (optional). **No `lineItems` on create.** | Field rename (`companyId` → `clientId`) + structural (line items must be added via a separate `POST /v2/quotes/{id}/line-items` after create) |
 | `PUT /v2/quotes/{id}` (update) | `{ lineItems?, expiresOn? }` | All five required: `{ expiresOn, introMessage, published, status, termsAndDisclaimers }` | Field-only PUT rejected — need fetch-then-merge. For line-item replacement, use `PUT /v2/quotes/{id}/line-items` instead. |
 | `PUT /v2/quotes/{id}` (setStatus / send) | `{ status }` | Same five required — no separate status-transition endpoint exists in the spec | Same as `update`: fetch-then-merge |
-| `POST /v2/quotes/{id}/line-items` (addLineItem) | `[{ type: "Standard", productId, quantity, billingTerm? }]` | For Standard: `{ type, productId, quantity, billingTerm, effectiveDate, price }` — **`effectiveDate` and `price` are required and currently missing** | Missing required fields |
+| `POST /v2/quotes/{id}/line-items` (addLineItem) | ~~`[{ type: "Standard", productId, quantity, billingTerm? }]`~~ → `[{ type: "Standard", productId, quantity, billingTerm?, effectiveDate, price }]` | For Standard: `{ type, productId, quantity, billingTerm, effectiveDate, price }` | **Resolved (#312).** `effectiveDate` defaults to today (UTC); `price` resolves from the product's list price (`suggestedRetailPrice`) for the chosen billing term. `--effective-date` and `--price` flags expose overrides. |
 
 The five read paths (`list`, `get`, `delete`, `removeLineItem`, `line-items list` via re-fetch) only need the wire-path fix.
 

--- a/packages/cli/src/__tests__/quotes.line-items.test.ts
+++ b/packages/cli/src/__tests__/quotes.line-items.test.ts
@@ -49,7 +49,7 @@ describe("pax8 quotes line-items", () => {
   });
 
   describe("line-items add", () => {
-    it("adds a line item and prints the new ID + count (auto-confirm with -y)", async () => {
+    it("adds a line item and prints the new ID + count (auto-confirm with -y, default price resolves from product catalog)", async () => {
       const result = await runCliExpectSuccess([
         "quotes",
         "line-items",
@@ -73,6 +73,101 @@ describe("pax8 quotes line-items", () => {
       expect(data[0].lineItemId).toMatch(/^li-/);
       // Started at 1 line item, should now be 2.
       expect(data[0].lineItemCount).toBe(2);
+      // The default-price resolution should produce a non-null unitPrice on
+      // the newly added line. Per #312: with no `--price` flag, the command
+      // looks up the product's list price for the chosen billing term.
+      const newLineId = data[0].lineItemId as string;
+      const newLine = (data[0].quote.lineItems as Array<{ id: string; unitPrice?: number }>).find(
+        (li) => li.id === newLineId,
+      );
+      expect(newLine).toBeDefined();
+      expect(typeof newLine?.unitPrice).toBe("number");
+      expect(newLine!.unitPrice).toBeGreaterThan(0);
+    });
+
+    it("--price overrides the resolved default", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-aad-p1-0008",
+        "--quantity",
+        "2",
+        "--billing-term",
+        "Monthly",
+        "--price",
+        "99.99",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      const newLineId = data[0].lineItemId as string;
+      const newLine = (data[0].quote.lineItems as Array<{ id: string; unitPrice?: number }>).find(
+        (li) => li.id === newLineId,
+      );
+      // Confirms the explicit --price flows through to the mock client and
+      // wins over the default list-price lookup.
+      expect(newLine?.unitPrice).toBe(99.99);
+    });
+
+    it("--effective-date accepts YYYY-MM-DD", async () => {
+      // The mock client doesn't persist effectiveDate in the demo line item
+      // shape, but we exercise the CLI plumbing end-to-end — the command must
+      // parse the flag, validate the format, and exit 0.
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-aad-p1-0008",
+        "--quantity",
+        "1",
+        "--effective-date",
+        "2026-06-15",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0]).toHaveProperty("lineItemId");
+    });
+
+    it("rejects malformed --effective-date", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-aad-p1-0008",
+        "--quantity",
+        "1",
+        "--effective-date",
+        "06/15/2026",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/effective-date/i);
+    });
+
+    it("rejects negative --price", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-aad-p1-0008",
+        "--quantity",
+        "1",
+        "--price",
+        "-1",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/[Ii]nvalid price/);
     });
 
     it("rejects non-positive quantity", async () => {

--- a/packages/cli/src/commands/quotes/line-items/add.ts
+++ b/packages/cli/src/commands/quotes/line-items/add.ts
@@ -11,8 +11,109 @@ import { confirm, replCmd } from "../../../lib/confirm.js";
 import { resolveProduct } from "../../../lib/resolve-product.js";
 import { invalidateCacheAfterWrite } from "../../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../../lib/signals.js";
-import { formatQuantity } from "../../../lib/formatters.js";
-import { ERROR_INVALID_INPUT, type BillingTerm, type AddQuoteLineItemInput } from "@pax8/core";
+import { formatQuantity, formatCurrency as formatPrice } from "../../../lib/formatters.js";
+import {
+  ERROR_INVALID_INPUT,
+  type BillingTerm,
+  type AddQuoteLineItemInput,
+  type ProductPricingPlan,
+} from "@pax8/core";
+import type { CommandContext } from "../../../lib/context.js";
+
+/**
+ * Normalize a user-supplied `--effective-date` (or the default of "today,
+ * UTC") to the ISO 8601 date-time string the v2 quoting API requires on
+ * `AddStandardLineItemPayload`. Accepts `YYYY-MM-DD` for the user-friendly
+ * shape; rejects anything that doesn't round-trip through `Date`. The output
+ * is always midnight UTC of the chosen day — line-item effective dates are
+ * day-grained on the upstream side, and pinning the time avoids accidental
+ * day shifts when the user's local zone is ahead/behind UTC.
+ */
+function resolveEffectiveDate(raw: string | undefined): string {
+  if (!raw) {
+    // Today in UTC, midnight.
+    const now = new Date();
+    return `${now.toISOString().slice(0, 10)}T00:00:00Z`;
+  }
+  // Accept `YYYY-MM-DD` (strict — anything else is rejected to avoid
+  // ambiguous zone-relative parses).
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    throw new CliError(
+      `Invalid --effective-date: "${raw}"`,
+      ["Use the YYYY-MM-DD format (e.g. 2026-06-01)"],
+      undefined,
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  const parsed = new Date(`${raw}T00:00:00Z`);
+  if (isNaN(parsed.getTime())) {
+    throw new CliError(
+      `Invalid --effective-date: "${raw}"`,
+      ["Use a real calendar date in YYYY-MM-DD form"],
+      undefined,
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return `${raw}T00:00:00Z`;
+}
+
+/**
+ * Resolve the default per-unit list price for a product at a given billing
+ * term. Returns `suggestedRetailPrice` from the first matching pricing plan
+ * (matching `cost-simulator` / `orders create` conventions). Returns
+ * `undefined` if the product has no pricing or no plan for the chosen term —
+ * callers fall back to requiring `--price` and surfacing a clear error.
+ *
+ * Caching is per-command-run via a module-level `Map` keyed by productId.
+ * `quotes line-items add` is a single write per invocation, so this is
+ * effectively a memoize on the one product the command touches.
+ */
+const pricingCache = new Map<string, ProductPricingPlan[]>();
+
+async function resolveListPrice(
+  ctx: CommandContext,
+  productId: string,
+  billingTerm: BillingTerm,
+): Promise<number | undefined> {
+  let pricing = pricingCache.get(productId);
+  if (!pricing) {
+    try {
+      pricing = await ctx.api.products.getPricing(productId);
+      pricingCache.set(productId, pricing);
+    } catch {
+      // Best-effort: a 404 / parse failure means we have no default to
+      // offer. The caller will fail closed with a helpful message.
+      return undefined;
+    }
+  }
+  if (!pricing || pricing.length === 0) return undefined;
+
+  // Term match: case-insensitive exact, with the Annual/Yearly alias the
+  // rest of the codebase honors (see `cost-simulator.findPlan`).
+  const want = billingTerm.toLowerCase();
+  let plan =
+    pricing.find((p) => p.billingTerm.toLowerCase() === want)
+    ?? (want.includes("annual") || want.includes("yearly")
+      ? pricing.find(
+          (p) =>
+            p.billingTerm.toLowerCase().includes("annual")
+            || p.billingTerm.toLowerCase().includes("yearly"),
+        )
+      : undefined)
+    ?? (want.includes("month")
+      ? pricing.find((p) => p.billingTerm.toLowerCase().includes("month"))
+      : undefined);
+
+  if (!plan) return undefined;
+
+  // First rate row — matches `orders create` (#312 note: real Pax8 pricing
+  // can carry multiple tiers; quotes don't use them and the partner can
+  // always override via `--price`).
+  const rate = plan.rates?.[0];
+  return rate?.suggestedRetailPrice;
+}
 
 export const quotesLineItemsAddCommand = new Command("add")
   .description("Add a line item to a quote")
@@ -20,6 +121,14 @@ export const quotesLineItemsAddCommand = new Command("add")
   .requiredOption("--product <id|name>", "Product ID or name (required)")
   .option("--quantity <number>", "Quantity", "1")
   .option("--billing-term <term>", "Billing term (Monthly or Annual)", "Monthly")
+  .option(
+    "--price <number>",
+    "Per-unit price for the line (defaults to the product's list price for the chosen billing term)",
+  )
+  .option(
+    "--effective-date <YYYY-MM-DD>",
+    "Effective date for the line (defaults to today, UTC)",
+  )
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
@@ -27,6 +136,8 @@ export const quotesLineItemsAddCommand = new Command("add")
 Examples:
   pax8 quotes line-items add quote-summit-001 --product "Microsoft 365 E3" --quantity 5
   pax8 quotes line-items add quote-summit-001 --product prod-aad-p1-0008 --quantity 5 --billing-term Annual
+  pax8 quotes line-items add quote-summit-001 --product prod-m365-e3-0003 --quantity 5 --price 22.50
+  pax8 quotes line-items add quote-summit-001 --product prod-m365-e3-0003 --quantity 5 --effective-date 2026-06-01
   pax8 quotes line-items add quote-summit-001 --product prod-m365-e3-0003 --quantity 5 --json --yes`,
   )
   .action(async (quoteId, options, command) => {
@@ -45,6 +156,28 @@ Examples:
         );
       }
 
+      // Resolve `--price` override if provided. Validate up-front so a bad
+      // value fails before any network/IO work.
+      let priceOverride: number | undefined;
+      if (options.price !== undefined) {
+        const parsed = Number(options.price);
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          throw new CliError(
+            `Invalid price: "${options.price}"`,
+            ["Price must be a non-negative number"],
+            undefined,
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+        priceOverride = parsed;
+      }
+
+      // Resolve `--effective-date` override or default to today (UTC). The v2
+      // spec requires an ISO 8601 date-time; we accept the friendlier
+      // `YYYY-MM-DD` shape from the user and normalize to `T00:00:00Z`.
+      const effectiveDate = resolveEffectiveDate(options.effectiveDate);
+
       const fetchSpinner = createSpinner("Fetching quote...").start();
       const quote = await ctx.api.quotes.get(quoteId);
       // Snapshot pre-state line-item IDs immediately. In demo mode the
@@ -57,11 +190,40 @@ Examples:
 
       const product = await resolveProduct(ctx, options.product);
 
+      // Resolve unit price: explicit `--price` wins; otherwise look up the
+      // product's list price (`suggestedRetailPrice`) for the chosen
+      // billing term. The lookup is best-effort and cached per command run,
+      // matching the convention used by `orders create` (#312).
+      const billingTerm = options.billingTerm as BillingTerm;
+      const price = priceOverride
+        ?? (await resolveListPrice(ctx, product.id, billingTerm));
+
+      if (price === undefined) {
+        throw new CliError(
+          `No list price found for "${product.name}" at billing term "${billingTerm}"`,
+          [
+            `Pass --price <number> to set the per-unit price explicitly`,
+            `Try a different --billing-term (Monthly or Annual)`,
+          ],
+          undefined,
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
       process.stderr.write(chalk.bold("\n  Add line item:\n\n"));
       process.stderr.write(`  ${chalk.dim("Quote:".padEnd(18))}${quote.id} ${chalk.dim(`(${quote.status})`)}\n`);
       process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${product.name}\n`);
       process.stderr.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(quantity)}\n`);
-      process.stderr.write(`  ${chalk.dim("Billing term:".padEnd(18))}${options.billingTerm}\n`);
+      process.stderr.write(`  ${chalk.dim("Billing term:".padEnd(18))}${billingTerm}\n`);
+      process.stderr.write(
+        `  ${chalk.dim("Unit price:".padEnd(18))}${formatPrice(price)}${
+          priceOverride !== undefined ? chalk.dim(" (override)") : chalk.dim(" (list)")
+        }\n`,
+      );
+      process.stderr.write(
+        `  ${chalk.dim("Effective date:".padEnd(18))}${effectiveDate.slice(0, 10)}\n`,
+      );
       process.stderr.write(`  ${chalk.dim("Existing items:".padEnd(18))}${quote.lineItems?.length ?? 0}\n\n`);
 
       const ok = await confirm("Add this line item?", { default: true });
@@ -73,7 +235,9 @@ Examples:
       const input: AddQuoteLineItemInput = {
         productId: product.id,
         quantity,
-        billingTerm: options.billingTerm as BillingTerm,
+        billingTerm,
+        effectiveDate,
+        price,
       };
 
       const spinner = createSpinner("Adding line item...").start();

--- a/packages/cli/src/commands/quotes/line-items/add.ts
+++ b/packages/cli/src/commands/quotes/line-items/add.ts
@@ -93,7 +93,7 @@ async function resolveListPrice(
   // Term match: case-insensitive exact, with the Annual/Yearly alias the
   // rest of the codebase honors (see `cost-simulator.findPlan`).
   const want = billingTerm.toLowerCase();
-  let plan =
+  const plan =
     pricing.find((p) => p.billingTerm.toLowerCase() === want)
     ?? (want.includes("annual") || want.includes("yearly")
       ? pricing.find(

--- a/packages/core/src/api/quotes.test.ts
+++ b/packages/core/src/api/quotes.test.ts
@@ -105,7 +105,7 @@ describe("QuotesApi", () => {
     expect(client.delete).toHaveBeenCalledWith(`/quotes/${QUOTE_ID}`, undefined, V2_OPTS);
   });
 
-  it("addLineItem POSTs an array with a Standard payload then re-fetches the quote (routed to /v2)", async () => {
+  it("addLineItem POSTs an array with a Standard payload including effectiveDate and price then re-fetches the quote (routed to /v2)", async () => {
     (client.post as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(sampleQuote);
     const productId = "d4e5f6a7-b890-1234-cdef-567890123456";
@@ -114,8 +114,14 @@ describe("QuotesApi", () => {
       productId,
       quantity: 4,
       billingTerm: "Annual",
+      effectiveDate: "2026-06-01T00:00:00Z",
+      price: 22.5,
     });
 
+    // Per #312: `effectiveDate` and `price` are required by the v2
+    // `AddStandardLineItemPayload` schema. If this assertion regresses, the
+    // command will start sending the pre-#312 payload and the API will reject
+    // it with a 4xx body-shape error.
     expect(client.post).toHaveBeenCalledWith(
       `/quotes/${QUOTE_ID}/line-items`,
       [
@@ -124,12 +130,41 @@ describe("QuotesApi", () => {
           productId,
           quantity: 4,
           billingTerm: "Annual",
+          effectiveDate: "2026-06-01T00:00:00Z",
+          price: 22.5,
         },
       ],
       V2_OPTS,
     );
     expect(client.get).toHaveBeenCalledWith(`/quotes/${QUOTE_ID}`, undefined, V2_OPTS);
     expect(result.id).toBe(QUOTE_ID);
+  });
+
+  it("addLineItem omits billingTerm from the payload when caller doesn't set it", async () => {
+    (client.post as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(sampleQuote);
+    const productId = "d4e5f6a7-b890-1234-cdef-567890123456";
+
+    await api.addLineItem(QUOTE_ID, {
+      productId,
+      quantity: 1,
+      effectiveDate: "2026-06-01T00:00:00Z",
+      price: 10,
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/quotes/${QUOTE_ID}/line-items`,
+      [
+        {
+          type: "Standard",
+          productId,
+          quantity: 1,
+          effectiveDate: "2026-06-01T00:00:00Z",
+          price: 10,
+        },
+      ],
+      V2_OPTS,
+    );
   });
 
   it("removeLineItem DELETEs the nested line-item path (routed to /v2)", async () => {

--- a/packages/core/src/api/quotes.ts
+++ b/packages/core/src/api/quotes.ts
@@ -74,12 +74,18 @@ export class QuotesApi {
    * about (totals, status).
    */
   async addLineItem(quoteId: string, input: AddQuoteLineItemInput): Promise<Quote> {
+    // `effectiveDate` and `price` are required fields on
+    // `AddStandardLineItemPayload` per the v2 quoting spec. See #312 and
+    // `docs/triage/quotes-api-version.md` §9.1 — the CLI command resolves
+    // sensible defaults (today, list price) before constructing this input.
     const payload = [
       {
         type: "Standard",
         productId: input.productId,
         quantity: input.quantity,
         ...(input.billingTerm ? { billingTerm: input.billingTerm } : {}),
+        effectiveDate: input.effectiveDate,
+        price: input.price,
       },
     ];
     await this.client.post<unknown>(`/quotes/${quoteId}/line-items`, payload, V2);

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -620,12 +620,21 @@ export type UpdateQuoteInput = z.infer<typeof UpdateQuoteInputSchema>;
  * line item. The upstream API accepts an array of mixed-type payloads
  * (Standard / Custom / UsageBased); we expose the common Standard shape here
  * because that's what `quotes line-items add` constructs from `--product`,
- * `--quantity`, and `--billing-term`.
+ * `--quantity`, `--billing-term`, `--price`, and `--effective-date`.
+ *
+ * `effectiveDate` and `price` are required by the v2 `AddStandardLineItemPayload`
+ * schema (see #312, `docs/triage/quotes-api-version.md` §9.1). `effectiveDate`
+ * is an ISO 8601 date-time string (e.g. `2026-05-11T00:00:00Z`); `price` is the
+ * per-unit price the partner is quoting to the customer (defaults to the
+ * product's list price / `suggestedRetailPrice` for the chosen `billingTerm`
+ * when the CLI resolves it).
  */
 export const AddQuoteLineItemInputSchema = z.object({
   productId: z.string(),
   quantity: z.number().int().positive(),
   billingTerm: BillingTermSchema.optional(),
+  effectiveDate: z.string(),
+  price: z.number(),
 });
 export type AddQuoteLineItemInput = z.infer<typeof AddQuoteLineItemInputSchema>;
 

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -622,13 +622,16 @@ class QuotesResource {
     await randomDelay();
     const quote = quotes.find((q) => q.id === quoteId);
     if (!quote) throw notFound("Quote", quoteId);
-    // Try to fetch a unit price from the demo product so the new line shows
-    // sensible totals in tables. Pricing lookups silently fall through —
-    // a missing price just means the line shows "—" in the UI.
+    // Prefer the explicit `input.price` (required since #312 to mirror the
+    // v2 `AddStandardLineItemPayload` schema). Fall back to the demo
+    // product's plan price only if the caller bypassed the CLI layer and
+    // somehow handed us an input without a price. Pricing lookups silently
+    // fall through — a missing price just means the line shows "—" in the UI.
     const product = products.find((p) => p.id === input.productId);
     const term = input.billingTerm ?? "Monthly";
     const plan = product?.pricing.find((p) => p.billingTerm === term);
-    const unitPrice = plan?.partnerBuyPrice;
+    const unitPrice =
+      typeof input.price === "number" ? input.price : plan?.partnerBuyPrice;
     const newId = `li-demo-${Date.now()}`;
     const newLine = {
       id: newId,


### PR DESCRIPTION
## Summary

After #316 routed `pax8 quotes line-items add` to `/v2`, the request still failed with a 4xx body-shape error: the v2 `AddStandardLineItemPayload` schema marks `effectiveDate` and `price` required, and the CLI sent neither. This PR resolves both with sensible defaults and exposes overrides for partner-customized pricing and future-dated lines.

- **`effectiveDate`** defaults to today (UTC), normalized to ISO 8601 `YYYY-MM-DDT00:00:00Z`; new `--effective-date <YYYY-MM-DD>` flag overrides (strict format).
- **`price`** defaults to the product's list price (`suggestedRetailPrice`) for the chosen billing term, resolved via `products getPricing` and cached per command run; new `--price <number>` flag overrides.
- `AddQuoteLineItemInputSchema` in `@pax8/core` now requires `effectiveDate: z.string()` and `price: z.number()`. `QuotesApi.addLineItem()` forwards both in the Standard payload. The mock client honors `input.price` so demo-mode line items reflect what the partner sent.
- Scope: Standard line-items only. Custom and UsageBased shapes remain out of scope per #310.
- `docs/triage/quotes-api-version.md` §9.1 updated to mark this row resolved.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` clean (1,621 pass / 8 pre-existing skips)
- [x] `pnpm lint` clean
- [x] Unit tests in `packages/core/src/api/quotes.test.ts` pin the new payload shape (including the `effectiveDate` + `price` fields) and verify `billingTerm` is still optional in the request
- [x] Subprocess tests in `packages/cli/src/__tests__/quotes.line-items.test.ts` cover the default-price resolution path, the `--price` override path, the `--effective-date` override path, malformed-date rejection, and negative-price rejection
- [ ] Integration test in `e2e/integration/` is read-only by design (per `harness.ts` doc) — writes against sandbox are out of scope for this PR; the harness already covers the v2 wire-path for `quotes list`

## Conventions

- Conventional Commits + DCO sign-off
- Changeset added (`@pax8/cli` + `@pax8/core` patch)
- Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)