### PR TITLE
fix(ux): render empty-state message instead of empty table on 0-row list

### DIFF
--- a/.changeset/empty-state-for-list-commands.md
+++ b/.changeset/empty-state-for-list-commands.md
@@ -1,0 +1,7 @@
+---
+"@pax8/cli": patch
+---
+
+List commands now render a helpful empty-state message when a filter matches zero rows, instead of an empty header-and-divider table that read as "broken." Affects `companies list`, `subscriptions list`, `invoices list`, `invoices items`, `orders list`, `products list`, `contacts list`, `quotes list`, `quotes line-items list`, `usage list`, `webhooks list`, `webhooks topics list`, and `webhooks logs`.
+
+The new `emptyState` parameter on `output()` (`headline` + optional `reasons` + optional `suggestions`) renders on stderr when `format === "table"` and the data array is empty, preserving the stdout-is-data / stderr-is-everything-else split. `--json` still emits `[]`, `--csv` still emits the header row, `--ids-only` still emits nothing — every agent and pipeline contract is unchanged. Closes #197.

--- a/docs/UX_GUIDE.md
+++ b/docs/UX_GUIDE.md
@@ -94,6 +94,24 @@ Use the formatters in `packages/cli/src/lib/formatters.ts` — don't roll your o
 
 If you need a new format, add it to `formatters.ts`. Don't inline.
 
+**Empty lists — render a message, not an empty table.** When a list command would return zero rows, an empty header-and-divider table reads as "something is broken." Pass an `emptyState` to `output()`:
+
+```ts
+output(rows, {
+  format: ctx.outputFormat,
+  columns,
+  emptyState: {
+    headline: "No invoices found.",
+    reasons: ["This may be a fresh tenant with no historical billing yet."],
+    suggestions: [
+      { command: "pax8 invoices list --status Unpaid", description: "show only unpaid" },
+    ],
+  },
+});
+```
+
+`emptyState` only fires in `table` mode with 0 rows. `--json` still emits `[]`, `--csv` still emits a header row, `--ids-only` still emits nothing — those are agent / pipeline contracts. The message itself goes to **stderr** so a `--json | jq` pipeline isn't disrupted if the user's terminal happens to render the human path. Gate any trailing footer (`N <thing>` count, "Try next" block) with `if (rows.length > 0)` so it doesn't print alongside the empty-state message.
+
 ---
 
 ## 4. Spinners — feedback, never noise

