### PR TITLE
fix(subscriptions): send cancelDate as ISO date-time on the wire

### DIFF
--- a/.changeset/subscriptions-cancel-date-time-wire-shape.md
+++ b/.changeset/subscriptions-cancel-date-time-wire-shape.md
@@ -1,0 +1,8 @@
+---
+"@pax8/core": patch
+"@pax8/cli": patch
+---
+
+Fix: `pax8 subscriptions cancel --cancel-date` now sends the `cancelDate` query parameter as RFC 3339 / ISO 8601 `date-time` (`YYYY-MM-DDT00:00:00Z`) to match the Pax8 OpenAPI spec, which types the parameter as `format: date-time`. Previously the CLI sent the date-only form `YYYY-MM-DD` — most APIs accept that leniently, but the contract mismatch was unverified and would have surprised partners reading the spec.
+
+User-facing behavior is unchanged: the `--cancel-date` flag still accepts (and only accepts) the simple `YYYY-MM-DD` form, and `--json` output still emits `cancelDate` as `YYYY-MM-DD`. The normalization happens inside `SubscriptionsApi.delete()` just before the wire call, mirroring the defensive `effectiveDate` normalization landed for `quotes line-items add` in #312. Closes #333.

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -539,6 +539,28 @@ describe("pax8 subscriptions cancel", () => {
     });
   });
 
