### PR TITLE
fix(webhooks): align create body with API spec — displayName + webhookTopics (closes #323)

### DIFF
--- a/.changeset/webhooks-create-body-shape.md
+++ b/.changeset/webhooks-create-body-shape.md
@@ -1,0 +1,12 @@
+---
+"@pax8/core": patch
+"@pax8/cli": patch
+---
+
+`pax8 webhooks create`: align the request body with the public Pax8 webhooks v2 OpenAPI contract. The CLI now sends `{ url, displayName, webhookTopics: [{ topic, filters }] }` instead of the pre-#323 `{ url, topics: string[] }`. A spec-strict server would 422 on the old shape (missing required `displayName`; wrong key name and element shape for the topic list).
+
+- Adds a required `--display-name <name>` flag to `pax8 webhooks create`. Help text explains why: the Pax8 API requires it.
+- Keeps the user-facing `--topics T1,T2` flag unchanged so partner scripts continue to work; the CLI transforms it into the structured `webhookTopics: [{ topic, filters: [] }]` shape at the wire layer.
+- `--events` continues to work as a deprecated alias for `--topics`.
+
+Per-topic `filters` are accepted by the spec but not yet exposed on the CLI surface — each topic ships with an empty filter array, which the server treats as "deliver every event for this topic". A structured filter-authoring UX is tracked separately.

--- a/e2e/webhooks-workflow.test.ts
+++ b/e2e/webhooks-workflow.test.ts
@@ -46,6 +46,8 @@ describe("E2E: Webhooks workflow — list, create, test, logs, delete", () => {
       "create",
       "--url",
       "not-a-url",
+      "--display-name",
+      "E2E hook",
       "--topics",
       "subscription.created",
       "--yes",
@@ -59,6 +61,8 @@ describe("E2E: Webhooks workflow — list, create, test, logs, delete", () => {
       "create",
       "--url",
       "https://example.com/e2e-hook",
+      "--display-name",
+      "E2E hook",
       "--topics",
       "subscription.created,invoice.paid",
       "--yes",
@@ -67,6 +71,7 @@ describe("E2E: Webhooks workflow — list, create, test, logs, delete", () => {
     const data = JSON.parse(result.stdout);
     expect(data.url).toBe("https://example.com/e2e-hook");
     expect(data.topics).toEqual(["subscription.created", "invoice.paid"]);
+    expect(data.displayName).toBe("E2E hook");
     expect(data.status).toBe("Active");
     expect(data).toHaveProperty("nextActions");
   });

--- a/packages/cli/src/__tests__/webhooks.test.ts
+++ b/packages/cli/src/__tests__/webhooks.test.ts
@@ -97,6 +97,8 @@ describe("pax8 webhooks create — --topics canonical with --events deprecated a
       "create",
       "--url",
       "https://example.com/topics-hook",
+      "--display-name",
+      "Topics hook",
       "--topics",
       "subscription.created,invoice.paid",
       "--yes",
@@ -115,6 +117,8 @@ describe("pax8 webhooks create — --topics canonical with --events deprecated a
       "create",
       "--url",
       "https://example.com/events-hook",
+      "--display-name",
+      "Events hook",
       "--events",
       "subscription.created",
       "--yes",
@@ -134,6 +138,8 @@ describe("pax8 webhooks create — --topics canonical with --events deprecated a
       "create",
       "--url",
       "https://example.com/dup-hook",
+      "--display-name",
+      "Dup hook",
       "--topics",
       "subscription.created",
       "--events",
@@ -152,5 +158,86 @@ describe("pax8 webhooks create — --topics canonical with --events deprecated a
     expect(result.stdout).toContain("--topics");
     expect(result.stdout).toContain("--events");
     expect(result.stdout.toLowerCase()).toContain("deprecated");
+  });
+});
+
+// #323: webhooks create body-shape mismatch. The CLI must require
+// `--display-name` (the Pax8 webhooks v2 spec marks it required and a
+// strict server 422s without it) and translate the flat `--topics` flag
+// into the structured `webhookTopics: [{ topic, filters }]` wire shape.
+// CLI vocabulary stays as `--topics` so partner scripts keep working.
+describe("pax8 webhooks create — #323 body-shape requirements", () => {
+  it("requires --display-name (Commander rejects when omitted)", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "create",
+      "--url",
+      "https://example.com/missing-name",
+      "--topics",
+      "subscription.created",
+      "--yes",
+    ]);
+    // Commander surfaces `error: required option '--display-name <name>' not specified`
+    // on stderr; assert on both the flag name and the canonical phrasing so a
+    // future help-text refactor can't silently drop the requirement.
+    expect(result.stderr.toLowerCase()).toContain("--display-name");
+    expect(result.stderr.toLowerCase()).toContain("required");
+  });
+
+  it("rejects whitespace-only --display-name with a clear ERROR_INVALID_INPUT", async () => {
+    const result = await runCliExpectFailure([
+      "webhooks",
+      "create",
+      "--url",
+      "https://example.com/blank-name",
+      "--display-name",
+      "   ",
+      "--topics",
+      "subscription.created",
+      "--yes",
+      "--json",
+    ]);
+    const start = result.stderr.indexOf("{");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const json = JSON.parse(result.stderr.slice(start));
+    expect(json.code).toBe("ERROR_INVALID_INPUT");
+    expect(JSON.stringify(json)).toContain("--display-name");
+  });
+
+  it("--help advertises --display-name and explains why it's required", async () => {
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "create",
+      "--help",
+    ]);
+    expect(result.stdout).toContain("--display-name");
+    // The help text justifies the flag in terms the partner can act on:
+    // the API requires it, so we require it. Pin the substring so a future
+    // copy-edit doesn't silently drop the rationale.
+    expect(result.stdout.toLowerCase()).toContain("pax8 api");
+  });
+
+  it("transforms --topics T1,T2 into the structured webhookTopics shape on the returned record", async () => {
+    // Demo mode's mock client receives the new `{ url, displayName,
+    // webhookTopics }` payload and surfaces a normal Webhook back. The
+    // returned record's `topics` field reflects the slugs the user asked
+    // for, confirming the CLI didn't drop them on the way through the
+    // structured wire shape.
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "create",
+      "--url",
+      "https://example.com/structured-hook",
+      "--display-name",
+      "Structured hook — prod",
+      "--topics",
+      "subscription.created,invoice.paid",
+      "--yes",
+      "--json",
+    ]);
+    const data = JSON.parse(result.stdout);
+    expect(data.url).toBe("https://example.com/structured-hook");
+    expect(data.displayName).toBe("Structured hook — prod");
+    expect(data.topics).toEqual(["subscription.created", "invoice.paid"]);
   });
 });