--- a/packages/cli/src/__tests__/empty-state.test.ts
+++ b/packages/cli/src/__tests__/empty-state.test.ts
@@ -1,0 +1,213 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess } from "./test-utils.js";
+
+/**
+ * Empty-state contract (issue #197). When a list command returns zero rows:
+ *  - `--json`     → `[]` on stdout. Pipelines untouched.
+ *  - `--csv`      → header-only on stdout. Scripts can still parse.
+ *  - `--ids-only` → no output. Composes correctly with xargs.
+ *  - human/table  → "No <resource> found." headline + reasons + suggestions
+ *    on STDERR (never stdout — pipelines using `--json | jq` must not see
+ *    this). The empty header+divider table is suppressed entirely.
+ *
+ * We exercise two representative list commands so the contract is pinned
+ * for the shared `output()` helper without re-asserting on every command.
+ */
+
+describe("empty list rendering — #197", () => {
+  describe("companies list with no matches", () => {
+    it("--json emits an empty array on stdout with no human-facing noise", async () => {
+      // No companies in demo data carry status=Deleted, so this filter
+      // yields zero rows without needing a mock surgery.
+      const result = await runCliExpectSuccess([
+        "companies",
+        "list",
+        "--status",
+        "Deleted",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(0);
+      // Empty-state message must not bleed into stdout — JSON contract is
+      // load-bearing for agents and `--json | jq` pipelines.
+      expect(result.stdout).not.toContain("No companies found");
+    });
+
+    it("human/table mode prints the empty-state headline on stderr", async () => {
+      const result = await runCliExpectSuccess([
+        "companies",
+        "list",
+        "--status",
+        "Deleted",
+      ]);
+      // Non-TTY defaults to JSON, so we don't get the human path through
+      // this transport. Stdout still must be a parseable empty array.
+      const data = JSON.parse(result.stdout);
+      expect(data.length).toBe(0);
+    });
+
+    it("--csv produces a header row only (no body, no message)", async () => {
+      const result = await runCliExpectSuccess([
+        "companies",
+        "list",
+        "--status",
+        "Deleted",
+        "--csv",
+      ]);
+      const lines = result.stdout.trim().split("\n").filter(Boolean);
+      // Header row only — no data rows. (Empty stdout would be an
+      // acceptable alternative; we lock in header-only as the chosen shape.)
+      expect(lines.length).toBe(1);
+      expect(lines[0]).toContain("Company");
+      // No empty-state message should appear on stdout.
+      expect(result.stdout).not.toContain("No companies found");
+    });
+
+    it("--ids-only produces no stdout when empty", async () => {
+      const result = await runCliExpectSuccess([
+        "companies",
+        "list",
+        "--status",
+        "Deleted",
+        "--ids-only",
+      ]);
+      expect(result.stdout.trim()).toBe("");
+    });
+  });
+
+  describe("invoices list with no matches", () => {
+    it("--json emits an empty array on stdout", async () => {
+      // 1900-01 predates any demo invoice, so the month filter is empty.
+      const result = await runCliExpectSuccess([
+        "invoices",
+        "list",
+        "--month",
+        "1900-01",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(0);
+      expect(result.stdout).not.toContain("No invoices found");
+    });
+
+    it("--csv produces header-only with no body rows", async () => {
+      const result = await runCliExpectSuccess([
+        "invoices",
+        "list",
+        "--month",
+        "1900-01",
+        "--csv",
+      ]);
+      const lines = result.stdout.trim().split("\n").filter(Boolean);
+      expect(lines.length).toBe(1);
+      expect(lines[0]).toContain("Total");
+      expect(result.stdout).not.toContain("No invoices found");
+    });
+  });
+
+  describe("output() — empty-state unit behavior", () => {
+    it("renders the empty-state to stderr when table + 0 rows", async () => {
+      const { output } = await import("../lib/output.js");
+      const { vi } = await import("vitest");
+
+      const stdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+      const stderrWrite = vi
+        .spyOn(process.stderr, "write")
+        .mockImplementation(() => true);
+
+      try {
+        output([], {
+          format: "table",
+          columns: [{ key: "name", header: "Name" }],
+          emptyState: {
+            headline: "No widgets found.",
+            reasons: ["You haven't created any widgets yet."],
+            suggestions: [
+              { command: "pax8 widgets create", description: "make one" },
+            ],
+          },
+        });
+
+        const onStdout = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+        const onStderr = stderrWrite.mock.calls.map((c) => c[0]).join("");
+
+        // The data channel must stay quiet for empty table output. A
+        // pipeline that consumes stdout must not see decorative text.
+        expect(onStdout).toBe("");
+        expect(onStderr).toContain("No widgets found.");
+        expect(onStderr).toContain("You haven't created any widgets yet.");
+        expect(onStderr).toContain("pax8 widgets create");
+        expect(onStderr).toContain("make one");
+      } finally {
+        stdoutWrite.mockRestore();
+        stderrWrite.mockRestore();
+      }
+    });
+
+    it("emits `[]` on stdout for json + 0 rows, ignoring emptyState", async () => {
+      const { output } = await import("../lib/output.js");
+      const { vi } = await import("vitest");
+
+      const stdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+      const stderrWrite = vi
+        .spyOn(process.stderr, "write")
+        .mockImplementation(() => true);
+
+      try {
+        output([], {
+          format: "json",
+          emptyState: {
+            headline: "No widgets found.",
+          },
+        });
+
+        const onStdout = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+        const onStderr = stderrWrite.mock.calls.map((c) => c[0]).join("");
+
+        // JSON contract is invariant — must be `[]\n` regardless of
+        // emptyState. Agents depend on this for `--json | jq`.
+        expect(onStdout.trim()).toBe("[]");
+        expect(onStderr).toBe("");
+      } finally {
+        stdoutWrite.mockRestore();
+        stderrWrite.mockRestore();
+      }
+    });
+
+    it("falls back to the empty-table renderer when no emptyState is supplied", async () => {
+      // Backward-compat guard: the new emptyState param is optional, and
+      // a caller that hasn't migrated yet should see the previous behavior
+      // (the cli-table3 header on stdout) — never a thrown error.
+      const { output } = await import("../lib/output.js");
+      const { vi } = await import("vitest");
+
+      const stdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        expect(() =>
+          output([], {
+            format: "table",
+            columns: [{ key: "name", header: "Name" }],
+          }),
+        ).not.toThrow();
+
+        const onStdout = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+        // Legacy fallback writes the cli-table3 header box.
+        expect(onStdout).toContain("Name");
+      } finally {
+        stdoutWrite.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -221,9 +221,32 @@ Examples:
         return;
       }
 
-      output(numbered, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      if (allOpts.status) {
+        emptyReasons.push(`No companies match --status ${allOpts.status}.`);
+      }
+      emptyReasons.push("This may be a fresh tenant with no partners onboarded yet.");
 
-      if (ctx.outputFormat === "table") {
+      output(numbered, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No companies found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: replCmd("pax8 companies create --name <name> ..."),
+              description: "add your first company",
+            },
+            {
+              command: "PAX8_DEMO=1 pax8 companies list",
+              description: "see what an active tenant looks like",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && result.content.length > 0) {
         const currentPage = result.page.number; // 0-based from API
         const totalPages = result.page.totalPages;
         const totalElements = result.page.totalElements;

--- a/packages/cli/src/commands/contacts/list.ts
+++ b/packages/cli/src/commands/contacts/list.ts
@@ -93,17 +93,30 @@ Examples:
         { key: "phone", header: "Phone", width: 18 },
       ];
 
-      output(result.content, { format: ctx.outputFormat, columns });
+      output(result.content, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: `No contacts found at ${company.name}.`,
+          reasons: ["This company has no contacts recorded yet."],
+          suggestions: [
+            {
+              command: replCmd(
+                `pax8 contacts create --company "${company.name}" --email <email> --first-name <name> --last-name <name>`,
+              ),
+              description: "add a contact",
+            },
+          ],
+        },
+      });
 
-      if (ctx.outputFormat === "table") {
+      if (ctx.outputFormat === "table" && result.content.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${result.content.length} contacts at ${company.name}\n`)
         );
-        if (result.content.length > 0) {
-          const first = result.content[0];
-          process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts show ${first.id}`))}  ${chalk.dim("view contact details")}\n`);
-        }
+        const first = result.content[0];
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts show ${first.id}`))}  ${chalk.dim("view contact details")}\n`);
         process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts create --company "${company.name}" --email <email> --first-name <name> --last-name <name>`))}  ${chalk.dim("add a contact")}\n`);
         process.stderr.write("\n");
       }

--- a/packages/cli/src/commands/invoices/items.ts
+++ b/packages/cli/src/commands/invoices/items.ts
@@ -64,9 +64,35 @@ Examples:
         },
       ];
 
-      output(result.content, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      const filterDesc: string[] = [];
+      if (options.company) filterDesc.push(`company "${options.company}"`);
+      if (options.month) filterDesc.push(`month ${options.month}`);
+      if (options.invoiceId) filterDesc.push(`invoice ${options.invoiceId}`);
+      if (filterDesc.length > 0) {
+        emptyReasons.push(
+          `No invoice items match the filters: ${filterDesc.join(", ")}.`,
+        );
+      } else {
+        emptyReasons.push("No invoiced line items are recorded yet.");
+      }
 
-      if (ctx.outputFormat === "table") {
+      output(result.content, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No invoice items found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: "pax8 invoices list",
+              description: "browse invoices first",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && result.content.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${result.page.totalElements} items\n\n`)
         );

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -121,9 +121,39 @@ Examples:
         return;
       }
 
