### PR TITLE
chore(release): reset versions to 0.1.0 and gate publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,21 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Create release PR or publish
+      # Publish gate (see #370): we intentionally do NOT pass a `publish:`
+      # command here, so this action only opens/updates the "chore: release"
+      # PR and never invokes `npm publish`. Versions have been auto-bumped
+      # past anything we've shipped (CHANGELOG headings for 0.2.0/0.3.0 exist
+      # but the registry has nothing), and we want a deliberate human signal
+      # before the first real publish.
+      #
+      # When the team is ready to ship the first release, restore the
+      # `publish: pnpm changeset publish` input below and merge — the next
+      # push to main will publish whatever the open "chore: release" PR has
+      # already version-bumped to.
+      - name: Create release PR (publish gated — see #370)
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          # publish: pnpm changeset publish  # gated — enable when ready to ship
           version: pnpm changeset version
           commit: "chore: release"
           title: "chore: release"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pax8/cli",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "description": "Pax8 open source CLI for MSPs to manage cloud marketplace operations",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pax8/core",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "description": "Core API client, auth, services, and types for Pax8",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Closes #370.

## Summary

The changesets release bot has been auto-bumping `@pax8/cli` and `@pax8/core` versions, but the publish step has never succeeded — neither package exists on npm. CHANGELOGs are claiming `0.2.0` (#276, May 8) and `0.3.0` (#286, today) under headings that don't correspond to anything on the registry.

This PR stops the bleed:

1. **Versions reset to `0.1.0`** in `packages/cli/package.json` and `packages/core/package.json`. Single-line edits each.
2. **CHANGELOG files left intact** as a historical record of pre-release development. They describe real work that landed — they're just (technically) under headings for versions that never shipped. When we do the first real publish, we'll bump from `0.1.0` to whatever the team decides (`0.1.0`, `1.0.0`, etc.) and the CHANGELOG history stays useful.
3. **Release workflow gated**: removed the `publish:` input from the `changesets/action@v1` step in `.github/workflows/release.yml`. The action keeps opening/updating the "chore: release" PR (so we can still see version intent), but it no longer invokes `npm publish` on push to `main`. To re-enable when the team is ready to ship: uncomment the `publish:` line in the workflow and merge.

## Gate strategy: option (a) — publish-step gate, bot kept

Of the four options outlined in #370 (manual `workflow_dispatch`; gate on a non-main branch; environment-with-required-reviewer; tag-based), I went with the smallest-surface change: keep the bot doing its PR-creation job, just remove the publish command. Why:

- Preserves the changesets PR-preview workflow exactly as-is — we still get to see "chore: release" PRs with version intent and CHANGELOG diffs.
- One-line revert (uncomment) to re-enable, no GitHub UI configuration needed.
- No new admin/Environment setup required.
- Decisively breaks the auto-publish path without touching trigger semantics or workflow plumbing.

## No changeset on purpose

This PR is explicitly about NOT making a new release. Adding a changeset would queue another version bump, defeating the entire point. The bot will see "no pending changesets" on the next push to `main` and quietly do nothing — which is the goal.

## Manual follow-up (none required now)

- Nothing required from the repo admin to make this PR work.
- **When ready to publish for real**: uncomment the `publish: pnpm changeset publish` line in `.github/workflows/release.yml` and merge. The next push to `main` will publish whatever the open "chore: release" PR has bumped to. If npm OIDC trusted publishing isn't wired up yet (see comment block in the workflow), that's the prerequisite — separate concern, called out as out-of-scope in #370.

## Test plan

- [x] `pnpm install` — lockfile up to date, no resolution churn
- [x] `pnpm build` — both packages build cleanly at 0.1.0
- [x] `pnpm test` — 1750/1750 pass (including version-aware tests that read from package.json)
- [x] `pnpm lint` — clean
- [x] `.github/workflows/release.yml` parses as valid YAML
- [ ] Post-merge: follow-up commit to `main` does NOT trigger publish (acceptance criterion from #370)

🤖 Generated with [Claude Code](https://claude.com/claude-code)