--- a/packages/cli/src/commands/webhooks/create.ts
+++ b/packages/cli/src/commands/webhooks/create.ts
@@ -30,6 +30,10 @@ function isValidUrl(input: string): boolean {
 export const webhooksCreateCommand = new Command("create")
   .description("Create a webhook subscription")
   .requiredOption("--url <url>", "Webhook delivery URL (https recommended)")
+  .requiredOption(
+    "--display-name <name>",
+    'Human-friendly label for the webhook (required by the Pax8 API). Pick something memorable — e.g. "Subscription events — prod"',
+  )
   .option(
     "--topics <comma-separated-topics>",
     'Topics to subscribe to, comma-separated (e.g. "subscription.created,invoice.paid")',
@@ -46,10 +50,11 @@ export const webhooksCreateCommand = new Command("create")
     "after",
     `
 Examples:
-  pax8 webhooks create --url https://example.com/hook --topics subscription.created,subscription.cancelled
-  pax8 webhooks create --url https://example.com/hook --topics invoice.paid --yes
+  pax8 webhooks create --url https://example.com/hook --display-name "Subscription events" --topics subscription.created,subscription.cancelled
+  pax8 webhooks create --url https://example.com/hook --display-name "Invoice events" --topics invoice.paid --yes
 
-Note: --events is a deprecated alias for --topics; it still works but will be removed in v1.0.`,
+Note: --events is a deprecated alias for --topics; it still works but will be removed in v1.0.
+Note: --display-name is required by the Pax8 webhooks API; the server will reject creates that omit it.`,
   )
   .action(async (_options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -58,6 +63,7 @@ Note: --events is a deprecated alias for --topics; it still works but will be re
       const ctx = await buildContext(allOpts);
 
       const url = String(allOpts.url);
+      const displayName = String(allOpts.displayName ?? "").trim();
 
       // Resolve the canonical `--topics` value, accepting `--events` as a
       // deprecated alias. Erroring if both are passed avoids a silent
@@ -104,7 +110,25 @@ Note: --events is a deprecated alias for --topics; it still works but will be re
           `Invalid webhook URL: "${url}"`,
           ["URL must be an http:// or https:// URL"],
           [
-            `Example: ${replCmd("pax8 webhooks create")} --url https://example.com/hook --topics subscription.created`,
+            `Example: ${replCmd("pax8 webhooks create")} --url https://example.com/hook --display-name "Subscription events" --topics subscription.created`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      // `--display-name` is `requiredOption`, so Commander already rejects the
+      // missing case at parse time. Guard against the partner-script footgun
+      // of `--display-name ""` (the spec requires a non-empty string and a
+      // strict server 422s on whitespace-only).
+      if (displayName.length === 0) {
+        throw new CliError(
+          "Missing required option: --display-name",
+          [
+            "--display-name is required by the Pax8 webhooks API; the create call rejects empty values.",
+          ],
+          [
+            `Example: ${replCmd("pax8 webhooks create")} --url ${url} --display-name "Subscription events" --topics subscription.created,invoice.paid`,
           ],
           undefined,
           ERROR_INVALID_INPUT,
@@ -116,15 +140,23 @@ Note: --events is a deprecated alias for --topics; it still works but will be re
           "At least one event topic is required",
           ["--topics must contain one or more comma-separated topic names"],
           [
-            `Example: ${replCmd("pax8 webhooks create")} --url ${url} --topics subscription.created,invoice.paid`,
+            `Example: ${replCmd("pax8 webhooks create")} --url ${url} --display-name "${displayName}" --topics subscription.created,invoice.paid`,
           ],
           undefined,
           ERROR_INVALID_INPUT,
         );
       }
 
+      // Transform the CLI's flat `--topics T1,T2` into the spec's structured
+      // `webhookTopics: [{ topic, filters }]` shape. The CLI doesn't expose
+      // per-topic filter expressions yet (#323 out-of-scope), so each entry
+      // ships with an empty filter array — the server accepts that as
+      // "deliver every event for this topic".
+      const webhookTopics = topics.map((topic) => ({ topic, filters: [] }));
+
       // Show what will be created
       process.stderr.write(chalk.bold("\n  Creating webhook subscription:\n\n"));
+      process.stderr.write(`  ${chalk.dim("Name:".padEnd(10))}${displayName}\n`);
       process.stderr.write(`  ${chalk.dim("URL:".padEnd(10))}${url}\n`);
       process.stderr.write(`  ${chalk.dim("Events:".padEnd(10))}${topics.join(", ")}\n`);
       process.stderr.write("\n");
@@ -139,7 +171,11 @@ Note: --events is a deprecated alias for --topics; it still works but will be re
       const doneCreate = markWriteInFlight("webhooks");
       let webhook;
       try {
-        webhook = await ctx.api.webhooks.create({ url, topics });
+        webhook = await ctx.api.webhooks.create({
+          url,
+          displayName,
+          webhookTopics,
+        });
       } finally {
         doneCreate();
       }

--- a/packages/cli/src/commands/webhooks/list.ts
+++ b/packages/cli/src/commands/webhooks/list.ts
@@ -55,7 +55,8 @@ Examples:
           const nextActions: { command: string; description: string }[] = [];
           if (webhooks.length === 0) {
             nextActions.push({
-              command: "pax8 webhooks create --url <url> --topics <comma-separated-topics>",
+              command:
+                "pax8 webhooks create --url <url> --display-name <name> --topics <comma-separated-topics>",
               description: "Create your first webhook subscription",
             });
           } else {
@@ -118,7 +119,7 @@ Examples:
         if (webhooks.length === 0) {
           process.stderr.write(chalk.dim("\n  Try next:\n"));
           process.stderr.write(
-            `    ${chalk.cyan(replCmd("pax8 webhooks create --url <url> --topics <topics>"))}  ${chalk.dim("create your first subscription")}\n`,
+            `    ${chalk.cyan(replCmd("pax8 webhooks create --url <url> --display-name <name> --topics <topics>"))}  ${chalk.dim("create your first subscription")}\n`,
           );
         } else {
           const first = webhooks[0];

--- a/packages/cli/src/commands/webhooks/topics/list.ts
+++ b/packages/cli/src/commands/webhooks/topics/list.ts
@@ -53,7 +53,7 @@ Examples:
           if (sorted.length > 0) {
             nextActions.push({
               command:
-                "pax8 webhooks create --url https://example.com/hook --topics " +
+                'pax8 webhooks create --url https://example.com/hook --display-name "My webhook" --topics ' +
                 sorted[0].topic,
               description: "Create a webhook subscribed to this topic",
             });
@@ -86,7 +86,7 @@ Examples:
         if (sorted.length > 0) {
           process.stderr.write(chalk.dim("\n  Try next:\n"));
           process.stderr.write(
-            `    ${chalk.cyan(replCmd(`pax8 webhooks create --url https://example.com/hook --topics ${sorted[0].topic}`))}  ${chalk.dim("subscribe to a topic")}\n`,
+            `    ${chalk.cyan(replCmd(`pax8 webhooks create --url https://example.com/hook --display-name "My webhook" --topics ${sorted[0].topic}`))}  ${chalk.dim("subscribe to a topic")}\n`,
           );
           process.stderr.write("\n");
         }

--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -706,27 +706,66 @@ describe("WebhookSchema", () => {
   });
 });
 
-describe("CreateWebhookInputSchema", () => {
-  it("validates correct input", () => {
+describe("CreateWebhookInputSchema (#323)", () => {
+  // The Pax8 webhooks v2 spec marks `displayName` required and uses the
+  // structured `webhookTopics: Array<{ topic, filters }>` shape. Tests pin
+  // both the happy path and the two known rejection cases the issue calls
+  // out (missing displayName, wrong topics shape).
+  it("validates a spec-shaped create body", () => {
     const input = {
+      displayName: "Subscription events",
       url: "https://example.com/webhook",
-      topics: ["subscription.created"],
+      webhookTopics: [{ topic: "subscription.created", filters: [] }],
     };
     expect(CreateWebhookInputSchema.parse(input)).toEqual(input);
   });
 
-  it("rejects empty topics", () => {
+  it("defaults filters to [] when omitted on a topic entry", () => {
+    const input = {
+      displayName: "Subscription events",
+      url: "https://example.com/webhook",
+      webhookTopics: [{ topic: "subscription.created" }],
+    };
+    const parsed = CreateWebhookInputSchema.parse(input);
+    expect(parsed.webhookTopics[0].filters).toEqual([]);
+  });
+
+  it("rejects missing displayName (required by spec)", () => {
     expect(() =>
       CreateWebhookInputSchema.parse({
         url: "https://example.com/webhook",
-        topics: [],
+        webhookTopics: [{ topic: "subscription.created", filters: [] }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects empty webhookTopics", () => {
+    expect(() =>
+      CreateWebhookInputSchema.parse({
+        displayName: "Empty",
+        url: "https://example.com/webhook",
+        webhookTopics: [],
       }),
     ).toThrow();
   });
 
   it("rejects invalid url", () => {
     expect(() =>
-      CreateWebhookInputSchema.parse({ url: "bad", topics: ["sub.created"] }),
+      CreateWebhookInputSchema.parse({
+        displayName: "Bad URL",
+        url: "bad",
+        webhookTopics: [{ topic: "sub.created", filters: [] }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects the legacy `topics: string[]` shape (regression guard for #323)", () => {
+    expect(() =>
+      CreateWebhookInputSchema.parse({
+        displayName: "Legacy shape",
+        url: "https://example.com/webhook",
+        topics: ["subscription.created"],
+      }),
     ).toThrow();
   });
 });

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -515,9 +515,40 @@ export const WebhookSchema = z.object({
 });
 export type Webhook = z.infer<typeof WebhookSchema>;
 
+/**
+ * One entry in the `webhookTopics` array on `POST /webhooks` (Pax8 webhooks
+ * API v2 `AddWebhookTopic` schema). The wire shape is structured —
+ * `{ topic, filters }` — not a bare string. `filters` is required on the
+ * server side, but the CLI doesn't expose per-topic filter expressions yet,
+ * so the default-empty `[]` is sent. The `filters` element type is left
+ * loose (`z.unknown()`) on purpose: the spec accepts `UpdateWebhookFilter`
+ * objects ({ action, conditions: [{ field, operator, value }] }) but the
+ * CLI surface for authoring them is a separate feature and the schema
+ * shouldn't reject filters the user assembles by hand against the spec.
+ */
+export const AddWebhookTopicSchema = z.object({
+  topic: z.string().min(1),
+  filters: z.array(z.unknown()).default([]),
+});
+export type AddWebhookTopic = z.infer<typeof AddWebhookTopicSchema>;
+
+/**
+ * Request body for `POST /webhooks` (Pax8 webhooks API v2 `CreateWebhook`
+ * schema). `displayName` is required by the spec — a spec-strict server
+ * 422s without it. `webhookTopics` is the structured replacement for the
+ * pre-#323 `topics: string[]` shape; each entry carries a `topic` slug and
+ * an optional filter array.
+ *
+ * Only the two fields the spec marks required plus the topic subscription
+ * list are modeled here. `authorization`, `active`, `contactEmail`,
+ * `errorThreshold`, and `integrationId` are accepted by the spec on create
+ * but are intentionally not exposed by the CLI yet — they're tracked as
+ * separate flag-surface enhancements in #323's "out of scope" section.
+ */
 export const CreateWebhookInputSchema = z.object({
+  displayName: z.string().min(1),
   url: z.string().url(),
-  topics: z.array(z.string()).min(1),
+  webhookTopics: z.array(AddWebhookTopicSchema).min(1),
 });
 export type CreateWebhookInput = z.infer<typeof CreateWebhookInputSchema>;
 

--- a/packages/core/src/api/webhooks.test.ts
+++ b/packages/core/src/api/webhooks.test.ts
@@ -75,15 +75,34 @@ describe("WebhooksApi", () => {
     expect(result.topics).toContain("subscription.created");
   });
 
-  it("create sends correct body (routed to /api/v2)", async () => {
-    const input = { url: "https://example.com/new", topics: ["order.created"] };
-    const created = { ...sampleWebhook, ...input, id: "c3d4e5f6-a7b8-9012-cdef-123456789012" };
+  it("create sends the spec-shaped body { url, displayName, webhookTopics } (routed to /api/v2, #323)", async () => {
+    // The Pax8 webhooks v2 spec requires `displayName` and uses the
+    // structured `webhookTopics: Array<{ topic, filters }>` shape — not the
+    // pre-#323 `topics: string[]`. WebhooksApi.create must serialize the
+    // input it receives verbatim onto the wire so a spec-strict server
+    // accepts it.
+    const input = {
+      url: "https://example.com/new",
+      displayName: "Order events — prod",
+      webhookTopics: [
+        { topic: "order.created", filters: [] },
+        { topic: "order.completed", filters: [] },
+      ],
+    };
+    const created = {
+      ...sampleWebhook,
+      id: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+      url: input.url,
+      topics: ["order.created", "order.completed"],
+      displayName: input.displayName,
+    };
     (client.post as ReturnType<typeof vi.fn>).mockResolvedValue(created);
 
     const result = await api.create(input);
 
     expect(client.post).toHaveBeenCalledWith("/webhooks", input, WEBHOOKS_OPTS);
     expect(result.url).toBe("https://example.com/new");
+    expect(result.displayName).toBe("Order events — prod");
   });
 
   it("updateConfiguration POSTs to /configuration with the partial body (routed to /api/v2)", async () => {
@@ -284,12 +303,21 @@ describe("WebhooksApi wire-level routing (#322)", () => {
 
     await api.create({
       url: "https://example.com/new",
-      topics: ["order.created"],
+      displayName: "Order events",
+      webhookTopics: [{ topic: "order.created", filters: [] }],
     });
 
     const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(url.toString()).toBe("https://api.pax8.com/api/v2/webhooks");
     expect(init.method).toBe("POST");
+    // Pin the wire body shape: confirms #323 reshape is preserved through
+    // serialization, not just at the typed input boundary.
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({
+      url: "https://example.com/new",
+      displayName: "Order events",
+      webhookTopics: [{ topic: "order.created", filters: [] }],
+    });
   });
 
   it("setStatus resolves to https://api.pax8.com/api/v2/webhooks/{id}/status", async () => {

--- a/packages/core/src/mock/mock-client-extended.test.ts
+++ b/packages/core/src/mock/mock-client-extended.test.ts
@@ -447,13 +447,18 @@ describe("MockPax8Client — extended coverage", () => {
   });
 
   describe("webhooks.create()", () => {
-    it("creates a webhook", async () => {
+    it("creates a webhook (#323 spec-shaped body)", async () => {
       const result = await client.webhooks.create({
         url: "https://example.com/hook",
-        topics: ["subscription.created"],
+        displayName: "Subs hook",
+        webhookTopics: [{ topic: "subscription.created", filters: [] }],
       });
       expect(result.status).toBe("Active");
       expect(result.url).toBe("https://example.com/hook");
+      expect(result.displayName).toBe("Subs hook");
+      // The read-side `Webhook` still surfaces a flat `topics: string[]`; the
+      // mock derives it from `webhookTopics[].topic` until the read schema
+      // realignment ships.
       expect(result.topics).toEqual(["subscription.created"]);
     });
   });

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -710,17 +710,27 @@ class WebhooksResource {
     return wh;
   }
 
-  async create(data: { url: string; topics: string[] }): Promise<Webhook> {
+  async create(data: {
+    url: string;
+    displayName: string;
+    webhookTopics: Array<{ topic: string; filters?: unknown[] }>;
+  }): Promise<Webhook> {
     await randomDelay();
     // Generate a deterministic-ish UUID-shaped id for demo mode.
     const newId = `99999999-aaaa-bbbb-cccc-${String(Date.now()).padStart(12, "0").slice(-12)}`;
+    // `WebhookSchema` (the read shape) still surfaces `topics: string[]` to
+    // CLI consumers, so we flatten the structured `webhookTopics` input back
+    // down to a slug list on the returned record. The structured read-side
+    // (`webhookTopics: Array<{topic, filters}>`) is tracked separately under
+    // #323's "out of scope" read-schema realignment step.
     const newWh: Webhook = {
       id: newId,
       url: data.url,
       status: "Active",
-      topics: data.topics,
+      topics: data.webhookTopics.map((t) => t.topic),
       createdDate: new Date().toISOString().split("T")[0],
       secret: `whsec_demo_${Date.now()}`,
+      displayName: data.displayName,
     };
     return newWh;
   }


### PR DESCRIPTION
## Summary

- `pax8 webhooks create` now sends the spec-shaped `{ url, displayName, webhookTopics: [{ topic, filters }] }` body that the public Pax8 webhooks v2 OpenAPI contract requires (closes #323).
- Adds a **required** `--display-name <name>` flag; help text explains why ("required by the Pax8 API; pick a memorable label").
- Keeps `--topics T1,T2` as the user-facing flag so partner scripts keep working — the CLI transforms it into the structured `webhookTopics: [{ topic, filters: [] }]` shape at the wire layer. `--events` remains a deprecated alias.

## What was broken

Before this PR the CLI sent `{ url, topics: string[] }`. The spec marks `displayName` required and uses the structured `webhookTopics` array; a spec-strict server would 422. `webhooks create` was therefore non-functional end-to-end against the real API, even after #322 fixed the wire path. See #323 for the full audit.

## Scope discipline

Per #323's "out of scope" list, this PR fixes only the two acceptance-blocking defects:

- `displayName` added as required.
- `topics: string[]` reshaped to `webhookTopics: Array<{topic, filters}>`.

`authorization`, `active`, `contactEmail`, `errorThreshold`, `integrationId`, and per-topic filter authoring are tracked separately. The read-side `WebhookSchema` is also unchanged — the mock continues to surface `topics: string[]` on returned records so `webhooks list` / `webhooks show` keep working without a read-schema realignment.

## What changed

- `packages/core/src/api/types.ts` — new `AddWebhookTopicSchema`; `CreateWebhookInputSchema` now requires `displayName` and `webhookTopics: Array<{topic, filters}>`. Filter element type is `z.unknown()` (the CLI doesn't author filters yet).
- `packages/cli/src/commands/webhooks/create.ts` — adds `--display-name <name>` (required), transforms `--topics T1,T2` into `webhookTopics: [{ topic: "T1", filters: [] }, { topic: "T2", filters: [] }]` before calling `ctx.api.webhooks.create`, and surfaces the display name in the create preview.
- `packages/core/src/mock/mock-client.ts` — mock `webhooks.create` accepts the new shape and derives `topics` from `webhookTopics[].topic` on the returned `Webhook` so read paths stay compatible.
- Next-action templates in `webhooks list` and `webhooks topics list` updated so suggested commands include `--display-name`.
- New tests pin the wire body shape (`packages/core/src/api/webhooks.test.ts`), the schema contract (`packages/core/src/api/types.test.ts`), and the CLI surface (`packages/cli/src/__tests__/webhooks.test.ts`): missing `--display-name` is rejected by Commander, whitespace-only `--display-name` is rejected with `ERROR_INVALID_INPUT`, and `--topics` is correctly transformed.

## Test plan

- [x] `pnpm build` (clean)
- [x] `pnpm lint` (clean)
- [x] Targeted suite (`webhooks.test.ts` × 2 + `types.test.ts` + `mock-client*.test.ts` + `e2e/webhooks-workflow.test.ts`) — 221/221 pass
- [x] `tsc --noEmit` across all packages (clean)
- [ ] `pnpm test` full suite — failed locally with ENOSPC (disk filled by coverage profiles); CI should run on a clean runner
- [ ] Sandbox smoke: `pax8 webhooks create --url ... --display-name ... --topics ...` against the real API (gated on #308)

🤖 Generated with [Claude Code](https://claude.com/claude-code)