+  // #333: the underlying wire payload was changed from date-only to
+  // ISO date-time to match the OpenAPI spec (`format: date-time`). The
+  // partner-facing surface (--cancel-date flag input, --json output
+  // `cancelDate` field) intentionally stays date-only so existing
+  // partner scripts keep working. This test pins that contract.
+  it("--cancel-date 2026-06-01 yields a date-only JSON output (#333)", async () => {
+    const result = await runCliExpectSuccess([
+      "subscriptions",
+      "cancel",
+      "sub-summit-m365bp-001",
+      "--cancel-date",
+      "2026-06-01",
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data[0].cancelDate).toBe("2026-06-01");
+    // Pin the shape so a future "normalize the JSON output too" change
+    // can't silently break partner scripts that expect YYYY-MM-DD.
+    expect(data[0].cancelDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
   // Regression for #294: commitment-aware preview + safe-path defaults.
   describe("commitment-aware behavior (#294)", () => {
     // sub-summit-m365bp-001 is a 1-Year committed sub in demo data — its

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -38,9 +38,14 @@ function summarizeActiveCommitment(
 /**
  * Validate a `YYYY-MM-DD` cancel date. Returns the normalized string on
  * success, throws a `CliError(ERROR_INVALID_INPUT)` with recovery hints on
- * failure. We accept the simple ISO calendar form only — the Pax8 API treats
- * `cancelDate` as a date (not a timestamp), and accepting timestamps would
- * silently drop the time portion.
+ * failure.
+ *
+ * Surface-shape note (#333): we accept the simple ISO calendar form only on
+ * the CLI surface so partner scripts keep working. The Pax8 OpenAPI spec
+ * types the underlying `cancelDate` query parameter as `format: date-time`
+ * (RFC 3339, e.g. `2026-12-31T00:00:00Z`); `SubscriptionsApi.delete()`
+ * normalizes the date-only form to `YYYY-MM-DDT00:00:00Z` before the wire
+ * call, matching the spec without forcing partners to pass timestamps.
  */
 function parseCancelDate(raw: string): string {
   const trimmed = raw.trim();

--- a/packages/core/src/api/subscriptions.test.ts
+++ b/packages/core/src/api/subscriptions.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { SubscriptionsApi } from "./subscriptions.js";
+import { SubscriptionsApi, normalizeCancelDateForWire } from "./subscriptions.js";
 import type { Pax8Client } from "./client.js";
 
 function createMockClient(): Pax8Client {
@@ -104,15 +104,48 @@ describe("SubscriptionsApi", () => {
     expect(client.delete).toHaveBeenCalledWith(`/subscriptions/${SUB_ID}`, undefined);
   });
 
-  it("delete forwards cancelDate as a query parameter", async () => {
+  // #333: spec types `cancelDate` as `format: date-time`. The CLI surface
+  // takes `YYYY-MM-DD` for partner ergonomics; the API client normalizes
+  // it to `YYYY-MM-DDT00:00:00Z` before the wire call so the wire payload
+  // matches the spec.
+  it("delete normalizes YYYY-MM-DD cancelDate to ISO date-time on the wire (#333)", async () => {
     (client.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     await api.delete(SUB_ID, { cancelDate: "2026-12-31" });
 
     expect(client.delete).toHaveBeenCalledWith(
       `/subscriptions/${SUB_ID}`,
-      { cancelDate: "2026-12-31" },
+      { cancelDate: "2026-12-31T00:00:00Z" },
     );
+  });
+
+  it("delete passes through an already-formatted ISO date-time unchanged (#333)", async () => {
+    (client.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const iso = "2026-12-31T01:30:00.000-05:00";
+    await api.delete(SUB_ID, { cancelDate: iso });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `/subscriptions/${SUB_ID}`,
+      { cancelDate: iso },
+    );
+  });
+
+  describe("normalizeCancelDateForWire (#333)", () => {
+    it("promotes YYYY-MM-DD to midnight-UTC date-time", () => {
+      expect(normalizeCancelDateForWire("2026-12-31")).toBe(
+        "2026-12-31T00:00:00Z",
+      );
+    });
+
+    it("passes through full ISO date-time strings unchanged", () => {
+      expect(normalizeCancelDateForWire("2026-12-31T00:00:00Z")).toBe(
+        "2026-12-31T00:00:00Z",
+      );
+      expect(
+        normalizeCancelDateForWire("2026-12-31T01:30:00.000-05:00"),
+      ).toBe("2026-12-31T01:30:00.000-05:00");
+    });
   });
 
   it("throws on invalid response data", async () => {

--- a/packages/core/src/api/subscriptions.ts
+++ b/packages/core/src/api/subscriptions.ts
@@ -45,11 +45,49 @@ export class SubscriptionsApi {
 
   /**
    * Cancel a subscription. By default the cancellation is immediate; pass
-   * `cancelDate` (ISO `YYYY-MM-DD`) to schedule the cancellation for a future
-   * date — the Pax8 API forwards it as the `cancelDate` query parameter.
+   * `cancelDate` to schedule the cancellation for a future date — the Pax8
+   * API forwards it as the `cancelDate` query parameter.
+   *
+   * Wire-format note (#333): the Pax8 OpenAPI spec types `cancelDate` as
+   * `format: date-time` (RFC 3339 / ISO 8601 with a zone offset, e.g.
+   * `2026-12-31T00:00:00Z`). The CLI surface accepts user-friendly
+   * `YYYY-MM-DD`; this method normalizes that shape to `YYYY-MM-DDT00:00:00Z`
+   * before forwarding so the wire payload matches the spec. Full
+   * `date-time` strings (with `T` and offset) are passed through unchanged,
+   * letting callers that already hold an ISO timestamp use it as-is.
+   *
+   * Same defensive-normalization approach #312 used for `effectiveDate` on
+   * `quotes line-items add`.
    */
   async delete(id: string, params?: { cancelDate?: string }): Promise<void> {
-    const query = params?.cancelDate ? { cancelDate: params.cancelDate } : undefined;
+    const query = params?.cancelDate
+      ? { cancelDate: normalizeCancelDateForWire(params.cancelDate) }
+      : undefined;
     await this.client.delete(`/subscriptions/${id}`, query);
   }
+}
+
+/**
+ * Normalize a `cancelDate` value to the RFC 3339 / ISO 8601 `date-time`
+ * shape the Pax8 API spec requires (`format: date-time` on the
+ * `cancelDate` query parameter of `DELETE /subscriptions/{id}`).
+ *
+ * - `YYYY-MM-DD` → `YYYY-MM-DDT00:00:00Z` (midnight UTC of the given day).
+ *   Pinning to UTC midnight avoids day-shift bugs when the caller's local
+ *   zone differs from the API's interpretation.
+ * - Strings already containing `T` are assumed to be full ISO `date-time`
+ *   and are passed through unchanged — callers that already hold a
+ *   timestamp shouldn't have it rewritten.
+ *
+ * Exported for the unit test that pins the wire shape.
+ */
+export function normalizeCancelDateForWire(raw: string): string {
+  // Date-only shape `YYYY-MM-DD` — promote to midnight-UTC date-time.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    return `${raw}T00:00:00Z`;
+  }
+  // Anything else is treated as already-formatted ISO date-time and
+  // passed through. Validation of arbitrary input happens at the CLI
+  // boundary (`packages/cli/src/commands/subscriptions/cancel.ts`).
+  return raw;
 }


### PR DESCRIPTION
## Summary

- Spec verified: `DELETE /subscriptions/{id}`'s `cancelDate` query parameter is typed `format: date-time` in `partner-endpoints.json` (`{"type":"string","format":"date-time","example":"2000-10-31T01:30:00.000-05:00"}`). The CLI was sending date-only `YYYY-MM-DD`. Outcome C from the issue: defensive normalization with no downside.
- `SubscriptionsApi.delete()` (`@pax8/core`) now promotes `YYYY-MM-DD` to `YYYY-MM-DDT00:00:00Z` before the wire call. Already-formatted ISO date-time strings pass through unchanged. Same precedent as the `effectiveDate` normalization for `quotes line-items add` (#312).
- User-facing surface unchanged so partner scripts keep working: `--cancel-date` still accepts only `YYYY-MM-DD`, and the `--json` output's `cancelDate` field stays `YYYY-MM-DD`. Only the wire payload changes.
- Inline comment at `packages/cli/src/commands/subscriptions/cancel.ts` that previously claimed "the Pax8 API treats `cancelDate` as a date" now cites the verified spec typing and points at the normalization layer.
- Changeset: `@pax8/core` + `@pax8/cli` patch.

## Test plan

- [x] `pnpm build` — passes.
- [x] `pnpm test` — 1620 tests pass, 8 skipped (no new failures).
- [x] `pnpm lint` — clean.
- [x] Unit test in `packages/core/src/api/subscriptions.test.ts` pins the wire shape: `cancelDate: "2026-12-31"` → `{ cancelDate: "2026-12-31T00:00:00Z" }`.
- [x] Unit test pins passthrough for already-ISO date-time strings (e.g. `2026-12-31T01:30:00.000-05:00`).
- [x] Subprocess test in `packages/cli/src/__tests__/subscriptions.test.ts` pins the date-only shape of the partner-facing `--json` output so a future "normalize JSON output too" change can't silently break partner scripts.

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)