### PR TITLE
fix(contacts): nested /companies/{companyId}/contacts/* wire paths

### DIFF
--- a/.changeset/contacts-nested-wire-path.md
+++ b/.changeset/contacts-nested-wire-path.md
@@ -1,0 +1,10 @@
+---
+"@pax8/core": patch
+"@pax8/cli": patch
+---
+
+Fix: `pax8 contacts` commands now target the documented nested API paths under `/v1/companies/{companyId}/contacts/*`. Previously `ContactsApi.{get,create,update,delete}` called flat `/v1/contacts/*` endpoints that do not exist in the Pax8 public spec; the public OpenAPI definition only addresses contacts via `/v1/companies/{companyId}/contacts[/{contactId}]`.
+
+**Breaking change at the CLI surface** for `contacts show`, `contacts update`, and `contacts delete`: each now requires `--company <id|name>` because the spec has no flat per-contact lookup. The CLI emits a clear migration error when `--company` is missing. `contacts list` and `contacts create` already required `--company`, so their surface is unchanged. Body-shape bugs surfaced in the same audit (#325) are intentionally out of scope for this PR.
+
+Closes #324.

--- a/docs/domain-review.md
+++ b/docs/domain-review.md
@@ -63,10 +63,10 @@ Full audit, including the retrospective on why the initial wire-path investigati
 | `pax8 companies update <id\|name>` | `--name`, `--phone`, `--website`, `-y` | | No address/billing-flag updates exposed |
 | `pax8 companies more` | (interactive paging helper) | | CLI-only |
 | `pax8 contacts list` | `--company <id\|name>` (required), `--page`, `--size`, `--ids-only` | size=50 | |
-| `pax8 contacts show <id>` | | | |
-| `pax8 contacts create` | `--first-name`, `--last-name`, `--email`, `--phone`, `--type <list>`, `-y` | type=Admin | `--type` accepts a comma-separated list (`Admin,Billing`) post-#255 |
-| `pax8 contacts update <id>` | `--first-name`, `--last-name`, `--email`, `--phone`, `--type <list>`, `-y` | | `--type` accepts a comma-separated list post-#255 |
-| `pax8 contacts delete <id>` | `-y` | | |
+| `pax8 contacts show <id>` | `--company <id\|name>` (required) | | `--company` required post-#324 — the Pax8 public API only addresses contacts under `/companies/{companyId}/contacts/{contactId}` |
+| `pax8 contacts create` | `--company <id\|name>` (required), `--first-name`, `--last-name`, `--email`, `--phone`, `--type <list>`, `-y` | type=Admin | `--type` accepts a comma-separated list (`Admin,Billing`) post-#255 |
+| `pax8 contacts update <id>` | `--company <id\|name>` (required), `--first-name`, `--last-name`, `--email`, `--phone`, `--type <list>`, `-y` | | `--type` accepts a comma-separated list post-#255; `--company` required post-#324 |
+| `pax8 contacts delete <id>` | `--company <id\|name>` (required), `-y` | | `--company` required post-#324 |
 
 CLI output schemas (Zod) — `Company`: `id, name, address{street,city,state,zip,country}, phone, website, status, billOnBehalfOfEnabled, selfServiceAllowed, orderApprovalRequired, created, modified`. `Contact`: `id, firstName, lastName, email, phone, companyId, types[]`.
 

--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -471,7 +471,14 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
         "--company",
         "Summit Healthcare Partners",
       ]);
-      return ["contacts", "show", id];
+      // `contacts show` requires --company per the v2 nested wire path (#324).
+      return [
+        "contacts",
+        "show",
+        id,
+        "--company",
+        "Summit Healthcare Partners",
+      ];
     },
     demo: {
       forbiddenFragments: ["undefined"],

--- a/e2e/contacts-workflow.test.ts
+++ b/e2e/contacts-workflow.test.ts
@@ -53,11 +53,27 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
     ]);
     const id = JSON.parse(list.stdout)[0].id;
 
-    const result = await runCliExpectSuccess(["contacts", "show", id, "--json"]);
+    const result = await runCliExpectSuccess([
+      "contacts",
+      "show",
+      id,
+      "--company",
+      "Summit Healthcare Partners",
+      "--json",
+    ]);
     const data = JSON.parse(result.stdout);
     // `show` returns a single object, not an array (#208)
     expect(Array.isArray(data)).toBe(false);
     expect(data.id).toBe(id);
+  });
+
+  it("pax8 contacts show requires --company (nested wire path, #324)", async () => {
+    const result = await runCliExpectFailure([
+      "contacts",
+      "show",
+      "contact-summit-001",
+    ]);
+    expect(result.stderr).toContain("--company");
   });
 
   it("pax8 contacts show fails for unknown id", async () => {
@@ -65,6 +81,8 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
       "contacts",
       "show",
       "definitely-not-a-real-contact-id",
+      "--company",
+      "Summit Healthcare Partners",
     ]);
     expect(result.stderr.length).toBeGreaterThan(0);
   });
@@ -155,6 +173,8 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
       "contacts",
       "update",
       id,
+      "--company",
+      "Summit Healthcare Partners",
       "--email",
       "renamed@example.com",
       "--yes",
@@ -163,6 +183,18 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
     const data = JSON.parse(result.stdout);
     expect(data[0].id).toBe(id);
     expect(data[0].email).toBe("renamed@example.com");
+  });
+
+  it("pax8 contacts update requires --company (nested wire path, #324)", async () => {
+    const result = await runCliExpectFailure([
+      "contacts",
+      "update",
+      "contact-summit-001",
+      "--email",
+      "x@example.com",
+      "--yes",
+    ]);
+    expect(result.stderr).toContain("--company");
   });
 
   it("pax8 contacts update fails when no fields are provided", async () => {
@@ -175,7 +207,14 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
     ]);
     const id = JSON.parse(list.stdout)[0].id;
 
-    const result = await runCliExpectFailure(["contacts", "update", id, "--yes"]);
+    const result = await runCliExpectFailure([
+      "contacts",
+      "update",
+      id,
+      "--company",
+      "Summit Healthcare Partners",
+      "--yes",
+    ]);
     expect(result.stderr.toLowerCase()).toContain("update");
   });
 
@@ -193,11 +232,23 @@ describe("E2E: Contacts workflow — list, show, write commands", () => {
       "contacts",
       "delete",
       id,
+      "--company",
+      "Summit Healthcare Partners",
       "--yes",
       "--json",
     ]);
     const data = JSON.parse(result.stdout);
     expect(data[0].id).toBe(id);
     expect(data[0].status).toBe("Deleted");
+  });
+
+  it("pax8 contacts delete requires --company (nested wire path, #324)", async () => {
+    const result = await runCliExpectFailure([
+      "contacts",
+      "delete",
+      "contact-summit-001",
+      "--yes",
+    ]);
+    expect(result.stderr).toContain("--company");
   });
 });

--- a/packages/cli/src/__tests__/contacts.test.ts
+++ b/packages/cli/src/__tests__/contacts.test.ts
@@ -7,6 +7,59 @@ import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 const SUMMIT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 
 describe("pax8 contacts", () => {
+  // ─── nested wire path / `--company` requirement (#324) ─────────────────
+
+  describe("contacts list", () => {
+    it("lists contacts for a company", async () => {
+      const result = await runCliExpectSuccess([
+        "contacts",
+        "list",
+        "--company",
+        SUMMIT_ID,
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+      for (const c of data) {
+        expect(c.companyId).toBe(SUMMIT_ID);
+      }
+    });
+  });
+
+  describe("contacts show", () => {
+    it("requires --company", async () => {
+      const result = await runCliExpectFailure([
+        "contacts",
+        "show",
+        "contact-summit-001",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/--company is required/);
+      expect(combined).toMatch(/Contacts in v2 must be addressed under a company/);
+    });
+
+    it("returns the contact when --company is provided", async () => {
+      const result = await runCliExpectSuccess([
+        "contacts",
+        "show",
+        "contact-summit-001",
+        "--company",
+        SUMMIT_ID,
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.id).toBe("contact-summit-001");
+      expect(data.companyId).toBe(SUMMIT_ID);
+    });
+
+    it("shows the migration note in --help", async () => {
+      const result = await runCliExpectSuccess(["contacts", "show", "--help"]);
+      expect(result.stdout).toContain("--company");
+      expect(result.stdout).toMatch(/companies\/\{companyId\}\/contacts/);
+    });
+  });
+
   describe("contacts create --type", () => {
     it("accepts a single ContactType (default Admin)", async () => {
       const result = await runCliExpectSuccess(
@@ -29,6 +82,7 @@ describe("pax8 contacts", () => {
       const data = JSON.parse(result.stdout);
       expect(Array.isArray(data)).toBe(true);
       expect(data[0].types).toEqual(["Admin"]);
+      expect(data[0].companyId).toBe(SUMMIT_ID);
     });
 
     it("accepts comma-separated multiple ContactTypes", async () => {
@@ -114,13 +168,32 @@ describe("pax8 contacts", () => {
     });
   });
 
-  describe("contacts update --type", () => {
+  describe("contacts update", () => {
+    it("requires --company", async () => {
+      const result = await runCliExpectFailure(
+        [
+          "contacts",
+          "update",
+          "contact-summit-001",
+          "--email",
+          "x@example.com",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/--company is required/);
+      expect(combined).toMatch(/Contacts in v2 must be addressed under a company/);
+    });
+
     it("accepts comma-separated multiple ContactTypes", async () => {
       const result = await runCliExpectSuccess(
         [
           "contacts",
           "update",
           "contact-summit-001",
+          "--company",
+          SUMMIT_ID,
           "--type",
           "Admin,Technical",
           "--json",
@@ -139,6 +212,8 @@ describe("pax8 contacts", () => {
           "contacts",
           "update",
           "contact-summit-001",
+          "--company",
+          SUMMIT_ID,
           "--type",
           " , ,",
           "--yes",
@@ -155,6 +230,8 @@ describe("pax8 contacts", () => {
           "contacts",
           "update",
           "contact-summit-001",
+          "--company",
+          SUMMIT_ID,
           "--type",
           "Admin,NotReal",
           "--yes",
@@ -164,6 +241,41 @@ describe("pax8 contacts", () => {
       const combined = result.stdout + result.stderr;
       expect(combined).toMatch(/Invalid --type/);
       expect(combined).toContain("NotReal");
+    });
+  });
+
+  describe("contacts delete", () => {
+    it("requires --company", async () => {
+      const result = await runCliExpectFailure(
+        [
+          "contacts",
+          "delete",
+          "contact-summit-001",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/--company is required/);
+      expect(combined).toMatch(/Contacts in v2 must be addressed under a company/);
+    });
+
+    it("deletes when --company is provided", async () => {
+      const result = await runCliExpectSuccess(
+        [
+          "contacts",
+          "delete",
+          "contact-summit-001",
+          "--company",
+          SUMMIT_ID,
+          "--json",
+          "--yes",
+        ],
+        { PAX8_YES: "1" },
+      );
+      const data = JSON.parse(result.stdout);
+      expect(data[0].id).toBe("contact-summit-001");
+      expect(data[0].status).toBe("Deleted");
     });
   });
 });

--- a/packages/cli/src/commands/contacts/create.ts
+++ b/packages/cli/src/commands/contacts/create.ts
@@ -44,7 +44,12 @@ export const contactsCreateCommand = new Command("create")
 Examples:
   pax8 contacts create --company "Summit Healthcare Partners" --email rachel@example.com --first-name Rachel --last-name Thornton
   pax8 contacts create --company a1b2c3d4 --email tech@example.com --first-name Sam --last-name Lee --type Technical
-  pax8 contacts create --company a1b2c3d4 --email ops@example.com --first-name Pat --last-name Kim --type Admin,Billing`
+  pax8 contacts create --company a1b2c3d4 --email ops@example.com --first-name Pat --last-name Kim --type Admin,Billing
+
+Notes:
+  Contacts in the Pax8 public API are addressed only under their owning
+  company (\`POST /v1/companies/{companyId}/contacts\`). The \`--company\`
+  flag is required; there is no flat create endpoint.`
   )
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();
@@ -104,7 +109,7 @@ Examples:
       const doneCreate = markWriteInFlight("contacts");
       let contact;
       try {
-        contact = await ctx.api.contacts.create(input);
+        contact = await ctx.api.contacts.create(company.id, input);
       } finally {
         doneCreate();
       }

--- a/packages/cli/src/commands/contacts/delete.ts
+++ b/packages/cli/src/commands/contacts/delete.ts
@@ -3,32 +3,57 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
-import { handleCommandError } from "../../lib/errors.js";
-import { confirmDestructive } from "../../lib/confirm.js";
+import { handleCommandError, CliError } from "../../lib/errors.js";
+import { confirmDestructive, replCmd } from "../../lib/confirm.js";
+import { resolveCompany } from "../../lib/resolve-company.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 
 export const contactsDeleteCommand = new Command("delete")
   .description("Delete a contact")
   .argument("<id>", "Contact ID")
+  .option("--company <id|name>", "Owning company ID or name (required)")
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
     `
 Examples:
-  pax8 contacts delete contact-summit-001
-  pax8 contacts delete contact-summit-001 --yes`
+  pax8 contacts delete contact-summit-001 --company "Summit Healthcare Partners"
+  pax8 contacts delete contact-summit-001 --company a1b2c3d4 --yes
+
+Notes:
+  Contacts in the Pax8 public API are addressed only under their owning
+  company (\`DELETE /v1/companies/{companyId}/contacts/{contactId}\`). The
+  \`--company\` flag is required; there is no flat delete endpoint.`
   )
   .action(async (id, _options, command) => {
     const globalOpts = command.optsWithGlobals();
     const ctx = await buildContext(globalOpts);
 
     try {
+      if (!globalOpts.company) {
+        throw new CliError(
+          "--company is required",
+          [
+            "Contacts in v2 must be addressed under a company. Pass `--company <id|name>`.",
+            "(Previously: `pax8 contacts delete <contact-id>`.)",
+          ],
+          [
+            `Pick a company first: ${replCmd("pax8 companies list")}`,
+            `Then: ${replCmd(`pax8 contacts delete ${id}`)} --company <id|name>`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
       const spinner = createSpinner("Fetching contact...").start();
-      const contact = await ctx.api.contacts.get(id);
+      const company = await resolveCompany(ctx, globalOpts.company);
+      const contact = await ctx.api.contacts.get(company.id, id);
       spinner.stop();
 
       if (ctx.outputFormat !== "quiet") {
@@ -52,7 +77,7 @@ Examples:
       const delSpinner = createSpinner("Deleting contact...").start();
       const doneDelete = markWriteInFlight("contacts");
       try {
-        await ctx.api.contacts.delete(id);
+        await ctx.api.contacts.delete(company.id, id);
       } finally {
         doneDelete();
       }

--- a/packages/cli/src/commands/contacts/show.ts
+++ b/packages/cli/src/commands/contacts/show.ts
@@ -3,22 +3,30 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
-import { handleCommandError } from "../../lib/errors.js";
+import { handleCommandError, CliError } from "../../lib/errors.js";
 import { replCmd } from "../../lib/confirm.js";
+import { resolveCompany } from "../../lib/resolve-company.js";
 
 export const contactsShowCommand = new Command("show")
   .description("Show contact details")
   .argument("<id>", "Contact ID")
+  .option("--company <id|name>", "Owning company ID or name (required)")
   .addHelpText(
     "after",
     `
 Examples:
-  pax8 contacts show contact-summit-001
-  pax8 contacts show contact-summit-001 --json
-  pax8 contacts show contact-summit-001 --csv`
+  pax8 contacts show contact-summit-001 --company "Summit Healthcare Partners"
+  pax8 contacts show contact-summit-001 --company a1b2c3d4 --json
+  pax8 contacts show contact-summit-001 --company a1b2c3d4 --csv
+
+Notes:
+  Contacts in the Pax8 public API are addressed only under their owning
+  company (\`GET /v1/companies/{companyId}/contacts/{contactId}\`). The
+  \`--company\` flag is required; there is no flat lookup endpoint.`
   )
   .action(async (id, _options, command) => {
     const globalOpts = command.optsWithGlobals();
@@ -26,8 +34,25 @@ Examples:
     const spinner = createSpinner("Fetching contact...");
 
     try {
+      if (!globalOpts.company) {
+        throw new CliError(
+          "--company is required",
+          [
+            "Contacts in v2 must be addressed under a company. Pass `--company <id|name>`.",
+            "(Previously: `pax8 contacts show <contact-id>`.)",
+          ],
+          [
+            `Pick a company first: ${replCmd("pax8 companies list")}`,
+            `Then: ${replCmd(`pax8 contacts show ${id}`)} --company <id|name>`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
       spinner.start();
-      const contact = await ctx.api.contacts.get(id);
+      const company = await resolveCompany(ctx, globalOpts.company);
+      const contact = await ctx.api.contacts.get(company.id, id);
       spinner.stop();
 
       if (ctx.outputFormat === "json") {
@@ -63,8 +88,8 @@ Examples:
       process.stdout.write("\n");
 
       process.stderr.write(chalk.dim("  Try next:\n"));
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts update ${contact.id} --email <new-email>`))}  ${chalk.dim("update this contact")}\n`);
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts delete ${contact.id}`))}  ${chalk.dim("delete this contact")}\n`);
+      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts update ${contact.id} --company "${company.name}" --email <new-email>`))}  ${chalk.dim("update this contact")}\n`);
+      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts delete ${contact.id} --company "${company.name}"`))}  ${chalk.dim("delete this contact")}\n`);
       process.stderr.write("\n");
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to show contact");

--- a/packages/cli/src/commands/contacts/update.ts
+++ b/packages/cli/src/commands/contacts/update.ts
@@ -9,6 +9,7 @@ import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
 import { confirm, replCmd } from "../../lib/confirm.js";
+import { resolveCompany } from "../../lib/resolve-company.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 import type { UpdateContactInput, ContactType } from "@pax8/core";
@@ -31,6 +32,7 @@ function parseTypes(input: string): string[] {
 export const contactsUpdateCommand = new Command("update")
   .description("Update a contact")
   .argument("<id>", "Contact ID")
+  .option("--company <id|name>", "Owning company ID or name (required)")
   .option("--first-name <name>", "New first name")
   .option("--last-name <name>", "New last name")
   .option("--email <email>", "New email")
@@ -41,16 +43,37 @@ export const contactsUpdateCommand = new Command("update")
     "after",
     `
 Examples:
-  pax8 contacts update contact-summit-001 --email rachel.new@example.com
-  pax8 contacts update contact-summit-001 --type Billing
-  pax8 contacts update contact-summit-001 --type Admin,Billing
-  pax8 contacts update contact-summit-001 --phone "+1-303-555-9999" --yes`
+  pax8 contacts update contact-summit-001 --company "Summit Healthcare Partners" --email rachel.new@example.com
+  pax8 contacts update contact-summit-001 --company a1b2c3d4 --type Billing
+  pax8 contacts update contact-summit-001 --company a1b2c3d4 --type Admin,Billing
+  pax8 contacts update contact-summit-001 --company a1b2c3d4 --phone "+1-303-555-9999" --yes
+
+Notes:
+  Contacts in the Pax8 public API are addressed only under their owning
+  company (\`PUT /v1/companies/{companyId}/contacts/{contactId}\`). The
+  \`--company\` flag is required; there is no flat update endpoint.`
   )
   .action(async (id, options, command) => {
     const globalOpts = command.optsWithGlobals();
     const ctx = await buildContext(globalOpts);
 
     try {
+      if (!globalOpts.company) {
+        throw new CliError(
+          "--company is required",
+          [
+            "Contacts in v2 must be addressed under a company. Pass `--company <id|name>`.",
+            "(Previously: `pax8 contacts update <contact-id> ...`.)",
+          ],
+          [
+            `Pick a company first: ${replCmd("pax8 companies list")}`,
+            `Then: ${replCmd(`pax8 contacts update ${id}`)} --company <id|name> --email <new-email>`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
       const data: UpdateContactInput = {};
       if (options.firstName) data.firstName = options.firstName;
       if (options.lastName) data.lastName = options.lastName;
@@ -62,7 +85,7 @@ Examples:
           throw new CliError(
             "At least one contact type is required when --type is provided",
             [`--type must contain one or more comma-separated values from: ${VALID_TYPES.join(", ")}`],
-            [`Try: ${replCmd("pax8 contacts update")} ${id} --type Admin,Billing`],
+            [`Try: ${replCmd("pax8 contacts update")} ${id} --company <id|name> --type Admin,Billing`],
             undefined,
             ERROR_INVALID_INPUT,
           );
@@ -72,7 +95,7 @@ Examples:
           throw new CliError(
             `Invalid --type value(s): ${invalid.map((v) => `"${v}"`).join(", ")}`,
             [`Allowed values: ${VALID_TYPES.join(", ")}`],
-            [`Try: ${replCmd("pax8 contacts update")} ${id} --type Admin,Billing`],
+            [`Try: ${replCmd("pax8 contacts update")} ${id} --company <id|name> --type Admin,Billing`],
             undefined,
             ERROR_INVALID_INPUT,
           );
@@ -84,14 +107,15 @@ Examples:
         throw new CliError(
           "No fields to update",
           ["At least one of --first-name, --last-name, --email, --phone, or --type is required"],
-          [`Try: ${replCmd("pax8 contacts update")} ${id} --email <new-email>`],
+          [`Try: ${replCmd("pax8 contacts update")} ${id} --company <id|name> --email <new-email>`],
           undefined,
           ERROR_INVALID_INPUT,
         );
       }
 
       const spinner = createSpinner("Fetching contact...").start();
-      const current = await ctx.api.contacts.get(id);
+      const company = await resolveCompany(ctx, globalOpts.company);
+      const current = await ctx.api.contacts.get(company.id, id);
       spinner.stop();
 
       process.stderr.write(chalk.bold("\n  Update Contact:\n\n"));
@@ -114,7 +138,7 @@ Examples:
       const doneUpdate = markWriteInFlight("contacts");
       let updated;
       try {
-        updated = await ctx.api.contacts.update(id, data);
+        updated = await ctx.api.contacts.update(company.id, id, data);
       } finally {
         doneUpdate();
       }

--- a/packages/core/src/api/contacts.test.ts
+++ b/packages/core/src/api/contacts.test.ts
@@ -43,7 +43,7 @@ describe("ContactsApi", () => {
     api = new ContactsApi(client);
   });
 
-  it("list returns paginated contacts for a company", async () => {
+  it("list hits nested /companies/{companyId}/contacts", async () => {
     (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(samplePaginatedResponse);
 
     const result = await api.list(COMPANY_ID, { page: 0, size: 50 });
@@ -56,17 +56,19 @@ describe("ContactsApi", () => {
     expect(result.content[0].firstName).toBe("John");
   });
 
-  it("get returns a single contact", async () => {
+  it("get hits nested /companies/{companyId}/contacts/{contactId}", async () => {
     (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(sampleContact);
 
-    const result = await api.get(CONTACT_ID);
+    const result = await api.get(COMPANY_ID, CONTACT_ID);
 
-    expect(client.get).toHaveBeenCalledWith(`/contacts/${CONTACT_ID}`);
+    expect(client.get).toHaveBeenCalledWith(
+      `/companies/${COMPANY_ID}/contacts/${CONTACT_ID}`,
+    );
     expect(result.id).toBe(CONTACT_ID);
     expect(result.email).toBe("john@example.com");
   });
 
-  it("create sends correct body and returns contact", async () => {
+  it("create POSTs to nested /companies/{companyId}/contacts", async () => {
     const input = {
       firstName: "Jane",
       lastName: "Smith",
@@ -77,28 +79,36 @@ describe("ContactsApi", () => {
     const created = { ...sampleContact, ...input, id: "b2c3d4e5-f6a7-8901-bcde-f12345678901" };
     (client.post as ReturnType<typeof vi.fn>).mockResolvedValue(created);
 
-    const result = await api.create(input);
+    const result = await api.create(COMPANY_ID, input);
 
-    expect(client.post).toHaveBeenCalledWith("/contacts", input);
+    expect(client.post).toHaveBeenCalledWith(
+      `/companies/${COMPANY_ID}/contacts`,
+      input,
+    );
     expect(result.firstName).toBe("Jane");
   });
 
-  it("update sends correct body and returns contact", async () => {
+  it("update PUTs to nested /companies/{companyId}/contacts/{contactId}", async () => {
     const input = { firstName: "Updated" };
     const updated = { ...sampleContact, firstName: "Updated" };
     (client.put as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
 
-    const result = await api.update(CONTACT_ID, input);
+    const result = await api.update(COMPANY_ID, CONTACT_ID, input);
 
-    expect(client.put).toHaveBeenCalledWith(`/contacts/${CONTACT_ID}`, input);
+    expect(client.put).toHaveBeenCalledWith(
+      `/companies/${COMPANY_ID}/contacts/${CONTACT_ID}`,
+      input,
+    );
     expect(result.firstName).toBe("Updated");
   });
 
-  it("delete calls client.delete", async () => {
+  it("delete hits nested /companies/{companyId}/contacts/{contactId}", async () => {
     (client.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
-    await api.delete(CONTACT_ID);
+    await api.delete(COMPANY_ID, CONTACT_ID);
 
-    expect(client.delete).toHaveBeenCalledWith(`/contacts/${CONTACT_ID}`);
+    expect(client.delete).toHaveBeenCalledWith(
+      `/companies/${COMPANY_ID}/contacts/${CONTACT_ID}`,
+    );
   });
 });

--- a/packages/core/src/api/contacts.ts
+++ b/packages/core/src/api/contacts.ts
@@ -13,6 +13,13 @@ import {
 
 const PaginatedContactSchema = PaginatedResponseSchema(ContactSchema);
 
+/**
+ * Pax8 Contacts API.
+ *
+ * Wire paths are always nested under `/companies/{companyId}/contacts` per the
+ * Pax8 public spec. There is no flat `/contacts` endpoint at any version —
+ * every method threads `companyId` into the URL path.
+ */
 export class ContactsApi {
   constructor(private client: Pax8Client) {}
 
@@ -20,26 +27,43 @@ export class ContactsApi {
     companyId: string,
     params?: { page?: number; size?: number },
   ): Promise<PaginatedResponse<Contact>> {
-    const raw = await this.client.get<unknown>(`/companies/${companyId}/contacts`, params as Record<string, string | number | undefined>);
+    const raw = await this.client.get<unknown>(
+      `/companies/${companyId}/contacts`,
+      params as Record<string, string | number | undefined>,
+    );
     return PaginatedContactSchema.parse(raw);
   }
 
-  async get(id: string): Promise<Contact> {
-    const raw = await this.client.get<unknown>(`/contacts/${id}`);
+  async get(companyId: string, contactId: string): Promise<Contact> {
+    const raw = await this.client.get<unknown>(
+      `/companies/${companyId}/contacts/${contactId}`,
+    );
     return ContactSchema.parse(raw);
   }
 
-  async create(data: CreateContactInput): Promise<Contact> {
-    const raw = await this.client.post<unknown>("/contacts", data);
+  async create(companyId: string, data: CreateContactInput): Promise<Contact> {
+    const raw = await this.client.post<unknown>(
+      `/companies/${companyId}/contacts`,
+      data,
+    );
     return ContactSchema.parse(raw);
   }
 
-  async update(id: string, data: UpdateContactInput): Promise<Contact> {
-    const raw = await this.client.put<unknown>(`/contacts/${id}`, data);
+  async update(
+    companyId: string,
+    contactId: string,
+    data: UpdateContactInput,
+  ): Promise<Contact> {
+    const raw = await this.client.put<unknown>(
+      `/companies/${companyId}/contacts/${contactId}`,
+      data,
+    );
     return ContactSchema.parse(raw);
   }
 
-  async delete(id: string): Promise<void> {
-    await this.client.delete(`/contacts/${id}`);
+  async delete(companyId: string, contactId: string): Promise<void> {
+    await this.client.delete(
+      `/companies/${companyId}/contacts/${contactId}`,
+    );
   }
 }

--- a/packages/core/src/mock/mock-client-extended.test.ts
+++ b/packages/core/src/mock/mock-client-extended.test.ts
@@ -235,66 +235,72 @@ describe("MockPax8Client — extended coverage", () => {
 
   // ─── Contacts ────────────────────────────────────────────────────────────
 
+  // The Pax8 public spec only addresses contacts under
+  // `/companies/{companyId}/contacts[/{contactId}]` — there is no flat
+  // `/contacts` endpoint — so the mock now mirrors that contract (#324).
+  const SUMMIT_COMPANY_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
   describe("contacts.get()", () => {
-    it("returns contact by id", async () => {
-      const all = await client.contacts.list(
-        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-        { size: 100 },
-      );
+    it("returns contact by id under its owning company", async () => {
+      const all = await client.contacts.list(SUMMIT_COMPANY_ID, { size: 100 });
       const firstId = all.content[0].id;
-      const contact = await client.contacts.get(firstId);
+      const contact = await client.contacts.get(SUMMIT_COMPANY_ID, firstId);
       expect(contact.id).toBe(firstId);
     });
 
     it("throws NotFoundError for unknown contact", async () => {
-      await expect(client.contacts.get("nonexistent")).rejects.toThrow(NotFoundError);
+      await expect(
+        client.contacts.get(SUMMIT_COMPANY_ID, "nonexistent"),
+      ).rejects.toThrow(NotFoundError);
     });
   });
 
   describe("contacts.create()", () => {
-    it("creates a contact", async () => {
-      const result = await client.contacts.create({
-        companyId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    it("creates a contact under the given company", async () => {
+      const result = await client.contacts.create(SUMMIT_COMPANY_ID, {
         firstName: "Jane",
         lastName: "Doe",
         email: "jane@example.com",
       });
       expect(result.id).toContain("contact-demo-");
       expect(result.firstName).toBe("Jane");
+      expect(result.companyId).toBe(SUMMIT_COMPANY_ID);
     });
   });
 
   describe("contacts.update()", () => {
-    it("updates a contact", async () => {
-      const all = await client.contacts.list(
-        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-        { size: 100 },
-      );
+    it("updates a contact under its owning company", async () => {
+      const all = await client.contacts.list(SUMMIT_COMPANY_ID, { size: 100 });
       const firstId = all.content[0].id;
-      const result = await client.contacts.update(firstId, { firstName: "Updated" });
+      const result = await client.contacts.update(
+        SUMMIT_COMPANY_ID,
+        firstId,
+        { firstName: "Updated" },
+      );
       expect(result.firstName).toBe("Updated");
       expect(result.id).toBe(firstId);
     });
 
     it("throws NotFoundError for unknown contact", async () => {
       await expect(
-        client.contacts.update("nonexistent", { firstName: "X" }),
+        client.contacts.update(SUMMIT_COMPANY_ID, "nonexistent", { firstName: "X" }),
       ).rejects.toThrow(NotFoundError);
     });
   });
 
   describe("contacts.delete()", () => {
-    it("deletes existing contact", async () => {
-      const all = await client.contacts.list(
-        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-        { size: 100 },
-      );
+    it("deletes existing contact under its owning company", async () => {
+      const all = await client.contacts.list(SUMMIT_COMPANY_ID, { size: 100 });
       const firstId = all.content[0].id;
-      await expect(client.contacts.delete(firstId)).resolves.toBeUndefined();
+      await expect(
+        client.contacts.delete(SUMMIT_COMPANY_ID, firstId),
+      ).resolves.toBeUndefined();
     });
 
     it("throws NotFoundError for unknown contact", async () => {
-      await expect(client.contacts.delete("nonexistent")).rejects.toThrow(NotFoundError);
+      await expect(
+        client.contacts.delete(SUMMIT_COMPANY_ID, "nonexistent"),
+      ).rejects.toThrow(NotFoundError);
     });
   });
 

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -492,7 +492,9 @@ class OrdersResource {
 }
 
 class ContactsResource {
-  // Mirrors ContactsApi.list — companyId is the first positional argument.
+  // Mirrors ContactsApi — every method threads companyId as the first argument
+  // because the Pax8 public spec only addresses contacts under the nested
+  // `/companies/{companyId}/contacts[/{contactId}]` paths.
   async list(
     companyId: string,
     params?: ListParams,
@@ -502,18 +504,20 @@ class ContactsResource {
     return paginate(filtered, params);
   }
 
-  async get(id: string): Promise<Contact> {
+  async get(companyId: string, contactId: string): Promise<Contact> {
     await randomDelay();
-    const contact = contacts.find((c) => c.id === id);
-    if (!contact) throw notFound("Contact", id);
+    const contact = contacts.find(
+      (c) => c.id === contactId && c.companyId === companyId,
+    );
+    if (!contact) throw notFound("Contact", contactId);
     return contact;
   }
 
-  async create(data: Partial<Contact>): Promise<Contact> {
+  async create(companyId: string, data: Partial<Contact>): Promise<Contact> {
     await randomDelay();
     const newContact: Contact = {
       id: `contact-demo-${Date.now()}`,
-      companyId: data.companyId ?? "",
+      companyId,
       firstName: data.firstName ?? "",
       lastName: data.lastName ?? "",
       email: data.email ?? "",
@@ -523,17 +527,25 @@ class ContactsResource {
     return newContact;
   }
 
-  async update(id: string, data: Partial<Contact>): Promise<Contact> {
+  async update(
+    companyId: string,
+    contactId: string,
+    data: Partial<Contact>,
+  ): Promise<Contact> {
     await randomDelay();
-    const contact = contacts.find((c) => c.id === id);
-    if (!contact) throw notFound("Contact", id);
-    return { ...contact, ...data, id: contact.id };
+    const contact = contacts.find(
+      (c) => c.id === contactId && c.companyId === companyId,
+    );
+    if (!contact) throw notFound("Contact", contactId);
+    return { ...contact, ...data, id: contact.id, companyId: contact.companyId };
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(companyId: string, contactId: string): Promise<void> {
     await randomDelay();
-    const contact = contacts.find((c) => c.id === id);
-    if (!contact) throw notFound("Contact", id);
+    const contact = contacts.find(
+      (c) => c.id === contactId && c.companyId === companyId,
+    );
+    if (!contact) throw notFound("Contact", contactId);
   }
 }
 


### PR DESCRIPTION
## Summary

`ContactsApi.{get,create,update,delete}` called flat `/v1/contacts/*` paths that do not exist in the Pax8 public spec — `partner-endpoints.json` only addresses contacts via `/v1/companies/{companyId}/contacts[/{contactId}]`. Same bug class as the usage fix in #343; this PR adopts the same Option A pattern: thread `companyId` into every method (or as a member of the input), and require `--company` at the CLI for any operation that targets a specific contact.

Confirmed against the live OpenAPI: `/companies/{companyId}/contacts` supports `GET`/`POST` and `/companies/{companyId}/contacts/{contactId}` supports `GET`/`PUT`/`DELETE` (PUT, not PATCH).

### Wire-path changes (`@pax8/core`)

- `ContactsApi.get(companyId, contactId)` → `GET /companies/{companyId}/contacts/{contactId}`
- `ContactsApi.create(companyId, data)` → `POST /companies/{companyId}/contacts`
- `ContactsApi.update(companyId, contactId, data)` → `PUT /companies/{companyId}/contacts/{contactId}`
- `ContactsApi.delete(companyId, contactId)` → `DELETE /companies/{companyId}/contacts/{contactId}`
- `ContactsApi.list(companyId, params)` was already nested; unchanged.

The mock client (`MockPax8Client.contacts`) mirrors the new contract.

### CLI surface

- **No change**: `contacts list --company X`, `contacts create --company X ...`.
- **Breaking change** (necessary — the flat paths don't exist): `contacts show <id>`, `contacts update <id>`, and `contacts delete <id>` now require `--company <id|name>`. The CLI emits a clear migration error when missing:
  > `--company is required`
  > `Contacts in v2 must be addressed under a company. Pass \`--company <id|name>\`.`
  > `(Previously: \`pax8 contacts show <contact-id>\`.)`
- A one-line note appears in each command's `--help` footer explaining the requirement and the spec rationale.

### Out of scope

Body-shape problems on `contacts create` and `contacts update` (#325) are intentionally not addressed here — this PR is path/signature only.

## Test plan

- [x] `pnpm build` — clean across `@pax8/core` and `@pax8/cli`
- [x] `pnpm test` — 1646 passed / 8 skipped (105 files). New URL pinning in `packages/core/src/api/contacts.test.ts` for every method. Subprocess tests in `packages/cli/src/__tests__/contacts.test.ts` and `e2e/contacts-workflow.test.ts` cover the missing-`--company` errors for show/update/delete plus the happy paths. `MockPax8Client` contacts coverage in `mock-client-extended.test.ts` updated to the new signature.
- [x] `pnpm lint` — clean
- [ ] Manual verification against a real Pax8 sandbox tenant (closes the audit gap end-to-end)

Closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)