### PR TITLE
docs(triage): batch-commit triage docs left in working tree by audit agents

### DIFF
--- a/docs/triage/companies-create-atomic-endpoint.md
+++ b/docs/triage/companies-create-atomic-endpoint.md
@@ -3,55 +3,103 @@
 **Priority:** P0 — publish-blocking
 **Class:** CLI built against a stale API picture (same class as #307 quotes wire-path)
 **Reporter:** Franco Aurieme (PM, Account Management), via domain review of the Companies & Contacts section
-**Confirmed by:** Vinton Lee (PAM backend) — the CLI is on the pre-PAM-997 path
+**Confirmed by:** Vinton Lee (PAM backend), Mari Astapova (PAM-997)
+**Activation behavior verified by:** Rovo against Pax8 API Reference + PAM-997 + ARC-774
 
 ---
 
 ## TL;DR
 
-`pax8 companies create` posts to `POST /v1/companies` with company fields only (`name`, `phone`, `website`, `address`) and no contact. That is the **legacy two-step path** Pax8 deprecated under PAM-997 / PAM-1171 / ARC-774. The atomic create-with-contact endpoint that replaced it was specifically built so newly-created companies do not land in `Inactive` state. Every partner and AI agent driving `pax8 companies create` today creates an Inactive ghost client, then has to remediate with a separate `pax8 contacts create` to activate it. The CLI reports success while the company is broken — the failure is silent at the surface and only manifests when downstream operations against the Inactive company fail.
+`pax8 companies create` posts to `POST /v1/companies` with company fields only (`name`, `phone`, `website`, `address`) and no `contacts` payload. This path leaves the company in `Inactive` state because Pax8 requires a primary contact for each of three types (`Admin`, `Billing`, `Technical`) before a company activates. The atomic create-with-contact behavior — passing a `contacts: [...]` array in the same `POST /companies` body — was added under PAM-997 specifically so the partner doesn't have to stage two-plus calls and risk leaving a ghost client.
+
+Every partner and AI agent driving `pax8 companies create` today creates an Inactive ghost client, then has to remediate. The CLI reports success while the company is broken — the failure is silent at the surface and only manifests when downstream operations against the Inactive company fail.
 
 This is publish-blocking for the same reason the quotes wire-path issue was: the CLI's flag list is the contract that AI agents read, and right now it tells them a lie.
 
 ---
 
-## Evidence — current state of the CLI
+## Activation requirements (verified via Rovo / Pax8 API Reference)
 
-The CLI's `create` is a thin single-call wrapper around the legacy endpoint, with no contact fields on the command surface:
+The company activates only when it has at least one contact with `primary: true` on **each** of the three contact types: `Admin`, `Billing`, `Technical`.
+
+**Sources:**
+
+- **Pax8 API Reference PDF:** *"A Company is required to have a primary Contact for each Contact Type ('Admin', 'Billing', 'Technical'). One contact with all three types and marked as primary for each type is sufficient."*
+- **PAM-997 (Mari Astapova's confirmation comment):** *"We implemented changes to the public API for company creation to support passing a contact in the payload. This enables a company to be created in an Active state immediately."*
+- **ARC-774** — architecture review confirming the activation gate
+
+**Edge cases that do NOT activate the company:**
+
+- Contact with no `types` array
+- Contact with `types: [...]` but `primary: false` on every type
+- Contact with `primary: true` on fewer than all three types
+
+The CLI assigns the supplied contact as `primary: true` on all three types automatically. The alternative (requiring `--type` from the partner) trades one common-case verbosity for an edge case the CLI handles less well (separate-contacts-per-type) than the dedicated `pax8 contacts add` command.
+
+---
+
+## Evidence — current state of the CLI
 
 | Layer | File | What's there today |
 |---|---|---|
-| API client | `packages/core/src/api/companies.ts:29-32` | `create()` does `client.post("/companies", data)` with `CreateCompanyInput` (company-only fields). No contact payload, no atomic endpoint. |
-| CLI command flags | `packages/cli/src/commands/companies/create.ts:14-22` | `--name` (required), then `--phone`, `--website`, `--city`, `--state`, `--zip`, `--country`. No `--first-name`, `--last-name`, `--email`, or `--type`. |
+| API client | `packages/core/src/api/companies.ts:29-32` | `create()` does `client.post("/companies", data)` with `CreateCompanyInput` (company-only fields). No `contacts` payload. |
+| CLI command flags | `packages/cli/src/commands/companies/create.ts:14-22` | `--name` (required), `--phone`, `--website`, `--city`, `--state`, `--zip`, `--country`. No `--first-name`, `--last-name`, `--email`. |
 | CLI call site | `packages/cli/src/commands/companies/create.ts:59-70` | Passes only company fields to `ctx.api.companies.create()`. |
-| Contacts command (separate) | `packages/cli/src/commands/contacts/create.ts:32-48` | Already requires `--company`, `--email`, `--first-name`, `--last-name`, `--type`. This is the command partners are *currently* expected to call as the second step. |
+| Contacts command (separate) | `packages/cli/src/commands/contacts/create.ts:32-48` | Already requires `--company`, `--email`, `--first-name`, `--last-name`, `--type`. The remediation path partners currently use after `companies create` returns Inactive. |
 
-The status field on the response (`packages/cli/src/commands/companies/create.ts:86`) is what surfaces "Inactive" to the user after a successful-looking create — but only when the user prints non-JSON output, and only if they read it. Agents reading `--json` get a `status: "Inactive"` field that they have no reason to flag as an error.
+The status field on the response (`packages/cli/src/commands/companies/create.ts:86`) surfaces "Inactive" to the user after a successful-looking create — but only when the user prints non-JSON output, and only if they read it. Agents reading `--json` get a `status: "Inactive"` field that they have no reason to flag as an error.
+
+---
 
 ## Why this is publish-blocking
 
 Two factors compound:
 
-1. **Silent failure.** The command exits 0, the spinner shows `Company created 🎉`, and the JSON output looks valid. There is no error to catch. The breakage only surfaces downstream — when a subscription, order, or quote against the Inactive company fails for reasons that look unrelated.
-2. **Agents read the flag list as the contract.** A flag list with no contact fields tells the agent "creating a company doesn't need a contact." That is the exact misrepresentation the agent-friendly surface is supposed to prevent. Humans at least see the `Inactive` line and can google it; agents fire-and-forget and move on.
+1. **Silent failure.** The command exits 0, the spinner shows `Company created 🎉`, and the JSON output looks valid. The breakage only surfaces downstream — when a subscription, order, or quote against the Inactive company fails for reasons that look unrelated.
+2. **Agents read the flag list as the contract.** A flag list with no contact fields tells the agent "creating a company doesn't need a contact." That is the exact misrepresentation the agent-friendly surface is supposed to prevent.
 
-This is the same class of bug as #307 (quotes wire-path): correct intent, stale wire layer, no test exercising the real API. The `docs/triage/quotes-api-version.md` §10 retrospective applies directly — paper-only verification of "what the CLI sends" does not catch this.
-
-## Decision
-
-Update `companies create` to call the atomic create-with-contact endpoint. Surface `--first-name`, `--last-name`, `--email`, and `--type` as required flags on the same command. Keep `contacts create` for adding *subsequent* contacts to an existing company.
-
-This is a breaking change for any script using `companies create`. Pre-1.0; acceptable.
+Same class of bug as #307 (quotes wire-path): correct intent, stale wire layer, no test exercising the real API.
 
 ---
 
-## Investigate before implementation
+## CLI design
 
-1. **Sync with Franco and Vinton Lee.** Franco offered to walk through it. Take him up — the atomic endpoint may have nuances (required contact types, response shape, whether there is an equivalent atomic *update* path) that surface faster in conversation than from JIRA archaeology.
-2. **Read the JIRA tickets.** PAM-997, PAM-1171, ARC-774. Understand the original Inactive-state regression, why the atomic path was built, and the contract it commits to.
-3. **Locate the endpoint in the public spec.** Check `https://devx.pax8.com/openapi/partner-endpoints.json` for the atomic create. If the spec still documents only the legacy two-step path, that is a separate finding worth flagging to the API team — the canonical endpoint should be the one the spec promotes.
+**Default (atomic) path** — required flags:
 
-The methodology lesson from #307 applies: **verify request body shape against the spec, not just the URL.** Don't repeat the audit pattern that missed body-shape mismatches on quotes.
+- `--first-name <name>` (spec-required)
+- `--last-name <name>` (spec-required)
+- `--email <email>` (spec-required)
+- `--phone <phone>` (spec-required — Franco's original recommendation missed this; same gap that hit standalone `contacts create` before #325 fixed it)
+
+The CLI implicitly sets the supplied contact as `primary: true` for all three contact types (`Admin`, `Billing`, `Technical`). No `--type` flag is exposed. Rationale: activation requires primary on each type; the common case is one human runs the new company; partners needing per-type contact distribution use `pax8 contacts add` after creation.
+
+**Constructed request body:**
+
+```json
+{
+  "name": "...",
+  "address": { ... },
+  "contacts": [{
+    "firstName": "...",
+    "lastName": "...",
+    "email": "...",
+    "phone": "...",
+    "types": [
+      { "type": "Admin",     "primary": true },
+      { "type": "Billing",   "primary": true },
+      { "type": "Technical", "primary": true }
+    ]
+  }]
+}
+```
+
+**Opt-out flag for the company-only path:**
+
+- `--company-only` — creates the company without the `contacts` array. Prints a loud warning: company will be Inactive, will not appear in the portal or support orders, will block re-creation with "already exists" until primary contacts are added via `pax8 contacts add`.
+
+The `--company-only` path sends `POST /companies` without the `contacts` field at all (not with an empty `contacts: []`), matching the current CLI behavior plus the warning.
+
+This is a breaking change for any script using `companies create`. Pre-1.0; acceptable.
 
 ---
 
@@ -59,69 +107,81 @@ The methodology lesson from #307 applies: **verify request body shape against th
 
 ### Step 1 — API client (`packages/core/src/api/companies.ts`)
 
-Replace the `POST /companies` call in `CompaniesApi.create()` with the atomic create-with-contact endpoint. The request body must carry both company fields and the first contact's fields. Add an inline comment citing PAM-997 + Franco's review so a future contributor doesn't quietly revert to the legacy path because it "looks simpler."
+Extend `CompaniesApi.create()` to accept an optional `contacts` payload alongside company fields. The same `POST /companies` accepts both shapes. Add an inline comment citing PAM-997 + Franco's review + Rovo activation findings so a future contributor doesn't quietly revert.
 
 ### Step 2 — CLI command (`packages/cli/src/commands/companies/create.ts`)
 
-- Add `--first-name`, `--last-name`, `--email`, `--type` as **required** flags (matching `contacts create`'s existing vocabulary, see `packages/cli/src/commands/contacts/create.ts:35-39`).
-- Reuse the `Admin | Billing | Technical` enum validation from `contacts create` (`packages/cli/src/commands/contacts/create.ts:17,19-30,54-73`) — don't fork it.
-- Update `.description()` and `addHelpText("after", ...)` so the help output says, in plain language: *"Every company in Pax8 must have at least one contact. This command creates both in one call."* and shows examples with all four flags populated.
-- Update the preview block (`create.ts:38-46`) so the contact's name, email, and types are part of what the user confirms.
-- Update Zod input validation accordingly (likely a new `CreateCompanyWithContactInput` in `packages/core/src/api/types.ts`, or extend the existing `CreateCompanyInput`).
+- Add `--first-name`, `--last-name`, `--email`, `--phone` as required flags on the default path.
+- Add `--company-only` as the opt-out boolean flag.
+- Validate that `--company-only` is mutually exclusive with `--first-name` / `--last-name` / `--email` / `--phone` (you either supply a contact or you don't).
+- On the default path, construct the `contacts: [...]` payload with `types: [{Admin, primary: true}, {Billing, primary: true}, {Technical, primary: true}]`.
+- On `--company-only`, send `POST /companies` without `contacts` and print the loud Inactive warning.
+- Reuse `Admin | Billing | Technical` enum validation from `packages/cli/src/commands/contacts/create.ts` (`17,19-30,54-73`) — don't fork it.
+- Update `.description()` and `addHelpText("after", ...)` to say in plain language: *"Every company in Pax8 must have a primary contact on each of Admin, Billing, and Technical to be active. This command creates both in one call."*
 
-### Step 3 — Contacts create (`packages/cli/src/commands/contacts/create.ts`)
+### Step 3 — Body shape
 
-`contacts create` still works for additional contacts on an existing company; confirm with backend it does not conflict with the atomic create path. Update its `.description()` to disambiguate: *"Add an additional contact to an existing company. The first contact is created together with the company via `companies create`."*
+- Default path: `{ name, address, contacts: [{firstName, lastName, email, phone, types: [{type, primary: true} × 3]}] }`.
+- Company-only path: `{ name, address }` (no `contacts` key).
 
 ### Step 4 — Schema review
 
-Verify `CompanySchema` covers any fields the atomic endpoint returns that the legacy response didn't (in particular, the initial contact alongside the company). If the response shape differs, update the schema. Carry the §9.2/§10 lesson from the quotes triage: response-shape verification and request-shape verification are independent audits — finish both.
+Verify `CompanySchema` covers any fields the atomic-with-contact response returns that the contact-less response didn't (in particular, the initial contact alongside the company). Extend or add `CreateCompanyWithContactInput` in `packages/core/src/api/types.ts` to match.
 
 ### Step 5 — Tests
 
-- **Unit test** (`packages/core/src/api/companies.test.ts`, may need to be created): the atomic endpoint is called with both company and contact fields in the body.
-- **CLI integration test** (`packages/cli/src/__tests__/companies.create.test.ts`): under `PAX8_DEMO=1`, `companies create` with all required flags produces a company in `Active` state (not `Inactive`).
-- **CLI integration test**: `companies create` without contact flags fails CLI-side validation before any wire call, with an actionable error and the correct exit code.
-- **Regression assertion**: the legacy `POST /v1/companies` *without* a contact body is never called — either by asserting on the request body shape in the unit test, or by removing the legacy code path entirely so the regression is structurally impossible.
+- **Unit test** (`packages/core/src/api/companies.test.ts`): the `POST /companies` body carries both company fields and a properly-shaped `contacts` array on the default path; carries no `contacts` field on the `--company-only` path.
+- **CLI integration test** (`packages/cli/src/__tests__/companies.create.test.ts`): under `PAX8_DEMO=1`, `companies create` with all required flags produces a company in `Active` state.
+- **CLI integration test**: `companies create` without contact flags and without `--company-only` fails CLI-side validation before any wire call.
+- **CLI integration test**: `companies create --company-only` produces an `Inactive` company and prints the warning.
+- **Regression assertion**: `POST /companies` without `contacts` is never called on the default path.
 
-Demo mode is the test posture (`CLAUDE.md` — "Demo mode is the test posture, not a side project"). The mock client (`MockPax8Client`) needs to model the atomic endpoint and return an `Active`-status company.
+Demo mode is the test posture. `MockPax8Client` needs to model the contacts-bearing request body and return an `Active`-status company.
 
 ### Step 6 — Domain review doc
 
-The Orders & Quotes section was updated for the quotes audit findings; the Companies & Contacts section needs a parallel **"Open from review"** entry citing Franco's catch. After the fix lands, the entry moves to **"What changed since your feedback"** with a PR link.
+The Companies & Contacts section gets a parallel **"Open from review"** → **"What changed since your feedback"** entry after this lands.
 
 ### Step 7 — Changeset
 
 ```
-Fix: `companies create` now uses the atomic create-with-contact endpoint
-shipped under PAM-997. New required flags: `--first-name`, `--last-name`,
-`--email`, `--type`. Previously, the CLI was calling a legacy two-step path
-that left companies in `Inactive` state — discovered by Franco Aurieme during
-domain review. AI agents and scripts using the prior surface should be
-updated to pass the new required flags.
+Fix: `pax8 companies create` now uses the atomic create-with-contact behavior
+on the same `POST /companies` endpoint, so newly-created companies land in
+`Active` state instead of `Inactive`. New required flags: `--first-name`,
+`--last-name`, `--email`, `--phone`. The CLI sets the supplied contact as
+primary on all three contact types (Admin, Billing, Technical) — activation
+requires one primary per type, per the Pax8 API Reference. New opt-out flag
+`--company-only` preserves the contact-less single-call behavior with a
+loud warning. Previously, the CLI was calling the contact-less path that
+left companies in `Inactive` state — discovered by Franco Aurieme during
+domain review.
 ```
 
 ---
 
 ## Out of scope
 
-- `companies update` having an equivalent atomic path. Likely a separate question — confirm with Franco/Vinton during the sync. If one exists, file separately.
-- Auditing every other CLI command for "calls a legacy endpoint where an atomic/improved one exists." That belongs in the parallel audit issue; the audit methodology should explicitly include this case (legacy-endpoint usage where an atomic alternative exists). See the §10 retrospective in `docs/triage/quotes-api-version.md` for the verification pattern.
-- Renaming or restructuring `contacts create`.
+- `companies update` having an equivalent atomic path. Separate question; file separately if it exists.
+- Auditing every other CLI command for "calls a legacy endpoint where an atomic/improved one exists." Belongs in the parallel audit issue.
+- Renaming or restructuring `contacts create` / `contacts add`.
 
 ## Acceptance criteria
 
-- [ ] `companies create` calls the atomic create-with-contact endpoint, not the legacy two-step path.
-- [ ] `--first-name`, `--last-name`, `--email`, `--type` are required flags on `companies create`, validated CLI-side before any wire call.
-- [ ] Help text on both `companies create` and `contacts create` makes the relationship between the two explicit.
-- [ ] Tests cover the atomic path and assert the legacy path is never called.
-- [ ] `CompanySchema` (and any new input schema) matches the atomic endpoint's request and response shapes.
-- [ ] Domain review doc updated: Companies & Contacts section has the "Open from review" → "What changed" entry.
-- [ ] Changeset landed under `.changeset/`.
+- [ ] `companies create` sends `POST /companies` with a `contacts: [...]` array on the default path.
+- [ ] The CLI sets `primary: true` on `Admin`, `Billing`, and `Technical` types for the supplied contact.
+- [ ] `--first-name`, `--last-name`, `--email`, `--phone` are required on the default path, validated CLI-side before any wire call.
+- [ ] `--company-only` is supported as an opt-out and sends `POST /companies` without the `contacts` field.
+- [ ] `--company-only` is mutually exclusive with the contact flags.
+- [ ] Help text on `companies create` makes the activation requirement explicit.
+- [ ] Tests cover both paths and assert the wire body shape.
+- [ ] `CompanySchema` (and any new input schema) matches the spec's request and response shapes.
+- [ ] Domain review doc updated.
+- [ ] Changeset landed.
 - [ ] CI green (`pnpm build && pnpm test && pnpm lint`).
 
 ## Closes / relates
 
-- Closes: Franco Aurieme's domain-review comment on Companies & Contacts (link once doc is published).
-- Relates to: #307 (quotes wire-path fix) — same class of bug; the §10 retrospective in `docs/triage/quotes-api-version.md` captures the verification methodology this issue's investigation should follow.
-- Relates to: parallel audit issue (legacy-endpoint sweep) — methodology must explicitly look for "legacy endpoint used when an atomic alternative exists," not only "endpoint not found."
+- Closes: Franco Aurieme's domain-review comment on Companies & Contacts.
+- Activation behavior verified: Rovo against Pax8 API Reference + PAM-997 + ARC-774.
+- Relates: #307 (quotes wire-path) — same class of bug.
+- Relates: parallel audit issue (legacy-endpoint sweep).

--- a/docs/triage/mcp-use-case-alignment.md
+++ b/docs/triage/mcp-use-case-alignment.md
@@ -1,0 +1,109 @@
+# Triage — Pax8 MCP use case catalog vs. CLI recommendations engine
+
+**Status:** Research-only audit. No code changes. **Date:** 2026-05-11.
+
+## 1. Source access — gaps disclosed up front
+
+The user referenced an internal doc citing ~8 MCP use cases. **The authoritative catalog at `https://app.pax8.com/integrations/guides` and the partner-portal MCP tab at `https://app.pax8.com/integrations/mcp` are gated; WebFetch returned permission-denied for both.** Findings below are composed from:
+
+- `https://devx.pax8.com/docs/mcp-server` — accessible; lists capability *domains* and defers the full inventory to the gated Hub.
+- Repo evidence: `README.md`, `docs/PRD.md`, `docs/domain-review.md`, `docs/pm-review-response-2026-05.md`, `packages/claude-skill/skill.md`.
+
+**Baseline:** the accessible MCP surface lists **6 capability domains**; the repo's PM-facing PRD lists **6 AI-assisted use cases**. The "~8" figure is **unverified** pending an authenticated read of the Integrations Hub.
+
+## 2. Pax8 MCP capability domains (devx, public)
+
+Source: `https://devx.pax8.com/docs/mcp-server`. These are domains, not workflow use cases — Pax8's published MCP exposes raw resource CRUD.
+
+| # | Domain | One-sentence description | Underlying API surface |
+|---|---|---|---|
+| D1 | Company & Contact Management | Access and manage organizational and personnel records. | `/companies`, `/contacts` |
+| D2 | Invoices | Retrieve and interact with billing documents. | `/invoices` |
+| D3 | Order Management | Place and inspect orders. | `/orders` |
+| D4 | Products | Browse and retrieve product-catalog information. | `/products`, `/products/{id}/pricing` |
+| D5 | Quoting | Generate and manage sales quotes. | `/v2/quotes`, `/v2/quotes/{id}/line-items` |
+| D6 | Subscriptions | Oversee recurring service agreements. | `/subscriptions` |
+| — | "Core use case" | "Unlock the power of integrating your Pax8 data with your favorite LLMs." | (marketing copy) |
+
+**Named MCP tool in repo:** `pax8-submit-order` (Linear AI-865) — `docs/domain-review.md:518`.
+
+## 3. CLI's computed surface
+
+**Seven product categories** (`packages/core/src/services/recommendations.ts:11-64`): `productivity, email, security, endpoint_protection, identity, backup, cloud_infrastructure`. Pattern-matched against product names.
+
+**Seven cross-sell rules** (`recommendations.ts:89-146`), shape "if has X, missing Y → recommend Z":
+
+| # | If has | Missing | Priority | Suggested first product |
+|---|---|---|---|---|
+| R1 | productivity | backup | high | AvePoint Cloud Backup for M365 |
+| R2 | productivity | endpoint_protection | high | Microsoft Defender for O365 P1 |
+| R3 | productivity | identity | high | Microsoft Entra ID P1 |
+| R4 | email | security | medium | Microsoft Defender for O365 P1 |
+| R5 | cloud_infrastructure | backup | medium | AvePoint / Veeam |
+| R6 | cloud_infrastructure | security | medium | CrowdStrike / SentinelOne |
+| R7 | security | backup | low | AvePoint / Datto SaaS |
+
+**Seat-gap detector** (`recommendations.ts:161-206`): within a category, sort subs by quantity; flag a secondary product when coverage `< 50%` of primary **and** missing ≥10 seats **and** primary ≥10 seats. High if missing >20 else medium.
+
+**Surfaces exposing the engine:**
+- `pax8 recommendations list` — `packages/cli/src/commands/recommendations/list.ts:59-306` (read-only).
+- `pax8 recommendations act` — `packages/cli/src/commands/recommendations/act.ts:157-334` (multi-select picker → batched `orders.create`; confirm or `--yes`).
+- `pax8 companies list --coverage` — `packages/cli/src/commands/companies/list.ts:45,84-156` via `getPortfolioCoverage` (`recommendations.ts:274-320`).
+- `pax8 dashboard` — `packages/cli/src/commands/dashboard.ts:139-156,221-222` (fuses top-priority recs with renewals + MRR).
+
+**Estimate semantics:** `estimatedMrrUplift = unitPrice × seatCount`, tagged `estimateType: "upper_bound"`. Help text (`list.ts:93-97`) disclaims this is **not** Pax8 PMRR.
+
+## 4. Alignment matrix — MCP capability vs. CLI
+
+| MCP domain / use case | CLI analog | Status | Notes |
+|---|---|---|---|
+| D1 Company & Contact Mgmt | `companies *`, `contacts *` | **Aligned (raw)** | CLI adds `--coverage` (computed). |
+| D2 Invoices | `invoices list/show` | **Aligned (raw)** | CLI adds `audit`, `dispute` (CLI-only). |
+| D3 Order Management | `orders *` | **Aligned (raw)** | `pax8-submit-order` ↔ `orders create`. Flag-naming coord flagged at `domain-review.md:518`. |
+| D4 Products | `products search/show` | **Aligned (raw)** | CLI collapses pricing/provisioning/dependencies. |
+| D5 Quoting | `quotes *` (line-items, send) | **Aligned (raw)** | Full Quote-to-Cash covered (`domain-review.md:506-516`). |
+| D6 Subscriptions | `subscriptions *` | **Aligned (raw)** | CLI adds `renewals` (computed). |
+| PRD: **Renewal triage** | `subscriptions renewals` + `dashboard` | **Aligned** | CLI composes; MCP path = LLM-composes from raw. |
+| PRD: **Billing investigation** | `invoices audit`, `dispute` | **CLI-only** | No MCP analog visible. |
+| PRD: **Customer overview** | `companies show`, `dashboard` | **Aligned** | Both can compose; CLI canonical via `dashboard`. |
+| PRD: **Order assistance** | `products search` + `orders create` | **Aligned** | MCP path = `pax8-submit-order`. |
+| PRD: **What-if / pricing delta** | `cost sim` | **CLI-only** | No documented MCP simulation tool. |
+| PRD: **Anomaly detection** | `invoices audit` outliers | **CLI-only** | No MCP analog visible. |
+| Cross-sell rules R1–R7 | `recommendations list` | **CLI-only** | Hardcoded; help text acknowledges collapses OE's 5-type taxonomy (`pm-review-response-2026-05.md:296`). |
+| Seat-gap detection | `recommendations list --type seat_gap` | **Diverges** | CLI heuristic ≠ Pax8 "Seat Utilization." Retire when OE ships (#62). |
+| Portfolio coverage (n/7) | `companies list --coverage` | **CLI-only / Diverges** | Category taxonomy is repo-invented. |
+| Closed-loop batch ordering | `recommendations act` | **CLI-only** | MCP per-order tool doesn't batch. |
+| Dashboard composition | `pax8 dashboard` | **CLI-only** | Fused MRR + renewals + recs; MCP is raw-resource. |
+| OE 5-type taxonomy | (not implemented) | **Joint gap** | Neither side ships; #62 is the migration pivot. |
+| MRR / ARR / growth analytics | `report mrr`, `report growth`, ARR-at-risk | **CLI-only** | Not a documented MCP capability. |
+
+## 5. Strategic recommendations
+
+**Align (shared-vocabulary opportunities):**
+
+1. **`pax8-submit-order` ↔ `orders create` flag naming** — already flagged at `domain-review.md:518`. One-time coordination, high payoff before partners automate against both.
+2. **Category taxonomy** — the seven CLI categories (`recommendations.ts:11-18`) are repo-invented. If OE has a canonical model, align before partners filter on `--type` (open Q1 at `domain-review.md:395`).
+3. **`seat_gap` framing** — diverges from Pax8's canonical "Seat Utilization." Already planned for retirement when OE ships (#62). Do not market externally as Pax8-blessed in the meantime.
+
+**Keep as CLI value-add (no MCP analog):**
+
+4. **`invoices audit` / `invoices dispute`** — already framed as CLI-differentiating in `README.md:33`.
+5. **`cost sim`** — what-if pricing without ordering.
+6. **`dashboard`** — fused MRR + renewals + recs; the canonical landing surface per skill manifest.
+7. **`recommendations act`** (closed-loop batch ordering) — MCP's per-order tool does not compose into a batch. Keep, but preserve the strict confirm-before-write contract (`skill.md:37-39`).
+
+**Joint gaps (neither side ships):**
+
+8. **OE 5-type opportunity taxonomy** (Upsell / Cross-Sell / Add-On / Upgrade / Net-New) — CLI collapses to 2 types as a stopgap; #62 is the migration pivot.
+9. **License utilization / per-user assignments** — upstream API gap, not a CLI-vs-MCP divergence (`PRD.md:429-430`).
+
+**Conflicts to flag:**
+
+- Cross-sell reason strings (`recommendations.ts:93,99,108,…`) make security claims ("#1 attack vector") that need Pax8 messaging-owner review before external blessing (`domain-review.md:389`).
+- Hardcoded SKU names (e.g. `"Microsoft Defender for Office 365 (Plan 1) [New Commerce Experience]"`) will silently break on vendor rename.
+
+## 6. Named gaps in this audit
+
+- **Cannot verify "~8" figure** — re-run from an authenticated portal session to close §2.
+- **No public list of named MCP tools** beyond `pax8-submit-order`. Fold any per-tool inventory into §2/§4 when available.
+- **OE first-party recs API (#62)** is the joint pivot; until it ships, both surfaces diverge informally.

--- a/docs/triage/orders-status-server-behavior.md
+++ b/docs/triage/orders-status-server-behavior.md
@@ -1,0 +1,267 @@
+# Orders status filter — server-side honor test
+
+**Status:** Test gated by missing sandbox credentials. Requires maintainer with `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` configured to execute.
+
+**Question:** PR #360 added a disclaimer that `pax8 orders list --status` is not in the public OpenAPI spec. Does the Pax8 server actually honor the filter, or is it ignored client-side?
+
+**Impact:** If the server honors the filter, the disclaimer is misleading and should be softened to flag the spec gap (server accepts it but docs don't expose it). If the server silently ignores it, the current disclaimer is accurate.
+
+---
+
+## 1. Current CLI behavior
+
+**File:** `packages/cli/src/commands/orders/list.ts:56–58`
+
+```ts
+if (allOpts.status) {
+  params.status = allOpts.status;
+}
+```
+
+The `--status` flag is passed directly to the API as a query parameter:
+
+**File:** `packages/core/src/api/orders.ts:18–26`
+
+```ts
+async list(params?: {
+  page?: number;
+  size?: number;
+  companyId?: string;
+  status?: string;
+}): Promise<PaginatedResponse<Order>> {
+  const raw = await this.client.get<unknown>("/orders", params as Record<string, string | number | undefined>);
+  return PaginatedOrderSchema.parse(raw);
+}
+```
+
+The `params` object is passed to `client.get()` as query-string parameters — **no client-side filtering occurs.** The `status` parameter is forwarded unmodified to `GET /orders?status=<value>`.
+
+---
+
+## 2. Spec posture
+
+**Source:** PR #360 description and audit file (`eea4409:docs/triage/api-version-audit/orders-status-enum.md`)
+
+The public Pax8 OpenAPI (`partner-endpoints.json`) declares:
+
+- **`paths."/orders".get`** — Query parameters limited to pagination and `companyId`. **No `status` parameter.**
+- **`components.schemas.Order`** — Fields: `id, companyId, createdDate, isScheduled, lineItems, orderedBy, orderedByUserEmail, orderedByUserId`. **No `status` field.**
+
+**Help text:** `packages/cli/src/commands/orders/list.ts:26` (post-#360)
+
+```ts
+.option("--status <status>", "Filter by status (Completed, Processing, Failed, PendingManual)")
+```
+
+The help text was rewritten in #360 to flag the spec gap. The comment block above the option reads:
+
+```ts
+// Honesty note (#250): the public Pax8 OpenAPI does NOT document a `status`
+// field on `Order` nor a `status` query parameter on `GET /orders`. The
+// values below are observed in real API responses (and mirrored by the demo
+// fixtures) but are NOT part of the published contract — they may change
+// without notice. The flag is kept so partner scripts that already use it
+// don't break; see docs/triage/api-version-audit/orders-status-enum.md.
+```
+
+---
+
+## 3. Proposed sandbox test code
+
+The test follows the harness pattern from `e2e/integration/companies.integration.test.ts` and uses the credential-gate pattern from `e2e/integration/harness.ts`.
+
+**File location (proposed):** `e2e/integration/orders-status-filter.integration.test.ts`
+
+```typescript
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Orders status filter — server-side honor test (#360 follow-up).
+ *
+ * Verifies whether `pax8 orders list --status <X>` filters on the server side.
+ * If the server honors the status parameter, the result set should differ from
+ * the unfiltered baseline. If the server ignores it, counts match.
+ *
+ * This test is gated on sandbox credentials (PAX8_CLIENT_ID / PAX8_CLIENT_SECRET)
+ * and is skipped when they are absent, per the harness pattern in #308.
+ */
+
+import { it, expect } from "vitest";
+import {
+  describeIntegration,
+  runCliVerbose,
+  expectExitZero,
+} from "./harness.js";
+
+describeIntegration("orders list --status filter (v1)", () => {
+  it(
+    "should filter results when --status is passed, if server honors it",
+    async () => {
+      // Step 1: Get the unfiltered baseline
+      const baselineResult = await runCliVerbose([
+        "orders",
+        "list",
+        "--json",
+      ]);
+      expectExitZero(baselineResult);
+
+      const baselineData = JSON.parse(baselineResult.stdout);
+      const baselineOrders = Array.isArray(baselineData) ? baselineData : baselineData.content || [];
+      const baselineCount = baselineOrders.length;
+
+      if (baselineCount === 0) {
+        // If no orders exist in the sandbox, the test is inconclusive.
+        // Document this clearly and skip the filter assertion.
+        console.log(
+          "[orders-status-filter] Sandbox has no orders; filter test is inconclusive"
+        );
+        expect(baselineCount).toBe(0);
+        return;
+      }
+
+      // Step 2: Collect statuses present in the baseline
+      const statusSet = new Set<string>();
+      for (const order of baselineOrders) {
+        if (order.status) {
+          statusSet.add(String(order.status));
+        }
+      }
+
+      if (statusSet.size === 0) {
+        // No orders have a status field in the response. This means either:
+        // (a) the server does not return status at all (spec is correct, no field)
+        // (b) status is always null/undefined in the current sandbox data
+        console.log(
+          "[orders-status-filter] No status values found in baseline; cannot test filter"
+        );
+        expect(statusSet.size).toBe(0);
+        return;
+      }
+
+      // Step 3: Test filtering by the first two distinct statuses
+      const statuses = Array.from(statusSet).slice(0, 2);
+
+      for (const status of statuses) {
+        const filteredResult = await runCliVerbose([
+          "orders",
+          "list",
+          "--status",
+          status,
+          "--json",
+        ]);
+        expectExitZero(filteredResult);
+
+        const filteredData = JSON.parse(filteredResult.stdout);
+        const filteredOrders = Array.isArray(filteredData) ? filteredData : filteredData.content || [];
+        const filteredCount = filteredOrders.length;
+
+        // Log the observation for the report
+        console.log(
+          `[orders-status-filter] status="${status}" => ${filteredCount} orders (baseline: ${baselineCount})`
+        );
+
+        // Step 4: Assert whether filtering occurred
+        // If server honors the filter:
+        //   - filtered count <= baseline count (usually strict <)
+        //   - all filtered orders have status === <filter value>
+        // If server ignores the filter:
+        //   - filtered count === baseline count
+        //   - orders in filtered result may have any status (same as baseline)
+
+        // Non-strict assertion: if counts differ, the server appears to honor the filter.
+        // If counts are equal, the server may be ignoring the filter (or baseline == filtered by coincidence).
+        if (filteredCount < baselineCount) {
+          console.log(
+            `[orders-status-filter] FILTER HONORED: count reduced from ${baselineCount} to ${filteredCount}`
+          );
+          // Verify that all returned orders match the filter
+          for (const order of filteredOrders) {
+            expect(order.status).toBe(status);
+          }
+        } else if (filteredCount === baselineCount) {
+          console.log(
+            `[orders-status-filter] FILTER POSSIBLY IGNORED: count unchanged at ${baselineCount}`
+          );
+          // Count unchanged; either all baseline orders match this status,
+          // or the server is ignoring the filter. Check the status values
+          // in the filtered result to distinguish.
+          const mismatchCount = filteredOrders.filter(
+            (o) => o.status !== status
+          ).length;
+          if (mismatchCount > 0) {
+            console.log(
+              `[orders-status-filter] WARNING: filtered result contains ${mismatchCount} orders with status !== "${status}" — server may be ignoring the filter`
+            );
+          } else {
+            console.log(
+              `[orders-status-filter] All returned orders match the filter (count unchanged because all baseline orders share this status)`
+            );
+          }
+        } else {
+          // filteredCount > baselineCount — should never happen
+          console.log(
+            `[orders-status-filter] UNEXPECTED: filtered count (${filteredCount}) exceeds baseline (${baselineCount})`
+          );
+        }
+      }
+
+      // The test passes if we reach here without error.
+      // The console logs and counts provide the diagnostic signal.
+      expect(true).toBe(true);
+    },
+    120_000 // 2 min timeout for multiple wire calls
+  );
+});
+```
+
+---
+
+## 4. Test execution attempt
+
+**Environment:** Local dev environment, no sandbox credentials configured.
+
+**Command:** `pnpm test:integration`
+
+**Result:**
+
+```
+[integration] PAX8_CLIENT_ID / PAX8_CLIENT_SECRET not set — skipping wire-level integration tests. This is expected for forks, local dev, and credential-less CI runs.
+
+Test Files  2 skipped (2)
+     Tests  2 skipped (2)
+Duration  451ms
+```
+
+**Outcome:** Test is cleanly skipped when credentials are absent, as designed. The harness gate worked as intended — no exception, no false failure.
+
+---
+
+## 5. One-sentence recommendation
+
+**Needs sandbox run by maintainer with `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` configured** — proposed test above can be added to `e2e/integration/` and run via `pnpm test:integration` to observe whether the server honors the `--status` filter; if yes, soften the disclaimer to acknowledge the server accepts it despite the spec gap; if no, current disclaimer is accurate.
+
+---
+
+## Notes for maintainer
+
+1. **To execute the test:**
+   - Copy the proposed test code above to `e2e/integration/orders-status-filter.integration.test.ts`
+   - Set `PAX8_CLIENT_ID` and `PAX8_CLIENT_SECRET` from sandbox credentials
+   - Run `pnpm build && pnpm test:integration`
+   - Examine the console output (`[orders-status-filter]` prefixed lines) to determine filter behavior
+
+2. **Expected outcomes:**
+   - **Filter honored:** Counts drop when `--status` is applied; all returned orders match the filter value
+   - **Filter ignored:** Counts unchanged; returned orders may have any status
+   - **Inconclusive:** Sandbox has no orders or no status field in responses
+
+3. **Follow-up actions:**
+   - If filter is honored: file a doc-gap issue to Pax8 API team to add `status` to the OpenAPI spec
+   - If filter is ignored: close as expected behavior; current disclaimer is correct
+   - If inconclusive: note the sandbox state and re-test with a fuller order set
+
+4. **This audit does not**:
+   - Modify any CLI source code
+   - Make live API calls (test is read-only on the CLI, wire calls only happen in `pnpm test:integration` when credentials are present)
+   - Commit the test fixture (proposed code is for this doc only; maintainer decides whether to adopt it)

--- a/docs/triage/provisioning-details-cross-surface.md
+++ b/docs/triage/provisioning-details-cross-surface.md
@@ -1,0 +1,313 @@
+# Triage: Record<string, unknown> Schema Audit
+
+**Date:** 2026-05-11  
+**Scope:** Audit for shape mismatches between declared schemas and actual API usage across all loose types (`z.unknown()`, `Record<string, unknown>`)  
+**Related Issues:** #332 (orders provisioningDetails), #363 (subscriptions provisioningDetails)  
+**Status:** Read-only investigation — no fixes applied
+
+---
+
+## Executive Summary
+
+**Total loose schemas found:** 3 instances  
+**By classification:**
+- Read-side only: 2 instances (TopicDefinition fields)
+- Write-side only: 1 instance (AddWebhookTopic filters)
+- Both: 0
+
+**New issues to file:** 0  
+**Verdict:** All three instances are documented, intentional, and cover future extensibility. No spec mismatches detected.
+
+---
+
+## Inventory: All Record<string, unknown> / z.unknown() Occurrences
+
+| Schema Name | File:Line | Field | Type | Classification | Intentional? | Details |
+|---|---|---|---|---|---|
+| AddWebhookTopicSchema | types.ts:670 | filters | z.array(z.unknown()).default([]) | Write-side only | ✓ Yes | Filters for topic subscriptions; spec accepts UpdateWebhookFilter objects but CLI doesn't expose per-topic filter authoring yet (#323 out-of-scope). Default empty array sent. |
+| TopicDefinitionSchema | types.ts:738 | availableFilters | z.array(z.unknown()).optional() | Read-side only | ✓ Yes | Optional; returned by GET /webhooks/topic-definitions but not used by CLI yet. Deliberately loose to avoid shipping unvalidated filter schema. |
+| TopicDefinitionSchema | types.ts:739 | samplePayload | z.unknown().optional() | Read-side only | ✓ Yes | Optional; returned by API but not displayed or validated by CLI. Kept loose for forward-compat with payload changes. |
+
+---
+
+## Detailed Analysis
+
+### 1. AddWebhookTopicSchema.filters (Write-side)
+
+**Location:** `packages/core/src/api/types.ts:670`
+
+**Schema Definition:**
+```typescript
+export const AddWebhookTopicSchema = z.object({
+  topic: z.string().min(1),
+  filters: z.array(z.unknown()).default([]),
+});
+```
+
+**Purpose:**  
+Per-topic filter expression array for webhook subscriptions. Maps to Pax8 webhooks API v2 `AddWebhookTopic.filters` field.
+
+**Write Path Analysis:**
+
+1. **CLI Entry Point:** `packages/cli/src/commands/webhooks/create.ts:155`
+   ```typescript
+   const webhookTopics = topics.map((topic) => ({ topic, filters: [] }));
+   ```
+   - CLI always sends empty filter array `[]`
+   - No user-facing flag to author filters yet
+
+2. **Service Layer:** `packages/core/src/api/webhooks.ts:42-44`
+   ```typescript
+   async create(data: CreateWebhookInput): Promise<Webhook> {
+     const raw = await this.client.post<unknown>("/webhooks", data, WEBHOOKS);
+     return WebhookSchema.parse(raw);
+   }
+   ```
+   - CreateWebhookInput includes webhookTopics array
+   - Data passed verbatim to wire
+
+3. **Wire Test:** `packages/core/src/api/webhooks.test.ts:78-106`
+   ```typescript
+   const input = {
+     url: "https://example.com/new",
+     displayName: "Order events — prod",
+     webhookTopics: [
+       { topic: "order.created", filters: [] },
+       { topic: "order.completed", filters: [] },
+     ],
+   };
+   // Test confirms: client.post receives input unchanged
+   ```
+
+**OpenAPI Spec Alignment:**  
+✓ **Verified correct.** Per code comment (types.ts:663-666), the spec's `UpdateWebhookFilter` schema defines:
+```
+{ action: string, conditions: [{ field, operator, value }] }
+```
+The CLI's empty default `[]` satisfies the server's "deliver all events" behavior. When per-topic filter authoring is added (#323), structured UpdateWebhookFilter objects can be passed — the loose `z.unknown()` intentionally future-proofs for that.
+
+**Verdict:** ✓ **CORRECT**  
+- Shape matches spec (server accepts filter array)
+- Default empty array is spec-compliant
+- Loose typing is intentional for future filter UX
+
+---
+
+### 2. TopicDefinitionSchema.availableFilters (Read-side only)
+
+**Location:** `packages/core/src/api/types.ts:738`
+
+**Schema Definition:**
+```typescript
+export const TopicDefinitionSchema = z.object({
+  topic: z.string(),
+  name: z.string(),
+  description: z.string(),
+  availableFilters: z.array(z.unknown()).optional(),
+  samplePayload: z.unknown().optional(),
+});
+```
+
+**Purpose:**  
+Discoverable topic definition metadata returned by `GET /webhooks/topic-definitions`. Fields describe what filters and sample payloads a topic supports.
+
+**Read Path Analysis:**
+
+1. **API Method:** `packages/core/src/api/webhooks.ts:132-146`
+   ```typescript
+   async getTopicDefinitions(): Promise<TopicDefinition[]> {
+     const raw = await this.client.get<unknown>(
+       "/webhooks/topic-definitions",
+       { size: 200 },
+       WEBHOOKS,
+     );
+     // Defensive: handles both paginated and flat shapes
+     if (raw && typeof raw === "object" && "content" in (raw as object)) {
+       const content = (raw as { content: unknown }).content;
+       return z.array(TopicDefinitionSchema).parse(content);
+     }
+     return z.array(TopicDefinitionSchema).parse(raw);
+   }
+   ```
+
+2. **CLI Usage:** Not exposed by commands yet
+   - Returned by `GET` but not rendered
+   - No consumer modifies or sends these fields back
+
+**Why Loose?**  
+Per comment (types.ts:730-732):
+> The optional `availableFilters` and `samplePayload` fields are also defined by the upstream `TopicDefinition` schema; they're parsed loosely (`z.unknown()`) because the CLI surface only needs `topic` and `description` today and we'd rather not ship a full payload schema we don't validate against.
+
+**Verdict:** ✓ **CORRECT**  
+- Read-only; no write risk
+- Intentionally loose to avoid over-specifying response shape
+- Future-proof if Pax8 API changes filter/payload structures
+
+---
+
+### 3. TopicDefinitionSchema.samplePayload (Read-side only)
+
+**Location:** `packages/core/src/api/types.ts:739`
+
+**Schema Definition:**
+```typescript
+samplePayload: z.unknown().optional(),
+```
+
+**Purpose:**  
+Example webhook event payload for a topic. Returned by `GET /webhooks/topic-definitions`.
+
+**Read Path Analysis:**
+
+1. **Response Envelope:** Parsed in same `getTopicDefinitions()` call as availableFilters
+2. **CLI Usage:** Not exposed by any command
+3. **Downstream:** No service or command logic consumes this field
+
+**Why Loose?**  
+Payload structure is vendor-specific and version-dependent. Keeping it unvalidated allows:
+- Future payload schema changes by Pax8 without CLI updates
+- Partners to read raw payload structure directly if needed
+- No accidental data loss from strict schema validation
+
+**Verdict:** ✓ **CORRECT**  
+- Read-only; no write risk
+- Intentionally loose for forward-compat
+- Not used by CLI surface, so over-specification has no benefit
+
+---
+
+## Surface Coverage Summary
+
+### Contacts (POST /contacts, PUT /contacts/{id})
+
+**Schemas Used:**
+- CreateContactInputSchema (line 196)
+- UpdateContactInputSchema (line 215)
+
+**Analysis:** ✓ No loose types. All fields strictly typed.
+
+**Write Paths:**
+- `packages/core/src/api/contacts.ts:44-50` (create)
+- `packages/core/src/api/contacts.ts:52-62` (update)
+- `packages/cli/src/commands/contacts/create.ts`
+- `packages/cli/src/commands/contacts/update.ts`
+
+Both inputs strictly model the Pax8 public OpenAPI spec (per comment, types.ts:189-221). No `Record<string, unknown>` fields.
+
+---
+
+### Webhooks (POST /webhooks, POST /webhooks/{id}/configuration)
+
+**Schemas Used:**
+- CreateWebhookInputSchema (line 687)
+- UpdateWebhookConfigurationInputSchema (line 700)
+
+**Analysis:**
+- CreateWebhookInputSchema includes AddWebhookTopicSchema array (line 690)
+- AddWebhookTopicSchema.filters uses `z.array(z.unknown())` → **[Analyzed above]**
+- UpdateWebhookConfigurationInputSchema: strictly typed, no loose fields
+
+**Write Paths:**
+- `packages/core/src/api/webhooks.ts:42-44` (create)
+- `packages/core/src/api/webhooks.ts:57-67` (updateConfiguration)
+- `packages/cli/src/commands/webhooks/create.ts`
+- `packages/cli/src/commands/webhooks/update.ts`
+
+---
+
+### Orders (POST /orders)
+
+**Status:** Already audited and fixed in #332.
+
+**Relevant Schemas:**
+- OrderLineItemProvisioningDetailSchema (line 306) — structured `{ key, values[] }`
+- OrderLineItemProvisioningSchema (line 316) — array of above
+
+**Note:** The pre-#332 `Record<string, unknown>` error has been corrected. Current schema accurately reflects the spec's array-of-objects shape.
+
+---
+
+### Subscriptions
+
+**Status:** Already audited in #363 (pending resolution).
+
+No loose types in `SubscriptionSchema` or `UpdateSubscriptionInputSchema`. The audit scope for #363 is likely a read/write mismatch in related fields, not `Record<string, unknown>` declarations.
+
+---
+
+### Usage Endpoints
+
+**Schemas Used:**
+- UsageSummarySchema (line 511)
+- UsageLineSchema (line 535)
+
+**Analysis:** ✓ No loose types. Both strictly typed.
+
+**Write Paths:** None. Usage API is read-only (`GET` only).
+- `packages/core/src/api/usage.ts:29-42` (listSummaries — GET)
+- `packages/core/src/api/usage.ts:44-47` (getSummary — GET)
+- `packages/core/src/api/usage.ts:56-65` (listLines — GET)
+
+---
+
+### Quotes (POST /v2/quotes, PUT /v2/quotes/{id})
+
+**Schemas Used:**
+- CreateQuoteInputSchema (line 780)
+- UpdateQuoteInputSchema (line 819)
+- AddQuoteLineItemInputSchema (line 842)
+
+**Analysis:** ✓ No loose types. All fields strictly typed.
+
+**Note:** `QuoteSchema` (line 589) includes `lineItems: z.array(QuoteLineItemSchema).optional()` but QuoteLineItemSchema is fully specified (line 548).
+
+---
+
+### Companies (POST /companies, PUT /companies/{id})
+
+**Schemas Used:**
+- CreateCompanyInputSchema (line 149)
+- UpdateCompanyInputSchema (line 160)
+
+**Analysis:** ✓ No loose types. All fields strictly typed (addresses resolved in #327/#328).
+
+---
+
+## Intentionality Checklist
+
+| Instance | Is It Tested? | Is It Documented? | Is It Future-Proofing? | Risk Level |
+|---|---|---|---|---|
+| AddWebhookTopicSchema.filters | ✓ Yes (webhooks.test.ts:78-106) | ✓ Yes (types.ts:663-666) | ✓ Yes (#323 roadmap) | Low |
+| TopicDefinitionSchema.availableFilters | ✓ Yes (webhooks.test.ts:223-245) | ✓ Yes (types.ts:730-732) | ✓ Yes (future filters) | Low |
+| TopicDefinitionSchema.samplePayload | ✓ Yes (webhooks.test.ts:223-245) | ✓ Yes (types.ts:730-732) | ✓ Yes (forward-compat) | Low |
+
+---
+
+## Cross-Reference: Previous Issues
+
+### Issue #332: Order Line Item provisioningDetails
+**Resolution:** Changed from `Record<string, unknown>` (object map) to `OrderLineItemProvisioningSchema` (array of `{ key, values[] }` objects).
+
+**File:** packages/core/src/api/types.ts:306-318  
+**Status:** ✓ Fixed  
+**Verification:** No current usage sends wrong shape; test confirms correct wire format.
+
+### Issue #363: Subscription provisioningDetails
+**Status:** Pending. Not in scope of this audit (no loose type declaration, likely a read/write asymmetry in related field).
+
+---
+
+## Conclusion
+
+**No new issues identified.**
+
+All three `z.unknown()` instances in the schema layer are:
+1. Intentionally loose (documented in code comments)
+2. Correct for their use case (write-side filters, read-side metadata)
+3. Either write-side with safe defaults (empty filter array) or read-only (no write risk)
+4. Future-proofing for planned features (#323) or forward-compat
+
+The pattern from #332 (misaligned shape between schema and spec) does not recur elsewhere. Contacts, orders, subscriptions, quotes, companies, and usage endpoints all declare strict schemas matching their wire shapes.
+
+**Recommendation:** No follow-up issues to file. Continue per existing roadmap (#323 for webhook filter UX).
+

--- a/docs/triage/subscriptions-update-provisioning-details.md
+++ b/docs/triage/subscriptions-update-provisioning-details.md
@@ -1,0 +1,172 @@
+# Subscriptions `update` — missing `provisioningDetails` surface
+
+> **⚠️ Historical record — superseded.** This triage doc captured the v0.1 scoping of #363 ("file a CLI fix"). Subsequent Rovo-grounded internal research reversed that direction: #363 has been **closed and deferred to v0.2** as **#368**. This doc is retained as a historical artifact; do not act on its recommendations for v0.1.
+
+---
+
+**Status:** ~~Real CLI fix needed.~~ Superseded — see #368.
+
+**Context:** Fred Lintz flagged a gap in the subscription update surface during pre-publish review. The OpenAPI spec documents `provisioningDetails` as a write-only field on `PUT /subscriptions/{subscriptionId}` (request body only, not returned on GET). The CLI's `subscriptions update` command does not expose this field. This is the subscriptions-side analogue of issue #332 (orders line-item provisioning details).
+
+---
+
+## 1. What does the CLI do today?
+
+The CLI's `subscriptions update` command accepts only `--quantity` and `--billing-term` flags. The request body is constructed at `packages/cli/src/commands/subscriptions/update.ts:196-220`, which copies only these two fields from user options into the `updateData` object. There is no `--provisioning` flag and no code path to populate `provisioningDetails` in the request body.
+
+**Citation:** `packages/cli/src/commands/subscriptions/update.ts:196-220`.
+
+---
+
+## 2. What does the spec say?
+
+The Pax8 OpenAPI spec documents `provisioningDetails` as a field on the `Subscription` schema with `writeOnly: true` (accepted on request bodies, not returned on reads). It is an optional array of provisioning-detail objects, each with the shape `{ key: string, values: string[] }`. The spec permits `provisioningDetails` to be included alongside any of the mandatory update fields (`quantity`, `billingTerm`, `price`, or `startDate`). The field is **not required** — it is an optional companion to the mandatory at-least-one-of rule.
+
+**Spec location:** `https://devx.pax8.com/openapi/partner-endpoints.json`
+
+**JSON path:**
+```
+paths./subscriptions/{subscriptionId}.put.requestBody.content.application/json.schema.allOf[0].properties.provisioningDetails
+```
+
+**Spec excerpt:**
+```json
+"provisioningDetails": {
+  "writeOnly": true,
+  "type": "array",
+  "items": { "$ref": "#/components/schemas/ProvisioningDetail" }
+}
+```
+
+**ProvisioningDetail schema:**
+```json
+{
+  "type": "object",
+  "properties": {
+    "key": { "type": "string" },
+    "values": { "type": "array", "items": { "type": "string" } },
+    "label": { "type": "string", "readOnly": true },
+    "description": { "type": "string", "readOnly": true },
+    "valueType": { "type": "string", "readOnly": true },
+    "possibleValues": { "type": "array", "items": { "type": "string" }, "readOnly": true }
+  }
+}
+```
+
+---
+
+## 3. Is there a CLI fix to file, or close #363 as no-op?
+
+**File CLI fix.** The OpenAPI spec explicitly documents `provisioningDetails` on the subscription update request body. The field is optional but should be exposed as a `--provisioning` flag (or similar) to allow partners to update provisioning details alongside quantity or billing-term changes. Without it, partners who need to update provisioning are blocked and must use the web portal or a different API client. This is a real capability gap.
+
+---
+
+## 4. What should the doc/help-text say?
+
+The `--provisioning` flag (or equivalent) should document that it accepts provisioning details in the form `key:value[|value...]` and is repeatable (just as #351 landed for `pax8 orders create --line-item`). The help text should clarify that provisioning details are optional and can accompany any quantity or billing-term update. The spec does not require provisioning details on subscription updates, but some products or vendors may expect them when other fields are modified.
+
+---
+
+## 5. Appendix: Full quotes and citations
+
+### CLI code (update.ts:196-220)
+
+```typescript
+const updateData: Record<string, unknown> = {};
+
+if (options.quantity !== undefined) {
+  let newQty = parseInt(options.quantity, 10);
+
+  // Confirm quantity change (with option to adjust)
+  const confirmedQty = await confirmWithChange(
+    newQty < sub.quantity
+      ? `Reduce from ${formatQuantity(sub.quantity)} to ${formatQuantity(newQty)}?`
+      : `Update from ${formatQuantity(sub.quantity)} to ${formatQuantity(newQty)}?`,
+    newQty,
+    { label: "New quantity" },
+  );
+  if (confirmedQty === null) {
+    process.stderr.write(chalk.yellow("\n  Update cancelled.\n\n"));
+    return;
+  }
+  newQty = confirmedQty;
+
+  updateData.quantity = newQty;
+}
+
+if (options.billingTerm) {
+  updateData.billingTerm = options.billingTerm;
+}
+```
+
+**File:** `packages/cli/src/commands/subscriptions/update.ts:196-220`
+
+---
+
+### Current `UpdateSubscriptionInputSchema` (types.ts:454-458)
+
+```typescript
+export const UpdateSubscriptionInputSchema = z.object({
+  quantity: z.number().int().min(1).optional(),
+  billingTerm: BillingTermSchema.optional(),
+});
+export type UpdateSubscriptionInput = z.infer<typeof UpdateSubscriptionInputSchema>;
+```
+
+**File:** `packages/core/src/api/types.ts:454-458`
+
+**Note:** This schema needs to grow `provisioningDetails: OrderLineItemProvisioningSchema.optional()` to match the spec.
+
+---
+
+### Reusable provisioning schema (types.ts:306-318)
+
+```typescript
+/**
+ * Wire shape for `OrderLineItem.provisioningDetails` — an array of
+ * `{ key, values[] }` objects per the spec. See #332.
+ */
+export const OrderLineItemProvisioningDetailSchema = z.object({
+  key: z.string(),
+  values: z.array(z.string()),
+});
+export type OrderLineItemProvisioningDetail = z.infer<typeof OrderLineItemProvisioningDetailSchema>;
+
+export const OrderLineItemProvisioningSchema = z.array(
+  OrderLineItemProvisioningDetailSchema,
+);
+```
+
+**File:** `packages/core/src/api/types.ts:306-318`
+
+**Note:** This schema is currently named with the `OrderLineItem` prefix but is suitable for reuse on the subscription write surface. Issue #359 proposes a rename to the neutral `LineItemProvisioning*Schema` for clarity, but the existing `OrderLineItemProvisioningSchema` can be reused immediately (mild naming smell, no public-API churn).
+
+---
+
+### API audit conclusion (api-version-audit/subscriptions.md:70-73)
+
+The existing `docs/triage/api-version-audit/subscriptions.md` audited the subscription update endpoint and concluded it is **wire-clean and body-clean** for the currently exposed `quantity` and `billingTerm` fields. However, that audit did not flag the missing `provisioningDetails` because no `--provisioning` flag existed then to check. The spec explicitly supports the field; the audit's scope was limited to what the CLI surfaced at the time.
+
+---
+
+### Issue #363 statement
+
+The GitHub issue #363 contains the full spec evidence and proposed fix patterns. The issue was filed after Fred Lintz's pre-publish reviewer feedback and confirmed via manual inspection of `partner-endpoints.json`. The issue is a direct parallel to #332 (orders line-item provisioning), which landed in PR #351.
+
+---
+
+## Scope
+
+This triage does **not** require:
+
+- Changes to the `SubscriptionSchema` read shape (the spec's `writeOnly: true` annotation means GET responses do not carry the field).
+- Changes to commitment-aware pre-flight logic (`update.ts:135-194`). Provisioning-detail updates are not governed by commitment-term restrictions.
+- API-side changes. The API already accepts and documents the field.
+
+This triage **does** require:
+
+1. Expand `UpdateSubscriptionInputSchema` to include `provisioningDetails: OrderLineItemProvisioningSchema.optional()`.
+2. Add a `--provisioning` flag to `pax8 subscriptions update` mirroring the parser from #351.
+3. Update the command help text and examples.
+4. Update the mock client to echo `provisioningDetails` on subscription updates for subprocess test verification.
+5. File a follow-up PR to rename `OrderLineItemProvisioning*Schema` → `LineItemProvisioning*Schema` (suggest as optional cleanup, separate from this fix).


### PR DESCRIPTION
Five triage docs from research/audit agents that ran without isolation worktrees and dropped their findings on `main`'s working tree. Pure docs. Bundling into one PR for clean history.

| Doc | Origin | Status |
|---|---|---|
| `companies-create-atomic-endpoint.md` | parallel audit; post-#319 updates | refresh |
| `mcp-use-case-alignment.md` | MCP catalog audit (today) | new |
| `orders-status-server-behavior.md` | #250 audit | new |
| `provisioning-details-cross-surface.md` | provisioningDetails cross-surface audit (informed #332/#351/#363) | new |
| `subscriptions-update-provisioning-details.md` | research-agent output for #363 | new |

## Headline finding from `mcp-use-case-alignment.md`

`app.pax8.com/integrations/guides` and `/integrations/mcp` are partner-portal gated (WebFetch denied). The user-cited '~8 use cases' figure could not be verified authoritatively. The agent did not fabricate — it documented the gap and worked with what was accessible (`devx.pax8.com/docs/mcp-server` lists 6 capability domains; the repo's PRD enumerates 6 PM-facing AI-assisted use cases). The CLI-side enumeration of recommendations engine + related computed surface is complete; the matrix shows 6/6 MCP domain alignment and several CLI-only value-add surfaces.

## Test plan

- [ ] Docs-only; renders correctly in GitHub markdown
