### PR TITLE
fix(quotes): drop "Order" prefix on shared line-item provisioning schema (closes #356)

### DIFF
--- a/.changeset/quotes-line-item-provisioning-rename.md
+++ b/.changeset/quotes-line-item-provisioning-rename.md
@@ -1,0 +1,9 @@
+---
+"@pax8/core": patch
+---
+
+Refactor: `OrderLineItemProvisioningDetailSchema` / `OrderLineItemProvisioningSchema` renamed to `LineItemProvisioningDetailSchema` / `LineItemProvisioningSchema` (and the type alias `OrderLineItemProvisioningDetail` to `LineItemProvisioningDetail`). The `Order` prefix was misleading once the schemas became shared across line-item domains — the public quoting OpenAPI spec's `AddStandardLineItemPayload.provisioningDetails` carries the same `Array<{key, values: string[]}>` shape as the orders side (#332).
+
+Backward-compatible: the pre-#356 export names remain exported from `@pax8/core` as aliases that resolve to the same schema instances. Embedders that imported `OrderLineItemProvisioning*` continue to work unchanged; new code should prefer `LineItemProvisioning*`.
+
+No wire-shape change. No CLI flag change. The quotes-side line-item path (`POST /v2/quotes/{id}/line-items` via `AddQuoteLineItemInputSchema`) doesn't currently surface `provisioningDetails`, and #356 doesn't add it — when a future PR adds a `--provisioning` flag for `quotes line-items add`, the field can reuse `LineItemProvisioningSchema.optional()` directly. Closes #356.

--- a/packages/core/src/api/types.test.ts
+++ b/packages/core/src/api/types.test.ts
@@ -56,7 +56,12 @@ import {
   OrderLineItemInputSchema,
   OrderLineItemProvisioningDetailSchema,
   OrderLineItemProvisioningSchema,
+  LineItemProvisioningDetailSchema,
+  LineItemProvisioningSchema,
   CreateOrderInputSchema,
+  CreateQuoteInputSchema,
+  UpdateQuoteInputSchema,
+  AddQuoteLineItemInputSchema,
   SubscriptionSchema,
   UpdateSubscriptionInputSchema,
   SubscriptionHistorySchema,
@@ -526,57 +531,161 @@ describe("OrderLineItemInputSchema", () => {
   });
 });
 
