### PR TITLE
fix(recommendations): drop UUID-leaking duplicate "Quick actions" render (closes #195)

### DIFF
--- a/.changeset/recommendations-list-no-uuid-no-duplicate-render.md
+++ b/.changeset/recommendations-list-no-uuid-no-duplicate-render.md
@@ -1,0 +1,7 @@
+---
+"@pax8/cli": patch
+---
+
+Fix: `pax8 recommendations list` no longer leaks raw product IDs into human (table) output and no longer renders the same recommendation list twice. The "Quick actions" block — a per-rec `orders create --company "<name>" --product <uuid> --quantity <n>` snippet that re-printed every visible recommendation and exposed the product UUID in non-JSON output — has been replaced with a single one-line summary (`Top N alone capture $X/mo.`). The table above is the menu, and the existing one-line `promptNextSteps` drill-in hint stays unchanged. JSON output is untouched: every `recommendation.orderCommand` still includes the full `--product <id>` form so agents and downstream tooling can execute it verbatim. Closes #195.
+
+Also adds a `PAX8_OUTPUT_FORMAT` env-var escape hatch (`table` | `json` | `csv` | `quiet`) in `getOutputFormat` so subprocess tests can exercise the human-render code path — without it the non-TTY auto-fallback to JSON makes table-mode regressions like this one impossible to assert from a piped child process.

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -119,6 +119,63 @@ describe("pax8 recommendations", () => {
       // (JSON returns all recs; filtering only affects table mode)
       expect(allRecs.length).toBe(defaultRecs.length);
     });
+
+    // Issue #195: human render leaked product UUIDs in a "Quick actions"
+    // block AND re-printed every rec a second time as an `orders create
+    // --product <uuid>` snippet (in addition to the table and the
+    // promptNextSteps hint). The fix removes the Quick actions block; the
+    // table + the one-line drill-in hint stay.
+    //
+    // Forcing table mode under a subprocess: stdout in `execFile` isn't a
+    // TTY, so without `PAX8_OUTPUT_FORMAT=table` the CLI auto-falls back to
+    // JSON for machine consumption and the human-render code path is never
+    // exercised.
+    it("does not leak product IDs into human (table) output", async () => {
+      const result = await runCliExpectSuccess(
+        ["recommendations", "list"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      const combined = result.stdout + result.stderr;
+      // The demo mock uses `prod-*` IDs for products; a real Pax8 deploy
+      // uses RFC-4122 UUIDs. Neither shape should appear in human output.
+      expect(combined).not.toMatch(/--product\s+prod-/);
+      expect(combined).not.toMatch(
+        /--product\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+      );
+    });
+
+    it("renders the rec list exactly once (no Quick actions duplicate block)", async () => {
+      const result = await runCliExpectSuccess(
+        ["recommendations", "list"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      const combined = result.stdout + result.stderr;
+      // The "Quick actions:" header was the start of the duplicate block.
+      // It must not appear in the new human render.
+      expect(combined).not.toMatch(/Quick actions:/);
+      // The `orders create --product …` snippet was the per-rec second
+      // render that carried the UUID leak; it must not appear in human
+      // output. (JSON output's `orderCommand` field still has it — that
+      // contract is covered by the existing JSON tests above.)
+      expect(combined).not.toMatch(/orders create --product/);
+      // The drill-in hint stays.
+      expect(combined).toMatch(/Walk through all/);
+    });
+
+    it("--json output still carries the full orderCommand with product id (agent contract)", async () => {
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
+      const data = JSON.parse(result.stdout) as Array<{ orderCommand: string | null }>;
+      const withCommand = data.filter((r) => r.orderCommand);
+      expect(withCommand.length).toBeGreaterThan(0);
+      // The JSON `orderCommand` MUST still include `--product <id>` so
+      // agents and downstream tooling can execute it verbatim. Whether the
+      // id is a UUID (real API) or a demo-stub like `prod-xxx-0001` is
+      // env-dependent; what we require is that the `--product <token>`
+      // shape survives.
+      expect(
+        withCommand.every((r) => /--product\s+\S+/.test(r.orderCommand!)),
+      ).toBe(true);
+    });
   });
 
   describe("recommendations act", () => {

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -243,18 +243,22 @@ Estimate semantics:
         process.stderr.write(chalk.cyan(`\n  📈 A few conversations could add ${formatCurrency(totalUplift * 12)}/yr to your book.\n`));
       }
 
-      // Show actionable commands — copy-paste ready (cap at 5)
-      const quickActionCount = Math.min(displayRecs.length, 5);
-      process.stderr.write(chalk.dim("\n  Quick actions:\n\n"));
-      for (let i = 0; i < quickActionCount; i++) {
-        const rec = displayRecs[i];
-        const product = rec.suggestedProducts?.[0] ?? "product";
-        const seats = rec.targetSeats ?? "?";
-        const uplift = rec.estimatedMrrUplift ? chalk.green(` +${formatCurrency(rec.estimatedMrrUplift)}/mo`) : "";
-        process.stderr.write(`  ${chalk.cyan.bold(`${i + 1}.`)} ${product} for ${rec.companyName} (${seats} seats)${uplift}\n`);
-        if (rec.orderCommand) {
-          process.stderr.write(chalk.dim(`     ${replCmd(rec.orderCommand)}\n\n`));
-        }
+      // One-line "top N capture $X/mo" summary — replaces the old
+      // multi-paragraph "Quick actions" block (issue #195). The block
+      // re-printed every rec a second time AND leaked raw product UUIDs in
+      // the `orders create --product <uuid>` snippets. The table above is
+      // the menu; the `#` column + the `promptNextSteps` hint below already
+      // give the user everything they need to drill in.
+      const topN = Math.min(displayRecs.length, 5);
+      const topUplift = displayRecs
+        .slice(0, topN)
+        .reduce((sum, r) => sum + (r.estimatedMrrUplift ?? 0), 0);
+      if (topUplift > 0 && recs.length > topN) {
+        process.stderr.write(
+          chalk.dim(`\n  Top ${topN} alone capture `) +
+            chalk.green(`${formatCurrency(topUplift)}/mo`) +
+            chalk.dim(".\n")
+        );
       }
 
       if (hiddenCount > 0) {

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -108,6 +108,15 @@ export function getOutputFormat(
   if (options.json) return "json";
   if (options.csv) return "csv";
 
+  // Escape hatch for subprocess tests that need to exercise the table-mode
+  // render path (the human render only fires when stdout is a TTY, so without
+  // this override the non-JSON branches are unreachable from a piped
+  // subprocess). Accepted values: "table" | "json" | "csv" | "quiet".
+  const forced = process.env.PAX8_OUTPUT_FORMAT;
+  if (forced === "table" || forced === "json" || forced === "csv" || forced === "quiet") {
+    return forced;
+  }
+
   // Non-TTY (piped) output always defaults to JSON for machine consumption
   if (!process.stdout.isTTY) return "json";
 


### PR DESCRIPTION
## Summary

`pax8 recommendations list` had two presentation-layer defects in its human (table) render, surfaced in #195:

1. **UUID leak.** The "Quick actions" block printed a per-rec `orders create --company "<name>" --product <uuid> --quantity <n>` snippet under each visible recommendation, exposing raw product UUIDs in the human output. (UUIDs belong in JSON, where downstream tooling consumes them — never in the terminal.)
2. **Triple-print.** The same recommendations were rendered three times: the table itself, the "Quick actions" prose block, and the `promptNextSteps` drill-in hint.

This PR removes the "Quick actions" block entirely and replaces it with a single one-line summary — `Top N alone capture $X/mo.` — when there are more recs than fit in the top-5 cap. The table is the menu (the `#` column tells the user how to drill in), the existing one-line `promptNextSteps` hint stays, and total line count for a 10-rec list drops from ~70 to ~25 (per the issue's acceptance criteria).

JSON output is untouched: every `recommendation.orderCommand` still carries the full `--product <id>` form so agents and downstream tooling can execute it verbatim.

### Test infrastructure

Added a `PAX8_OUTPUT_FORMAT` env-var escape hatch in `getOutputFormat` (`packages/cli/src/lib/context.ts`). Without it, the existing non-TTY auto-fallback to JSON (line 112) makes table-mode regressions unreachable from a piped subprocess — every `runCli([...])` invocation that omits `--json` was silently getting JSON back, so the human-render code path was untestable end-to-end. The override is intentionally only honored after the explicit `--json` / `--csv` / `--quiet` flag checks, so user-facing behavior is unchanged.

### Acceptance criteria (from #195)

- [x] Default human render of `recommendations list` does NOT contain UUID-shaped strings — new subprocess test asserts no `--product <uuid>` or `--product prod-...` in `stdout + stderr` under `PAX8_OUTPUT_FORMAT=table`.
- [x] "Quick actions" multi-paragraph block removed; replaced with one summary line.
- [x] `--json` output's `orderCommand` field is unchanged — new test asserts every `orderCommand` still contains `--product <token>`.
- [x] Subprocess test asserts no UUID in human output (and that "Quick actions:" header is gone, and that "Walk through all" drill-in hint remains).

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 1714 passed, 8 skipped (3 new tests in `recommendations.test.ts`)
- [x] `pnpm lint` — clean
- [x] JSON output contract preserved: `recommendations list --json`, `--with-actions`, `--include-all`, `--priority`, `--company` filters all still pass their existing tests
- [x] Human render: top-5 cap, hidden-count line, drill-in hint, and `recommendations act` suggestion all stay; only the per-rec Quick-actions duplicate is gone

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)