### PR TITLE
fix(companies): use PATCH instead of PUT for update (closes #326)

### DIFF
--- a/.changeset/companies-update-patch-method.md
+++ b/.changeset/companies-update-patch-method.md
@@ -1,0 +1,5 @@
+---
+"@pax8/core": patch
+---
+
+`CompaniesApi.update` now uses PATCH instead of PUT to match the public OpenAPI contract. The public spec documents only `get` and `patch` on `/companies/{companyId}` — PUT is undocumented and would either 405 or rely on legacy aliasing. The CLI's partial-body approach is unchanged (it was always correct for PATCH semantics); only the verb on the wire moves. `pax8 companies update` UX is unaffected.

--- a/packages/core/src/api/companies.test.ts
+++ b/packages/core/src/api/companies.test.ts
@@ -72,14 +72,15 @@ describe("CompaniesApi", () => {
     expect(result.name).toBe("New Corp");
   });
 
-  it("update sends correct body and returns company", async () => {
+  it("update sends correct body and returns company via PATCH", async () => {
     const input = { name: "Updated Corp" };
     const updated = { ...sampleCompany, name: "Updated Corp" };
-    (client.put as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+    (client.patch as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
 
     const result = await api.update(COMPANY_ID, input);
 
-    expect(client.put).toHaveBeenCalledWith(`/companies/${COMPANY_ID}`, input);
+    expect(client.patch).toHaveBeenCalledWith(`/companies/${COMPANY_ID}`, input);
+    expect(client.put).not.toHaveBeenCalled();
     expect(result.name).toBe("Updated Corp");
   });
 

--- a/packages/core/src/api/companies.ts
+++ b/packages/core/src/api/companies.ts
@@ -32,7 +32,7 @@ export class CompaniesApi {
   }
 
   async update(id: string, data: UpdateCompanyInput): Promise<Company> {
-    const raw = await this.client.put<unknown>(`/companies/${id}`, data);
+    const raw = await this.client.patch<unknown>(`/companies/${id}`, data);
     return CompanySchema.parse(raw);
   }
 }


### PR DESCRIPTION
## Summary

- `CompaniesApi.update` now issues `PATCH /companies/{id}` instead of `PUT`. The public Pax8 OpenAPI spec documents only `get` and `patch` on `/companies/{companyId}`; PUT is undocumented and the API may 405 it or rely on legacy aliasing.
- Unit test updated to assert `client.patch` is called and `client.put` is not.
- CLI handler (`packages/cli/src/commands/companies/update.ts`) is unchanged — it already sends a true partial body containing only user-supplied flags, which is the correct shape for PATCH semantics.
- `@pax8/core` changeset (patch) explaining the wire-only change.

Verified the spec via the audit triage notes referenced in #326: PATCH operation `operationId: updateCompany` with description "Updates an existing Company. ATTENTION - at least one parameter has to be modified." The handler already enforces "at least one flag provided".

Generic `client.put` wire test in `client-extended.test.ts` left intact — it tests the generic verb, not `CompaniesApi.update` specifically. Per the issue, the mocked-client unit assertion is the contract for the API class.

Closes #326.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test packages/core/src/api/companies.test.ts` — 5/5 pass
- [x] `pnpm test packages/cli/src/__tests__/companies.test.ts` — 16/16 pass
- [x] `pnpm test` — all suites pass on re-run; one unrelated pre-existing flake in `e2e/per-command.test.ts > pax8 orders list > idempotent` (non-deterministic line counts) cleared on retry — not touched by this change
- [x] `pnpm lint` — clean (no new `let`/`prefer-const` issues; this PR adds no new variables)