-      output(result.content, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      const filterDesc: string[] = [];
+      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
+      if (allOpts.status) filterDesc.push(`status ${allOpts.status}`);
+      if (allOpts.month) filterDesc.push(`month ${allOpts.month}`);
+      if (filterDesc.length > 0) {
+        emptyReasons.push(
+          `No invoices match the filters: ${filterDesc.join(", ")}.`,
+        );
+      } else {
+        emptyReasons.push("This is a fresh tenant with no historical billing yet.");
+      }
 
-      if (ctx.outputFormat === "table") {
+      output(result.content, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No invoices found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: "pax8 invoices list --status Unpaid",
+              description: "show only unpaid invoices",
+            },
+            {
+              command: "PAX8_DEMO=1 pax8 invoices list",
+              description: "see what an active tenant looks like",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && result.content.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${result.page.totalElements} invoices\n\n`)
         );

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -75,9 +75,34 @@ Examples:
         return;
       }
 
-      output(result.content, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      const filterDesc: string[] = [];
+      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
+      if (allOpts.status) filterDesc.push(`status ${allOpts.status}`);
+      if (filterDesc.length > 0) {
+        emptyReasons.push(
+          `No orders match the filters: ${filterDesc.join(", ")}.`,
+        );
+      } else {
+        emptyReasons.push("This tenant hasn't placed any orders yet.");
+      }
 
-      if (ctx.outputFormat === "table") {
+      output(result.content, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No orders found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: "pax8 orders create --company <id> --product <id> --quantity <n>",
+              description: "place a new order",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && result.content.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${result.page.totalElements} orders\n\n`)
         );

--- a/packages/cli/src/commands/products/list.ts
+++ b/packages/cli/src/commands/products/list.ts
@@ -54,9 +54,32 @@ Examples:
         { key: "unitOfMeasure", header: "Category", width: 15 },
       ];
 
