### PR TITLE
ci(security): add CodeQL SAST workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+name: CodeQL
+
+# Static analysis (SAST) for JavaScript / TypeScript. Runs on every push to
+# main, every PR targeting main, and on a weekly schedule for a deeper scan.
+# Findings surface in the repo Security tab once "Code scanning" is enabled
+# in repo settings (one-time admin step, tracked in #138).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly deep scan, Mondays at 06:00 UTC.
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Initialize CodeQL BEFORE the build so it can observe compiler output
+      # and trace the TypeScript -> JavaScript transformation in our pnpm
+      # workspaces. `security-extended` is GitHub's recommended query suite
+      # for OSS projects — broader coverage than `security-and-quality` minus
+      # the noisier code-quality rules.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Build
+        run: pnpm build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,10 @@ The release workflow publishes via [npm OIDC trusted publishing](https://docs.np
 
 Do **not** open a GitHub Issue for security vulnerabilities. Report them via the process in [SECURITY.md](SECURITY.md) (email to `security@pax8.com`).
 
+### Static analysis (CodeQL)
+
+We run [CodeQL](https://codeql.github.com) on every push to `main`, every PR, and a weekly schedule via [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml). The job uses the `javascript-typescript` analysis with the `security-extended` query suite. Findings appear in the repo **Security → Code scanning** tab. If a PR introduces a new finding, the check will fail — fix the issue or, if it's a false positive, dismiss it from the Security tab with a justification.
+
 ## Reporting Issues
 
 Use GitHub Issues. Include:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` running GitHub's CodeQL static analysis on every push to `main`, every PR targeting `main`, and a weekly Monday cron (`0 6 * * 1`) for the scheduled deep scan.
- Uses the `javascript-typescript` analysis (covers both languages in one job) with the `security-extended` query suite — GitHub's standard recommendation for OSS projects.
- Mirrors `ci.yml`'s setup (`pnpm/action-setup`, `setup-node@v6` on Node 22, frozen-lockfile install, `pnpm build`) so CodeQL observes the real monorepo build output rather than falling back to `autobuild`. Permissions are scoped to the minimum required for code scanning (`security-events: write`, `actions: read`, `contents: read`), with a `concurrency` block to cancel in-flight runs on rapid pushes.
- Adds a brief "Static analysis (CodeQL)" note under `## Security Reports` in `CONTRIBUTING.md`.

Closes #120.

## Manual follow-up (NOT in this PR)

This PR only adds the workflow file. Findings will not actually surface in the Security tab until a repo admin **enables Code scanning** in repo settings — that is a one-time GitHub UI step the workflow cannot perform itself, tracked in #138. Until #138 is done, the `Analyze` step will upload the SARIF file successfully but GitHub will reject it with a `configuration error` (same failure mode the closed #127 hit). That is expected; merging this PR is still safe — the workflow simply lights up as soon as #138 is resolved.

## Boundaries (per scope)

- No customization of queries beyond `security-extended`.
- No Dependabot or other workflows added.
- No changeset (CI-only change, no user-facing package surface).

## Test plan

- [x] `python3 yaml.safe_load` parses `.github/workflows/codeql.yml` cleanly (triggers: push / pull_request / schedule; one `analyze` job)
- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 1,750 tests pass (106 files)
- [x] `pnpm lint` clean
- [ ] After merge: confirm the `Analyze (javascript-typescript)` job appears on the next PR; once #138 lands, confirm findings appear under Security → Code scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)