-describe("OrderLineItemProvisioningDetailSchema (#332)", () => {
+describe("LineItemProvisioningDetailSchema (#332 / renamed #356)", () => {
   it("requires both key and values", () => {
     const valid = { key: "domain", values: ["contoso.com"] };
-    expect(OrderLineItemProvisioningDetailSchema.parse(valid)).toEqual(valid);
+    expect(LineItemProvisioningDetailSchema.parse(valid)).toEqual(valid);
   });
 
   it("accepts multiple values per key", () => {
     const valid = { key: "region", values: ["us-east", "us-west", "eu-west"] };
-    expect(OrderLineItemProvisioningDetailSchema.parse(valid)).toEqual(valid);
+    expect(LineItemProvisioningDetailSchema.parse(valid)).toEqual(valid);
   });
 
   it("allows an empty values array (spec doesn't require non-empty)", () => {
     const valid = { key: "feature-flag", values: [] };
-    expect(OrderLineItemProvisioningDetailSchema.parse(valid)).toEqual(valid);
+    expect(LineItemProvisioningDetailSchema.parse(valid)).toEqual(valid);
   });
 
   it("rejects missing key", () => {
     expect(() =>
-      OrderLineItemProvisioningDetailSchema.parse({ values: ["x"] }),
+      LineItemProvisioningDetailSchema.parse({ values: ["x"] }),
     ).toThrow();
   });
 
   it("rejects missing values array", () => {
     expect(() =>
-      OrderLineItemProvisioningDetailSchema.parse({ key: "domain" }),
+      LineItemProvisioningDetailSchema.parse({ key: "domain" }),
     ).toThrow();
   });
 
   it("rejects non-string values", () => {
     expect(() =>
-      OrderLineItemProvisioningDetailSchema.parse({ key: "domain", values: [42] }),
+      LineItemProvisioningDetailSchema.parse({ key: "domain", values: [42] }),
     ).toThrow();
+  });
+
+  // Pre-#356 export name must keep resolving to the same schema so embedders
+  // that imported `OrderLineItemProvisioningDetailSchema` from `@pax8/core`
+  // continue to work after the rename.
+  it("is exported under the pre-#356 alias `OrderLineItemProvisioningDetailSchema`", () => {
+    expect(OrderLineItemProvisioningDetailSchema).toBe(
+      LineItemProvisioningDetailSchema,
+    );
   });
 });
 
-describe("OrderLineItemProvisioningSchema (#332)", () => {
+describe("LineItemProvisioningSchema (#332 / renamed #356)", () => {
   it("is an array of provisioning details", () => {
     const valid = [
       { key: "domain", values: ["contoso.com"] },
       { key: "tier", values: ["premium"] },
     ];
-    expect(OrderLineItemProvisioningSchema.parse(valid)).toEqual(valid);
+    expect(LineItemProvisioningSchema.parse(valid)).toEqual(valid);
   });
 
   it("accepts an empty array (no provisioning details required)", () => {
-    expect(OrderLineItemProvisioningSchema.parse([])).toEqual([]);
+    expect(LineItemProvisioningSchema.parse([])).toEqual([]);
   });
 
   it("rejects a record / object map (the pre-#332 shape)", () => {
     expect(() =>
-      OrderLineItemProvisioningSchema.parse({ domain: "contoso.com" }),
+      LineItemProvisioningSchema.parse({ domain: "contoso.com" }),
+    ).toThrow();
+  });
+
+  // Pre-#356 export name must keep resolving to the same schema so embedders
+  // that imported `OrderLineItemProvisioningSchema` from `@pax8/core` continue
+  // to work after the rename.
+  it("is exported under the pre-#356 alias `OrderLineItemProvisioningSchema`", () => {
+    expect(OrderLineItemProvisioningSchema).toBe(LineItemProvisioningSchema);
+  });
+});
+
+// ─── Quotes line-item provisioningDetails (#356) ────────────────────────────
+//
+// Background: #332 reshaped `OrderLineItemInputSchema.provisioningDetails`
+// from the wrong `Record<string, unknown>` shape to the spec-correct
+// `Array<{key, values: string[]}>` shape for orders. The agent who fixed it
+// flagged the same record/array mismatch on the quotes-side `lineItems[]`
+// path as an adjacent finding (PR #351 body, "Scope-honoring callouts").
+// #356 is the follow-up.
+//
+// State of the world at the time of #356:
+//
+// - `CreateQuoteInputSchema` and `UpdateQuoteInputSchema` no longer carry a
+//   `lineItems` field at all. #354 restructured both to match the v2
+//   `POST /v2/quotes` (`{ clientId, quoteRequestId? }`) and
+//   `PUT /v2/quotes/{id}` (the 5-field full-update body) wire shapes; line
+//   items live on the separate `POST /v2/quotes/{id}/line-items` endpoint
+//   via `AddQuoteLineItemInputSchema`. So the original defect described in
+//   #356 — the `Record<string, unknown>` typing of
+//   `CreateQuoteInputSchema.lineItems[].provisioningDetails` — no longer
+//   exists as a shape, because the carrier field itself is gone.
+//
+// - `AddQuoteLineItemInputSchema` (the v2 line-item POST body) intentionally
+//   does NOT expose `provisioningDetails` today. The CLI's
+//   `quotes line-items add` doesn't surface a `--provisioning` flag, and #356
+//   is explicit about not adding one in this PR. When that flag lands the
+//   field can be added here using `LineItemProvisioningSchema.optional()` —
+//   same shape as the orders side — and the rename done by #356 means that
+//   single import already reads as domain-neutral.
+//
+// The tests below pin both invariants so a future PR can't quietly slip the
+// pre-fix record shape back in via the wrong carrier.
+describe("Quotes line-item input schemas (#356)", () => {
+  it("CreateQuoteInputSchema does not accept a `lineItems` field (post-#354 v2 POST body)", () => {
+    const valid = { clientId: uuid };
+    expect(CreateQuoteInputSchema.parse(valid)).toEqual(valid);
+    // zod is permissive by default — `lineItems` is just stripped, not
+    // rejected. Pin that it doesn't survive parsing, so a future caller
+    // can't accidentally rely on it making it through to the wire.
+    const parsed = CreateQuoteInputSchema.parse({
+      clientId: uuid,
+      lineItems: [
+        { productId: uuid2, quantity: 1, provisioningDetails: [{ key: "k", values: ["v"] }] },
+      ],
+    } as unknown as { clientId: string });
+    expect(parsed).not.toHaveProperty("lineItems");
+  });
+
+  it("UpdateQuoteInputSchema does not accept a `lineItems` field (post-#354 v2 PUT body)", () => {
+    const valid = { status: "sent" as const };
+    expect(UpdateQuoteInputSchema.parse(valid)).toEqual(valid);
+    const parsed = UpdateQuoteInputSchema.parse({
+      status: "sent",
+      lineItems: [
+        { productId: uuid2, quantity: 1, provisioningDetails: [{ key: "k", values: ["v"] }] },
+      ],
+    } as unknown as { status: "sent" });
+    expect(parsed).not.toHaveProperty("lineItems");
+  });
+
+  // The current `AddQuoteLineItemInputSchema` (#312) intentionally omits
+  // `provisioningDetails`. If a future PR adds it, this test will start
+  // failing — at which point the new field MUST be wired to
+  // `LineItemProvisioningSchema.optional()` so the spec-shape parity with
+  // orders is preserved from day one. Update the test to mirror the orders
+  // assertions in that PR.
+  it("AddQuoteLineItemInputSchema does not yet surface `provisioningDetails` (canary for the future flag)", () => {
+    const validBase = {
+      productId: uuid2,
+      quantity: 1,
+      effectiveDate: "2026-05-11T00:00:00Z",
+      price: 9.99,
+    };
+    const parsed = AddQuoteLineItemInputSchema.parse({
+      ...validBase,
+      provisioningDetails: [{ key: "domain", values: ["contoso.com"] }],
+    } as unknown as typeof validBase);
+    expect(parsed).not.toHaveProperty("provisioningDetails");
+
+    // If/when `provisioningDetails` lands on this schema, the record shape
+    // (the pre-#332 bug) must never be accepted. Pre-pin the regression
+    // guard using `LineItemProvisioningSchema` directly so the contract is
+    // documented even though the carrier field doesn't exist yet.
+    expect(() =>
+      LineItemProvisioningSchema.parse({ domain: "contoso.com" }),
     ).toThrow();
   });
 });

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -285,11 +285,12 @@ export const ProvisioningDetailSchema = z.object({
 });
 export type ProvisioningDetail = z.infer<typeof ProvisioningDetailSchema>;
 
-// ─── Order ───────────────────────────────────────────────────────────────────
+// ─── Line-item provisioning (shared by Orders + Quotes) ─────────────────────
 
 /**
  * Per-line provisioning detail, matching the public Pax8 OpenAPI spec's
- * `ProvisioningDetail` schema (partner-endpoints.json):
+ * `ProvisioningDetail` schema (partner-endpoints.json + quoting-endpoints.json
+ * both share this shape):
  *
  *   { key: string, values: string[] }
  *
@@ -302,20 +303,43 @@ export type ProvisioningDetail = z.infer<typeof ProvisioningDetailSchema>;
  * with the products-side `ProvisioningDetailSchema` (which describes a
  * *product's* provisioning requirements, not an order-line's provisioning
  * values — same word, different concept).
+ *
+ * Initially introduced as `OrderLineItemProvisioningDetailSchema` in #332;
+ * renamed to drop the `Order` prefix in #356 because the quotes line-item
+ * path (`POST /v2/quotes/{id}/line-items`) carries the same `ProvisioningDetail`
+ * shape per the public quoting OpenAPI spec
+ * (`AddStandardLineItemPayload.provisioningDetails`). The old export names
+ * remain as aliases at the bottom of this section for embedders that imported
+ * them under the original symbol.
  */
-export const OrderLineItemProvisioningDetailSchema = z.object({
+export const LineItemProvisioningDetailSchema = z.object({
   key: z.string(),
   values: z.array(z.string()),
 });
-export type OrderLineItemProvisioningDetail = z.infer<typeof OrderLineItemProvisioningDetailSchema>;
+export type LineItemProvisioningDetail = z.infer<typeof LineItemProvisioningDetailSchema>;
 
 /**
- * Wire shape for `OrderLineItem.provisioningDetails` — an array of
- * `{ key, values[] }` objects per the spec. See #332.
+ * Wire shape for a line item's `provisioningDetails` — an array of
+ * `{ key, values[] }` objects per the spec. Used by both orders
+ * (`OrderLineItem` / `OrderLineItemInput`) and quotes (the v2
+ * `AddStandardLineItemPayload`). See #332 (orders) and #356 (rename + quotes
+ * surface).
  */
-export const OrderLineItemProvisioningSchema = z.array(
-  OrderLineItemProvisioningDetailSchema,
+export const LineItemProvisioningSchema = z.array(
+  LineItemProvisioningDetailSchema,
 );
+
+/**
+ * Backward-compatibility aliases for the pre-#356 names. Embedders that
+ * imported `OrderLineItemProvisioningDetailSchema` /
+ * `OrderLineItemProvisioningSchema` / `OrderLineItemProvisioningDetail` from
+ * `@pax8/core` continue to work unchanged. Prefer the domain-neutral names
+ * (`LineItemProvisioning*`) in new code — the schemas are shared by orders
+ * and quotes.
+ */
+export const OrderLineItemProvisioningDetailSchema = LineItemProvisioningDetailSchema;
+export const OrderLineItemProvisioningSchema = LineItemProvisioningSchema;
+export type OrderLineItemProvisioningDetail = LineItemProvisioningDetail;
 
 export const CommitmentTermSchema = z.enum([
   "Monthly",
@@ -339,7 +363,7 @@ export const OrderLineItemInputSchema = z.object({
   quantity: z.number().int().min(1),
   billingTerm: BillingTermSchema.optional(),
   commitmentTermId: z.string().optional(),
-  provisioningDetails: OrderLineItemProvisioningSchema.optional(),
+  provisioningDetails: LineItemProvisioningSchema.optional(),
 });
 export type OrderLineItemInput = z.infer<typeof OrderLineItemInputSchema>;
 
@@ -365,7 +389,7 @@ export const OrderLineItemSchema = z.object({
   billingTerm: BillingTermSchema.optional(),
   lineItemNumber: z.number().int().optional(),
   quantity: z.number(),
-  provisioningDetails: OrderLineItemProvisioningSchema.optional(),
+  provisioningDetails: LineItemProvisioningSchema.optional(),
 });
 export type OrderLineItem = z.infer<typeof OrderLineItemSchema>;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,9 @@ export {
   OrderLineItemSchema,
   OrderLineItemInputSchema,
   OrderLineItemCreateInputSchema,
+  LineItemProvisioningSchema,
+  LineItemProvisioningDetailSchema,
+  // Backward-compat aliases (pre-#356) — prefer the domain-neutral names above.
   OrderLineItemProvisioningSchema,
   OrderLineItemProvisioningDetailSchema,
   CreateOrderInputSchema,
@@ -147,6 +150,8 @@ export type {
   OrderLineItem,
   OrderLineItemInput,
   OrderLineItemCreateInput,
+  LineItemProvisioningDetail,
+  // Backward-compat alias (pre-#356) — prefer `LineItemProvisioningDetail`.
   OrderLineItemProvisioningDetail,
   CreateOrderInput,
   Commitment,


### PR DESCRIPTION
## Summary

Closes #356.

#332 introduced `OrderLineItemProvisioningDetailSchema` / `OrderLineItemProvisioningSchema` for the spec-correct `Array<{key, values: string[]}>` shape on order line items. The agent who landed #351 surfaced that the same `ProvisioningDetail` shape is defined by the public quoting OpenAPI spec on the v2 line-items POST (`AddStandardLineItemPayload.provisioningDetails`) — i.e. the schema is already domain-neutral, the `Order` prefix is just stale.

This PR:

- Renames `OrderLineItemProvisioningDetailSchema` → `LineItemProvisioningDetailSchema`, `OrderLineItemProvisioningSchema` → `LineItemProvisioningSchema`, and the inferred type `OrderLineItemProvisioningDetail` → `LineItemProvisioningDetail`.
- Keeps the pre-#356 names exported from `@pax8/core` as aliases resolving to the same schema instances, so embedders importing the original symbols continue to work unchanged.
- Adds alias-identity tests + a regression-guard canary on `AddQuoteLineItemInputSchema` so when a future PR surfaces `provisioningDetails` for `quotes line-items add` it lands on `LineItemProvisioningSchema.optional()` from day one (no quiet reintroduction of the pre-#332 `Record<string, unknown>` shape).

## Scope-honoring callouts

- **`CreateQuoteInputSchema` / `UpdateQuoteInputSchema` no longer carry a `lineItems` field** as of #354 (v2 5-field PUT-body restructure). The original defect description in the issue body — `CreateQuoteInputSchema.lineItems[].provisioningDetails` typed as `Record<string, unknown>` — no longer exists as a shape because the carrier field itself is gone. New tests pin both schemas don't accept `lineItems`, so a future regression can't slip the pre-fix shape back in via the wrong path.
- **`AddQuoteLineItemInputSchema` (the current v2 line-item POST body from #312) intentionally does NOT yet expose `provisioningDetails`.** The CLI's `quotes line-items add` doesn't surface a `--provisioning` flag, and #356 is explicit about not adding one here. The canary test will fail loudly if the field is added without wiring it to `LineItemProvisioningSchema`.
- **No CLI parser changes. No wire-shape changes for orders.** The orders parser already imports `OrderLineItemProvisioningDetail` — that import now resolves to the alias and still works.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 1716 passed, 8 skipped
- [x] `pnpm lint` — clean
- [x] New tests pin: `LineItemProvisioningDetailSchema` / `LineItemProvisioningSchema` accept the spec array shape and reject the pre-#332 record shape (existing #332 coverage migrated to the new names).
- [x] Alias-identity tests pin: `OrderLineItemProvisioningDetailSchema === LineItemProvisioningDetailSchema` and `OrderLineItemProvisioningSchema === LineItemProvisioningSchema` (embedder backward compat).
- [x] Quotes-side regression guards pin: `CreateQuoteInputSchema` and `UpdateQuoteInputSchema` strip a stray `lineItems` field; `AddQuoteLineItemInputSchema` doesn't yet surface `provisioningDetails` and won't until a future PR explicitly adds it.
- [x] Changeset entry — `@pax8/core` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)