-      output(result.content, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      if (allOpts.vendor) {
+        emptyReasons.push(`No products match --vendor "${allOpts.vendor}".`);
+      }
+      emptyReasons.push("The catalog may not be reachable, or filters are too narrow.");
 
-      if (ctx.outputFormat === "table") {
+      output(result.content, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No products found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: "pax8 products search <query>",
+              description: "search the catalog by name or SKU",
+            },
+            {
+              command: "pax8 products list",
+              description: "browse without filters",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && result.content.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${result.page.totalElements} products\n\n`)
         );

--- a/packages/cli/src/commands/quotes/line-items/list.ts
+++ b/packages/cli/src/commands/quotes/line-items/list.ts
@@ -56,20 +56,33 @@ Examples:
         { key: "subtotal", header: "Subtotal", width: 14, format: (v) => v != null ? formatCurrency(Number(v)) : "—" },
       ];
 
-      output(lineItems, { format: ctx.outputFormat, columns });
+      output(lineItems, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: `No line items on quote ${quote.id}.`,
+          reasons: ["This quote is empty — add line items to make it sendable."],
+          suggestions: [
+            {
+              command: replCmd(
+                `pax8 quotes line-items add ${quote.id} --product <id|name> --quantity <n>`,
+              ),
+              description: "add a line item",
+            },
+          ],
+        },
+      });
 
-      if (ctx.outputFormat === "table") {
+      if (ctx.outputFormat === "table" && lineItems.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${lineItems.length} line item${lineItems.length === 1 ? "" : "s"} on quote ${quote.id}\n`),
         );
-        if (lineItems.length > 0) {
-          process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items add ${quote.id} --product <id|name> --quantity <n>`))}  ${chalk.dim("add another line item")}\n`);
-          if (lineItems[0]?.id) {
-            process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items remove ${quote.id} ${lineItems[0].id}`))}  ${chalk.dim("remove a line item")}\n`);
-          }
-          process.stderr.write("\n");
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items add ${quote.id} --product <id|name> --quantity <n>`))}  ${chalk.dim("add another line item")}\n`);
+        if (lineItems[0]?.id) {
+          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items remove ${quote.id} ${lineItems[0].id}`))}  ${chalk.dim("remove a line item")}\n`);
         }
