### PR TITLE
fix(companies): align address field names with spec + send required booleans on create

### DIFF
--- a/.changeset/companies-address-and-required-booleans.md
+++ b/.changeset/companies-address-and-required-booleans.md
@@ -1,0 +1,13 @@
+---
+"@pax8/core": patch
+"@pax8/cli": patch
+---
+
+`pax8 companies create` and `pax8 companies show` (and every other read that surfaces `address`) now align with the public Pax8 spec:
+
+- **`AddressSchema` rename (closes #327, #328):** wire field names are now `stateOrProvince` and `postalCode` (previously `state` and `zip`). The CLI flag names `--state` and `--zip` are unchanged for UX continuity — flag vocabulary and wire vocabulary are intentionally separate. Pre-rename, the wrong leaf names silently (a) dropped state/postal data on `companies create` (the API didn't recognize them) and (b) dropped state/postal data on every read (Zod stripped the API's `stateOrProvince` / `postalCode` as unknowns).
+- **Three required billing booleans (closes #329):** `companies create` now sends `billOnBehalfOfEnabled`, `selfServiceAllowed`, and `orderApprovalRequired` via new `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required` flags (all default to `false`, matching the conservative shape in the OpenAPI `company-post` example). `CreateCompanyInputSchema` now requires the three booleans at the type level.
+- **Fail-fast on empty address (closes #329):** the handler no longer constructs a degenerate empty `address` object on the wire when partners omit address flags. It throws `ERROR_INVALID_INPUT` with a structured error pointing at the spec's `address` requirement.
+- **New `--street` flag** on `companies create` for the spec's `address.street`.
+
+Demo fixtures and the mock client are renamed to match. Read-side rendering in `companies show` now reads from `address.stateOrProvince` and `address.postalCode`.

--- a/docs/domain-review.md
+++ b/docs/domain-review.md
@@ -59,7 +59,7 @@ Full audit, including the retrospective on why the initial wire-path investigati
 |---|---|---|---|
 | `pax8 companies list` | `--status`, `--page`, `--size`, `--ids-only`, `--coverage`, `--with-actions` | size=25 | `--coverage` adds portfolio coverage analysis (computed) |
 | `pax8 companies show <id\|name>` | accepts name as alternative to UUID | | |
-| `pax8 companies create` | `--name`, `--phone`, `--website`, `--city`, `--state`, `--zip`, `--country`, `-y` | country=US | |
+| `pax8 companies create` | `--name`, `--phone`, `--website`, `--street`, `--city`, `--state`, `--zip`, `--country`, `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required`, `-y` | country=US; booleans all default to `false` | Address required (fail-fast); three billing booleans added in #329 |
 | `pax8 companies update <id\|name>` | `--name`, `--phone`, `--website`, `-y` | | No address/billing-flag updates exposed |
 | `pax8 companies more` | (interactive paging helper) | | CLI-only |
 | `pax8 contacts list` | `--company <id\|name>` (required), `--page`, `--size`, `--ids-only` | size=50 | |
@@ -68,7 +68,7 @@ Full audit, including the retrospective on why the initial wire-path investigati
 | `pax8 contacts update <id>` | `--first-name`, `--last-name`, `--email`, `--phone`, `--type <list>`, `-y` | | `--type` accepts a comma-separated list post-#255 |
 | `pax8 contacts delete <id>` | `-y` | | |
 
-CLI output schemas (Zod) — `Company`: `id, name, address{street,city,state,zip,country}, phone, website, status, billOnBehalfOfEnabled, selfServiceAllowed, orderApprovalRequired, created, modified`. `Contact`: `id, firstName, lastName, email, phone, companyId, types[]`.
+CLI output schemas (Zod) — `Company`: `id, name, address{street,street2,city,stateOrProvince,postalCode,country}, phone, website, status, billOnBehalfOfEnabled, selfServiceAllowed, orderApprovalRequired, externalId, created, updatedDate`. `Contact`: `id, firstName, lastName, email, phone, companyId, types[]`.
 
 ### Public API Surface
 
@@ -80,8 +80,8 @@ API `Company`: `id, name, address, phone, website, status, billOnBehalfOfEnabled
 
 | API Term | CLI Term | Notes |
 |---|---|---|
-| `address.stateOrProvince` (query) / `state` (body) | `--state` | API is inconsistent; CLI normalizes to `state` |
-| `address.postalCode` (query) / `zip` (body) | `--zip` | Same — CLI picks the shorter body field |
+| `address.stateOrProvince` | `--state` | Wire field is `stateOrProvince`; CLI keeps the shorter `--state` flag for UX continuity [Wire rename in #327/#328] |
+| `address.postalCode` | `--zip` | Wire field is `postalCode`; CLI keeps the shorter `--zip` flag for UX continuity [Wire rename in #327/#328] |
 | `externalId` | `externalId` | Surfaced on Company in `pax8 companies show` (table + `--json`) [Resolved in #273] |
 | `updatedDate` | `updatedDate` | Aligned with API in #273 (was `modified`) |
 | `createdDate` (Contact) | (not exposed on Contact) | Only surfaced on Company-ish resources |

--- a/packages/cli/src/__tests__/companies.test.ts
+++ b/packages/cli/src/__tests__/companies.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 
 describe("pax8 companies", () => {
   describe("companies list", () => {
@@ -143,6 +143,124 @@ describe("pax8 companies", () => {
       const data = JSON.parse(result.stdout);
       expect(data.subscriptions).toBeDefined();
       expect(data.subscriptions.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("companies show — address wire field names", () => {
+    it("surfaces stateOrProvince and postalCode (not state/zip) in --json", async () => {
+      // Read-side fix from #328: pre-rename, Zod silently dropped the API's
+      // `stateOrProvince` / `postalCode` because the schema parsed `state` /
+      // `zip`. This test pins the new behavior against the renamed demo data.
+      const result = await runCliExpectSuccess([
+        "companies",
+        "show",
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.address).toBeDefined();
+      expect(data.address).toHaveProperty("stateOrProvince", "CO");
+      expect(data.address).toHaveProperty("postalCode", "80246");
+      expect(data.address).not.toHaveProperty("state");
+      expect(data.address).not.toHaveProperty("zip");
+    });
+  });
+
+  describe("companies create — required booleans + address mapping", () => {
+    it("fails with ERROR_INVALID_INPUT when no address flags are supplied", async () => {
+      // #329 fail-fast: spec marks `address` as required on POST /companies.
+      // The handler refuses to construct a degenerate empty `{}` on the wire.
+      const result = await runCliExpectFailure([
+        "companies",
+        "create",
+        "--name",
+        "Addressless Co",
+        "--phone",
+        "+1-555-0100",
+        "--website",
+        "https://addressless.example.com",
+        "--yes",
+        "--json",
+      ]);
+      // Structured error on stderr in --json mode
+      const stderr = result.stderr;
+      expect(stderr).toContain("ERROR_INVALID_INPUT");
+      expect(stderr.toLowerCase()).toContain("address");
+    });
+
+    it("succeeds and reflects the three booleans + city/state when address is supplied", async () => {
+      // Defaults (no --bill-on-behalf-of / --self-service-allowed /
+      // --order-approval-required flags) all resolve to `false`. Demo mock
+      // echoes the body's booleans back so we can assert them on the
+      // returned company.
+      const result = await runCliExpectSuccess([
+        "companies",
+        "create",
+        "--name",
+        "Defaults Co",
+        "--phone",
+        "+1-555-0101",
+        "--website",
+        "https://defaults.example.com",
+        "--city",
+        "Denver",
+        "--state",
+        "CO",
+        "--zip",
+        "80202",
+        "--country",
+        "US",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("name", "Defaults Co");
+      expect(data).toHaveProperty("billOnBehalfOfEnabled", false);
+      expect(data).toHaveProperty("selfServiceAllowed", false);
+      expect(data).toHaveProperty("orderApprovalRequired", false);
+      // The mock client passes the address through verbatim; the wire field
+      // names must be `stateOrProvince` / `postalCode` (not `state` / `zip`).
+      expect(data.address).toHaveProperty("stateOrProvince", "CO");
+      expect(data.address).toHaveProperty("postalCode", "80202");
+      expect(data.address).not.toHaveProperty("state");
+      expect(data.address).not.toHaveProperty("zip");
+    });
+
+    it("--bill-on-behalf-of true / --order-approval-required true override defaults", async () => {
+      const result = await runCliExpectSuccess([
+        "companies",
+        "create",
+        "--name",
+        "Override Co",
+        "--phone",
+        "+1-555-0102",
+        "--website",
+        "https://override.example.com",
+        "--city",
+        "Austin",
+        "--state",
+        "TX",
+        "--zip",
+        "78704",
+        "--bill-on-behalf-of",
+        "true",
+        "--order-approval-required",
+        "true",
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("billOnBehalfOfEnabled", true);
+      expect(data).toHaveProperty("selfServiceAllowed", false);
+      expect(data).toHaveProperty("orderApprovalRequired", true);
+    });
+
+    it("shows the new boolean flags in --help", async () => {
+      const result = await runCliExpectSuccess(["companies", "create", "--help"]);
+      expect(result.stdout).toContain("--bill-on-behalf-of");
+      expect(result.stdout).toContain("--self-service-allowed");
+      expect(result.stdout).toContain("--order-approval-required");
+      expect(result.stdout).toContain("--street");
     });
   });
 

--- a/packages/cli/src/commands/companies/create.ts
+++ b/packages/cli/src/commands/companies/create.ts
@@ -3,30 +3,64 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
+import { ERROR_INVALID_INPUT, type CreateCompanyInput } from "@pax8/core";
 import { createSpinner } from "../../lib/spinner.js";
-import { handleCommandError } from "../../lib/errors.js";
+import { CliError, handleCommandError } from "../../lib/errors.js";
 import { buildContext } from "../../lib/context.js";
 import { confirm } from "../../lib/confirm.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
+
+/**
+ * Commander hands us boolean-ish flags as the string Commander parsed
+ * (`"true"`, `"false"`) or the default. Coerce defensively — any value that
+ * isn't literally `"true"` (case-insensitive) becomes `false`.
+ */
+function parseBool(value: unknown, defaultValue: boolean): boolean {
+  if (value === undefined || value === null) return defaultValue;
+  if (typeof value === "boolean") return value;
+  const s = String(value).trim().toLowerCase();
+  if (s === "true" || s === "1" || s === "yes") return true;
+  if (s === "false" || s === "0" || s === "no") return false;
+  return defaultValue;
+}
 
 export const companiesCreateCommand = new Command("create")
   .description("Create a new company")
   .requiredOption("--name <name>", "Company name (required)")
   .option("--phone <phone>", "Company phone number")
   .option("--website <url>", "Company website")
+  .option("--street <street>", "Street address")
   .option("--city <city>", "City")
-  .option("--state <state>", "State or province")
-  .option("--zip <zip>", "Postal code")
+  .option("--state <state>", "State or province (maps to address.stateOrProvince on the wire)")
+  .option("--zip <zip>", "Postal code (maps to address.postalCode on the wire)")
   .option("--country <country>", "Country code (e.g. US)", "US")
+  // Three spec-required billing booleans (`#329`). Defaults match the
+  // conservative shape in the OpenAPI `company-post` example: every flag
+  // off. Partners who need a different posture pass the flag explicitly.
+  .option(
+    "--bill-on-behalf-of <true|false>",
+    "Pax8 bills the customer on the partner's behalf (defaults to false)",
+    "false"
+  )
+  .option(
+    "--self-service-allowed <true|false>",
+    "Customer can self-service via the marketplace (defaults to false)",
+    "false"
+  )
+  .option(
+    "--order-approval-required <true|false>",
+    "Orders require partner approval (defaults to false)",
+    "false"
+  )
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
     `
 Examples:
-  pax8 companies create --name "Summit Healthcare Partners" --phone "+1-303-555-0101" --website "https://summithealthcare.example.com"
-  pax8 companies create --name "Test Co" --city Denver --state CO --zip 80202 --country US
-  pax8 companies create --name "Quick Co" --yes`
+  pax8 companies create --name "Summit Healthcare Partners" --phone "+1-303-555-0101" --website "https://summithealthcare.example.com" --city Denver --state CO --zip 80246
+  pax8 companies create --name "Test Co" --city Denver --state CO --zip 80202 --country US --bill-on-behalf-of true
+  pax8 companies create --name "Approval Co" --city NYC --state NY --zip 10001 --order-approval-required true --yes`
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -34,15 +68,39 @@ Examples:
     try {
       const ctx = await buildContext(allOpts);
 
+      // Spec requires a non-empty address on `POST /companies`. Fail-fast
+      // with a structured error rather than silently shipping a degenerate
+      // empty address object on the wire (#329).
+      const hasAddress = Boolean(
+        allOpts.street || allOpts.city || allOpts.state || allOpts.zip
+      );
+      if (!hasAddress) {
+        throw new CliError(
+          "Address is required to create a company",
+          ["The Pax8 spec marks `address` as a required field on POST /companies."],
+          [
+            "Pass at least one of --street, --city, --state, --zip (and --country if not US).",
+            "Example: pax8 companies create --name \"Acme\" --city Denver --state CO --zip 80202",
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      const billOnBehalfOfEnabled = parseBool(allOpts.billOnBehalfOf, false);
+      const selfServiceAllowed = parseBool(allOpts.selfServiceAllowed, false);
+      const orderApprovalRequired = parseBool(allOpts.orderApprovalRequired, false);
+
       // Show what will be created
       process.stderr.write(chalk.bold("\n  Creating company:\n\n"));
       process.stderr.write(`  ${chalk.dim("Name:")}     ${allOpts.name}\n`);
       if (allOpts.phone) process.stderr.write(`  ${chalk.dim("Phone:")}    ${allOpts.phone}\n`);
       if (allOpts.website) process.stderr.write(`  ${chalk.dim("Website:")}  ${allOpts.website}\n`);
-      if (allOpts.city || allOpts.state || allOpts.zip) {
-        const addrParts = [allOpts.city, allOpts.state, allOpts.zip].filter(Boolean);
-        process.stderr.write(`  ${chalk.dim("Location:")} ${addrParts.join(", ")} ${allOpts.country}\n`);
-      }
+      const addrParts = [allOpts.street, allOpts.city, allOpts.state, allOpts.zip].filter(Boolean);
+      process.stderr.write(`  ${chalk.dim("Location:")} ${addrParts.join(", ")} ${allOpts.country}\n`);
+      process.stderr.write(`  ${chalk.dim("Bill-on-behalf-of:")} ${billOnBehalfOfEnabled}\n`);
+      process.stderr.write(`  ${chalk.dim("Self-service:")}      ${selfServiceAllowed}\n`);
+      process.stderr.write(`  ${chalk.dim("Order approval:")}    ${orderApprovalRequired}\n`);
       process.stderr.write("\n");
 
       const confirmed = await confirm("Create this company?", { default: true });
@@ -53,21 +111,30 @@ Examples:
 
       const spinner = createSpinner("Creating company...").start();
 
+      // Wire mapping: the user-facing CLI flag names `--state` / `--zip`
+      // intentionally stay as-is (see `docs/UX_GUIDE.md` and the vocabulary
+      // mapping table in `docs/domain-review.md`). The wire field names are
+      // `stateOrProvince` / `postalCode` per the public Pax8 OpenAPI spec.
+      const payload: CreateCompanyInput = {
+        name: allOpts.name,
+        phone: allOpts.phone || "",
+        website: allOpts.website || "",
+        address: {
+          street: allOpts.street || "",
+          city: allOpts.city || "",
+          stateOrProvince: allOpts.state || "",
+          postalCode: allOpts.zip || "",
+          country: allOpts.country || "US",
+        },
+        billOnBehalfOfEnabled,
+        selfServiceAllowed,
+        orderApprovalRequired,
+      };
+
       const doneCreate = markWriteInFlight("companies");
       let company;
       try {
-        company = await ctx.api.companies.create({
-          name: allOpts.name,
-          phone: allOpts.phone || "",
-          website: allOpts.website || "",
-          address: {
-            street: "",
-            city: allOpts.city || "",
-            state: allOpts.state || "",
-            zip: allOpts.zip || "",
-            country: allOpts.country || "US",
-          },
-        });
+        company = await ctx.api.companies.create(payload);
       } finally {
         doneCreate();
       }

--- a/packages/cli/src/commands/companies/show.ts
+++ b/packages/cli/src/commands/companies/show.ts
@@ -106,7 +106,10 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Website:".padEnd(18))}${company.website || chalk.dim("—")}\n`);
       if (company.address) {
         const addr = company.address;
-        const parts = [addr.city, addr.state, addr.zip, addr.country].filter(Boolean);
+        // Wire field names are `stateOrProvince` / `postalCode` (renamed in
+        // #327/#328 to match the public spec). Pre-rename this branch read
+        // `addr.state` / `addr.zip`, which were silently dropped by Zod.
+        const parts = [addr.city, addr.stateOrProvince, addr.postalCode, addr.country].filter(Boolean);
         process.stdout.write(`  ${chalk.dim("Address:".padEnd(18))}${addr.street || ""}\n`);
         if (parts.length > 0) {
           process.stdout.write(`  ${"".padEnd(18)}${parts.join(", ")}\n`);

--- a/packages/core/src/api/companies.test.ts
+++ b/packages/core/src/api/companies.test.ts
@@ -62,14 +62,94 @@ describe("CompaniesApi", () => {
   });
 
   it("create sends correct body and returns company", async () => {
-    const input = { name: "New Corp" };
+    // Spec-required shape: address with `stateOrProvince` and `postalCode`
+    // (renamed from `state` / `zip` in #327), plus the three billing booleans
+    // that were previously `.optional()` (#329).
+    const input = {
+      name: "New Corp",
+      phone: "555-0100",
+      website: "https://newcorp.example.com",
+      address: {
+        street: "1 Main",
+        city: "Denver",
+        stateOrProvince: "CO",
+        postalCode: "80202",
+        country: "US",
+      },
+      billOnBehalfOfEnabled: false,
+      selfServiceAllowed: false,
+      orderApprovalRequired: false,
+    };
     const created = { ...sampleCompany, id: "b2c3d4e5-f6a7-8901-bcde-f12345678901", name: "New Corp" };
     (client.post as ReturnType<typeof vi.fn>).mockResolvedValue(created);
 
     const result = await api.create(input);
 
+    // The exact body must include `stateOrProvince` / `postalCode` and all
+    // three billing booleans. Pin the shape so a future regression to
+    // `state` / `zip` (or to dropping the booleans) shows up here.
     expect(client.post).toHaveBeenCalledWith("/companies", input);
+    const sentBody = (client.post as ReturnType<typeof vi.fn>).mock.calls[0][1] as Record<string, unknown>;
+    const sentAddress = sentBody.address as Record<string, unknown>;
+    expect(sentAddress).toHaveProperty("stateOrProvince", "CO");
+    expect(sentAddress).toHaveProperty("postalCode", "80202");
+    expect(sentAddress).not.toHaveProperty("state");
+    expect(sentAddress).not.toHaveProperty("zip");
+    expect(sentBody).toHaveProperty("billOnBehalfOfEnabled", false);
+    expect(sentBody).toHaveProperty("selfServiceAllowed", false);
+    expect(sentBody).toHaveProperty("orderApprovalRequired", false);
     expect(result.name).toBe("New Corp");
+  });
+
+  it("get parses address with stateOrProvince and postalCode (not state/zip)", async () => {
+    // Read-side companion to #327: the API returns `stateOrProvince` and
+    // `postalCode` on `Address`. Pre-#328 Zod silently dropped these (the
+    // schema parsed `state` / `zip`) — this test pins the new behavior.
+    const apiResponse = {
+      id: COMPANY_ID,
+      name: "Acme Corp",
+      address: {
+        street: "123 Main St",
+        city: "Denver",
+        stateOrProvince: "CO",
+        postalCode: "80202",
+        country: "US",
+      },
+    };
+    (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(apiResponse);
+
+    const result = await api.get(COMPANY_ID);
+
+    expect(result.address?.stateOrProvince).toBe("CO");
+    expect(result.address?.postalCode).toBe("80202");
+  });
+
+  it("get drops legacy state/zip wire keys (Zod strips unknowns)", async () => {
+    // Defensive: if a stale server still sends `state` / `zip` (or a partner
+    // crafts a payload using the old names), the schema should silently strip
+    // them. The fix is on the spec-conformant side — partners need the new
+    // names — but we don't want stale data leaking through as `address.state`.
+    const apiResponse = {
+      id: COMPANY_ID,
+      name: "Acme Corp",
+      address: {
+        street: "123 Main St",
+        city: "Denver",
+        state: "CO",
+        zip: "80202",
+        country: "US",
+      },
+    };
+    (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(apiResponse);
+
+    const result = await api.get(COMPANY_ID);
+
+    expect(result.address?.stateOrProvince).toBeUndefined();
+    expect(result.address?.postalCode).toBeUndefined();
+    // `state` / `zip` are unknown keys — Zod strips them, so they're not on
+    // the parsed object either.
+    expect(result.address as unknown as { state?: string }).not.toHaveProperty("state");
+    expect(result.address as unknown as { zip?: string }).not.toHaveProperty("zip");
   });
 
   it("update sends correct body and returns company via PATCH", async () => {

--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -77,7 +77,7 @@ describe("CompanySchema", () => {
   const valid = {
     id: uuid,
     name: "Acme Corp",
-    address: { street: "123 Main St", city: "Denver", state: "CO", zip: "80202", country: "US" },
+    address: { street: "123 Main St", city: "Denver", stateOrProvince: "CO", postalCode: "80202", country: "US" },
     phone: "555-1234",
     website: "https://acme.com",
     status: "Active",
@@ -118,17 +118,76 @@ describe("CompanySchema", () => {
 });
 
 describe("CreateCompanyInputSchema", () => {
+  // The spec marks `name`, `address`, `phone`, `website`, and the three
+  // billing booleans as required (#329). Optional `.optional()` slipped
+  // through pre-#327/#329, so these tests pin the contract.
+  const validInput = {
+    name: "New Corp",
+    phone: "555-9999",
+    website: "https://newcorp.example.com",
+    address: {
+      street: "1 Main",
+      city: "Denver",
+      stateOrProvince: "CO",
+      postalCode: "80202",
+      country: "US",
+    },
+    billOnBehalfOfEnabled: false,
+    selfServiceAllowed: false,
+    orderApprovalRequired: false,
+  };
+
   it("validates a correct input", () => {
-    const input = { name: "New Corp", phone: "555-9999" };
-    expect(CreateCompanyInputSchema.parse(input)).toEqual(input);
+    expect(CreateCompanyInputSchema.parse(validInput)).toEqual(validInput);
   });
 
   it("rejects empty name", () => {
-    expect(() => CreateCompanyInputSchema.parse({ name: "" })).toThrow();
+    expect(() => CreateCompanyInputSchema.parse({ ...validInput, name: "" })).toThrow();
   });
 
   it("rejects missing name", () => {
-    expect(() => CreateCompanyInputSchema.parse({})).toThrow();
+    const { name: _name, ...rest } = validInput;
+    void _name;
+    expect(() => CreateCompanyInputSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects missing phone", () => {
+    const { phone: _phone, ...rest } = validInput;
+    void _phone;
+    expect(() => CreateCompanyInputSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects missing website", () => {
+    const { website: _website, ...rest } = validInput;
+    void _website;
+    expect(() => CreateCompanyInputSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects missing billOnBehalfOfEnabled", () => {
+    const { billOnBehalfOfEnabled: _b, ...rest } = validInput;
+    void _b;
+    expect(() => CreateCompanyInputSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects missing selfServiceAllowed", () => {
+    const { selfServiceAllowed: _s, ...rest } = validInput;
+    void _s;
+    expect(() => CreateCompanyInputSchema.parse(rest)).toThrow();
+  });
+
+  it("rejects missing orderApprovalRequired", () => {
+    const { orderApprovalRequired: _o, ...rest } = validInput;
+    void _o;
+    expect(() => CreateCompanyInputSchema.parse(rest)).toThrow();
+  });
+
+  it("accepts an absent address (handler-layer validation per #329)", () => {
+    // Address is `.optional()` at the type layer so the no-address branch
+    // doesn't produce a degenerate empty object on the wire. The CLI's
+    // `companies create` handler fail-fasts before this is reached.
+    const { address: _addr, ...rest } = validInput;
+    void _addr;
+    expect(() => CreateCompanyInputSchema.parse(rest)).not.toThrow();
   });
 });
 

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -53,11 +53,29 @@ export type CompanyStatus = z.infer<typeof CompanyStatusSchema>;
 
 // ─── Address ─────────────────────────────────────────────────────────────────
 
+/**
+ * Address shape on the wire. Field names mirror the public Pax8 OpenAPI
+ * `Address` schema (`partner-endpoints.json` → `components.schemas.Address`):
+ * `stateOrProvince` and `postalCode`, NOT `state` / `zip`.
+ *
+ * Pre-#327/#328 the CLI used `state` and `zip` here, which silently
+ * (a) dropped state/postal data on `companies create` (the API didn't
+ * recognize the leaf names) and (b) dropped the corresponding fields on
+ * every read (Zod's default non-strict mode strips unknown keys). The
+ * read- and write-side share this schema, so renaming here fixes both.
+ *
+ * The user-facing CLI flag names (`--state`, `--zip`) are deliberately
+ * unchanged — flag vocabulary and wire vocabulary are intentionally
+ * separate (see `docs/UX_GUIDE.md`, `docs/domain-review.md` §Companies).
+ * The mapping happens at body-construction time in
+ * `packages/cli/src/commands/companies/{create,update}.ts`.
+ */
 export const AddressSchema = z.object({
   street: z.string().optional(),
+  street2: z.string().optional(),
   city: z.string().optional(),
-  state: z.string().optional(),
-  zip: z.string().optional(),
+  stateOrProvince: z.string().optional(),
+  postalCode: z.string().optional(),
   country: z.string().optional(),
 });
 export type Address = z.infer<typeof AddressSchema>;
@@ -87,14 +105,28 @@ export const CompanySchema = z.object({
 });
 export type Company = z.infer<typeof CompanySchema>;
 
+/**
+ * Body for `POST /companies`. The public OpenAPI marks
+ * `["name", "address", "phone", "website", "billOnBehalfOfEnabled",
+ *   "selfServiceAllowed", "orderApprovalRequired"]` as required (see
+ * `partner-endpoints.json` → `components.schemas.Company.required`). The
+ * three boolean flags previously slipped through as `.optional()`, leaving
+ * required-field-violating requests on the wire — fixed in #329.
+ *
+ * `address` is intentionally `.optional()` at the type level so callers that
+ * omit it don't produce a degenerate empty `{ street: "", city: "", ... }`
+ * object on the wire. The CLI's `companies create` handler fail-fasts with
+ * `ERROR_INVALID_INPUT` when no address flag is supplied (matches the spec's
+ * `address` requirement at the UX layer).
+ */
 export const CreateCompanyInputSchema = z.object({
   name: z.string().min(1),
   address: AddressSchema.optional(),
-  phone: z.string().optional(),
-  website: z.string().optional(),
-  billOnBehalfOfEnabled: z.boolean().optional(),
-  selfServiceAllowed: z.boolean().optional(),
-  orderApprovalRequired: z.boolean().optional(),
+  phone: z.string(),
+  website: z.string(),
+  billOnBehalfOfEnabled: z.boolean(),
+  selfServiceAllowed: z.boolean(),
+  orderApprovalRequired: z.boolean(),
 });
 export type CreateCompanyInput = z.infer<typeof CreateCompanyInputSchema>;
 

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -24,13 +24,19 @@ function monthsAgo(months: number): string {
 export interface Company {
   id: string;
   name: string;
-  address: {
+  /**
+   * Address is optional on the type even though the spec marks it required on
+   * `POST /companies`. The `companies create` handler fail-fasts before
+   * reaching the wire when no address is supplied (#329), but mock fixtures
+   * and tests need to be able to represent companies without an address.
+   */
+  address?: {
     street: string;
     city: string;
-    /** Mirrors the public `Address` schema field name. */
-    state: string;
-    /** Mirrors the public `Address` schema field name. */
-    zip: string;
+    /** Mirrors the public `Address` schema field name (renamed in #327/#328). */
+    stateOrProvince: string;
+    /** Mirrors the public `Address` schema field name (renamed in #327/#328). */
+    postalCode: string;
     country: string;
   };
   phone: string;
@@ -298,8 +304,8 @@ export const companies: Company[] = [
     address: {
       street: "4500 Cherry Creek Dr S",
       city: "Denver",
-      state: "CO",
-      zip: "80246",
+      stateOrProvince: "CO",
+      postalCode: "80246",
       country: "US",
     },
     phone: "+1-303-555-0101",
@@ -324,8 +330,8 @@ export const companies: Company[] = [
     address: {
       street: "1200 Brickell Ave, Suite 1800",
       city: "Miami",
-      state: "FL",
-      zip: "33131",
+      stateOrProvince: "FL",
+      postalCode: "33131",
       country: "US",
     },
     phone: "+1-305-555-0202",
@@ -348,8 +354,8 @@ export const companies: Company[] = [
     address: {
       street: "8900 NW Industrial Way",
       city: "Portland",
-      state: "OR",
-      zip: "97210",
+      stateOrProvince: "OR",
+      postalCode: "97210",
       country: "US",
     },
     phone: "+1-503-555-0303",
@@ -372,8 +378,8 @@ export const companies: Company[] = [
     address: {
       street: "2100 S Lamar Blvd",
       city: "Austin",
-      state: "TX",
-      zip: "78704",
+      stateOrProvince: "TX",
+      postalCode: "78704",
       country: "US",
     },
     phone: "+1-512-555-0404",
@@ -396,8 +402,8 @@ export const companies: Company[] = [
     address: {
       street: "233 S Wacker Dr, Suite 4200",
       city: "Chicago",
-      state: "IL",
-      zip: "60606",
+      stateOrProvince: "IL",
+      postalCode: "60606",
       country: "US",
     },
     phone: "+1-312-555-0505",
@@ -425,8 +431,8 @@ export const companies: Company[] = [
     address: {
       street: "1 Acme Plaza, Suite 100",
       city: "Springfield",
-      state: "MA",
-      zip: "01103",
+      stateOrProvince: "MA",
+      postalCode: "01103",
       country: "US",
     },
     phone: "+1-413-555-0606",

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -31,13 +31,14 @@ export interface Company {
    * and tests need to be able to represent companies without an address.
    */
   address?: {
-    street: string;
-    city: string;
+    street?: string;
+    street2?: string;
+    city?: string;
     /** Mirrors the public `Address` schema field name (renamed in #327/#328). */
-    stateOrProvince: string;
+    stateOrProvince?: string;
     /** Mirrors the public `Address` schema field name (renamed in #327/#328). */
-    postalCode: string;
-    country: string;
+    postalCode?: string;
+    country?: string;
   };
   phone: string;
   website: string;

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -128,22 +128,21 @@ class CompaniesResource {
 
   async create(data: Partial<Company>): Promise<Company> {
     await randomDelay();
+    // Mirror the spec's required-field contract: when no address is supplied
+    // the mock leaves `address` undefined rather than fabricating an empty
+    // object. The real `companies create` UX fail-fasts before reaching the
+    // wire (see #329), but tests that call the mock directly with a partial
+    // body should see the same shape they'd send.
     const newCompany: Company = {
       id: `demo-new-${Date.now()}`,
       name: data.name ?? "New Company",
-      address: data.address ?? {
-        street: "",
-        city: "",
-        state: "",
-        zip: "",
-        country: "US",
-      },
+      address: data.address,
       phone: data.phone ?? "",
       website: data.website ?? "",
       status: "Active",
-      billOnBehalfOfEnabled: false,
-      selfServiceAllowed: false,
-      orderApprovalRequired: false,
+      billOnBehalfOfEnabled: data.billOnBehalfOfEnabled ?? false,
+      selfServiceAllowed: data.selfServiceAllowed ?? false,
+      orderApprovalRequired: data.orderApprovalRequired ?? false,
       created: new Date().toISOString().split("T")[0],
     };
     return newCompany;


### PR DESCRIPTION
## Summary

Three tightly-coupled companies-address bugs that all touch `AddressSchema` and `CreateCompanyInputSchema`, bundled as one PR to avoid rebase churn between three near-identical schema/handler edits.

- **#327** — `companies/create` body sends `address.stateOrProvince` / `address.postalCode` (was `state` / `zip`, which the API silently dropped or 422'd).
- **#328** — `companies/read` schema parses the same spec-correct field names, so `pax8 companies show` no longer silently drops state/postal data via Zod's strip-unknowns default. Read-side rendering in `show.ts` updated to read from the renamed fields.
- **#329** — `companies/create` now sends the three spec-required booleans (`billOnBehalfOfEnabled`, `selfServiceAllowed`, `orderApprovalRequired`) via three new flags (`--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required`) all defaulting to `false`. The handler also fail-fasts with `ERROR_INVALID_INPUT` when no address flags are supplied, instead of shipping a degenerate empty `address` object on the wire. `--street` flag also added.

CLI flag names `--state` / `--zip` are **unchanged** — per the established vocabulary-vs-wire split in `docs/UX_GUIDE.md` and `docs/domain-review.md`, flag vocabulary stays user-facing while wire names follow the spec. Mapping happens at body-construction time.

Demo fixtures and the mock client are renamed to match. PATCH-based `companies update` (just-merged in #346) is unaffected — `UpdateCompanyInputSchema` reuses the renamed `AddressSchema` cleanly.

`docs/domain-review.md` vocabulary mapping + CLI Surface tables for the Companies section updated to reflect the new wire/flag split and the three new boolean flags.

Closes #327
Closes #328
Closes #329

## Test plan

- [x] `pnpm build` — green (both `@pax8/core` and `@pax8/cli`).
- [x] `pnpm lint` — green.
- [x] `pnpm test` — 1649 passed (8 skipped); 7 new tests added across:
  - `packages/core/src/api/companies.test.ts` — wire body shape on `create` pins `stateOrProvince` / `postalCode` and the three booleans; `get` parses the new field names and strips legacy `state` / `zip` cleanly.
  - `packages/core/src/api/types.test.ts` — `CreateCompanyInputSchema` rejects each missing required field individually; accepts an absent address (handler-layer validation per #329).
  - `packages/cli/src/__tests__/companies.test.ts` — subprocess tests for `companies show --json` surfacing `stateOrProvince` / `postalCode`; `companies create` fail-fast on no-address; default-false booleans round-trip through the mock; `--bill-on-behalf-of true --order-approval-required true` overrides reflected on the returned company.
- [ ] Manual smoke against demo mode: `PAX8_DEMO=1 pax8 companies show "Summit Healthcare Partners" --json | jq .address`
- [ ] Sandbox verification (gated on #308): real company round-trip — create with address + booleans, fetch via `show`, confirm 2xx and that all fields round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)