### PR TITLE
docs: refresh feedback queue + domain review after the body-shape batch

### DIFF
--- a/docs/Pre-publish reviewer feedback queue
+++ b/docs/Pre-publish reviewer feedback queue
@@ -4,7 +4,7 @@ Tracking domain-review reviewer comments through resolution. Updated as work lan
 
 **Owner:** Josh Dulberger
 **Status:** Publish held pending resolution of all unchecked items below.
-**Last updated:** 2026-05-11
+**Last updated:** 2026-05-11 (post body-shape batch — 20+ PRs merged today)
 
 ## Tanner Horsey (Subscriptions & Renewals)
 
@@ -17,25 +17,26 @@ Tracking domain-review reviewer comments through resolution. Updated as work lan
 
 ## Fred Lintz (Subscriptions)
 
-- [ ] `--billing-term` enum scope — issue filed: <!-- #??? --> (mirror API request-body enum; widen CLI to match)
-- [ ] `provisioningDetails` on update — verification in flight: <!-- #??? --> (triage doc at `docs/triage/subscriptions-update-provisioning-details.md`)
+- [x] `--billing-term` enum scope — shipped in #336 (mirrors the API request-body enum; CLI accepts full set)
+- [ ] `provisioningDetails` on update — verification in flight: <!-- #??? --> (triage doc at `docs/triage/subscriptions-update-provisioning-details.md`). **Adjacent finding from #332**: orders `provisioningDetails` shape was wrong (record vs array); fixed in #351. Subscriptions schema does not currently expose `provisioningDetails` — verify whether the API returns it on subscription reads, and if so whether the CLI should surface it.
 
 ## Fred Lintz (Orders & Quotes)
 
 - [x] `intentType` writability — resolved via read-only convention: #304 (codebase comment + regression test + README user-scope note)
-- [x] `quotes create` shorthand semantics — superseded by #311 (decision preserved in domain review; implementation rolls into v2 rewrite)
-- [ ] `quotes create --expiration-date` silent no-op — #306 (surfaced during the #305 audit; flag is declared and displayed in the confirm prompt but never sent to the API)
+- [x] `quotes create` shorthand semantics — superseded by #311 → #345 (decision preserved in domain review; v2 rewrite landed)
+- [x] `quotes create --expiration-date` silent no-op — shipped in #339 (flag removed; help text directs to `quotes update --expiration-date`)
 - [ ] v2 surface scope (sections, attachments, access-list, take-ownership) — Q4 in re-review block, open for domain owner
 
 ## Franco Aurieme (Companies & Contacts)
 
-- [ ] `companies create` atomic endpoint — issue filed: <!-- #??? --> (calls legacy two-step path; should call PAM-997 atomic endpoint with required contact fields)
+- [ ] `companies create` atomic endpoint — issue filed: #330 (calls legacy two-step path; should call PAM-997 atomic endpoint with required contact fields). Substantial new-feature scope; design conversation needed before dispatching.
+- [x] Companies-side body-shape adjacent fixes shipped during the parallel-audit cycle (independent of the atomic-endpoint adoption): #346 (PATCH instead of PUT on update), #352 (address field renames `state`→`stateOrProvince`, `zip`→`postalCode` + the three required billing booleans on create + drop empty-address-on-the-wire). Contacts-side: #350 (nested wire path), #353 (body shape — drop `companyId` from body, fetch-then-merge on update, `types` reshaped to spec object form).
 - [ ] Sync with Franco + Vinton Lee scheduled
 - [ ] Franco re-marks section ✅
 
 ## Josh Hollander
 
-- [x] `originalSubscriptionId` exclusion — CI guard issue: <!-- #??? --> (permanently-excluded fields enforced via test)
+- [x] `originalSubscriptionId` exclusion — CI guard shipped in #315 (recursive Zod-schema walker rejects forbidden field names across every exported schema)
 - [ ] `clients` rename — issue filed: #317 (rename command group with `companies` as deprecated alias; defer JSON field renames until Pax8 ships `/clients` endpoints)
 - [ ] Hollander re-reviews both items
 
@@ -46,26 +47,41 @@ Tracking domain-review reviewer comments through resolution. Updated as work lan
 Caught by Claude Code audit triggered by Fred's `quotes create` shorthand question. Pre-existing bug: CLI was hitting `/v1/quotes/...` while the API lives at `/v2/quotes/...`. Audit also surfaced body-shape mismatches on five write operations.
 
 - [x] Wire-path hotfix — #316 (closes #307)