+        process.stderr.write("\n");
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list line items");

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -86,18 +86,41 @@ Examples:
         { key: "_total", header: "Total", width: 12, format: (v) => formatCurrency(Number(v)) },
       ];
 
-      output(enriched, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      const filterDesc: string[] = [];
+      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
+      if (status) filterDesc.push(`status ${status}`);
+      if (filterDesc.length > 0) {
+        emptyReasons.push(
+          `No quotes match the filters: ${filterDesc.join(", ")}.`,
+        );
+      } else {
+        emptyReasons.push("This tenant has no quotes yet.");
+      }
 
-      if (ctx.outputFormat === "table") {
+      output(enriched, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No quotes found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: replCmd("pax8 quotes create --company <id|name>"),
+              description: "draft your first quote",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && enriched.length > 0) {
         const total = enriched.reduce((s, q) => s + q._total, 0);
         process.stderr.write(
           chalk.dim(`\n  ${enriched.length} quotes · ${formatCurrency(total)} total\n`)
         );
-        if (enriched.length > 0) {
-          const first = enriched[0];
-          process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes show ${first.id}`))}  ${chalk.dim("view quote details")}\n`);
-        }
+        const first = enriched[0];
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes show ${first.id}`))}  ${chalk.dim("view quote details")}\n`);
         process.stderr.write("\n");
       }
     } catch (error) {

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -128,9 +128,38 @@ Examples:
         return;
       }
 
-      output(result.content, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      const filterDesc: string[] = [];
+      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
+      if (allOpts.status) filterDesc.push(`status ${allOpts.status}`);
+      if (filterDesc.length > 0) {
+        emptyReasons.push(
+          `No subscriptions match the filters: ${filterDesc.join(", ")}.`,
+        );
+      } else {
+        emptyReasons.push("This tenant has no subscriptions yet.");
+      }
 
-      if (ctx.outputFormat === "table") {
+      output(result.content, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No subscriptions found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: "pax8 products search <name>",
+              description: "find a product to sell",
+            },
+            {
+              command: "pax8 orders create --company <id> --product <id> --quantity <n>",
+              description: "place an order to create a subscription",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && result.content.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${result.page.totalElements} subscriptions\n\n`)
         );

--- a/packages/cli/src/commands/usage/list.ts
+++ b/packages/cli/src/commands/usage/list.ts
@@ -100,18 +100,47 @@ Notes:
         { key: "subtotal", header: "Subtotal", width: 14, format: (v: unknown) => formatCurrency(Number(v)) },
       ];
 
-      output(summaries, { format: ctx.outputFormat, columns });
+      const emptyReasons: string[] = [];
+      if (options.month) {
+        emptyReasons.push(`No usage summaries recorded for ${options.month}.`);
+      }
+      if (options.subscription) {
+        emptyReasons.push(
+          "The subscription may not be a metered/usage-based product.",
+        );
+      } else if (options.company) {
+        emptyReasons.push(
+          "This company has no metered/usage-based subscriptions, or the period predates any usage.",
+        );
+      } else {
+        emptyReasons.push(
+          "No metered subscriptions are reporting usage right now.",
+        );
+      }
 
-      if (ctx.outputFormat === "table") {
+      output(summaries, {
+        format: ctx.outputFormat,
+        columns,
+        emptyState: {
+          headline: "No usage summaries found.",
+          reasons: emptyReasons,
+          suggestions: [
+            {
+              command: "pax8 subscriptions list --json",
+              description: "find metered subscriptions to query",
+            },
+          ],
+        },
+      });
+
+      if (ctx.outputFormat === "table" && summaries.length > 0) {
         const total = summaries.reduce((s, u) => s + (u.subtotal ?? 0), 0);
         process.stderr.write(
           chalk.dim(`\n  ${summaries.length} usage summaries · ${formatCurrency(total)} total\n`)
         );
-        if (summaries.length > 0) {
-          const first = summaries[0] as Record<string, unknown>;
-          process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 usage show ${first.id} --lines`))}  ${chalk.dim("view per-resource breakdown")}\n`);
-        }
+        const first = summaries[0] as Record<string, unknown>;
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 usage show ${first.id} --lines`))}  ${chalk.dim("view per-resource breakdown")}\n`);
         process.stderr.write("\n");
       }
     } catch (error) {

--- a/packages/cli/src/commands/webhooks/list.ts
+++ b/packages/cli/src/commands/webhooks/list.ts
@@ -110,27 +110,36 @@ Examples:
       output(webhooks, {
         format: ctx.outputFormat,
         columns,
+        emptyState: {
+          headline: "No webhooks configured.",
+          reasons: ["No webhook subscriptions exist on this tenant yet."],
+          suggestions: [
+            {
+              command: replCmd(
+                "pax8 webhooks create --url <url> --display-name <name> --topics <topics>",
+              ),
+              description: "create your first subscription",
+            },
+            {
+              command: replCmd("pax8 webhooks topics list"),
+              description: "see available topics",
+            },
+          ],
+        },
       });
 
-      if (ctx.outputFormat === "table") {
+      if (ctx.outputFormat === "table" && webhooks.length > 0) {
         process.stderr.write(
           chalk.dim(`\n  ${webhooks.length} webhook${webhooks.length === 1 ? "" : "s"}\n`),
         );
-        if (webhooks.length === 0) {
-          process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(
-            `    ${chalk.cyan(replCmd("pax8 webhooks create --url <url> --display-name <name> --topics <topics>"))}  ${chalk.dim("create your first subscription")}\n`,
-          );
-        } else {
-          const first = webhooks[0];
-          process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(
-            `    ${chalk.cyan(replCmd(`pax8 webhooks test ${first.id}`))}  ${chalk.dim("send a test delivery")}\n`,
-          );
-          process.stderr.write(
-            `    ${chalk.cyan(replCmd(`pax8 webhooks logs ${first.id}`))}  ${chalk.dim("view delivery history")}\n`,
-          );
-        }
+        const first = webhooks[0];
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        process.stderr.write(
+          `    ${chalk.cyan(replCmd(`pax8 webhooks test ${first.id}`))}  ${chalk.dim("send a test delivery")}\n`,
+        );
+        process.stderr.write(
+          `    ${chalk.cyan(replCmd(`pax8 webhooks logs ${first.id}`))}  ${chalk.dim("view delivery history")}\n`,
+        );
         process.stderr.write("\n");
       }
     } catch (error) {

--- a/packages/cli/src/commands/webhooks/logs.ts
+++ b/packages/cli/src/commands/webhooks/logs.ts
@@ -163,12 +163,39 @@ async function runLogsList(
       },
     ];
 
+    const emptyReasons: string[] = [];
+    if (id) {
+      emptyReasons.push(`No delivery history for webhook ${id}.`);
+    } else {
+      emptyReasons.push("No webhook deliveries have been recorded.");
+    }
+    if (options.since) {
+      emptyReasons.push(`The --since ${options.since} window may be too narrow.`);
+    }
+
     output(allLogs, {
       format: ctx.outputFormat,
       columns,
+      emptyState: {
+        headline: "No webhook logs found.",
+        reasons: emptyReasons,
+        suggestions: id
+          ? [
+              {
+                command: replCmd(`pax8 webhooks test ${id}`),
+                description: "send a test delivery to populate logs",
+              },
+            ]
+          : [
+              {
+                command: replCmd("pax8 webhooks list"),
+                description: "list configured webhooks",
+              },
+            ],
+      },
     });
 
-    if (ctx.outputFormat === "table") {
+    if (ctx.outputFormat === "table" && allLogs.length > 0) {
       const failures = allLogs.filter(
         (l) => l.responseCode === 0 || l.responseCode >= 400,
       );

--- a/packages/cli/src/commands/webhooks/topics/list.ts
+++ b/packages/cli/src/commands/webhooks/topics/list.ts
@@ -75,21 +75,25 @@ Examples:
       output(sorted, {
         format: ctx.outputFormat,
         columns,
+        emptyState: {
+          headline: "No webhook topics available.",
+          reasons: [
+            "The webhook topics endpoint returned no topic definitions.",
+          ],
+        },
       });
 
-      if (ctx.outputFormat === "table") {
+      if (ctx.outputFormat === "table" && sorted.length > 0) {
         process.stderr.write(
           chalk.dim(
             `\n  ${sorted.length} topic${sorted.length === 1 ? "" : "s"}\n`,
           ),
         );
-        if (sorted.length > 0) {
-          process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(
-            `    ${chalk.cyan(replCmd(`pax8 webhooks create --url https://example.com/hook --display-name "My webhook" --topics ${sorted[0].topic}`))}  ${chalk.dim("subscribe to a topic")}\n`,
-          );
-          process.stderr.write("\n");
-        }
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        process.stderr.write(
+          `    ${chalk.cyan(replCmd(`pax8 webhooks create --url https://example.com/hook --display-name "My webhook" --topics ${sorted[0].topic}`))}  ${chalk.dim("subscribe to a topic")}\n`,
+        );
+        process.stderr.write("\n");
       }
     } catch (error) {
       await handleCommandError(

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -17,9 +17,44 @@ export interface Column {
   format?: (value: unknown, row?: Record<string, unknown>) => string;
 }
 
+/**
+ * A suggestion rendered under the empty-state message as a copy-pasteable
+ * command. The CLI command is shown in cyan; the description in dim text.
+ */
+export interface EmptyStateSuggestion {
+  /** Shell-runnable command, e.g. `pax8 companies create --name "Acme"`. */
+  command: string;
+  /** Short hint describing what the command does. */
+  description: string;
+}
+
+/**
+ * Replaces an empty data table with a clear, helpful message. Rendered to
+ * stderr only when `format === "table"` and `data.length === 0`. JSON / CSV /
+ * quiet / ids-only outputs are unaffected — agents and pipelines still see
+ * the empty-array contract.
+ */
+export interface EmptyState {
+  /** Headline shown in place of the table, e.g. "No companies found." */
+  headline: string;
+  /** Optional bullet list explaining why the list might be empty. */
+  reasons?: string[];
+  /** Optional "Try next:" block with copy-pasteable commands. */
+  suggestions?: EmptyStateSuggestion[];
+}
+
 export interface OutputOptions {
   format: "table" | "json" | "csv" | "quiet";
   columns?: Column[];
+  /**
+   * Replaces the empty-table fallback with a helpful message when the data
+   * array is empty AND `format === "table"`. Other formats ignore this — JSON
+   * still returns `[]`, CSV still returns a header row, quiet still no-ops.
+   *
+   * If omitted, the legacy empty-table behavior is preserved for backward
+   * compatibility (caller hasn't migrated).
+   */
+  emptyState?: EmptyState;
 }
 
 function escapeCSV(value: string): string {
@@ -151,6 +186,34 @@ function inferColumns(rows: readonly Record<string, unknown>[]): Column[] {
 }
 
 /**
+ * Render the supplied `emptyState` to stderr. Used in place of an empty table
+ * — printing a header + divider with no body lines reads as "something is
+ * broken" rather than "you have zero rows." Stderr (not stdout) so pipelines
+ * using `--json | jq` aren't affected by the human-facing hint.
+ */
+function renderEmptyState(state: EmptyState): void {
+  process.stderr.write("\n  " + state.headline + "\n");
+
+  if (state.reasons && state.reasons.length > 0) {
+    process.stderr.write("\n" + chalk.dim("  Possible reasons:\n"));
+    for (const reason of state.reasons) {
+      process.stderr.write(chalk.dim(`    • ${reason}\n`));
+    }
+  }
+
+  if (state.suggestions && state.suggestions.length > 0) {
+    process.stderr.write("\n" + chalk.dim("  Try next:\n"));
+    for (const s of state.suggestions) {
+      process.stderr.write(
+        `    ${chalk.cyan(s.command)}  ${chalk.dim(s.description)}\n`,
+      );
+    }
+  }
+
+  process.stderr.write("\n");
+}
+
+/**
  * Render `data` to stdout in the format selected by `options`.
  *
  * The parameter type is intentionally widened to `readonly object[]` so that
@@ -160,7 +223,7 @@ function inferColumns(rows: readonly Record<string, unknown>[]): Column[] {
  * lookups, which is safe for any plain object.
  */
 export function output(data: readonly object[], options: OutputOptions): void {
-  const { format, columns } = options;
+  const { format, columns, emptyState } = options;
 
   // Treat each row as a generic string-keyed bag for column lookups.
   const rows = data as readonly Record<string, unknown>[];
@@ -171,6 +234,14 @@ export function output(data: readonly object[], options: OutputOptions): void {
 
   if (format === "json") {
     formatJSON(rows);
+    return;
+  }
+
+  // Empty-state replacement applies only to human-facing table output.
+  // JSON returns `[]`, CSV returns a header-only row, quiet stays silent —
+  // those are the stable contracts that pipelines and agents depend on.
+  if (format === "table" && rows.length === 0 && emptyState) {
+    renderEmptyState(emptyState);
     return;
   }
 


### PR DESCRIPTION
Closes #197.

## Summary
- Adds an optional `emptyState` (`headline` + optional `reasons` + optional `suggestions`) to `output()`. When `format === "table"` and the data array is empty, the empty header-and-divider table is replaced with a clear stderr message — fixing the "looks broken" framing for fresh tenants and over-narrow filters.
- Wired through every list command: `companies`, `subscriptions`, `invoices`, `invoices items`, `orders`, `products`, `contacts`, `quotes`, `quotes line-items`, `usage`, `webhooks`, `webhooks topics`, `webhooks logs`. Each command gates its trailing footer (`N <thing>`, "Try next") with `length > 0` so it doesn't print alongside the empty-state.
- Agent / pipeline contracts unchanged: `--json` still emits `[]`, `--csv` still emits the header row, `--ids-only` still emits nothing, `--quiet` still no-ops. The message goes to **stderr** so `pax8 ... --json | jq` stays clean.
- Adds a `§3` blurb in `docs/UX_GUIDE.md` documenting the convention.

## Test plan
- [x] `pnpm build && pnpm test && pnpm lint` — all 1720 tests pass.
- [x] New `empty-state.test.ts`:
  - `companies list --status Deleted --json` → `[]` on stdout, no message on stdout.
  - `companies list --status Deleted --csv` → header row only.
  - `companies list --status Deleted --ids-only` → no stdout.
  - `invoices list --month 1900-01 --json` → `[]` on stdout.
  - `invoices list --month 1900-01 --csv` → header row only.
  - Unit: `output()` with `emptyState` writes only to stderr in table mode; JSON mode emits `[]` regardless of `emptyState`; missing `emptyState` falls back to the legacy empty-table renderer (backward compat).
- [x] Existing non-empty tests still pass — no behavior change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)