-- [ ] Integration test pattern (sandbox-backed, broader than quotes-only) — #308
-- [ ] `quotes create` body-shape fix — #311 (gated on #308)
-- [ ] `quotes line-items add` body-shape fix — #312 (gated on #308)
-- [ ] `quotes update` fetch-then-merge — #313 (gated on #308)
-- [ ] `quotes send` / `setStatus` fetch-then-merge — #314 (gated on #308)
+- [x] Integration test pattern (sandbox-backed, broader than quotes-only) — shipped in #341 (closes #308); harness at `e2e/integration/` with opt-in CI job; companies (v1) + quotes (v2) seed tests
+- [x] Per-API base URL mechanism (infra unblock that #322 et al. depend on) — shipped in #340 (closes #321)
+- [x] `quotes create` body-shape fix — shipped in #345 (closes #311); rewrites create with `clientId` rename + two-call orchestration
+- [x] `quotes line-items add` body-shape fix — shipped in #342 (closes #312); adds required `effectiveDate` + `price` with sensible defaults
+- [x] `quotes update` fetch-then-merge — shipped in #354 (closes #313); reads current quote, sends full 5-field PUT body. Note: line-item replacement now decomposes into delete+add per the spec (`PUT /v2/quotes/{id}/line-items` is update-in-place, not replace)
+- [x] `quotes send` / `setStatus` fetch-then-merge — shipped in #354 (closes #314); same mechanism as `update`
 
 ### Parallel audit across other write-heavy domains
 
-In flight. Auditing `subscriptions update/cancel`, `orders create`, `companies create/update`, `contacts create/update/delete`, `webhooks create/update/enable/disable/delete/logs retry`, `invoices dispute` for the same class of bug. Output: per-domain triage docs at `docs/triage/api-version-audit/`.
+- [x] Audit complete — triage docs at `docs/triage/api-version-audit/` published in #319 (covers webhooks, contacts, companies, orders, subscriptions, invoices). Caught the same bug class as the quotes audit across every write-heavy domain.
+- [x] Findings triaged into per-issue follow-ups: 13 issues filed (#317, #321–#333)
+- [x] Wire-path / nested-path fixes shipped:
+  - `webhooks` `/v1` → `/api/v2` — #344 (closes #322)
+  - `contacts` flat → nested under `/companies/{id}/contacts/*` — #350 (closes #324)
+  - `usage` flat → nested `/subscriptions/{id}/usage-summaries`; leaf `/lines` → `/usage-lines` — #343 (closes #337, transitively #212)
+- [x] Body-shape / payload fixes shipped:
+  - `webhooks create` — `displayName` + `webhookTopics` structured array — #349 (closes #323)
+  - `contacts create/update` — drop `companyId` from body, `types` to spec object form, fetch-then-merge on update — #353 (closes #325)
+  - `companies update` — PUT → PATCH — #346 (closes #326)
+  - `companies create/read` address — `state`/`zip` → `stateOrProvince`/`postalCode` + three required billing booleans + drop empty-address — #352 (closes #327, #328, #329)
+  - `orders create` — required `lineItemNumber` per line — #348 (closes #331)
+  - `orders` — `provisioningDetails` shape (record → array of `{key, values[]}`) — #351 (closes #332)
+  - `subscriptions cancel` — date-only → ISO 8601 date-time normalization — #347 (closes #333)
+- [ ] `companies create` atomic endpoint adoption (PAM-997) — #330 still open. Substantial new-feature scope (replaces the legacy two-step path); design conversation pending.
+- [ ] `clients` rename — #317 still open. Coordinated with Hollander.
 
-- [ ] Audit complete
-- [ ] Findings triaged into per-issue follow-ups (if any)
+**Aggregate scoreboard:** 13 audit-surfaced issues filed → 11 shipped, 2 open (#317 design + #330 new feature). Plus the 6 quotes-side body-shape items (#311–#314, #312, #306) all shipped.
+
+**Adjacent follow-up surfaced during the batch:** `CreateQuoteInputSchema` / `UpdateQuoteInputSchema` carry the same `Record<string,unknown>` provisioningDetails shape mismatch on the quotes-side line items (flagged by the #332 agent). Small follow-up to file when domain review settles — same fix pattern as #351 applied to the quotes line-item path.
 
 ## Doc updates pending
 
-Held until #316 merges and parallel audit returns, so updates land once with full context rather than piecemeal.
-
-- [ ] Orders & Quotes section — partial-status framing, Open from review entry for audit findings
-- [ ] Companies & Contacts section — Franco's atomic endpoint, Hollander's `clients` rename
-- [ ] Subscriptions & Renewals section — Tanner re-review framing
+- [x] Orders & Quotes section in `docs/domain-review.md` — refreshed post-batch (Summary of Concerns item (4) + Orders & Quotes section + Workflow section + Methodology / Recent changes)
+- [ ] Companies & Contacts section in `docs/domain-review.md` — needs refresh: address field renames, three new boolean flags on create, contacts nested wire path, contacts breaking `--company` requirement on per-contact ops, contacts body reshape
+- [ ] Subscriptions & Renewals section in `docs/domain-review.md` — Tanner re-review framing; also reflect #336 (`--billing-term` widened), #347 (cancelDate ISO normalization), #315 (originalSubscriptionId guard now CI-enforced)
 - [ ] Strategy brief — one-line publish-hold note
 
 ## Consolidated reviewer replies pending

--- a/docs/domain-review.md
+++ b/docs/domain-review.md
@@ -40,12 +40,7 @@ Five themes were flagged for domain-owner attention. After the 2026-05-07 merges
 
 **(3) `commitmentTermEndDate` and `renewalDate` renames — UNCHANGED.** The CLI still normalizes `subscription.commitmentTerm.endDate` into a top-level `commitmentTermEndDate` and renames it `renewalDate` in the renewals view. Still needs a domain-owner call on canonical vocabulary.
 
-**(4) Quotes v1-shaped over v2 endpoint — PARTIALLY ADDRESSED.** Schema and surface work in #261, #264, and #266 surfaced accept/decline workflow fields, lowercased the status help text, added a destructive-update confirmation, and built out `line-items list/add/remove` plus `send`. A subsequent audit caught a deeper bug: every quote command was resolving to `https://api.pax8.com/v1/quotes/...`, but the public API hosts quotes only at `/v2/quotes/...`. #316 fixes the wire path via a per-call `apiVersion` override on `Pax8Client`. Status post-#316:
-
-- **Five read commands** (`list`, `show`, `delete`, `line-items list`, `line-items remove`) work end-to-end against real v2.
-- **Five write commands** (`create`, `update`, `send`, `setStatus`, `line-items add`) hit the right URL but fail with 4xx body-shape errors — request bodies don't match the v2 spec (different field names, required fields the CLI doesn't send). Tracked under #311 (`create`: `clientId` rename + two-call orchestration), #312 (`line-items add`: missing `effectiveDate`/`price`), #313 (`update`: fetch-then-merge against the 5-field PUT body), #314 (`send`/`setStatus`: same fetch-then-merge). All four labeled `quotes-v2-body-shape` and gated on #308 (sandbox integration test pattern). They will land before publish.
-
-Full audit, including the retrospective on why the initial wire-path investigation missed the body-shape problems, lives at `docs/triage/quotes-api-version.md`. Surface-level deferrals (out of scope for the body-shape work): attachments, sections, access-list, take-ownership/claim, library-level `/v2/quote-attachments`, and `/v2/quote-preferences`.
+**(4) Quotes v1-shaped over v2 endpoint — RESOLVED.** Wire path on `/v2` (#316), the per-API base URL infra that unblocks future v2-only resources (#321 / #340), the sandbox integration test pattern that prevents this bug class from recurring (#308 / #341), and every body-shape fix on the write side: `create` `clientId` rename + two-call orchestration (#311 / #345), `line-items add` required `effectiveDate`/`price` (#312 / #342), `update` and `send`/`setStatus` 5-field PUT with fetch-then-merge (#313 / #314 / #354), plus the `--expiration-date` silent no-op removal (#306 / #339). Full audit in `docs/triage/quotes-api-version.md`. Surface-level deferrals (out of scope, still): attachments, sections, access-list, take-ownership/claim, library-level `/v2/quote-attachments`, `/v2/quote-preferences`. **Quote writes now work end-to-end against the real v2 API.**
 
 **(5) Webhook v1 fine-grained sub-routes — PARTIALLY ADDRESSED.** #265 adds `webhooks show/update/enable/disable`. #267 adds `webhooks logs retry`, `webhooks topics list`, and `webhooks test --topic <topic>` (with topic validation against `/webhooks/topic-definitions`). `webhooks logs` is now a subcommand group (`logs list` + `logs retry`) with the bare `logs [id]` form preserved as the default action for backward-compat. Still deferred: `topics add/remove/replace`, per-topic configuration (filter expressions on a single topic), and per-topic-config CRUD.
 
@@ -64,11 +59,11 @@ Full audit, including the retrospective on why the initial wire-path investigati
 | `pax8 companies more` | (interactive paging helper) | | CLI-only |
 | `pax8 contacts list` | `--company <id\|name>` (required), `--page`, `--size`, `--ids-only` | size=50 | |
 | `pax8 contacts show <id>` | `--company <id\|name>` (required) | | `--company` required post-#324 — the Pax8 public API only addresses contacts under `/companies/{companyId}/contacts/{contactId}` |
-| `pax8 contacts create` | `--company <id\|name>` (required), `--first-name`, `--last-name`, `--email`, `--phone`, `--type <list>`, `-y` | type=Admin | `--type` accepts a comma-separated list (`Admin,Billing`) post-#255 |
+| `pax8 contacts create` | `--company <id\|name>` (required), `--first-name`, `--last-name`, `--email`, `--phone` (required post-#325), `--type <list>`, `-y` | type=Admin | `--type` accepts a comma-separated list (`Admin,Billing`); `--phone` now required because the v2 spec contract mandates a non-empty phone (#325/#353) |
 | `pax8 contacts update <id>` | `--company <id\|name>` (required), `--first-name`, `--last-name`, `--email`, `--phone`, `--type <list>`, `-y` | | `--type` accepts a comma-separated list post-#255; `--company` required post-#324 |
 | `pax8 contacts delete <id>` | `--company <id\|name>` (required), `-y` | | `--company` required post-#324 |
 
-CLI output schemas (Zod) — `Company`: `id, name, address{street,street2,city,stateOrProvince,postalCode,country}, phone, website, status, billOnBehalfOfEnabled, selfServiceAllowed, orderApprovalRequired, externalId, created, updatedDate`. `Contact`: `id, firstName, lastName, email, phone, companyId, types[]`.
+CLI output schemas (Zod) — `Company`: `id, name, address{street,street2,city,stateOrProvince,postalCode,country}, phone, website, status, billOnBehalfOfEnabled, selfServiceAllowed, orderApprovalRequired, externalId, created, updatedDate`. `Contact`: `id, firstName, lastName, email, phone, types[{type, primary}]` [contact `types` reshaped to spec object form in #325/#353; `companyId` no longer carried on the body since the nested URL identifies it].
 
 ### Public API Surface
 
@@ -86,7 +81,11 @@ API `Company`: `id, name, address, phone, website, status, billOnBehalfOfEnabled
 | `updatedDate` | `updatedDate` | Aligned with API in #273 (was `modified`) |
 | `createdDate` (Contact) | (not exposed on Contact) | Only surfaced on Company-ish resources |
 | `contacts[]` (embedded on Company) | (separate `contacts list`) | CLI separates rather than embeds |
-| `types[]` (array of `Admin\|Billing\|Technical`) | `--type <comma-list>` | CLI accepts multiple types as a comma-separated string [Resolved in #255] |
+| `types[]` (spec shape: `Array<{type: ContactType, primary: boolean}>`) | `--type <comma-list>` | CLI accepts multiple types as a comma-separated string [Surface flag resolved in #255; wire shape aligned with spec in #325/#353 — was bare string array, now object array. Primary defaults to `false` on create] |
+| `Partial PUT` on `contacts update` | Fetch-then-merge | v2 spec requires full body on PUT; CLI now reads the current contact and merges overrides before sending [Resolved in #325/#353] |
+| `companies update` PUT vs PATCH | PATCH | v2 spec documents only PATCH; CLI switched from PUT [Resolved in #326/#346] |
+| `companies create` required fields | `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required` (default `false`) | The three booleans are required by the spec but not user-facing concerns for partners in most cases; defaults preserve the previous UX [Resolved in #329/#352] |
+| Contacts wire path (`/contacts/{id}` vs `/companies/{cid}/contacts/{id}`) | Nested per spec | Flat path doesn't exist in the API; CLI commands now thread `--company` through all per-contact operations [Resolved in #324/#350] |
 
 ### Coverage
 
@@ -98,6 +97,7 @@ API `Company`: `id, name, address, phone, website, status, billOnBehalfOfEnabled
 - `--type` accepts one value; API accepts an array. [Resolved in #255 — comma-separated list now accepted on both create and update.]
 - `companies update` cannot change address or the three boolean billing flags. Confirm whether this is an intentional safety choice or an oversight.
 - CLI `Company.modified` vs API `updatedDate` — pick one and align. [Resolved in #273 — renamed to `updatedDate`.]
+- Per-contact operations (`show`, `update`, `delete`) now require `--company` — breaking change. The flat `/contacts/{id}` path doesn't exist in the v2 spec, so the CLI cannot address a contact without its company. [Resolved in #324/#350; migration message included in each command's error path.]
 
 ### Questions for Domain Owner
 
@@ -114,8 +114,8 @@ API `Company`: `id, name, address, phone, website, status, billOnBehalfOfEnabled
 |---|---|---|---|
 | `pax8 subscriptions list` | `--company`, `--status`, `--page`, `--size`, `--ids-only`, `--with-actions` | size=25 | |
 | `pax8 subscriptions show <id>` | `--history` | | |
-| `pax8 subscriptions update <id>` | `--quantity`, `--billing-term`, `-y` | | |
-| `pax8 subscriptions cancel <id>` | `--cancel-date <YYYY-MM-DD>`, `-y` | | `--cancel-date` for scheduled cancellation [Added in #256] |
+| `pax8 subscriptions update <id>` | `--quantity`, `--billing-term`, `-y` | | `--billing-term` now accepts the full API enum (`Monthly, Annual, 2-Year, 3-Year, One-Time, Trial, Activation`) per #336 — was previously limited to `Monthly`/`Annual` |
+| `pax8 subscriptions cancel <id>` | `--cancel-date <YYYY-MM-DD>`, `-y` | | `--cancel-date` for scheduled cancellation [Added in #256]; wire payload now ISO-normalizes to `YYYY-MM-DDT00:00:00Z` per spec [#333/#347] |
 | `pax8 subscriptions renewals` | `--within <period>`, `--company`, `--with-actions` | within=30d | **Computed — see below** |
 
 CLI `Subscription`: `id, companyId, productId, quantity, startDate, endDate, createdDate, billingStart, status, price, billingTerm, commitment{id,term,endDate}, commitmentTermEndDate, companyName, productName`.
@@ -164,7 +164,7 @@ API `SubscriptionStatus` enum: `Active, Cancelled, PendingManual, PendingAutomat
 
 1. Is "renewal date" the right name for `commitmentTerm.endDate`, or should the CLI just call it `commitmentTermEndDate` everywhere?
 2. The CLI's MRR-at-risk calculation is `price × quantity ÷ 12 (if annual)` — is that the formula your team uses, and is it OK to make this part of a public contract?
-3. Should `--billing-term` on update accept the full enum (`Monthly, Annual, 2-Year, 3-Year, One-Time, Trial, Activation`) or only `Monthly`/`Annual` as today?
+3. ~~Should `--billing-term` on update accept the full enum (`Monthly, Annual, 2-Year, 3-Year, One-Time, Trial, Activation`) or only `Monthly`/`Annual` as today?~~ [Resolved in #336 — full enum now accepted on `subscriptions update`.]
 
 ---
 
@@ -237,9 +237,9 @@ API `InvoiceItem` fields (32 total — selected): `id, productId, productName, s
 |---|---|---|---|
 | `pax8 orders list` | `--company`, `--status`, `--page`, `--size`, `--ids-only` | size=25 | Status enum is CLI-defined |
 | `pax8 orders show <id>` | | | |
-| `pax8 orders create` | `--company`, `--product`, `--quantity`, `--billing-term`, `--commitment-term`, `--commitment-term-id`, `--line-item <spec>` (repeatable), `--dry-run`, `-y`, `--idempotency-key` | qty=1, billing=Monthly | Multi-line via repeated `--line-item product=…,quantity=…[,billing-term=…][,commitment-term=…][,commitment-term-id=…]`; `--dry-run` maps to API `isMock=true` [Added in #259] |
+| `pax8 orders create` | `--company`, `--product`, `--quantity`, `--billing-term`, `--commitment-term`, `--commitment-term-id`, `--line-item <spec>` (repeatable), `--dry-run`, `-y`, `--idempotency-key` | qty=1, billing=Monthly | Multi-line via repeated `--line-item product=…,quantity=…[,billing-term=…][,commitment-term=…][,commitment-term-id=…][,provisioning=key:value\|value...]`; `--dry-run` maps to API `isMock=true` [Added in #259]; required `lineItemNumber` auto-injected per line [#331/#348]; `provisioning=...` parses into the spec-required `Array<{key, values[]}>` shape [#332/#351] |
 
-CLI `Order`: `id, companyId, companyName, orderedBy, orderedByEmail, status, createdDate, lineItems[{id, offerId, productId, productName, billingTerm, lineItemNumber, quantity, provisioningDetails}]`.
+CLI `Order`: `id, companyId, companyName, orderedBy, orderedByEmail, status, createdDate, lineItems[{id, offerId, productId, productName, billingTerm, lineItemNumber, quantity, provisioningDetails: Array<{key, values[]}>}]` [`provisioningDetails` reshaped from record to array of `{key, values[]}` in #351 to match the spec].
 
 ### Public API Surface — Orders
 
@@ -259,9 +259,9 @@ CLI `Order`: `id, companyId, companyName, orderedBy, orderedByEmail, status, cre
 | `pax8 quotes line-items remove <quote-id> <line-item-id>` | `-y` | | Removes a single line item [Added in #266] |
 | `pax8 quotes send <quote-id>` | `-y` | | Sets quote status to `sent` (generates customer-facing link) via `PUT /v2/quotes/{id}` [Added in #266] |
 
-CLI `Quote`: `id, companyId, createdOn, expiresOn, status, lineItems[{id, productId, quantity, billingTerm, unitPrice, subtotal}], acceptedBy?, declinedBy?, respondedOn?, revokedOn?, publishedOn?, published?, referenceCode?, salesMarginPercentage?, intentType?` [accept/decline workflow fields added in #261; line-item `id` surfaced for use with `line-items remove`; top-level dates aligned with API in #273].
+CLI `Quote`: `id, companyId, createdOn, expiresOn, status, introMessage, termsAndDisclaimers, lineItems[{id, productId, quantity, billingTerm, unitPrice, subtotal}], acceptedBy?, declinedBy?, respondedOn?, revokedOn?, publishedOn?, published?, referenceCode?, salesMarginPercentage?, intentType?` [accept/decline workflow fields in #261; line-item `id` for `line-items remove`; top-level dates in #273; `introMessage`/`termsAndDisclaimers` in #354 to support fetch-then-merge on update/send].
 
-**Status (post-#316).** The quote commands now resolve to `https://api.pax8.com/v2/quotes/...` after #316 fixed an inherited `/v1` wire path. The five read commands (`list`, `show`, `delete`, `line-items list`, `line-items remove`) work end-to-end. The five write commands (`create`, `update`, `send`, `setStatus`, `line-items add`) hit the right URL but fail with 4xx body-shape errors — request bodies need updating to match the v2 spec. Body-shape fixes are tracked under #311 (`create`), #312 (`line-items add`), #313 (`update`), #314 (`send`/`setStatus`), all labeled `quotes-v2-body-shape` and gated on #308 (sandbox integration test pattern). All four will land before publish. Audit in `docs/triage/quotes-api-version.md`.
+**Status (post body-shape batch).** All ten quote commands now work end-to-end against the real v2 API. Wire path on `/v2` (#316/#340/#341); write bodies match the v2 spec: `create` is `{ clientId, quoteRequestId? }` with two-call orchestration when `--product` is passed (#345); `line-items add` carries required `effectiveDate` + `price` with sensible defaults (#342); `update` and `send`/`setStatus` fetch-then-merge against the 5-field PUT body (#354); `--expiration-date` no-op flag removed (#339). Line-item replacement on `quotes update --product` decomposes into delete-then-add per the spec (`PUT /v2/quotes/{id}/line-items` is update-in-place, not replace). Full audit + retrospective at `docs/triage/quotes-api-version.md`.
 
 ### Public API Surface — Quotes (v2)
 
@@ -408,7 +408,7 @@ The seven categories, the seven cross-sell rules, the seat-gap thresholds (10 se
 |---|---|---|---|
 | `pax8 webhooks list` | `--ids-only`, `--with-actions` | | |
 | `pax8 webhooks show <id>` | | | View a single webhook subscription [Added in #265] |
-| `pax8 webhooks create` | `--url`, `--topics <comma-list>`, `-y` (with `--events` as a deprecated alias) | | |
+| `pax8 webhooks create` | `--url`, `--display-name` (required post-#323), `--topics <comma-list>`, `-y` (with `--events` as a deprecated alias) | | `--display-name` is required by the v2 spec (#323/#349); wire body uses `webhookTopics: Array<{topic, filters[]}>` (CLI flattens `--topics T1,T2` into the structured shape); calls now route to `https://api.pax8.com/api/v2/webhooks/...` per spec [#322/#344] |
 | `pax8 webhooks update <id>` | `--display-name`, `--authorization`, `--contact-email`, `--error-threshold`, `-y` | | Configures the four mutable fields via `PUT /webhooks/{id}/configuration` [Added in #265]; redacts `--authorization` in echo |
 | `pax8 webhooks enable <id>` | `-y` | | Sets `active=true` via `PUT /webhooks/{id}/status` [Added in #265] |
 | `pax8 webhooks disable <id>` | `-y` | | Sets `active=false` via `PUT /webhooks/{id}/status` [Added in #265] |
@@ -422,9 +422,9 @@ The seven categories, the seven cross-sell rules, the seat-gap thresholds (10 se
 CLI `Webhook`: `id, url, topics[], status ('Active' \| 'Disabled'), createdDate, secret` [`secret` is the real HMAC-signing secret returned on `POST /webhooks` (visible only on create-response, per JSDoc clarified in #254)].
 CLI `WebhookLog`: `id, webhookId, topic, responseCode, responseBody, sentAt`.
 
-### Public API Surface (Webhooks v1)
+### Public API Surface (Webhooks)
 
-12 endpoints. CRUD on `/webhooks` and `/webhooks/{id}`. Three sub-resources for fine-grained updates the CLI doesn't expose: `/configuration` (authorization, contactEmail, errorThreshold), `/status` (enable/disable), `/topics` (add, replace, remove, per-topic config, per-topic `test`). A topic-definitions catalog at `/webhooks/topic-definitions`. Logs at `/webhooks/{id}/logs` with a per-log `retry` action.
+Base: `https://api.pax8.com/api/v2` (not `/v1` — a peculiarity that motivated the per-API base URL infra in #321/#340). 12 endpoints. CRUD on `/webhooks` and `/webhooks/{id}`. Three sub-resources for fine-grained updates: `/configuration` (authorization, contactEmail, errorThreshold), `/status` (enable/disable), `/topics` (add, replace, remove, per-topic config, per-topic `test`). A topic-definitions catalog at `/webhooks/topic-definitions`. Logs at `/webhooks/{id}/logs` with a per-log `retry` action.
 
 API `Webhook` fields: `id, accountId, displayName, url, authorization, active, contactEmail, errorThreshold, integrationId, webhookTopics[], lastDeliveryStatus, createdAt, updatedAt`.
 
@@ -513,7 +513,7 @@ The Pax8 internal **Preliminary Workflows** doc enumerates canonical end-to-end 
 | 4. Subscribe to QUOTE.Accepted webhook events | `POST /webhooks` with `topics: ["QUOTE.Accepted"]` | `pax8 webhooks create --url X --topics QUOTE.Accepted`; discover topics via `pax8 webhooks topics list` (#267) |
 | 5. On QUOTE.Accepted, trigger order placement | `POST /orders` | `pax8 orders create --company X --product Y --quantity N` |
 
-**Implementation status (post-#316).** Steps 1–3 all hit the v2 API after #316; previously they resolved to a non-existent `/v1/quotes` path. Write bodies still need updating to match the v2 spec — tracked under #311 (step 1: `clientId` rename + two-call orchestration since v2 `POST /quotes` doesn't accept inline `lineItems`), #312 (step 2: missing required `effectiveDate`/`price` on the Standard line-item payload), #313 (step 3 + line-item replacement: fetch-then-merge against the 5-field PUT body), #314 (step 3 status transition: same fetch-then-merge mechanic). All four are gated on #308 (sandbox integration test pattern) and will land before publish. The workflow ends-to-end story stands; the writes that compose it are in-flight.
+**Implementation status (post body-shape batch).** All five steps now work end-to-end against the real v2 API. Step 1 (#345, `clientId` body + optional two-call orchestration when `--product` is passed). Step 2 (#342, required `effectiveDate` + `price` with product-pricing defaults). Step 3 (#354, fetch-then-merge against the 5-field PUT body). Step 4 was already working (webhook subscription was on its own path; #344 routed the writes to `/api/v2/webhooks` and #349 fixed the create body shape). Step 5 (`orders create`) also benefited from the same audit cycle: #348 (required `lineItemNumber` per line) and #351 (`provisioningDetails` shape fix). The Automated Quoting and Sales Cycle is now a real end-to-end flow against the documented spec.
 
 **Naming-coordination note:** the workflow assumes the `pax8-submit-order` MCP tool (Linear AI-865) and the CLI's `orders create` will eventually converge on the same vocabulary. Flag-naming coordination between the CLI team and the MCP team is worth doing once, before partners start building automations against both.
 
@@ -567,4 +567,10 @@ Note: "the CLI consumes endpoint X" is **not** evidence here — this doc review
 
 11 PRs landed on 2026-05-07 closing or partially-closing issues #239–#246. The squash commits are #252–#269. This refresh re-states resolved concerns as `[Resolved in #NUM]` annotations rather than deleting them — so reviewers can still trace the history of each drift item. PR set, in merge order: #252, #254, #255, #256, #259, #260, #261, #264, #265, #266, #267.
 
-**2026-05-11 follow-up.** Reviewer-triggered audit of the Orders & Quotes section (Fred Lintz) surfaced a v1-vs-v2 wire-path bug: every quote command was resolving to `https://api.pax8.com/v1/quotes/...`, but the API hosts quotes only at `/v2/quotes/...`. #316 landed a per-call `apiVersion` override on `Pax8Client` and routes every `QuotesApi` method to `/v2`. Read commands now work end-to-end against real v2; write commands hit the right URL but fail with 4xx body-shape errors, tracked under #311–#314 (label `quotes-v2-body-shape`) and gated on #308 (sandbox integration test pattern). Full audit including audit-quality retrospective in `docs/triage/quotes-api-version.md`. Adjacent reviewer items from the same cycle: #304 (`intentType` writability, resolved via read-only convention), #305 (`quotes create` shorthand semantics, resolved via help-text clarification + audit), #306 (`quotes create --expiration-date` silent no-op, surfaced during the #305 audit).
+**2026-05-11 batch.** Reviewer-triggered audit of the Orders & Quotes section (Fred Lintz) surfaced a v1-vs-v2 wire-path bug in quotes (#316). That investigation generalized into a parallel audit across every write-heavy domain (#319's `docs/triage/api-version-audit/` set), which surfaced 13 sibling issues (#317, #321–#333) plus four quotes-side body-shape follow-ups (#311–#314).
+
+By end of day, the entire wave had shipped: infra unblock (#321 / #340), sandbox integration test pattern as the safety net (#308 / #341), quotes wire path + body shapes for all five write commands (#316 / #339 / #342 / #345 / #354), webhooks wire path + create body (#322 / #323 / #344 / #349), contacts nested paths + body shapes (#324 / #325 / #350 / #353), companies update PATCH + address renames + required booleans (#326 / #327 / #328 / #329 / #346 / #352), orders required `lineItemNumber` + `provisioningDetails` shape (#331 / #332 / #348 / #351), subscriptions cancelDate ISO-normalization (#333 / #347), usage nested paths (#337 / #343, transitively closes #212), and the `originalSubscriptionId` CI-enforced exclusion (#315). Adjacent reviewer items also landed: #304 (`intentType` read-only), #306/#339 (`quotes create --expiration-date` no-op removed), #336 (`--billing-term` enum widened on subscriptions update).
+
+Still open from this cycle: #317 (`clients` rename, coordinated with Hollander), #330 (companies atomic endpoint adoption — PAM-997, substantial new-feature scope). All other audit-surfaced issues are resolved.
+
+The audit-quality retrospective at `docs/triage/quotes-api-version.md` §10 (URL audit vs. body audit are separate verification tracks; code comments are hypotheses, not evidence; response-shape alignment is not full alignment) generalized cleanly across the parallel-audit work — every body-shape issue followed the same investigative shape.

--- a/docs/triage/companies-create-atomic-endpoint.md
+++ b/docs/triage/companies-create-atomic-endpoint.md
@@ -1,0 +1,127 @@
+# fix(companies): `companies create` calls the legacy two-step path, leaving companies Inactive
+
+**Priority:** P0 — publish-blocking
+**Class:** CLI built against a stale API picture (same class as #307 quotes wire-path)
+**Reporter:** Franco Aurieme (PM, Account Management), via domain review of the Companies & Contacts section
+**Confirmed by:** Vinton Lee (PAM backend) — the CLI is on the pre-PAM-997 path
+
+---
+
+## TL;DR
+
+`pax8 companies create` posts to `POST /v1/companies` with company fields only (`name`, `phone`, `website`, `address`) and no contact. That is the **legacy two-step path** Pax8 deprecated under PAM-997 / PAM-1171 / ARC-774. The atomic create-with-contact endpoint that replaced it was specifically built so newly-created companies do not land in `Inactive` state. Every partner and AI agent driving `pax8 companies create` today creates an Inactive ghost client, then has to remediate with a separate `pax8 contacts create` to activate it. The CLI reports success while the company is broken — the failure is silent at the surface and only manifests when downstream operations against the Inactive company fail.
+
+This is publish-blocking for the same reason the quotes wire-path issue was: the CLI's flag list is the contract that AI agents read, and right now it tells them a lie.
+
+---
+
+## Evidence — current state of the CLI
+
+The CLI's `create` is a thin single-call wrapper around the legacy endpoint, with no contact fields on the command surface:
+
+| Layer | File | What's there today |
+|---|---|---|
+| API client | `packages/core/src/api/companies.ts:29-32` | `create()` does `client.post("/companies", data)` with `CreateCompanyInput` (company-only fields). No contact payload, no atomic endpoint. |
+| CLI command flags | `packages/cli/src/commands/companies/create.ts:14-22` | `--name` (required), then `--phone`, `--website`, `--city`, `--state`, `--zip`, `--country`. No `--first-name`, `--last-name`, `--email`, or `--type`. |
+| CLI call site | `packages/cli/src/commands/companies/create.ts:59-70` | Passes only company fields to `ctx.api.companies.create()`. |
+| Contacts command (separate) | `packages/cli/src/commands/contacts/create.ts:32-48` | Already requires `--company`, `--email`, `--first-name`, `--last-name`, `--type`. This is the command partners are *currently* expected to call as the second step. |
+
+The status field on the response (`packages/cli/src/commands/companies/create.ts:86`) is what surfaces "Inactive" to the user after a successful-looking create — but only when the user prints non-JSON output, and only if they read it. Agents reading `--json` get a `status: "Inactive"` field that they have no reason to flag as an error.
+
+## Why this is publish-blocking
+
+Two factors compound:
+
+1. **Silent failure.** The command exits 0, the spinner shows `Company created 🎉`, and the JSON output looks valid. There is no error to catch. The breakage only surfaces downstream — when a subscription, order, or quote against the Inactive company fails for reasons that look unrelated.
+2. **Agents read the flag list as the contract.** A flag list with no contact fields tells the agent "creating a company doesn't need a contact." That is the exact misrepresentation the agent-friendly surface is supposed to prevent. Humans at least see the `Inactive` line and can google it; agents fire-and-forget and move on.
+
+This is the same class of bug as #307 (quotes wire-path): correct intent, stale wire layer, no test exercising the real API. The `docs/triage/quotes-api-version.md` §10 retrospective applies directly — paper-only verification of "what the CLI sends" does not catch this.
+
+## Decision
+
+Update `companies create` to call the atomic create-with-contact endpoint. Surface `--first-name`, `--last-name`, `--email`, and `--type` as required flags on the same command. Keep `contacts create` for adding *subsequent* contacts to an existing company.
+
+This is a breaking change for any script using `companies create`. Pre-1.0; acceptable.
+
+---
+
+## Investigate before implementation
+
+1. **Sync with Franco and Vinton Lee.** Franco offered to walk through it. Take him up — the atomic endpoint may have nuances (required contact types, response shape, whether there is an equivalent atomic *update* path) that surface faster in conversation than from JIRA archaeology.
+2. **Read the JIRA tickets.** PAM-997, PAM-1171, ARC-774. Understand the original Inactive-state regression, why the atomic path was built, and the contract it commits to.
+3. **Locate the endpoint in the public spec.** Check `https://devx.pax8.com/openapi/partner-endpoints.json` for the atomic create. If the spec still documents only the legacy two-step path, that is a separate finding worth flagging to the API team — the canonical endpoint should be the one the spec promotes.
+
+The methodology lesson from #307 applies: **verify request body shape against the spec, not just the URL.** Don't repeat the audit pattern that missed body-shape mismatches on quotes.
+
+---
+
+## Implementation
+
+### Step 1 — API client (`packages/core/src/api/companies.ts`)
+
+Replace the `POST /companies` call in `CompaniesApi.create()` with the atomic create-with-contact endpoint. The request body must carry both company fields and the first contact's fields. Add an inline comment citing PAM-997 + Franco's review so a future contributor doesn't quietly revert to the legacy path because it "looks simpler."
+
+### Step 2 — CLI command (`packages/cli/src/commands/companies/create.ts`)
+
+- Add `--first-name`, `--last-name`, `--email`, `--type` as **required** flags (matching `contacts create`'s existing vocabulary, see `packages/cli/src/commands/contacts/create.ts:35-39`).
+- Reuse the `Admin | Billing | Technical` enum validation from `contacts create` (`packages/cli/src/commands/contacts/create.ts:17,19-30,54-73`) — don't fork it.
+- Update `.description()` and `addHelpText("after", ...)` so the help output says, in plain language: *"Every company in Pax8 must have at least one contact. This command creates both in one call."* and shows examples with all four flags populated.
+- Update the preview block (`create.ts:38-46`) so the contact's name, email, and types are part of what the user confirms.
+- Update Zod input validation accordingly (likely a new `CreateCompanyWithContactInput` in `packages/core/src/api/types.ts`, or extend the existing `CreateCompanyInput`).
+
+### Step 3 — Contacts create (`packages/cli/src/commands/contacts/create.ts`)
+
+`contacts create` still works for additional contacts on an existing company; confirm with backend it does not conflict with the atomic create path. Update its `.description()` to disambiguate: *"Add an additional contact to an existing company. The first contact is created together with the company via `companies create`."*
+
+### Step 4 — Schema review
+
+Verify `CompanySchema` covers any fields the atomic endpoint returns that the legacy response didn't (in particular, the initial contact alongside the company). If the response shape differs, update the schema. Carry the §9.2/§10 lesson from the quotes triage: response-shape verification and request-shape verification are independent audits — finish both.
+
+### Step 5 — Tests
+
+- **Unit test** (`packages/core/src/api/companies.test.ts`, may need to be created): the atomic endpoint is called with both company and contact fields in the body.
+- **CLI integration test** (`packages/cli/src/__tests__/companies.create.test.ts`): under `PAX8_DEMO=1`, `companies create` with all required flags produces a company in `Active` state (not `Inactive`).
+- **CLI integration test**: `companies create` without contact flags fails CLI-side validation before any wire call, with an actionable error and the correct exit code.
+- **Regression assertion**: the legacy `POST /v1/companies` *without* a contact body is never called — either by asserting on the request body shape in the unit test, or by removing the legacy code path entirely so the regression is structurally impossible.
+
+Demo mode is the test posture (`CLAUDE.md` — "Demo mode is the test posture, not a side project"). The mock client (`MockPax8Client`) needs to model the atomic endpoint and return an `Active`-status company.
+
+### Step 6 — Domain review doc
+
+The Orders & Quotes section was updated for the quotes audit findings; the Companies & Contacts section needs a parallel **"Open from review"** entry citing Franco's catch. After the fix lands, the entry moves to **"What changed since your feedback"** with a PR link.
+
+### Step 7 — Changeset
+
+```
+Fix: `companies create` now uses the atomic create-with-contact endpoint
+shipped under PAM-997. New required flags: `--first-name`, `--last-name`,
+`--email`, `--type`. Previously, the CLI was calling a legacy two-step path
+that left companies in `Inactive` state — discovered by Franco Aurieme during
+domain review. AI agents and scripts using the prior surface should be
+updated to pass the new required flags.
+```
+
+---
+
+## Out of scope
+
+- `companies update` having an equivalent atomic path. Likely a separate question — confirm with Franco/Vinton during the sync. If one exists, file separately.
+- Auditing every other CLI command for "calls a legacy endpoint where an atomic/improved one exists." That belongs in the parallel audit issue; the audit methodology should explicitly include this case (legacy-endpoint usage where an atomic alternative exists). See the §10 retrospective in `docs/triage/quotes-api-version.md` for the verification pattern.
+- Renaming or restructuring `contacts create`.
+
+## Acceptance criteria
+
+- [ ] `companies create` calls the atomic create-with-contact endpoint, not the legacy two-step path.
+- [ ] `--first-name`, `--last-name`, `--email`, `--type` are required flags on `companies create`, validated CLI-side before any wire call.
+- [ ] Help text on both `companies create` and `contacts create` makes the relationship between the two explicit.
+- [ ] Tests cover the atomic path and assert the legacy path is never called.
+- [ ] `CompanySchema` (and any new input schema) matches the atomic endpoint's request and response shapes.
+- [ ] Domain review doc updated: Companies & Contacts section has the "Open from review" → "What changed" entry.
+- [ ] Changeset landed under `.changeset/`.
+- [ ] CI green (`pnpm build && pnpm test && pnpm lint`).
+
+## Closes / relates
+
+- Closes: Franco Aurieme's domain-review comment on Companies & Contacts (link once doc is published).
+- Relates to: #307 (quotes wire-path fix) — same class of bug; the §10 retrospective in `docs/triage/quotes-api-version.md` captures the verification methodology this issue's investigation should follow.
+- Relates to: parallel audit issue (legacy-endpoint sweep) — methodology must explicitly look for "legacy endpoint used when an atomic alternative exists," not only "endpoint not found."


### PR DESCRIPTION
## Summary

Post-batch doc housekeeping reflecting today's body-shape wave (~20 merges).

**Feedback queue** (\`docs/Pre-publish reviewer feedback queue\`)
- ~13 checkboxes flipped to \`[x]\` reflecting today's merges
- Parallel-audit findings (#317, #321–#333) tied to their resolving PRs
- Two remaining open items called out explicitly: #317 (\`clients\` rename, Hollander) and #330 (atomic endpoint, design)
- In-flight quotes-side provisioningDetails follow-up flagged (surfaced during #332)

**Domain review** (\`docs/domain-review.md\`)
- Summary of Concerns item (4) — Quotes — flipped from \"PARTIALLY ADDRESSED\" to \"RESOLVED\" with the eight-PR roll-up
- Orders & Quotes Status callout refreshed
- Workflows / Automated Quoting and Sales Cycle implementation note updated — flow now works end-to-end against real v2
- Companies & Contacts section refreshed: address renames, three new booleans on create, contacts nested path + body shape, \`--phone\` now required, PUT→PATCH
- Subscriptions: #336 (\`--billing-term\` widened), #347 (cancelDate ISO-normalize) reflected
- Webhooks Public API Surface header corrected (\`/api/v2\` not \`/v1\`)
- 2026-05-11 Recent changes paragraph rewritten as a batch retrospective

**Also included:** Josh's pre-existing-but-untracked \`docs/triage/companies-create-atomic-endpoint.md\` (was sitting locally on main from the parallel audit; folding it in here so it lands).

## Test plan

- [ ] Docs-only; no code changed
- [ ] Renders cleanly in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)