### PR TITLE
fix(context): PAX8_DEMO=false overrides demo:true in config

### DIFF
--- a/.changeset/pax8-demo-env-override.md
+++ b/.changeset/pax8-demo-env-override.md
@@ -1,0 +1,14 @@
+---
+"@pax8/cli": patch
+---
+
+`PAX8_DEMO=false` / `PAX8_DEMO=0` now correctly overrides `demo: true` in `~/.pax8/config.yaml`, letting users keep demo as a safe default while opting into the real API per-invocation. Previously the env var could only force demo ON; force-OFF required editing config.
+
+Centralizes the precedence logic into a single `resolveDemoMode(config)` / `resolveDemoModeAsync()` helper in `lib/context.ts` and updates the four sites that previously had inline copies with subtly different behavior:
+
+- `buildContext()` — what command code sees as `ctx.isDemo`
+- `pax8 doctor` — auth check + diagnostic body
+- The top-level `✨ Demo mode — showing sample data` banner
+- The telemetry `isDemo` event tag
+
+Truthy env values (`1`, `true`) and falsy values (`0`, `false`) take precedence over config in either direction; an unset env var defers to `config.demo`.

--- a/docs/triage/partner-readiness-audit.md
+++ b/docs/triage/partner-readiness-audit.md
@@ -1,0 +1,148 @@
+# Partner-readiness audit — v0.1.0
+
+**Audit date:** 2026-05-11
+**Repo state:** `main @ 830774a` (post-#381 atomic companies create, post-#379 clients rename, post-#376 recommendations OE axis)
+**Method:** Six parallel dimension agents, plus a top-level synthesis. Each dimension report lives under `docs/triage/partner-readiness-audit/`.
+**Scope:** Read-only audit. No code changes, no PRs, no issue filings.
+
+---
+
+## Executive summary
+
+**Recommendation: ship v0.1.0 after fixing 3 specific block-launch items, accepting 10 fix-before items as launch-window work, and documenting the rest as known issues.**
+
+The CLI is in noticeably better shape than the agent-driven assembly process would suggest. The 25+ PRs that landed in the last two days settled cleanly — the vocabulary, atomic-create, clients-rename, and recommendations refactors all left consistent surfaces. The strategic/forensic pass (dimension 6) found **0 block-launch findings and 0 trust-damaging discoveries**. The CLI feels designed, not assembled.
+
+But three concrete things would visibly break partners in the first hour:
+
+1. **Quotes read schema mismatch** — `GET /quotes` returns a nested `client` object but the Zod schema expects flat `companyId`. Silent failure on real API; masked by demo mode. (`packages/core/src/api/types.ts:659-692`, dim 1)
+2. **Timestamp field naming scatter** — `created` / `createdDate` / `createdOn` / `updatedAt` across the type system. Generic `--json` consumers must handle 5 conventions. (dim 2)
+3. **Zero wire-level coverage for any write operation** — 18 write commands tested only against `MockPax8Client`. Same regression class as the #307 quotes `/v1` vs `/v2` bug that started this whole cycle. (dim 4)
+
+Numbers 1 and 2 are concrete, scoped fixes (~half a day combined). Number 3 is an architectural gap that's worth landing one canonical write integration test before shipping (e.g., orders create) and the rest can roll into v0.1.1.
+
+---
+
+## Findings rolled up by severity
+
+### Block-launch (3)
+
+| # | Dimension | Finding | File |
+|---|---|---|---|
+| 1 | API conformity | Quotes API schema mismatch: spec returns nested `client`, schema expects flat `companyId` | `packages/core/src/api/types.ts:659-692`, `packages/core/src/api/quotes.ts:94-96` |
+| 2 | Internal consistency | Timestamp field naming inconsistent across types (`created` / `createdDate` / `createdOn` / `updatedAt`) | `packages/core/src/api/types.ts:140,452,504,667-668,701,723` |
+| 3 | Test coverage | Zero wire-level integration tests for ANY write operation (18 write commands mocked-only) | `e2e/integration/` (5 read-only files) |
+
+### Fix-before-launch (10)
+
+| # | Dimension | Finding | File |
+|---|---|---|---|
+| 4 | API conformity | Quotes `--status` filtered client-side; spec supports server-side filter | `packages/cli/src/commands/quotes/list.ts:59-64` |
+| 5 | API conformity | Companies missing geo/business-rule filters (`city`, `country`, `stateOrProvince`, `selfServiceAllowed`, etc.) | `packages/core/src/api/companies.ts:19-22` |
+| 6 | API conformity | Invoices missing advanced filters (`sort`, date range, balance, `status` not surfaced in CLI) | `packages/core/src/api/invoices.ts:20-27` |
+| 7 | Internal consistency | README + AGENTS.md still lead with `pax8 companies *` after the rename | `README.md:84,102,105`, `AGENTS.md:78-81` |
+| 8 | Internal consistency | `Company.created` is bare; all other types use camelCase timestamps | `packages/core/src/api/types.ts:140` |
+| 9 | Docs accuracy | skill.md + AGENTS.md document `pax8 invoices items <invoice-id>` as a positional; command requires `--invoice-id` flag | `packages/claude-skill/skill.md:22`, `AGENTS.md:24` |
+| 10 | Docs accuracy | `CLAUDE.md` missing `pax8 report growth` row in queries table (present in AGENTS.md) | `CLAUDE.md:9-24` |
+| 11 | Test coverage | Branch coverage on products (0%), invoices (34%), webhooks (57%) APIs leaves error paths untested | `packages/core/src/api/products.test.ts`, `invoices.test.ts`, `webhooks.test.ts` |
+| 12 | Test coverage | Easter-eggs, completions, init, report-bug have no test references | `packages/cli/src/__tests__/` |
+| 13 | Strategic | Integration-test CI workflow silently skips when secrets aren't configured; no docs/checklist warns about this | `.github/workflows/integration.yml:22,49-66` |
+
+### Fix-soon-after-launch (7)
+
+| # | Dimension | Finding |
+|---|---|---|
+| 14 | API conformity | Recommendations STAX divergence disclosed in help but not in `--json` output |
+| 15 | API conformity | Usage API pagination contract undocumented |
+| 16 | Internal consistency | Quote `createdOn`/`expiresOn` vs Order `createdDate` divergence (intentional but undocumented) |
+| 17 | Internal consistency | `mrrAtRisk` deprecation timeline invisible in help text and JSON output |
+| 18 | Test coverage | Per-command e2e matrix skips 29 of 78 commands in live runs (write + interactive) |
+| 19 | Surface scope | 18 internal `PAX8_*` env vars undocumented; partners could stumble on `PAX8_ALLOW_INSECURE_BASE` or `PAX8_DEBUG_RAW` |
+| 20 | Strategic | **[wants-second-opinion]** Deprecation marker for `mrrAtRisk` in JSON output itself (vs. just help text + TS docstring) |
+
+### Accept (8+)
+
+- D1: Invoice `status` field missing from OpenAPI but schema correctly defends with `.optional()`
+- D1: Subscriptions list missing optional filters (`billingTerm`, `productId`, `sort`) — partial completeness OK for v0.1.0
+- D3: README.md duplicates "Credential Setup Guide" link at line 487 (cosmetic)
+- D4: Mock data is fresh and schema-aligned via invariant tests
+- D4: CI gating split (unit always, integration credential-gated) is intentional and correct
+- D5: Deprecated `status` command alias correctly hidden
+- D5: Easter-eggs (`moo`, `coffee`) intentionally hidden
+- D5: `@pax8/core` exports surface is intentional and well-documented
+- D5: Configuration schema is clean and Zod-validated
+- D5: No half-built commands; only TODO is external (Pax8 API Idempotency-Key support)
+- D6: 10+ PASS items including recovery hints, parity test, taxonomy disclosure, doctor checks, version output, demo banner, address validation, contact validation, spinner/stdout separation
+
+---
+
+## Coverage snapshot
+
+| | Result |
+|---|---|
+| Total commands | 68 (39 reads / 29 writes) |
+| Command groups | 16 |
+| Hidden commands | 3 (1 deprecation alias, 2 easter eggs) |
+| `PAX8_*` env vars | 24 (6 documented for partners, 18 internal) |
+| Unit test coverage | 74.22% statements / 59.11% branches (thresholds: 60% / 42%) |
+| Wire-level integration tests | 5 files, all read-only (companies, quotes, products, subscriptions, invoices) |
+| Write operations without integration tests | 18 |
+
+---
+
+## Per-dimension reports
+
+Each dimension agent produced a detailed report with citations. The top-level synthesis above is intentionally compressed — go to the dimension docs for full findings, evidence quotes, and recommended-fix sketches.
+
+- **[01 — API conformity (read surfaces)](./partner-readiness-audit/01-api-conformity-reads.md)** — 7 findings (1 block, 3 fix-before, 2 fix-soon, 2 accept). Quotes schema mismatch is the biggest.
+- **[02 — Internal consistency](./partner-readiness-audit/02-internal-consistency.md)** — 5 findings (1 block, 2 fix-before, 2 fix-soon). Timestamp naming is the biggest.
+- **[03 — Documentation accuracy](./partner-readiness-audit/03-docs-accuracy.md)** — 3 findings (0 block, 2 fix-before, 1 accept). `invoices items` positional vs flag is the most embarrassing.
+- **[04 — Test coverage](./partner-readiness-audit/04-test-coverage.md)** — 6 findings (1 block, 2 fix-before, 1 fix-soon, 2 accept). No wire write coverage is the systemic gap.
+- **[05 — Surface area and scope](./partner-readiness-audit/05-surface-scope.md)** — 7 findings (0 block, 0 fix-before, 1 fix-soon, 6 accept). Includes the full command tree appendix.
+- **[06 — Strategic / forensic](./partner-readiness-audit/06-strategic-forensic.md)** — 17 findings (0 block, 7 fix-before, 9 fix-soon, 1 accept, 1 wants-second-opinion). The judgment-driven pass.
+
+---
+
+## The narrative
+
+A read on where this codebase actually sits, written for a peer engineer.
+
+**This isn't a prototype.** The CLI has 68 commands, real Zod-validated schemas, an integration test harness with a credential gate, an `@pax8/core` package with intentional exports, a config schema with sensible defaults, a doctor command that recognizes three credential paths, a deprecation alias pattern for renamed commands, and a parity test that catches drift between command-group aliases. None of those are prototype-grade.
+
+**It also isn't yet production.** Three things stand between current state and "I'd publish this for partners on Monday":
+
+1. **The quotes schema bug is a v0.1.0 launch-killer.** Demo mode hides it. A partner setting up real credentials and running `pax8 quotes list` is going to hit it within their first 10 minutes. The fix is small — a `.transform()` in the Zod schema or a flatten step in `QuotesApi.list()` — but it has to land before publish. The fact that it exists now, after a write-side audit, is the strongest evidence that read paths got less rigor than write paths and the audit doc structure should be updated to include reads in its scope.
+
+2. **Timestamp naming is a "this is what an assembly job feels like" smell.** Five conventions across five types isn't a bug per type — every individual field was probably chosen for a reason (matching upstream API, matching prior internal naming). But the aggregate is a partner reading `--json` from two different commands and getting back `createdDate` from one and `createdOn` from another. That's the kind of thing they'll quietly route around rather than file an issue about, and the routing-around becomes the lasting impression. It's mechanical to fix, but it's the kind of work you'd do once and then never want to touch again, so doing it right pre-launch is the right call.
+
+3. **Write coverage is fine for now but bad as a long-term posture.** Every write command went through demo-mode subprocess testing, which catches obvious bugs but doesn't catch the wire-level mismatches that #307 surfaced. Landing one integration test for one write path (orders create against a sandbox tenant) closes the architectural gap, even if you don't backfill all 18 writes immediately. Without that one, the read-only integration suite gives a false sense of security: it caught the quotes URL bug because it exercised the URL, but it wouldn't catch a writes-side equivalent.
+
+**Beyond those three, the audit found surprisingly little.** The strategic/forensic pass — the one designed to find "this was hand-edited" smells — found zero block-launch issues and reported the CLI "feels designed, not assembled." Help text is honest about CLI-invented heuristics (seat_gap, opportunityType taxonomy), recovery hints point to real commands with correct flag syntax, the parity test between `clients` and `companies` actually works, the demo banner shows correctly, error paths use canonical error codes from a single source, spinner output goes to stderr while data goes to stdout. Those are all signs of someone (or, in this case, multiple agents under careful direction) caring about the surface and getting the details right.
+
+The dimension that surprised me the least was internal consistency. The recent refactors (vocabulary #298/299, clients rename #379, atomic create #381) all landed cleanly, and the consistency agent found only loose ends — README still uses old vocabulary in two demo-flow examples, one bare `created` field on Company — not systemic drift. That's a good signal about how the agent-driven workflow has been operating: refactors are landing as actual refactors, not as partial pattern-applications that leave the codebase in a fragmented state.
+
+**One thing the audit doesn't capture: partner expectations.** The CLI is marketed (per the README) as turning the Pax8 marketplace into computed answers — renewals, MRR, invoice audits, recommendations. Those are the features that need to work cleanly out of the box for v0.1.0 to feel valuable. The audit covers conformity and consistency, but not "is this product useful at all." That question is closer to the recommendations engine, the renewals computation, and the dashboard, and all three of those have passing tests and accurate help text per the audit. Whether they're useful in practice is a different question that requires real partner trials, not a static read.
+
+**Net read:** This is closer to production than to prototype. Two-thirds of the way, maybe a little more. The three block-launch findings are concrete and small; they don't represent architectural debt, they represent oversights. Fix them and the v0.1.0 launch is honest. Ship as-is and partners will hit the quotes bug in the first hour and quietly decide the CLI isn't ready.
+
+If the question is "should we ship this Monday" the answer is "fix three things and yes." If the question is "is there a deeper rot we're missing" the answer this audit gives is "no — six parallel audits across read paths, consistency, docs, tests, surface area, and judgment-driven forensic all came back with finite, scoped findings."
+
+---
+
+## Caveats on the audit itself
+
+- **Scope tradeoff.** Each dimension agent had ~30-60 minutes. Coverage is broad but not exhaustive. The audit prioritized high-signal checks (does the README quick-start work, do schemas match the spec, is the parity test real) over thorough enumeration. A two-week audit would find more — most of it would probably be in the fix-soon-after-launch tier.
+- **Read-only constraint.** The audit deliberately didn't fix things, and a few findings would be one-line fixes (the `invoices items` docs, the CLAUDE.md row). That's intentional — the audit's job is to surface, the fix decisions are Josh's.
+- **One second-opinion item.** Whether to add a deprecation marker to `--json` output for the `mrrAtRisk` alias is a policy call (the technical work is clear). Flagged for Josh to decide rather than assumed away.
+- **Dimensions might double-count.** Two agents independently flagged the README-uses-`companies` issue (dim 2 and dim 3) from slightly different angles. They agree on the finding; the synthesis lists it once. Where dimensions disagreed (e.g., dim 3 said "no stale vocabulary in agent-facing docs" while dim 2 said "README leads with companies"), the synthesis prefers the more conservative reading — the discrepancy is documented inline in dim 3.
+- **What the audit didn't check:** Telemetry contract correctness, security-sensitive paths (credential storage, token handling) beyond what the doctor command verifies, performance characteristics on large portfolios, accessibility of help-text rendering on non-default terminals.
+
+---
+
+## Recommended action for Josh
+
+1. **Land the three block-launch fixes.** Quotes schema (~half day), timestamps consolidation (~2 hours), one canonical write integration test (~2-4 hours).
+2. **Land the docs-accuracy fix-before items.** `invoices items` flag-vs-positional in skill.md + AGENTS.md, CLAUDE.md missing row, README + AGENTS.md `companies` → `clients` swap. Maybe 30 minutes total.
+3. **Decide on the wants-second-opinion item** (JSON-level deprecation marker for `mrrAtRisk`).
+4. **Defer the rest.** The fix-soon-after-launch and accept items can ride in v0.1.1 with a known-issues section in the v0.1.0 release notes that points at this audit doc.
+5. **Use the audit's per-dimension docs as the source of truth** if specific findings need elaboration; this top-level doc is the synthesis but the dimension reports have the evidence and citations.

--- a/docs/triage/partner-readiness-audit/01-api-conformity-reads.md
+++ b/docs/triage/partner-readiness-audit/01-api-conformity-reads.md
@@ -1,0 +1,284 @@
+# 01 — API conformity (read surfaces)
+
+## Methodology
+
+Verified wire URLs match OpenAPI specs (`partner-endpoints.json`, `quoting-endpoints.json`, `webhooks-api.json`, `vendor-provisioning-endpoints.json`, `vendor-usage-endpoints.json`) using `jq`. Checked Zod schemas against the spec's `components.schemas` for shape conformity. Inspected command handlers for pagination, filtering, sorting, and error handling — focusing on the surfaces listed below.
+
+**Out of scope (already audited in earlier passes):** write operations, pre-#379 company/client surface, pre-#325 contact types.
+
+**Scope covered:** `subscriptions list/show/renewals`, `companies list/show`, `contacts list/show`, `invoices list/show/audit`, `orders list/show`, `quotes list/show/line-items`, `webhooks list/show/logs`, `usage` surfaces, `recommendations list`, `report mrr/growth`, `dashboard`, `products` catalog. Did NOT fully audit every CLI command's error handling, just spot-checked critical paths.
+
+## Summary
+
+- **1 block-launch** — quotes API shape mismatch (companyId vs. client object)
+- **3 fix-before-launch** — missing filter parameters exposed by spec (quotes status, companies geo, invoices advanced; CLI clients downstream could work around via spec-native calls but should have CLI support)
+- **2 fix-soon-after-launch** — incomplete feature disclosure (STAX divergence on recommendations not prominent; usage shows no pagination contract)
+- **1 accept** — invoice status field missing from OpenAPI but present on wire (acceptable defensive optional in schema)
+
+## Findings
+
+### block-launch — Quotes API — Schema mismatch on client identifier
+
+**File:** `packages/core/src/api/types.ts:659-692`, `packages/core/src/api/quotes.ts:94-96`
+
+**Evidence:**
+
+OpenAPI v2 `/quotes` response schema (`quoting-endpoints.json` → `components.schemas.QuoteResponse`):
+```json
+{
+  "client": {
+    "$ref": "#/components/schemas/ClientDetails"
+  }
+  // where ClientDetails = { id, isShadowCompany, name } — all required
+}
+```
+
+Zod schema in `types.ts:661`:
+```typescript
+companyId: z.string(),
+```
+
+The API returns a nested `client` object; the Zod schema expects a flat `companyId` string. Quotes API does no transformation (line 96: `return QuoteSchema.parse(raw)`). Default Zod behavior drops unknown keys, so the real API will silently drop `client.*` and leave `companyId` undefined, failing validation.
+
+**Why it matters:** Partners calling `pax8 quotes list` or `pax8 quotes show` against the real Pax8 API will get a silent Zod parsing failure or undefined `companyId` values, breaking quote drill-downs and company filtering. Demo mode masks this because mock data carries `companyId` directly.
+
+**Recommended fix:** Transform the API response to flatten `client.id` → `companyId` before Zod parsing, mirroring the approach used for ContactType (#325) and InvoiceItem (#273). Alternatively, restructure the Zod schema to accept both shapes defensively (e.g., `.transform()`).
+
+---
+
+### fix-before-launch — Quotes API — Missing status filter on list
+
+**File:** `packages/cli/src/commands/quotes/list.ts:59-64`, `packages/core/src/api/quotes.ts:81-92`
+
+**Evidence:**
+
+OpenAPI spec (`quoting-endpoints.json` → `/v2/quotes` GET parameters):
+```json
+{
+  "name": "status",
+  "schema": {
+    "enum": ["draft", "assigned", "sent", "closed", "declined", "accepted", "changes_requested", "expired", "pending"]
+  }
+}
+```
+
+CLI command line 59-60:
+```typescript
+// The Pax8 API doesn't expose a status filter on quotes list,
+// so honor --status client-side.
+```
+
+The spec clearly supports server-side status filtering, but the CLI comment claims it doesn't. Core API (`quotes.ts:81-92`) doesn't pass `status` to the server — it only accepts `{ page, size, companyId }`.
+
+**Why it matters:** Partners listing large quote volumes can't filter server-side; they must fetch all quotes and filter locally, wasting bandwidth and hitting pagination limits. The spec supports this.
+
+**Recommended fix:** Add `status?: string` parameter to `QuotesApi.list()` and thread it through to the HTTP GET. Update the CLI's `--status` flag to pass the parameter server-side instead of client-side filtering.
+
+---
+
+### fix-before-launch — Companies API — Missing geography/filter parameters
+
+**File:** `packages/core/src/api/companies.ts:19-22`, `packages/cli/src/commands/companies/list.ts:70-74`
+
+**Evidence:**
+
+OpenAPI spec (`partner-endpoints.json` → `/companies` GET parameters):
+```json
+{
+  "name": "city",     "schema": { "type": "string" }
+},
+{
+  "name": "country",  "schema": { "type": "string" }
+},
+{
+  "name": "stateOrProvince", "schema": { "type": "string" }
+},
+{
+  "name": "postalCode", "schema": { "type": "string" }
+},
+{
+  "name": "selfServiceAllowed",  "schema": { "type": "boolean" }
+},
+{
+  "name": "billOnBehalfOfEnabled", "schema": { "type": "boolean" }
+},
+{
+  "name": "orderApprovalRequired", "schema": { "type": "boolean" }
+},
+{
+  "name": "sort", "schema": { "enum": ["name", "city", "country", "stateOrProvince", "postalCode"] }
+}
+```
+
+Core API (`companies.ts:19`) only accepts:
+```typescript
+async list(params?: { page?: number; size?: number; status?: string; filter?: string })
+```
+
+The `filter` parameter is generic and doesn't align to any documented OpenAPI parameter. The spec's geography and capabilities filters are completely missing.
+
+**Why it matters:** Partners can't filter companies by location or business rules without downloading all companies locally. This limits usefulness for large portfolios with geographic segmentation needs.
+
+**Recommended fix:** Add typed parameters for `city`, `stateOrProvince`, `country`, `postalCode`, `selfServiceAllowed`, `billOnBehalfOfEnabled`, `orderApprovalRequired`, and `sort` to `CompaniesApi.list()`. Update the CLI's `companies list` command to expose these as options.
+
+---
+
+### fix-before-launch — Invoices API — Missing advanced filters
+
+**File:** `packages/core/src/api/invoices.ts:20-27`, `packages/cli/src/commands/invoices/list.ts`
+
+**Evidence:**
+
+OpenAPI spec (`partner-endpoints.json` → `/invoices` GET parameters) supports:
+```json
+{
+  "name": "status", "enum": ["Unpaid", "Paid", "Void", "Carried", "Nothing Due", "Credited"]
+},
+{
+  "name": "sort", "enum": ["invoiceDate", "dueDate", "status", "partnerName", "total", "balance", "carriedBalance"]
+},
+{
+  "name": "invoiceDateRangeStart", "format": "yyyy-MM-dd"
+},
+{
+  "name": "invoiceDateRangeEnd", "format": "yyyy-MM-dd"
+},
+{
+  "name": "dueDate", "format": "yyyy-MM-dd"
+},
+{
+  "name": "total", "type": "number"
+},
+{
+  "name": "balance", "type": "number"
+},
+{
+  "name": "carriedBalance", "type": "number"
+}
+```
+
+Core API (`invoices.ts:20-27`) only accepts:
+```typescript
+async list(params?: {
+  page?: number;
+  size?: number;
+  invoiceDate?: string;   // Note: mapped from CLI --month
+  month?: string;
+  companyId?: string;
+  status?: string;        // Accepted but not surfaced in CLI
+})
+```
+
+Notably missing: `sort`, date-range parameters, balance filters. The CLI's `invoices list` doesn't expose `status` as a flag even though the core API accepts it.
+
+**Why it matters:** Partners can't efficiently locate unpaid invoices or overdue items without local filtering. The audit surface (`pax8 invoices audit`) is unaffected since it does multi-step matching, but the read surface is incomplete.
+
+**Recommended fix:** Add `sort`, `invoiceDateRangeStart`, `invoiceDateRangeEnd`, `dueDate`, `total`, `balance`, `carriedBalance` parameters to `InvoicesApi.list()`. Surface status filter in the CLI (`--status Unpaid`, `--status Paid`, etc.). Consider date-range flags (`--from YYYY-MM-DD`, `--to YYYY-MM-DD`) for ergonomics.
+
+---
+
+### fix-soon-after-launch — Recommendations — STAX divergence not disclosed
+
+**File:** `packages/cli/src/commands/recommendations/list.ts:77-91`
+
+**Evidence:**
+
+Help text (lines 77-91) discloses that the CLI's seat-gap heuristic is not the same as Pax8's Seat Utilization metric and is "closest OE surrogate is Upsell" and "will likely be retired or remapped when OE's first-party API ships."
+
+However:
+1. The disclosure is in the `pax8 recommendations list --help` output, not in `--json` output where automated consumers might miss it.
+2. The comment says "CLI-invented heuristic" — this is accurate but could be more prominent in the README or docs.
+3. The `opportunityType` field maps the legacy `type` field to OE's canonical taxonomy, but this mapping logic is in the command handler, not documented in `packages/core`.
+
+**Why it matters:** Partners integrating `--json` output into scripts/dashboards may not discover that seat_gap diverges from Pax8's internal definitions. Low urgency since the `opportunityType` field provides the canonical taxonomy, but disclosure clarity matters for trust.
+
+**Recommended fix:** Add a note to `packages/core/README.md` or `docs/FEATURES.md` documenting the seat_gap heuristic and its eventual retirement. Optionally add an `internalNote` field to the JSON output flagging divergences (though this adds surface complexity).
+
+---
+
+### fix-soon-after-launch — Usage API — No pagination contract disclosed
+
+**File:** `packages/core/src/api/usage.ts:29-42`, `packages/cli/src/commands/usage/list.ts`
+
+**Evidence:**
+
+`UsageApi.listSummaries()` returns `PaginatedResponse<UsageSummary>`, suggesting paging is available. However:
+1. The OpenAPI spec doesn't explicitly document whether `/subscriptions/{id}/usage-summaries` supports `page` and `size` parameters (not verified in this audit).
+2. The CLI command doesn't surface pagination flags.
+3. The response contract (`page.totalElements`, `page.totalPages`) suggests paging, but there's no help text or flag documentation about how pagination works or when results are truncated.
+
+**Why it matters:** Partners with high-usage subscriptions may not discover that results are paginated or truncated. Low severity since usage-summaries are typically small, but undocumented pagination contracts can surprise users with large datasets.
+
+**Recommended fix:** Document the pagination behavior in the CLI help text. Consider adding `--page` and `--size` flags to `usage list` for parity with other list commands. Verify the spec's pagination contract against the implementation.
+
+---
+
+### accept — Invoices API — Status field missing from OpenAPI but on wire
+
+**File:** `packages/core/src/api/types.ts:543-556`
+
+**Evidence:**
+
+OpenAPI spec (`partner-endpoints.json` → `components.schemas.Invoice.properties`) lists:
+```json
+["balance", "carriedBalance", "companyId", "currencyCode", "dueDate", "externalId", "id", "invoiceDate", "partnerName", "total"]
+```
+
+No `status` field.
+
+Zod schema (line 552):
+```typescript
+status: InvoiceStatusSchema.optional(),
+```
+
+Comment (lines 548-550):
+```typescript
+// Optional defensively: the public OpenAPI Invoice properties block does
+// not declare `status`, even though the field appears in the spec's
+// example response. Until the spec is fixed, partners reading the schema
+// could legitimately produce payloads without this field.
+```
+
+**Why it matters:** The OpenAPI docs are incomplete (the spec's example does include `status`), but the CLI correctly defends against this gap. No action needed.
+
+**Recommended fix:** None — the schema is correctly defensive. Document this in the next Pax8 API docs audit.
+
+---
+
+### accept — Subscriptions API — Client implements core parameters, CLI doesn't expose all
+
+**File:** `packages/core/src/api/subscriptions.ts:21-29`, `packages/cli/src/commands/subscriptions/list.ts:47-88`
+
+**Evidence:**
+
+OpenAPI spec (`partner-endpoints.json` → `/subscriptions` GET parameters) supports:
+```json
+{
+  "name": "status",       "enum": [all 10 values matching CLI help — ✓ matches]
+},
+{
+  "name": "billingTerm",  "enum": ["Monthly", "Annual", "2-Year", "3-Year", "One-Time", "Trial", "Activation"]
+},
+{
+  "name": "productId",    "format": "uuid"
+},
+{
+  "name": "sort",         "enum": ["quantity,asc|desc", "startDate,asc|desc", ...]
+}
+```
+
+CLI only exposes `--company`, `--status`, `--page`, `--size`. Core API accepts these but **not** `billingTerm`, `productId`, or `sort` parameters.
+
+**Why it matters:** Partners can't filter subscriptions by billing term or product from the CLI (must use the API directly or filter locally). The gaps are less critical than other surfaces since `subscriptions list --company X` is the primary use case, but completeness is impacted.
+
+**Recommended fix:** Optional enhancement for v0.1.1+: add `--billing-term`, `--product`, and `--sort` flags to `subscriptions list`. Update core API to accept and pass these parameters.
+
+---
+
+## Out of Scope
+
+- Write operation surfaces (already audited in `docs/triage/api-version-audit/`)
+- Error-handling exhaustiveness (only spot-checked critical failures)
+- All CLI UX/affordance details (focused on API conformity)
+- Vendor usage/provisioning endpoints (read paths confirmed URLs match spec; detailed schema audit deferred)
+

--- a/docs/triage/partner-readiness-audit/02-internal-consistency.md
+++ b/docs/triage/partner-readiness-audit/02-internal-consistency.md
@@ -1,0 +1,257 @@
+# 02 — Internal Consistency
+
+## Methodology
+
+Systematic scan across six consistency dimensions:
+
+1. **Vocabulary** — `mrrAtRisk` → `mrrRenewing` rename (#299), "Partner Gross MRR" qualifiers, "commitment term end date" terminology
+2. **Command naming** — `pax8 clients *` (primary) vs `pax8 companies *` (alias) coverage, help text
+3. **Flag conventions** — `--company <id|name>` consistency, kebab-case, meaning across commands
+4. **JSON schemas** — Field names, timestamp conventions (`createdDate` vs `updatedAt`), money types, ID formats
+5. **Exit codes** — Use of canonical `ERROR_*` constants from `packages/core/src/errors/codes.ts`
+6. **Error handling** — `CliError` wrapper usage, structured vs raw API responses
+
+Scanned: 
+- `packages/core/src/api/types.ts` (canonical schema definitions)
+- `packages/core/src/errors/codes.ts` (error code constants)
+- `packages/cli/src/commands/**/*.ts` (command implementations, flags, error handling)
+- `docs/UX_GUIDE.md`, `README.md`, `AGENTS.md`, `packages/claude-skill/skill.md` (user-facing vocabulary)
+- `CHANGELOG.md`, `docs/pm-review-response-2026-05.md` (recent refactor context)
+
+---
+
+## Summary
+
+**Total findings: 5 (1 block-launch, 2 fix-before-launch, 2 fix-soon-after-launch, 0 accept)**
+
+| Severity | Count | Issues |
+|----------|-------|--------|
+| block-launch | 1 | Timestamp field naming inconsistency (createdDate + updatedAt + created mixed across types) |
+| fix-before-launch | 2 | Company.created (bare) vs Webhook.updatedAt (camelCase); README/AGENTS.md still reference `companies` as primary |
+| fix-soon-after-launch | 2 | Quote createdOn/expiresOn vs Order createdDate; deprecation clarity for mrrAtRisk alias |
+| accept | 0 | — |
+
+---
+
+## Findings
+
+### block-launch — JSON schemas — Timestamp field naming inconsistency
+
+**File:** `packages/core/src/api/types.ts:140-141` (Company), `types.ts:452` (Order), `types.ts:504` (Subscription), `types.ts:667-668` (Quote), `types.ts:701` (Webhook), `types.ts:723` (Webhook.updatedAt)
+
+**Evidence:**
+```
+Company:      { created, updatedDate }
+Order:        { createdDate }
+Subscription: { createdDate }
+Quote:        { createdOn, expiresOn }
+Webhook:      { createdDate, updatedAt }
+```
+
+Grep across types:
+```
+/packages/core/src/api/types.ts:  created: z.string().optional(),           # Company only
+/packages/core/src/api/types.ts:  updatedDate: z.string().optional(),       # Company + (none else)
+/packages/core/src/api/types.ts:  createdDate: z.string(),                  # Order, Subscription
+/packages/core/src/api/types.ts:  createdOn: z.string(),                    # Quote only
+/packages/core/src/api/types.ts:  updatedAt: z.string().optional(),         # Webhook only
+```
+
+**Why it matters:**
+
+Partners writing `--json` consumers (scripts, agents, integrations) expecting a canonical timestamp field pattern face silent failures. Webhook `updatedAt` exists alongside other types' `createdDate` / `created` fields; a generic timestamp extractor must handle five naming conventions for what semantically is "when did this record change." JSON output is the contract for agent/script consumers — this inconsistency breaks composability.
+
+**Recommended fix:**
+
+Establish canonical timestamp naming:
+- Created: `createdAt` (ISO 8601, always present on read)
+- Updated: `updatedAt` (ISO 8601, optional, populated only if the type supports updates)
+
+Migrate each type at the schema level:
+- Company: `created` → `createdAt`; keep `updatedDate` but rename to `updatedAt`
+- Order: no change needed (already `createdDate`; add `updatedAt` if API supports it)
+- Subscription: no change needed
+- Quote: rename `createdOn` → `createdAt`, `expiresOn` → `expiresAt` (aligns with semantic "when does it expire")
+- Webhook: `createdDate` → `createdAt` (keep `updatedAt` as-is)
+
+Emit deprecated aliases for one minor cycle so existing `--json` consumers don't break (follow the `mrrAtRisk` pattern from #299). Update all help text, README, and agent-facing contracts.
+
+---
+
+### fix-before-launch — Docs vocabulary — README and AGENTS.md still reference `companies` as primary command
+
+**File:** `README.md:84` (demo flow), `README.md:99-106` (Companies section), `AGENTS.md:78,80-81` (command examples)
+
+**Evidence:**
+
+README Demo Flow (line 84):
+```
+pax8 companies list                      # Browse customers (type # to drill in)
+pax8 companies more "Acme Corp"          # Full customer summary
+```
+
+AGENTS.md examples (lines 78-81):
+```
+| companies / customers | `pax8 companies list --json 2>/dev/null` |
+...
+- `pax8 companies list --json 2>/dev/null` (or ...)
+- `pax8 companies more <name>` — rich read-only summary
+```
+
+**Why it matters:**
+
+PR #379 and the `companies/index.ts` comment (line 12-26) make clear that `pax8 clients` is the canonical user-facing command and `pax8 companies` is a deprecated alias. Yet the README's "Quick Start" and "Demo Flow" sections (user-facing discovery docs) and AGENTS.md (agent training) still lead with `companies`. Partners following the README will never learn the canonical surface; agents trained on AGENTS.md perpetuate the old terminology.
+
+**Recommended fix:**
+
+Update before v0.1.0 ships:
+- README.md: swap `pax8 companies list` → `pax8 clients list` throughout (lines 84, 102, 105)
+- Add a sidebar note: "Alias: `pax8 companies *` works identically but is deprecated."
+- AGENTS.md: swap command examples to `pax8 clients *` (line 78, 80-81)
+- Retain both in the safety contract (skill.md line 16) so both invocations are documented, but lead with `clients`.
+
+---
+
+### fix-before-launch — Naming consistency — Company.created is bare; inconsistent with all other types' camelCase timestamps
+
+**File:** `packages/core/src/api/types.ts:140`
+
+**Evidence:**
+```typescript
+export const CompanySchema = z.object({
+  // ... other fields ...
+  created: z.string().optional(),          // <-- bare, not camelCase
+  updatedDate: z.string().optional(),       // <-- not camelCase either (should be updatedAt)
+});
+```
+
+All other types use camelCase `createdDate` or `createdAt`/`createdOn`. Company uses bare `created`.
+
+**Why it matters:**
+
+Type inconsistency signals incomplete refactoring. If Company's created field is from an older API version or internal naming, the schema should document why (see types.ts comment patterns elsewhere). Right now it reads as an oversight.
+
+**Recommended fix:**
+
+Rename `Company.created` → `Company.createdAt` alongside the broader timestamp-naming fix (block-launch finding). Emit as deprecated alias for one cycle.
+
+---
+
+### fix-soon-after-launch — JSON schemas — Quote uses createdOn/expiresOn, Order uses createdDate
+
+**File:** `packages/core/src/api/types.ts:667-668` (Quote), `types.ts:452` (Order)
+
+**Evidence:**
+```typescript
+export const QuoteSchema = z.object({
+  // ... 
+  createdOn: z.string(),       // Quote naming
+  expiresOn: z.string().optional(),
+});
+
+export const OrderSchema = z.object({
+  // ...
+  createdDate: z.string(),    // Order naming
+  // no expiresDate equivalent
+});
+```
+
+Comment in types.ts:662-666 documents this was intentional per quote v2 API alignment, but the naming divergence from Order creates a second-level inconsistency within "resources that track time."
+
+**Why it matters:**
+
+Minor but visible in `--json` output for agents doing comparative analysis (order vs quote lifecycle). The comment shows awareness of the API's field naming; this is a known-good state rather than a bug. However, it contributes to the overall timestamp fragmentation.
+
+**Recommended fix:**
+
+Document in CHANGELOG or `docs/NAMING_CONVENTIONS.md` why Quote uses `createdOn` (API alignment) while Order uses `createdDate` (internal consistency). This is a "known good reason for divergence" rather than a bug, but worth explaining. Revisit alongside the block-launch timestamp fix to see if a unified pattern is possible.
+
+---
+
+### fix-soon-after-launch — Vocabulary — mrrAtRisk deprecation clarity in help text and JSON
+
+**File:** `packages/cli/src/commands/subscriptions/renewals.ts:30-31` (help text), `packages/cli/src/commands/dashboard.ts:263` (JSON emission), `CHANGELOG.md:23` (deprecation note)
+
+**Evidence:**
+
+Help text (renewals.ts:30-31):
+```
+The previous \`mrrAtRisk\` / \`arrAtRisk\` keys are emitted alongside as
+```
+
+The comment is incomplete (ends mid-sentence). Help text should explicitly state:
+- "These are deprecated aliases; use `mrrRenewing` instead."
+- "Aliases will be removed in v0.3.0" (or whenever).
+
+CHANGELOG.md documents the deprecation clearly but users reading `pax8 subscriptions renewals --help` don't see it.
+
+**Why it matters:**
+
+Partners writing scripts against `--json` output don't know the deprecation timeline. Some may assume both fields are stable and bake both into their parsing logic. Clarity in help text and README prevents surprise when v0.3.0 drops the aliases.
+
+**Recommended fix:**
+
+1. Fix the incomplete help text in renewals.ts:30-31 to complete the sentence and add deprecation timeline.
+2. Add a "Deprecated fields" subsection to the command's help:
+   ```
+   Deprecated fields (removal in v0.3.0):
+     mrrAtRisk   → use mrrRenewing instead
+     arrAtRisk   → use arrRenewing instead
+     totalMrrAtRisk → use totalMrrRenewing instead
+   ```
+3. Add a note to README.md's renewals example clarifying the aliases are emitted for compatibility.
+
+---
+
+## Spot checks — Consistency maintained
+
+### ✓ Flag `--company <id|name>` consistency
+
+Checked across: `invoices list`, `invoices audit`, `invoices dispute`, `subscriptions list`, `subscriptions renewals`, `orders list`, `orders create`, `contacts list`, `contacts show`, `recommendations list`, `usage list`, `quotes list`.
+
+**Result:** All consistently use `--company <id|name>` with identical descriptions ("Filter by company ID or name" / "Company ID or name (required)"). No synonyms (`--cid`, `--client`, `--account`). ✓
+
+### ✓ Kebab-case flag naming
+
+Checked: `--ids-only`, `--with-actions`, `--billing-term`, `--commitment-term`, `--status`, `--page`, `--size`, `--company-only`.
+
+**Result:** All multi-word flags use kebab-case. No camelCase flags found. ✓
+
+### ✓ Exit codes use canonical constants
+
+Spot-checked 12 commands: `init`, `companies/create`, `orders/create`, `quotes/create`, `invoices/dispute`, `subscriptions/renewals`.
+
+**Result:** All `throw new CliError(...)` calls pass an `ERROR_*` constant from `packages/core/src/errors/codes.ts` as the fifth argument. No raw string error codes or bare `throw Error()`. ✓
+
+### ✓ "commitment term end date" vocabulary discipline
+
+Grep for "ETF", "penalty", "fee", "early-termination" in help text and error messages: 0 matches.
+
+Grep for "commitment term end date": 4 matches in `packages/cli/src/commands/subscriptions/cancel.ts` and docs.
+
+**Result:** Vocabulary regression-tested per #302. No "ETF" / "penalty" framing found. ✓
+
+### ✓ "Partner Gross MRR" qualifier present
+
+Checked: `packages/cli/src/commands/report/mrr.ts`, `subscriptions/renewals.ts`, `report/growth.ts`, `dashboard.ts`.
+
+**Result:** All MRR labels include "Partner Gross MRR" qualifier in help text and comments. ✓ Consistent with #298.
+
+### ✓ JSON field names in list commands
+
+Spot-checked: `subscriptions list`, `invoices list`, `orders list`, `companies list`.
+
+**Result:** All return arrays of objects with consistent field names (`companyId`, `companyName`, `productId`, `productName`, `price`, `total`, etc.). No field-name divergence between commands. ✓
+
+---
+
+## Recommendations for Josh
+
+1. **Priority 1 (blocking launch):** Consolidate timestamp field naming across all types. The createdDate + updatedAt + created + createdOn scatter breaks agent composability. Emit deprecated aliases for one cycle. Scope: ~2 hours, affects 5 schemas + help text.
+
+2. **Priority 2 (before v0.1.0 general availability):** Update README and AGENTS.md to lead with `pax8 clients *` instead of `pax8 companies *`. This is user-facing discovery; getting it wrong early is costly. Scope: ~15 minutes.
+
+3. **Priority 3 (v0.1.1):** Clarify mrrAtRisk deprecation timeline in help text and README so partners don't get surprised when aliases drop in v0.3.0. Document the "why" (API conflict with Pax8's Revenue at Risk Predictor) if you haven't already. Scope: ~20 minutes.
+
+All other consistency checks pass. The refactors (#298, #299, #379) landed cleanly; these three findings are loose ends rather than systemic drift.
+

--- a/docs/triage/partner-readiness-audit/03-docs-accuracy.md
+++ b/docs/triage/partner-readiness-audit/03-docs-accuracy.md
@@ -1,0 +1,110 @@
+# 03 — Documentation accuracy
+
+## Methodology
+
+1. **Quick-start validation** — Executed every command in README demo flow (lines 50-86) under `PAX8_DEMO=1`
+2. **Command help spot-check** — Verified 10+ commands (`subscriptions list`, `subscriptions renewals`, `orders create`, `companies create`, `contacts create`, `invoices items`, `cost sim`, `recommendations list`, `dashboard`, `invoices audit`)
+3. **Cross-reference audit** — Compared command tables in CLAUDE.md vs AGENTS.md vs skill.md; verified file paths; checked for old vocabulary (`mrrAtRisk`)
+4. **Source code review** — Examined recommendations service doc comments for STAX disclosure; validated command definitions against help text
+5. **Issue reference spot-check** — Reviewed 3 GitHub issue refs in code comments (#327/#328, #298/#299, #375)
+
+## Summary
+
+- **Total findings: 3**
+- **block-launch: 0**
+- **fix-before-launch: 2** (missing command in agent-facing table, inaccurate positional-arg syntax in skill.md and AGENTS.md)
+- **fix-soon-after-launch: 0**
+- **accept: 1** (duplicate reference line in README docs list)
+
+---
+
+## Findings
+
+### fix-before-launch — AGENTS.md and skill.md — `invoices items` positional argument syntax is incorrect
+
+**File:** `packages/claude-skill/skill.md:22` and `AGENTS.md:24`
+
+**Evidence:**
+```
+skill.md:22 — `pax8 invoices items` — line items for an invoice
+AGENTS.md:24 — `pax8 invoices items <invoice-id> --json 2>/dev/null`
+```
+
+Actual command definition (`packages/cli/src/commands/invoices/items.ts:13-28`):
+```typescript
+invoicesItemsCommand = new Command("items")
+  .option("--invoice-id <id>", "Filter by invoice ID")
+  // No positional argument defined
+Examples:
+  pax8 invoices items --invoice-id inv-summit-curr-001
+```
+
+Verified: invoking with a positional argument silently ignores it and returns ALL items.
+
+**Why it matters:** Agents (Claude Code, Cursor, etc.) reading skill.md and AGENTS.md will attempt to call `pax8 invoices items <id>`, which silently ignores the positional arg and returns all items instead of filtering to the specific invoice. This is a silent data-correctness failure that could cause agents to misinterpret invoice contents.
+
+**Recommended fix:** Update both docs to show `--invoice-id <id>` flag syntax:
+- `skill.md:22` — change to list the flag form
+- `AGENTS.md:24` — change `pax8 invoices items <invoice-id> --json` to `pax8 invoices items --invoice-id <invoice-id> --json`
+
+---
+
+### fix-before-launch — CLAUDE.md — Missing `pax8 report growth` command in Pax8 data queries table
+
+**File:** `CLAUDE.md:9-24` (command reference table)
+
+**Evidence:**
+
+`CLAUDE.md` lines 9-24 has these rows:
+```
+| User asks about | Run this |
+| overview / status | pax8 dashboard --json |
+| MRR / revenue | pax8 report mrr --json |
+| recommendations | pax8 recommendations list --json |
+...
+```
+
+But `AGENTS.md` lines 13-31 has the same table with an additional row at line 20:
+```
+| growth trend | pax8 report growth --json 2>/dev/null |
+```
+
+Command verified to exist and work under `PAX8_DEMO=1 pax8 report growth --json`.
+
+**Why it matters:** `CLAUDE.md` is the contract for agent execution inside this repo (per lines 1-3). Agents following `CLAUDE.md` won't know about the `report growth` command and may miss growth-trend questions. The command is in `AGENTS.md` (for non-Claude agents) but missing from the repo's own internal contract.
+
+**Recommended fix:** Add the missing row to `CLAUDE.md` between lines 15-16 (after "MRR / revenue" and before "recommendations"):
+```
+| growth trend | pax8 report growth --json 2>/dev/null |
+```
+
+---
+
+### accept — README.md — Duplicate "Credential Setup Guide" reference
+
+**File:** `README.md:485-487`
+
+**Evidence:**
+```markdown
+## Documentation
+
+- [Credential Setup Guide](docs/credential-setup.md)
+- [Product Requirements](docs/PRD.md)
+- [Credential Setup Guide](docs/credential-setup.md)  ← duplicate of line 485
+- [Build Prompt](docs/BUILD.md)
+```
+
+**Why it matters:** Minor — cleanliness only. Not a correctness issue; the file exists and the link works. No partner will notice, and it causes no functional harm.
+
+**Recommended fix:** Delete line 487 or replace with another doc (e.g., `[Pax8 API Reference](https://devx.pax8.com/)` is already on line 489, so no duplication needed).
+
+---
+
+## Additional validation (no issues found)
+
+- README quick-start commands all work end-to-end under `PAX8_DEMO=1` ✓
+- Help text on 10+ commands matches documented behavior ✓
+- STAX taxonomy divergence is well-disclosed in `packages/core/src/services/recommendations.ts:4-24` ✓
+- No references to stale vocabulary (`mrrAtRisk`, old "companies as primary" phrasing) in agent-facing docs ✓ (NOTE: this conflicts with dimension 2's finding that README and AGENTS.md still lead with `companies`; the discrepancy is that this agent checked the agent-facing query tables only; dim 2 caught the README demo-flow examples)
+- All referenced doc files exist (`docs/BUILD.md`, `docs/credential-setup.md`, `docs/PRD.md`) ✓
+- Commands in skill.md match actual surface (e.g., `dashboard --all|--customers|--renewals|--growth` all work) ✓

--- a/docs/triage/partner-readiness-audit/04-test-coverage.md
+++ b/docs/triage/partner-readiness-audit/04-test-coverage.md
@@ -1,0 +1,203 @@
+# 04 — Test coverage
+
+## Methodology
+
+Audited test coverage across three layers: unit tests (API client mocks), subprocess integration tests (CLI commands via `runCli` with `PAX8_DEMO=1`), and wire-level integration tests (real Pax8 API via `runCliVerbose`). Measured coverage via `pnpm test:coverage` (74.22% statements, 59.11% branches). Cross-referenced 78 commands against test files to identify coverage gaps. Checked CI gating (`ci.yml` vs `integration.yml`) and fixture freshness.
+
+## Summary
+
+**Integration test inventory:** 5 wire-smoke tests (companies, quotes, products, subscriptions, invoices) covering only read-only operations. Credentials-gated via `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` env vars; skips cleanly on absent credentials.
+
+**Write operations without integration tests:** 18 write commands tested only via mocked subprocess tests (companies create/update, contacts create/delete/update, orders create, quotes create/delete/send/line-items add+remove, subscriptions cancel/update, webhooks create/delete/enable/disable/update). No real-API coverage for state mutations.
+
+**Measured coverage:** 74.22% statements, 59.11% branches (vs thresholds of 60% / 42%). Core API coverage is 82.69% statements but only 64.78% branches (e.g., `invoices.ts` 55.55% statements, `products.ts` 59.25%). Commands coverage is uneven: `companies.update` 75.58%, `webhooks.logs` 59.45%, `usage.show` 39.21%.
+
+**Top coverage gaps:** (1) Subprocess tests for write operations rely entirely on mocked data and confirm-prompt flows, so malformed payloads or API version mismatches in mutations won't surface until prod. (2) Easter-eggs commands (coffee, moo, time-quip) and `report-bug` have zero test references. (3) Per-command e2e matrix covers only 45% of commands live (read-only excluded due to `isWrite: true` or `skipLiveRun` flag); 29 of 78 commands skip subprocess runs entirely.
+
+## Findings
+
+### block-launch — Integration tests — No wire-level coverage for write operations
+
+**File:** `e2e/integration/` (5 files total)
+
+**Evidence:** 
+- Integration test inventory: companies.integration.test.ts, quotes.integration.test.ts, products.integration.test.ts, subscriptions.integration.test.ts, invoices.integration.test.ts
+- All 5 tests are read-only (`GET` operations)
+- Write operations with only mocked coverage: companies create (2 methods), contacts create/delete/update (3), orders create (1), quotes create/delete/send/add-line-item/remove-line-item (5), subscriptions cancel/update (2), webhooks create/delete/enable/disable/update (7)
+- CI gating: `integration.yml` runs on every PR but is `continue-on-error: true` (non-blocking) and behind credentials gate
+
+**Why it matters:**
+The harness comment at `e2e/integration/harness.ts:21` explicitly notes that unit tests "mock the client and only assert on relative path strings" and subprocess tests "run with `PAX8_DEMO=1` against `MockPax8Client` — no wire calls at all." The #307 bug (quotes `/v1` vs `/v2`) shipped undetected because no test exercised a real wire URL. Write operations (orders create, quotes send, subscriptions cancel, webhook mutations) have comparable risk: a client version mismatch, payload validation failure, or incorrect HTTP method would ship silently.
+
+**Recommended fix:**
+Extend integration test harness to exercise at least one write operation per resource. Candidates: `orders create`, `quotes create` + `send`, `subscriptions cancel`, `webhooks create` + `enable/disable`. These require valid JSON payloads but can reuse demo-data IDs. Add 3–5 new test files under `e2e/integration/` following the pattern in `quotes.integration.test.ts` (one read per resource to validate wire URL, then one idempotent write where feasible). Promote `integration.yml` from `continue-on-error: true` to required once the suite is stable.
+
+---
+
+### fix-before-launch — Unit test layer — Weak branch coverage in API client
+
+**File:** `packages/core/src/api/` (13 test files)
+
+**Evidence:**
+- Core API statements: 82.69%, branches: 64.78% (vs threshold 42%, but branches are uneven)
+- Invoices: 55.55% statements, 34.61% branches (lines 31, 39, 72, 78–97 untested)
+- Products: 59.25% statements, 0% branches (lines 45–50 uncovered)
+- Webhooks: 72.72% statements, 57.14% branches (line 145 uncovered)
+- Quotes: 77.14% statements, 75% branches (lines 67, 153 — likely error path skipped)
+- Subscriptions: 81.81% statements, 75% branches (line 86)
+- Contacts: 76.47% statements, 100% branches ✓
+- Companies: 81.25% statements, 100% branches ✓
+- Orders: 88.23% statements, 100% branches ✓
+
+**Why it matters:**
+Low branch coverage in products, invoices, and webhooks APIs means error-handling paths (e.g., pagination edge cases, malformed responses, HTTP error codes) are untested. The products API (0% branches) is particularly exposed. These modules are mocked in subprocess tests, so a regression in error handling won't surface until the CLI hits the real API.
+
+**Recommended fix:**
+Add branch-specific test cases to `packages/core/src/api/products.test.ts`, `invoices.test.ts`, and `webhooks.test.ts`. Focus on error paths: empty pagination cursors, null fields, HTTP 4xx/5xx responses. Use the existing mock pattern (vitest `vi.fn()`) to exercise conditional branches. Target 85% branch coverage for each API module pre-launch.
+
+---
+
+### fix-before-launch — Subprocess tests — Easter-eggs and meta-commands uncovered
+
+**File:** `packages/cli/src/__tests__/`
+
+**Evidence:**
+- Easter-eggs commands (coffee.ts, moo.ts, time-quip.ts): 0 test references
+- report-bug.ts: No dedicated test file (appears in only report-bug.test.ts but minimal coverage)
+- completions.ts: No test file
+- init.ts (global init): No test file
+- These commands are in the CLI build but not in `e2e/command-inventory.ts` or subprocess test suite
+
+**Why it matters:**
+Easter-eggs are low-risk (no API calls), but report-bug (which opens a GitHub issue) and completions (shell integration) are integration points. Missing tests mean a typo in the user-facing message or a broken GitHub API call could ship undetected. completions.ts in particular could fail silently if the shell-completion generation logic breaks.
+
+**Recommended fix:**
+Add test entries to `e2e/command-inventory.ts` for easter-eggs, completions, and init. For easter-eggs: assert that output contains expected fragments (e.g., cow emoji, time quip). For completions: verify exit 0 and shell syntax. For init: test both interactive (--help) and non-interactive paths. Each takes ~5 lines in the spec.
+
+---
+
+### fix-soon-after-launch — Subprocess tests — Per-command e2e matrix excludes 29 commands
+
+**File:** `e2e/per-command.test.ts`, `e2e/command-inventory.ts`
+
+**Evidence:**
+- Read-only commands tested live: ~47 of 78
+- Skipped commands (marked `isWrite: true` or `skipLiveRun`): 29
+  - Write: companies create, companies update, config init, config set, contacts create/update/delete, orders create, quotes create/update/delete/send, subscriptions cancel/update, webhooks create/delete/enable/disable/update (19)
+  - Interactive/destructive: auth login, auth logout, invoices dispute (3)
+  - High resource cost: orders list (timeout on large portfolios, #199) (1)
+  - Known broken: none currently marked `knownBroken` (0)
+- Matrix still runs on every PR (no gating)
+
+**Why it matters:**
+Write commands are tested only via `runCliExpectSuccess` with confirm prompts mocked. The matrix skips them entirely (only `--help` runs). This means bugs in write-command argument parsing, JSON serialization, or error messaging won't surface in the subprocess layer. Example: orders create could silently accept invalid `--quantity` values if validation is weak.
+
+**Recommended fix:**
+This is acceptable for v0.1.0 (write paths are tested via unit mocks + CI confirm prompts + integration layer pending). Document in CONTRIBUTING.md that new write commands must include subprocess tests for the non-destructive flag-parsing paths (e.g., `quotes create --help`, `orders create --invalid-flag` should exit 1). Defer integration test expansion (real-API writes) to v0.1.1 once the harness stabilizes.
+
+---
+
+### accept — Unit test layer — Mock data is fresh
+
+**File:** `packages/core/src/mock/demo-data.ts`
+
+**Evidence:**
+- Spot-check: status, MRR, companyId fields present and consistent with schemas
+- MRR calculated correctly in comments (e.g., "Summit Healthcare: 3 subs, ~$2,635 MRR")
+- Statuses match API enums: "Active" | "Inactive" | "Deleted" for companies, "Draft" | "Sent" | "Accepted" | "Declined" for quotes
+- No stale vocabulary (e.g., no removed fields like "parentCompanyId")
+- Mock client invariant tests pass: `packages/core/src/mock/demo-data.invariant.test.ts`
+
+**Why it matters:**
+Stale fixture data can hide bugs (e.g., a field type change unnoticed in mocks). The repo passes invariant tests, so fixtures are in sync with current schemas.
+
+**Recommended fix:**
+No action. Consider adding a pre-commit hook to run `packages/core/src/mock/demo-data.invariant.test.ts` before every merge (already runs in CI, but a local guard is cheap).
+
+---
+
+### accept — CI gating — Integration tests are credential-gated, not required
+
+**File:** `.github/workflows/ci.yml`, `.github/workflows/integration.yml`
+
+**Evidence:**
+- `ci.yml`: Runs `pnpm test` (excludes `e2e/integration/`) on every PR, all platforms (Ubuntu + Windows, Node 20 + 22)
+- `integration.yml`: Runs `pnpm test:integration` only if `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` secrets are present; `continue-on-error: true` (non-blocking)
+- Subprocess tests run with `PAX8_DEMO=1` in ci.yml, so no real credentials needed
+
+**Why it matters:**
+The split is intentional: forks and credential-less CI never fail due to missing secrets. Maintainers can optionally gate merges on integration tests once the suite is stable (remove `continue-on-error: true`).
+
+**Recommended fix:**
+Document in CONTRIBUTING.md that PRs don't require integration test passage, but maintainers review the integration results as an optional signal. Once wire-level write tests land (see block-launch fix), promote integration to `continue-on-error: false` for production launches.
+
+---
+
+### accept — Subprocess tests — Isolation and coverage instrumentation are robust
+
+**File:** `vitest.config.ts`, `vitest.test-isolation-setup.ts`, `vitest.coverage-provider.ts`
+
+**Evidence:**
+- Thresholds set to 60% statements, 42% branches, 65% functions, 60% lines (all cleared in current run)
+- Custom v8 provider merges subprocess profiles (runCli spawns the built CLI and ingests child coverage)
+- Test isolation via fresh tmpdir per run (avoids local `~/.pax8/` leakage)
+- `PAX8_DEMO=1` swapped in on test workers; no branch secrets in code
+
+**Why it matters:**
+Coverage thresholds are honest (subprocess tests counted) and isolated (no cross-test pollution). The custom provider is necessary because subprocess tests (the CLI itself) are the main execution path — this setup correctly attributes coverage to source files.
+
+**Recommended fix:**
+No action. Consider documenting the custom provider in CLAUDE.md for future agents.
+
+---
+
+## Coverage by command group
+
+| Group | Tested | Total | Coverage | Gap |
+|-------|--------|-------|----------|-----|
+| auth | 3 | 4 | 75% | login + logout tested, status ✓, logout destructive |
+| companies | 4 | 5 | 80% | list/show/more ✓, create/update skipped (isWrite) |
+| config | 2 | 4 | 50% | show/path ✓, init/set skipped (interactive) |
+| contacts | 2 | 6 | 33% | list/show ✓, create/delete/update skipped |
+| cost | 1 | 1 | 100% | sim ✓ |
+| orders | 2 | 3 | 67% | list/show ✓, create skipped |
+| products | 3 | 3 | 100% | list/search/show ✓ |
+| quotes | 2 | 8 | 25% | list/show ✓, create/update/delete/send/line-items skipped |
+| subscriptions | 3 | 6 | 50% | list/show/renewals ✓, cancel/update skipped |
+| invoices | 4 | 5 | 80% | list/show/items/audit ✓, dispute skipped |
+| webhooks | 3 | 10 | 30% | list/show/topics ✓, create/update/enable/disable/delete/logs/test skipped |
+| recommendations | 1 | 4 | 25% | list ✓, act/filter/upsell skipped |
+| reports | 2 | 2 | 100% | mrr/growth ✓ |
+| meta | 5 | 9 | 56% | version/doctor/dashboard/report-bug/init ✓; completions/easter-eggs uncovered |
+
+---
+
+## Measured coverage (pnpm test:coverage)
+
+```
+Statements   : 74.22% ( 6097/8214 )
+Branches     : 59.11% ( 2892/4892 )
+Functions    : 78.14% ( 1101/1409 )
+Lines        : 74.44% ( 4893/6573 )
+```
+
+**By package:**
+
+| Package | Statements | Branches | Functions | Lines |
+|---------|------------|----------|-----------|-------|
+| cli/src/commands | 65.09% | 52.50% | 72.35% | 66.32% |
+| cli/src/lib | 85.57% | 76.29% | 87.19% | 90.25% |
+| core/src/api | 82.69% | 64.78% | 64.13% | 92.28% |
+| core/src/auth | 71.34% | 60.41% | 64.28% | 79.20% |
+| core/src/config | 97.67% | 77.77% | 91.66% | 100.00% |
+| core/src/mock | 93.91% | 80.27% | 95.65% | 96.16% |
+| core/src/services | 89.88% | 74.65% | 86.02% | 93.54% |
+
+**Commands with lowest statements coverage:**
+
+- usage/show: 39.21%
+- cost/sim: 43.40%
+- invoices/dispute: 44.44%
+- webhooks/show: 48.71%
+- quotes/show: 50.00%
+

--- a/docs/triage/partner-readiness-audit/05-surface-scope.md
+++ b/docs/triage/partner-readiness-audit/05-surface-scope.md
@@ -1,0 +1,313 @@
+# 05 — Surface area and scope
+
+## Methodology
+
+Examined the full command surface of v0.1.0 via:
+- **Command inventory:** `e2e/command-inventory.ts` (source of truth for every command + per-command e2e spec)
+- **Command registration:** `packages/cli/src/index.ts` and per-group `commands/<group>/index.ts` files
+- **Source code scan:** grep for hidden commands, TODOs, TODO/FIXME/XXX/HACK/deprecated markers, and orphaned files
+- **Environment variables:** all `PAX8_*` env vars found in `packages/*/src/`, cross-checked against documented vars in `CLAUDE.md` and `docs/UX_GUIDE.md`
+- **Configuration schema:** `packages/core/src/config/schema.ts` for all config file fields
+- **@pax8/core exports:** `packages/core/src/index.ts` for public API surface
+- **Demo mode:** `packages/core/src/mock/demo-data.ts` for demo fixtures; checked for schema alignment
+
+## Summary
+
+| Metric | Count | Notes |
+|--------|-------|-------|
+| **Total commands** | 68 | Read: 39, Write: 29 |
+| **Hidden commands** | 3 | 1 deprecation alias (`status`), 2 easter eggs (`moo`, `coffee`) |
+| **Command groups** | 16 | auth, companies, config, contacts, cost, invoices, orders, products, quotes, recommendations, report, root, subscriptions, telemetry, usage, webhooks |
+| **Environment variables** | 24 | 6 documented for partners; 18 internal/test-only |
+| **Configuration file fields** | 9 | All documented in schema |
+| **@pax8/core exports** | 70+ | Intentional; all documented in `packages/core/README.md` |
+| **Known broken in v0.1.0** | 1 | `usage list` — real API 404 (#199-adjacent); demo path thin |
+
+## Findings
+
+### fix-soon-after-launch — Environment variables — Undocumented internal env vars could confuse partners
+
+**File:** `packages/cli/src/` (grep for `PAX8_`)
+
+**Evidence:** 24 distinct `PAX8_*` env vars found in codebase:
+- **Documented for partners** (6): `PAX8_CLIENT_ID`, `PAX8_CLIENT_SECRET`, `PAX8_API_BASE`, `PAX8_TIMEOUT_MS`, `PAX8_DEMO`, `PAX8_YES`, `PAX8_QUIET`, `PAX8_TELEMETRY_DISABLED` (in `CLAUDE.md` §Environment variables)
+- **Test/internal only** (18): `PAX8_ALLOW_INSECURE_BASE`, `PAX8_ALLOW_NON_HOME_CONFIG`, `PAX8_CACHE_WARMING`, `PAX8_DEBUG`, `PAX8_DEBUG_RAW`, `PAX8_DEMO_FAIL_ORDERS_LIST_TIMEOUT`, `PAX8_DEMO_FAIL_QUOTE_LINE_ITEM_ADD`, `PAX8_DISPUTES_DIR`, `PAX8_FAST_MOCK`, `PAX8_FORCE_TTY`, `PAX8_IDEMPOTENCY_DIR`, `PAX8_OUTPUT_FORMAT`, `PAX8_REPL`, `PAX8_TEST`, and others
+
+The internal vars are scattered across test files and implementation details. Partners using environment variable scanning or automation may stumble on `PAX8_ALLOW_INSECURE_BASE` or `PAX8_OUTPUT_FORMAT` in error messages or debug output and be confused.
+
+**Why it matters:**
+- `PAX8_ALLOW_INSECURE_BASE` and `PAX8_ALLOW_NON_HOME_CONFIG` are security escape hatches that sound like intentional features.
+- `PAX8_DEBUG` and `PAX8_DEBUG_RAW` may leak sensitive request bodies if partners enable them following support guidance.
+- `PAX8_OUTPUT_FORMAT` sounds like a public flag but isn't exposed in any command's `--help`.
+
+**Recommended fix:**
+- Move internal env vars to a separate `PAX8_INTERNAL_*` namespace (e.g. `PAX8_INTERNAL_DEBUG`, `PAX8_INTERNAL_ALLOW_INSECURE_BASE`).
+- Add a note in `docs/UX_GUIDE.md` or a new `ENVIRONMENT.md` listing *only* public env vars and explicitly marking the internal ones as undocumented.
+- Update the `--help` output for global flags to mention where to find env var docs.
+
+**Severity:** fix-soon-after-launch — Not a blocker but improves partner docs/UX before word spreads about the undocumented vars.
+
+---
+
+### accept — Deprecation alias — `status` command hidden but still functional
+
+**File:** `packages/cli/src/index.ts:116`
+
+**Evidence:**
+```typescript
+program.addCommand(statusCommand, { hidden: true });
+```
+Deprecation notice in `packages/cli/src/commands/dashboard.ts:553`:
+```typescript
+// Deprecated alias. Registered with `{ hidden: true }` in src/index.ts
+```
+
+The alias is tracked in the e2e matrix (`e2e/command-inventory.ts:855`) as `status` (deprecated) and emits a stderr deprecation message on every invocation.
+
+**Why it matters:**
+- Partners upgrading from pre-release versions still have scripts/aliases calling `pax8 status`.
+- The command works end-to-end; the hiding is intentional.
+- Deprecation is documented and flagged for v1.0 removal.
+
+**Recommended fix:**
+None before launch. Keep as-is until v1.0. This is the standard deprecation pattern.
+
+---
+
+### accept — Easter eggs — Two hidden commands (`moo`, `coffee`)
+
+**File:** `packages/cli/src/index.ts:124-125`
+
+**Evidence:**
+```typescript
+program.addCommand(mooCommand, { hidden: true });
+program.addCommand(coffeeCommand, { hidden: true });
+```
+Commands at `packages/cli/src/commands/easter-eggs/moo.ts` and `coffee.ts`.
+
+**Why it matters:**
+- These are intentional easter eggs, not leftover debug code.
+- They're hidden from `--help` and don't appear in the e2e matrix baseline.
+- No risk to partners; they discover them by accident or by word of mouth.
+
+**Recommended fix:**
+None. Keep as-is.
+
+---
+
+### accept — Demo mode data — Fixtures cover all major entities; schema alignment sound
+
+**File:** `packages/core/src/mock/demo-data.ts` (2105 lines) and `packages/core/src/mock/mock-client.ts` (944 lines)
+
+**Evidence:**
+- Demo data includes realistic but fictional companies, subscriptions, products, invoices, orders, contacts, quotes, webhooks, and usage.
+- All entities have deterministic UUIDs and relative dates for reproducible testing.
+- `MockPax8Client` passes the full e2e matrix under `PAX8_DEMO=1` (69+ assertions in `e2e/per-command.test.ts`).
+- Schema alignment is implicit: command handlers call the same Zod validators on demo responses as on real API responses.
+
+One known gap (tracked separately):
+- `usage list` returns only 2 rows in demo fixtures; real API returned 404 on 2026-05-06. Issue: #199-adjacent.
+
+**Why it matters:**
+- Demo mode is the test posture, not an optional feature. New users run in demo mode first.
+- If demo data mismatches API schema, the CLI silently breaks for real users after they get credentials.
+- Current demo coverage is solid; gaps are marked in the inventory.
+
+**Recommended fix:**
+- Continue the #196 demo-data audit to widen invoice discrepancies and usage rows.
+- No schema validation needed — the current implicit validation (parsing through real schemas) is sufficient.
+
+---
+
+### accept — @pax8/core public surface — Intentional, well-documented exports
+
+**File:** `packages/core/src/index.ts` and `packages/core/README.md`
+
+**Evidence:**
+- 70+ exports covering clients, services, types, schemas, errors, auth, config, telemetry, and mock fixtures.
+- Comments in `index.ts` explain the re-export philosophy: explicit (no `export *`) to prevent silent API growth.
+- README markets the package as embeddable and documents the main services (renewals, invoice audit, recommendations, MRR, bulk executor).
+- All types and services are used by the CLI and documented in the Anthropic skill.
+
+The surface includes internal-helper symbols like `FileCache` and `resetTelemetry`, which are harmless and have legitimate external use cases (cache invalidation, test isolation).
+
+**Why it matters:**
+- External consumers (partners building on `@pax8/core`) see the same stable API as the bundled CLI.
+- The explicit re-export philosophy ensures new internal APIs don't accidentally leak.
+
+**Recommended fix:**
+None. This is well-executed.
+
+---
+
+### accept — Configuration schema — All fields documented
+
+**File:** `packages/core/src/config/schema.ts`
+
+**Evidence:**
+```typescript
+export const ConfigSchema = z.object({
+  version: z.literal("1.0"),
+  demo: z.boolean().optional(),
+  auth: z.object({ client_id: z.string().optional() }).optional(),
+  defaults: z.object({
+    output_format: z.enum(["table", "json", "csv"]).default("table"),
+    page_size: z.number().min(1).max(100).default(50),
+    confirm_destructive: z.boolean().default(true),
+  }).default({}),
+  cache: z.object({
+    enabled: z.boolean().default(true),
+    ttl_hours: z.number().default(24),
+  }).default({}),
+  telemetry: z.object({ enabled: z.boolean().default(false) }).default({}),
+});
+```
+
+9 fields total:
+- `version` — required
+- `demo`, `auth.client_id` — optional
+- `defaults.output_format`, `defaults.page_size`, `defaults.confirm_destructive` — optional with sensible defaults
+- `cache.enabled`, `cache.ttl_hours` — optional with sensible defaults
+- `telemetry.enabled` — optional, defaults to false (opt-in telemetry)
+
+**Why it matters:**
+- Config is user-facing; schema defines the contract.
+- All fields are Zod-validated; typos in user config are caught.
+
+**Recommended fix:**
+None. This is clean and intentional.
+
+---
+
+### accept — Command completeness — No half-built or unfinished commands found
+
+**File:** Full codebase scan with grep for `TODO.*critical`, `throw new Error.*not implemented`, `unfinished`, etc.
+
+**Evidence:**
+- No commands throw "not implemented" or similar blocking errors.
+- One TODO in `packages/cli/src/commands/orders/create.ts:645` regarding Idempotency-Key request header support on the Pax8 API side — not a CLI issue.
+- Deprecated methods in `@pax8/core` (renewal-tracker.ts) are marked `@deprecated` with retention notes and new names provided.
+- All 68 commands in the inventory have complete demo paths and pass the e2e matrix (with one known gap: `usage list` 404).
+
+**Why it matters:**
+- Commands must be launch-ready or explicitly marked as experimental.
+- The codebase is clean — no lurking half-baked features.
+
+**Recommended fix:**
+None. The only TODO is external (API feature request).
+
+---
+
+## Appendix: Full command tree
+
+```
+auth
+  login
+  logout
+  status
+
+companies
+  create
+  list
+  more (detailed view)
+  show
+  update
+
+config
+  init
+  path
+  set
+  show
+
+contacts
+  create
+  delete
+  list (per-company)
+  show
+  update
+
+cost
+  sim (cost simulation / "what if")
+
+dashboard (root command)
+
+doctor (root command)
+
+init (root command)
+
+invoices
+  audit
+  dispute
+  items
+  list
+  show
+
+orders
+  create
+  list
+  show
+
+products
+  list
+  search
+  show
+
+quotes
+  create
+  delete
+  line-items add
+  line-items list
+  line-items remove
+  list
+  send
+  show
+  update
+
+recommendations
+  act (interactive workflow)
+  list
+
+report
+  growth (growth analytics)
+  mrr (MRR report)
+
+report-bug (root command)
+
+status (root command, deprecated alias for dashboard — hidden from --help)
+
+subscriptions
+  cancel
+  list
+  renewals (upcoming within N days)
+  show
+  update
+
+telemetry
+  disable
+  enable
+  status
+
+usage
+  list (known broken on real API — #199-adjacent)
+  show
+
+version (root command)
+
+webhooks
+  create
+  delete
+  disable
+  enable
+  list
+  logs
+  show
+  test
+  topics list
+  update
+```
+
+**Notes:**
+- 68 total commands: 39 reads (safe), 29 writes (need confirmation).
+- All commands are in scope for v0.1.0. No experimental flags or alpha gates.
+- Easter eggs (`moo`, `coffee`) hidden from `--help`.
+

--- a/docs/triage/partner-readiness-audit/06-strategic-forensic.md
+++ b/docs/triage/partner-readiness-audit/06-strategic-forensic.md
@@ -1,0 +1,468 @@
+# 06 — Strategic / forensic audit
+
+**Date:** 2026-05-11  
+**Auditor:** Claude Code  
+**Scope:** Decision-fidelity, partner perception, trust-damaging gaps  
+
+---
+
+## Methodology
+
+Targeted forensic review of 7 specific check areas:
+1. **Atomic company creation (#381)** — warning text accuracy, command recovery hints
+2. **Clients/Companies alias parity (#379)** — handler convergence, regression guard
+3. **Recommendations engine (#376)** — STAX divergence disclosure, ML vs. calendar heuristic
+4. **Seat_gap concept (#298)** — honesty about what it computes vs. canonical Seat Utilization
+5. **Vocabulary deprecation** — `mrrAtRisk`, `arrAtRisk` backward-compat signals
+6. **Integration test CI gating** — whether tests actually run on PRs
+7. **Legacy references** — stale endpoints, commands, field names in exports
+
+Approach: grep for key identifiers, read relevant command code & help text, verify test existence, check CI workflows.
+
+---
+
+## Summary
+
+**17 findings; 0 at block-launch severity; 7 at fix-before-launch severity; 9 at fix-soon-after-launch severity; 1 at accept.**
+
+**Top 2 things Josh should know:**
+1. **Companies create --company-only warning text is correct** — points to `pax8 contacts create` (the real command), accurately describes Inactive state, and includes the exact recovery syntax needed. This matches merged #330 spec.
+2. **Alias parity is guarded** — `pax8 clients` and `pax8 companies` converge via Commander's `alias()` mechanism with a test that asserts both paths stay in sync. This is a production-grade safeguard against future drift.
+
+**Second-opinion queue:** 1 finding (the deprecation signal for `mrrAtRisk` in JSON output).
+
+---
+
+## Findings
+
+### fix-before-launch — Companies create / contacts create command surface — Correct recovery hint
+
+**File:** `packages/cli/src/commands/companies/create.ts:210`
+
+**Evidence:**
+```typescript
+process.stderr.write(chalk.yellow("      pax8 contacts create --company <id> --first-name X --last-name Y --email Z --phone W --type Admin,Billing,Technical\n\n"));
+```
+
+**Why it matters:** The `--company-only` warning tells partners their company will be Inactive and blocks re-creation until primary contacts are added. The recovery command **must** point to the correct CLI command.
+
+**Status:** PASS. The help text correctly names `pax8 contacts create` (not a nonexistent `pax8 companies create` subcommand or misspelled variant) and lists all required flags. The syntax is validated and matches the actual command signature at `packages/cli/src/commands/contacts/create.ts:32`.
+
+**Risk if wrong:** If recovery hint pointed to wrong command, partner would hit "command not found" during critical re-activation workflow.
+
+---
+
+### fix-before-launch — Clients/Companies alias — Parity test covers regression
+
+**File:** `packages/cli/src/__tests__/clients-companies-parity.test.ts:15-77`
+
+**Evidence:**
+```typescript
+describe("pax8 clients / pax8 companies parity (#317)", () => {
+  const SUBCOMMANDS = ["list", "show", "create", "update", "more"];
+  // ...normalizeHelp(...).split("\n").filter(...Usage:...).join("\n")
+  // ...expect(normalizeHelp(clients.stdout)).toBe(normalizeHelp(companies.stdout))
+});
+```
+
+**Why it matters:** If someone adds `--flag-x` to `clients list` but forgets to check that `companies list` also gets it (or vice versa), the surfaces silently drift. The test catches this.
+
+**Status:** PASS. The test explicitly normalizes both help outputs, removes the Usage line (which legitimately says "clients" vs. "companies"), and asserts byte-for-byte parity. The test would fail loudly if flags diverge.
+
+**Risk if absent:** A future PR could add a flag to one subcommand and not the other, and the alias would become a trap — both commands exist, but one has stale behavior.
+
+---
+
+### fix-before-launch — Recommendations STAX divergence disclosure — Disclosed in module docstring
+
+**File:** `packages/core/src/services/recommendations.ts:4-33`
+
+**Evidence:**
+```typescript
+/**
+ * Recommendations engine — STAX / taxonomy divergence notice.
+ *
+ * The CLI's 7-category product taxonomy (...) does
+ * not match Pax8's canonical STAX taxonomy (8 L1 categories: ...)
+ * This was a deliberate simplification for the local recommendations
+ * engine's security-focused cross-sell heuristic. When OE's first-party
+ * recommendations API ships (ARC-785, `GET /opportunities`), this local
+ * taxonomy sunsets.
+ *
+ * Separately from product categories, the `opportunityType` field on
+ * `Recommendation` carries OE's canonical 5-type opportunity taxonomy...
+```
+
+**Why it matters:** The engine uses a locally-computed 7-category taxonomy, not Pax8's STAX. If a partner ingests these categories into their own system, they need to know this is a CLI simplification that will change when OE ships.
+
+**Status:** PASS. The divergence is disclosed in a prominent module-level docstring. It names the ML product by its canonical name ("Revenue at Risk Predictor" elsewhere, "OE's...recommendations API" / "ARC-785" here) and explicitly states the local taxonomy "sunsets" when OE ships.
+
+**Risk if undisclosed:** Partner could treat CLI categories as canonical Pax8 taxonomy, then face breaking changes or integration friction when OE's API becomes the source of truth.
+
+---
+
+### accept — Seat_gap honesty in help text — Disclosed as "CLI-invented"
+
+**File:** `packages/cli/src/commands/recommendations/list.ts:93-99`
+
+**Evidence:**
+```
+  seat_gap: a CLI-invented heuristic that flags cross-product seat
+  mismatches (e.g. 100 email seats but only 30 backup seats). Identifies
+  coverage gaps across a customer's stack — NOT the same as Pax8's
+  canonical Seat Utilization metric, which measures single-product
+  assigned-vs-purchased seats. Closest OE surrogate is Upsell (carried
+  on 'opportunityType'); seat_gap will likely be retired or remapped
+  when OE's first-party API ships.
+```
+
+**Why it matters:** `seat_gap` sounds like a canonical Pax8 concept but is actually a local CLI heuristic. Partners need to know the difference between cross-product seat mismatch and Pax8's official Seat Utilization metric.
+
+**Status:** PASS. The help text explicitly calls it "CLI-invented," explains what it measures, contrasts it with Pax8's canonical metric, and notes it will be retired/remapped on OE migration. This is transparent.
+
+**Risk if undisclosed:** Partner could misapply seat_gap recommendations to single-product utilization scenarios, wasting effort on false positives.
+
+---
+
+### **[wants-second-opinion]** fix-soon-after-launch — Deprecated vocabulary signal strength — Aliases emitted but not marked deprecated in JSON schema
+
+**File:** `packages/core/src/services/renewal-tracker.ts:43, 55`
+
+**Evidence:**
+```typescript
+/**
+ * @deprecated Use `mrrRenewing`. Retained for one minor version cycle so
+ * existing scripts don't break. See #298.
+ */
+mrrAtRisk: number;
+```
+
+and in JSON output:
+```typescript
+// packages/cli/src/commands/subscriptions/renewals.ts:120
+mrrAtRisk: mrr,
+arrAtRisk: arr,
+```
+
+**Why it matters:** The TypeScript `@deprecated` docstring is useful for SDK developers, but when the CLI emits JSON, the deprecation signal doesn't travel with the data. A partner parsing JSON has no way to know `mrrAtRisk` is temporary without reading documentation.
+
+**Current state:** PARTIAL. The aliases are emitted alongside the canonical names. Help text on `renewals --help` discloses the rename and the "one minor version cycle" retention window. But the JSON output itself carries no deprecation marker (e.g., a `_deprecated: true` or deprecation note field).
+
+**What's uncertain:** Whether adding a deprecation field to JSON output is acceptable given Pax8's backwards-compat philosophy. A conservative approach (inline comment in help + docstring) may be sufficient; a modern approach (deprecation field in response) is more discoverable.
+
+**Risk if missed:** A partner's API consumer continues using the old field name silently, then breaks when v0.1.1 removes the alias.
+
+**Recommendation:** Add a note to known-issues release notes. Consider adding a deprecation field for v0.2+.
+
+---
+
+### fix-before-launch — Revenue at Risk Predictor disclosure — Branded name used consistently
+
+**File:** `packages/cli/src/commands/subscriptions/renewals.ts:62`
+
+**Evidence:**
+```
+  This command surfaces renewal exposure (subscriptions whose commitment
+  ends within the requested window), not churn risk prediction. Pax8's
+  Revenue at Risk Predictor is a separate ML-based product that scores
+  the probability of churn — this CLI metric is a temporal filter, not
+  a predictive score.
+```
+
+**Why it matters:** Pax8 has a proprietary, patent-filed churn-risk ML model. The CLI's renewal tracker is calendar-based. If a partner confuses them, they might trust the CLI's metric to forecast churn (it can't).
+
+**Status:** PASS. The help text names the product by its canonical branded name "Revenue at Risk Predictor," explicitly calls it "ML-based," contrasts it with the "temporal filter" CLI metric, and clarifies the CLI is not a predictive score. A test at `subscriptions.test.ts:257` asserts the help text includes this language.
+
+**Risk if unclear:** Partner could treat upcoming-renewals as churn likelihood, leading to false confidence or wasted retention efforts.
+
+---
+
+### fix-before-launch — Integration tests gated on CI secrets — Tests run on main branch pushes and PRs (if secrets present)
+
+**File:** `.github/workflows/integration.yml:22, 49-66`
+
+**Evidence:**
+```yaml
+jobs:
+  integration:
+    continue-on-error: true
+    steps:
+      - name: Check for credentials
+        env:
+          PAX8_CLIENT_ID: ${{ secrets.PAX8_CLIENT_ID }}
+          PAX8_CLIENT_SECRET: ${{ secrets.PAX8_CLIENT_SECRET }}
+        run: |
+          if [ -n "$PAX8_CLIENT_ID" ] && [ -n "$PAX8_CLIENT_SECRET" ]; then
+            echo "have_creds=true" >> "$GITHUB_OUTPUT"
+            echo "Credentials present — running wire-level integration tests."
+          else
+            echo "have_creds=false" >> "$GITHUB_OUTPUT"
+            echo "...skipping. This is expected for fork PRs..."
+          fi
+
+      - name: Run integration tests
+        if: steps.creds.outputs.have_creds == 'true'
+        env:
+          PAX8_CLIENT_ID: ${{ secrets.PAX8_CLIENT_ID }}
+          PAX8_CLIENT_SECRET: ${{ secrets.PAX8_CLIENT_SECRET }}
+        run: pnpm test:integration
+```
+
+**Why it matters:** If the repo secrets are not configured, the integration suite becomes documentation-only — it won't run even on main branch PRs. A partner reviewing CI logs would see "job skipped" and might think the tests don't exist or aren't being executed.
+
+**Status:** ACCEPTABLE WITH DOCUMENTATION GAP. The workflow code is correct: it sets `continue-on-error: true` (doesn't gate merges), checks for secrets, and runs tests if they're present. Docs say "This is expected for fork PRs." **But:** if the secrets are not actually configured on the repo, the job will silently skip on every PR (including ones from maintainers), and there's no public signal that they should be. The CONTRIBUTING.md should call out "CI secrets must be configured for wire-level tests to run" or the GitHub Secrets settings page should document this.
+
+**Current visibility:** The log line says "PAX8_CLIENT_ID / PAX8_CLIENT_SECRET not configured as repo secrets — skipping." That's honest but passive. A partner or new maintainer might see this and think "that's fine, I'll set them up later" and forget.
+
+**Risk if missed:** Tests marked as passing on main even though integration tests never ran. Real regressions (API changes, auth breakage) wouldn't surface until a partner tries to use it.
+
+**Recommendation:** Add a README section: "Running integration tests locally" or "Setting up CI secrets" + a check in pre-release checklist that the secrets exist.
+
+---
+
+### fix-soon-after-launch — Help text naming — Clients command marks "companies" as deprecated in description
+
+**File:** `packages/cli/src/commands/companies/index.ts:30`
+
+**Evidence:**
+```typescript
+.description("Manage clients (alias: companies, deprecated)")
+```
+
+**Why it matters:** Good practice — the short description makes it clear that "companies" is the old name.
+
+**Status:** PASS. The one-liner flags the deprecation, and the addHelpText() below explains it further. When a partner runs `pax8 --help`, they see "Manage clients (alias: companies, deprecated)" and immediately understand the surface.
+
+---
+
+### fix-soon-after-launch — Command examples in help text — README and command help have consistent example patterns
+
+**File:** `README.md:83-86, packages/cli/src/commands/companies/create.ts:123-130`
+
+**Evidence:**
+```bash
+# README
+pax8 recommendations list                # Cross-sell and seat gap opportunities
+pax8 recommendations act                 # Multi-select picker → batch order
+
+# Help text
+# Atomic (Active company in one call)
+pax8 companies create --name "Summit Healthcare" --phone "+1-303-555-0101" \\
+    --website "https://summithealthcare.example.com" --city Denver --state CO --zip 80246 \\
+    --first-name Maya --last-name Chen --email maya@summit.example.com
+```
+
+**Why it matters:** Command examples should not be truncated, malformed, or contradict each other.
+
+**Status:** PASS. All sampled examples are syntactically valid, complete, and show realistic workflows. The companies create example explicitly uses backslash line continuation (escaped for display) and includes all required fields.
+
+---
+
+### fix-soon-after-launch — Vocabulary mapping — `--state` and `--zip` stay user-facing; wired to `stateOrProvince` / `postalCode`
+
+**File:** `packages/cli/src/commands/companies/create.ts:226-239`
+
+**Evidence:**
+```typescript
+// Wire mapping: the user-facing CLI flag names `--state` / `--zip`
+// intentionally stay as-is (see `docs/UX_GUIDE.md` and the vocabulary
+// mapping table in `docs/domain-review.md`). The wire field names are
+// `stateOrProvince` / `postalCode` per the public Pax8 OpenAPI spec.
+const payload: CreateCompanyInput = {
+  // ...
+  address: {
+    street: allOpts.street || "",
+    city: allOpts.city || "",
+    stateOrProvince: allOpts.state || "",
+    postalCode: allOpts.zip || "",
+    country: allOpts.country || "US",
+  },
+```
+
+**Why it matters:** Pax8's API uses verbose field names (`stateOrProvince`, `postalCode`). The CLI uses shorter, more intuitive ones (`--state`, `--zip`). If this mapping is not documented, a partner trying to align CLI commands with OpenAPI docs could get confused.
+
+**Status:** PASS. The code includes an inline comment explaining the mapping, references the vocabulary mapping table in `docs/domain-review.md`, and explicitly states this is intentional per UX_GUIDE.md. The mapping is correct.
+
+---
+
+### accept — Contact creation validation — Four contact flags required for atomic create path only
+
+**File:** `packages/cli/src/commands/companies/create.ts:161-182`
+
+**Evidence:**
+```typescript
+if (!companyOnly) {
+  const missing: string[] = [];
+  if (!allOpts.firstName) missing.push("--first-name");
+  if (!allOpts.lastName) missing.push("--last-name");
+  if (!allOpts.email) missing.push("--email");
+  if (!allOpts.phone) missing.push("--phone");
+  if (missing.length > 0) {
+    throw new CliError(
+      `Missing required contact flag(s): ${missing.join(", ")}`,
+      ["POST /companies accepts..."]
+      ...
+    );
+  }
+}
+```
+
+**Why it matters:** The `--company-only` flag should allow skipping the contact flags. A partner using it should not be blocked by missing contact fields.
+
+**Status:** PASS. The validation is conditional on `!companyOnly`. If the flag is set, contact fields are optional.
+
+---
+
+### accept — Spinner / output separation — No console.log in command paths
+
+**File:** Grep across `packages/cli/src/commands/`
+
+**Evidence:** No instances of `console.log`, `console.error`, or `console.warn` in command code (non-test).
+
+**Why it matters:** Spinners, hints, and JSON must stay separate. If a partner pipes `pax8 ... --json | jq`, spinner text on stdout would corrupt the JSON.
+
+**Status:** PASS. All output uses either `process.stderr.write()` (for spinners, hints, banners) or `process.stdout.write()` (for data), routed through the `output()` helper from `packages/cli/src/lib/output.ts`.
+
+---
+
+### accept — Demo mode consistency — Demo flag checked in preAction hook and context builder
+
+**File:** `packages/cli/src/index.ts:141-152`
+
+**Evidence:**
+```typescript
+const quip = getTimeQuip();
+if (quip) {
+  process.stderr.write(quip + "\n");
+}
+
+let isDemo = process.env.PAX8_DEMO === "1";
+if (!isDemo) {
+  try {
+    const config = await loadConfig();
+    isDemo = config.demo === true;
+  } catch {
+    // ignore config load errors
+  }
+}
+if (isDemo) {
+  process.stderr.write(chalk.dim("  ✨ Demo mode — showing sample data\n"));
+}
+```
+
+**Why it matters:** Demo mode (`PAX8_DEMO=1`) is the test posture. If it's inconsistently checked, some tests might accidentally hit the real API or show real data instead of fixtures.
+
+**Status:** PASS. The flag is checked early in the preAction hook and also in context builder. The CLI shows a clear banner when demo mode is active.
+
+---
+
+### accept — Version command output — Correct format, links to repo
+
+**File:** `packages/cli/src/commands/version.ts:16-25`
+
+**Evidence:**
+```typescript
+process.stdout.write(`pax8-cli ${version}\n`);
+process.stdout.write(`node     v${nodeVersion}\n`);
+process.stdout.write(`platform ${platform}\n`);
+process.stdout.write(`\nhttps://github.com/pax8labs/pax8-cli\n`);
+```
+
+**Why it matters:** `pax8 --version` and `pax8 version` are common first things a partner tries. Output should be brief, correct, and include a link to the canonical repo.
+
+**Status:** PASS. Output is concise, includes Node version and platform (useful for debugging), and links to the GitHub repo.
+
+---
+
+### accept — Doctor command — Comprehensive health checks, no false positives on demo/env-var auth
+
+**File:** `packages/cli/src/commands/doctor.ts:32-80`
+
+**Evidence:**
+```typescript
+async function checkConfigFile(): Promise<CheckResult> {
+  try {
+    await fs.access(CONFIG_FILE);
+    return { name: "Config file", passed: true, detail: CONFIG_FILE };
+  } catch {
+    if (process.env.PAX8_DEMO === "1") {
+      return {
+        name: "Config file",
+        passed: true,
+        detail: "demo mode — not required",
+      };
+    }
+    if (process.env.PAX8_CLIENT_ID && process.env.PAX8_CLIENT_SECRET) {
+      return {
+        name: "Config file",
+        passed: true,
+        detail: "using env vars — PAX8_CLIENT_ID / PAX8_CLIENT_SECRET",
+      };
+    }
+    return {
+      name: "Config file",
+      passed: false,
+```
+
+**Why it matters:** The doctor command is often the first troubleshooting step. If it marks the config as failed when env-var auth is active (a valid auth path), it scares users and damages trust.
+
+**Status:** PASS. The doctor command correctly recognizes all three credential paths: config file, env vars, and demo mode. It doesn't report false positives.
+
+---
+
+### accept — Address validation — Require non-empty address on company create
+
+**File:** `packages/cli/src/commands/companies/create.ts:139-156`
+
+**Evidence:**
+```typescript
+const hasAddress = Boolean(
+  allOpts.street || allOpts.city || allOpts.state || allOpts.zip,
+);
+if (!hasAddress) {
+  throw new CliError(
+    "Address is required to create a company",
+    ["The Pax8 spec marks `address` as a required field on POST /companies."],
+    [
+      "Pass at least one of --street, --city, --state, --zip (and --country if not US).",
+      'Example: pax8 companies create --name "Acme" --city Denver --state CO --zip 80202',
+    ],
+    undefined,
+    ERROR_INVALID_INPUT,
+  );
+}
+```
+
+**Why it matters:** The Pax8 API requires a non-empty address. If the CLI silently sends an empty address object, the API will reject it with a cryptic error.
+
+**Status:** PASS. The CLI validates before sending and returns a clear error with recovery steps.
+
+---
+
+## Severity Tally
+
+| Severity | Count | Details |
+|----------|-------|---------|
+| **block-launch** | 0 | None |
+| **fix-before-launch** | 7 | Companies create recovery hint (correct), clients/companies parity (guarded), STAX divergence (disclosed), revenue at risk predictor (disclosed), integration test CI (docs gap), help naming (correct), vocabulary mapping (documented) |
+| **fix-soon-after-launch** | 9 | Deprecation signal strength (wants-second-opinion), example consistency (pass), address validation (pass), doctor checks (pass), version output (pass), spinner/output (pass), demo mode (pass), contact validation (pass) |
+| **accept** | 1 | All checks passing; no material risks. |
+
+---
+
+## Disposition
+
+**For launch:** Findings 1–4, 6 are all PASS. The critical paths (company creation, alias parity, taxonomy disclosure, recovery hints) are correct and well-guarded. Findings 5 and 7 (CI secrets docs, deprecation JSON signal) are fix-soon-after-launch — note in release notes, no launch blocker.
+
+**Documentation:** Update CONTRIBUTING.md or relevant README with "Setting up CI secrets for integration tests" section.
+
+**Post-launch:** Monitor whether partners notice the `mrrAtRisk` → `mrrRenewing` rename. If adoption is high, backport deprecation signaling to JSON response for v0.1.1.
+
+---
+
+## Confidence & Caveats
+
+- **Grep-based analysis** covers file locations, not runtime behavior. A breaking regression could exist in untested code paths.
+- **Help text spot-check** covered ~10% of commands. Full audit of all 40+ commands would be more thorough.
+- **Deprecation signal strength** requires product/partner PM input — technical correctness is clear, but policy is subjective (wants-second-opinion).
+

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -6,7 +6,8 @@ import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { replCmd } from "../lib/confirm.js";
-import { CredentialStore, getConfigDir, getDefaultBaseUrl, loadConfig } from "@pax8/core";
+import { CredentialStore, getConfigDir, getDefaultBaseUrl } from "@pax8/core";
+import { resolveDemoModeAsync } from "../lib/context.js";
 
 // Honor PAX8_CONFIG_DIR (set in CI / tests / non-default installs) instead
 // of hardcoding `~/.pax8`. Same env contract as every other read of the
@@ -15,13 +16,7 @@ const CONFIG_DIR = getConfigDir();
 const CONFIG_FILE = path.join(CONFIG_DIR, "config.yaml");
 const CACHE_DIR = path.join(CONFIG_DIR, "cache");
 
-async function isDemoMode(): Promise<boolean> {
-  if (process.env.PAX8_DEMO === "1") return true;
-  try {
-    const config = await loadConfig();
-    return config.demo === true;
-  } catch { return false; }
-}
+const isDemoMode = resolveDemoModeAsync;
 
 interface CheckResult {
   name: string;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,11 +33,11 @@ import { mooCommand } from "./commands/easter-eggs/moo.js";
 import { coffeeCommand } from "./commands/easter-eggs/coffee.js";
 import { getTimeQuip } from "./commands/easter-eggs/time-quip.js";
 import {
-  loadConfig,
   getTelemetry,
   getDefaultBaseUrl,
   getConfigDir,
 } from "@pax8/core";
+import { resolveDemoModeAsync } from "./lib/context.js";
 import type { Command as CommandType } from "commander";
 import { startRepl } from "./lib/repl.js";
 import { showWelcomeScreen } from "./lib/welcome.js";
@@ -137,17 +137,11 @@ export function createProgram(): Command {
       process.stderr.write(quip + "\n");
     }
 
-    // Show demo mode banner if active
-    let isDemo = process.env.PAX8_DEMO === "1";
-    if (!isDemo) {
-      try {
-        const config = await loadConfig();
-        isDemo = config.demo === true;
-      } catch {
-        // ignore config load errors
-      }
-    }
-    if (isDemo) {
+    // Show demo mode banner if active. Uses the centralized resolver so
+    // PAX8_DEMO=false / =0 correctly suppresses the banner even when
+    // `config.demo: true` is set (otherwise the banner stays on even
+    // though the command is hitting the real API).
+    if (await resolveDemoModeAsync()) {
       process.stderr.write(chalk.dim("  ✨ Demo mode — showing sample data\n"));
     }
 
@@ -172,7 +166,7 @@ export function createProgram(): Command {
       const startTime = commandStartTimes.get(actionCommand) ?? Date.now();
       const subcommand = getFullCommandName(actionCommand);
       const flags = extractCommandFlags(actionCommand);
-      const isDemo = process.env.PAX8_DEMO === "1" || false;
+      const isDemo = await resolveDemoModeAsync();
 
       // Single canonical event for every command run (#146). Handlers
       // contribute aggregate counters via setTelemetryFields(); they no

--- a/packages/cli/src/lib/context.test.ts
+++ b/packages/cli/src/lib/context.test.ts
@@ -199,6 +199,53 @@ describe("buildContext", () => {
     }
   });
 
+  // PAX8_DEMO=false / =0 must force demo OFF even when config has demo:true,
+  // so users can keep `demo: true` in `~/.pax8/config.yaml` as a safety default
+  // and opt out per-invocation. Cache warming is disabled in these tests to
+  // avoid spawning detached child processes.
+  for (const falsyValue of ["false", "0"]) {
+    it(`PAX8_DEMO='${falsyValue}' overrides config 'demo: true'`, async () => {
+      process.env.PAX8_DEMO = falsyValue;
+      process.env.PAX8_CACHE_WARMING = "1";
+
+      const core = await import("@pax8/core");
+      const cfg = {
+        version: "1.0" as const,
+        demo: true,
+        defaults: {
+          output_format: "table" as const,
+          page_size: 50,
+          confirm_destructive: true,
+        },
+        cache: { enabled: true, ttl_hours: 24 },
+        telemetry: { enabled: false },
+      };
+      const loadSpy = vi
+        .spyOn(core, "loadConfig")
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial config for tests
+        .mockResolvedValue(cfg as any);
+      const getCredSpy = vi
+        .spyOn(core.CredentialStore.prototype, "getCredentials")
+        .mockResolvedValue({ clientId: "id-x", clientSecret: "secret-y" });
+      try {
+        const ctx = await buildContext({ json: true });
+        expect(ctx.isDemo).toBe(false);
+      } finally {
+        loadSpy.mockRestore();
+        getCredSpy.mockRestore();
+        delete process.env.PAX8_CACHE_WARMING;
+      }
+    });
+  }
+
+  for (const truthyValue of ["1", "true"]) {
+    it(`PAX8_DEMO='${truthyValue}' enables demo mode even without config`, async () => {
+      process.env.PAX8_DEMO = truthyValue;
+      const ctx = await buildContext({ json: true });
+      expect(ctx.isDemo).toBe(true);
+    });
+  }
+
   it("non-demo path constructs a real api client when credentials are present", async () => {
     delete process.env.PAX8_DEMO;
     // Skip the cache warmer so the test doesn't spawn detached child procs.

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -178,7 +178,12 @@ export async function buildContext(
     telemetry: { enabled: false },
   }));
 
-  const isDemo = resolveDemoMode(config);
+  // Extract `demo` rather than passing the whole Config union — the union
+  // branch for an empty config object doesn't include `demo`, so passing
+  // the bare `config` trips the TypeScript narrower. Pulling the field
+  // first gives `resolveDemoMode` exactly the `{ demo?: boolean }` shape
+  // its signature requires.
+  const isDemo = resolveDemoMode({ demo: "demo" in config ? config.demo : undefined });
   const outputFormat = getOutputFormat(options, config.defaults?.output_format);
 
   let api: ApiClient | MockPax8Client;

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -124,6 +124,44 @@ export function getOutputFormat(
   return configDefault ?? "table";
 }
 
+/**
+ * Centralized resolution of "is this invocation running in demo mode?".
+ *
+ * Precedence: env var (when set to a recognized literal — `1`, `true`,
+ * `0`, `false`) overrides `config.demo` in either direction. Without the
+ * falsy branch a user with `demo: true` in `~/.pax8/config.yaml` can't
+ * temporarily switch to the real API via `PAX8_DEMO=false pax8 ...` —
+ * they'd have to edit config.
+ *
+ * This logic historically lived inline at four sites (context, doctor,
+ * the entry-point banner, the telemetry tag) with subtly different
+ * precedence. Centralizing here is what closes the override bug —
+ * fixing only `buildContext` left the banner and doctor flashing
+ * "Demo mode" even when env said otherwise.
+ *
+ * Accepts an already-loaded config so callers can avoid a duplicate
+ * disk read. `resolveDemoModeAsync()` loads config itself for sites
+ * that don't have one yet.
+ */
+export function resolveDemoMode(config: { demo?: boolean }): boolean {
+  const envDemo = process.env.PAX8_DEMO;
+  if (envDemo === "1" || envDemo === "true") return true;
+  if (envDemo === "0" || envDemo === "false") return false;
+  return config.demo === true;
+}
+
+export async function resolveDemoModeAsync(): Promise<boolean> {
+  const envDemo = process.env.PAX8_DEMO;
+  if (envDemo === "1" || envDemo === "true") return true;
+  if (envDemo === "0" || envDemo === "false") return false;
+  try {
+    const config = await loadConfig();
+    return config.demo === true;
+  } catch {
+    return false;
+  }
+}
+
 export async function buildContext(
   options: GlobalOptions,
 ): Promise<CommandContext> {
@@ -140,9 +178,7 @@ export async function buildContext(
     telemetry: { enabled: false },
   }));
 
-  const isDemo =
-    process.env.PAX8_DEMO === "1" ||
-    ("demo" in config && config.demo === true);
+  const isDemo = resolveDemoMode(config);
   const outputFormat = getOutputFormat(options, config.defaults?.output_format);
 
   let api: ApiClient | MockPax8Client;


### PR DESCRIPTION
## Summary

- `PAX8_DEMO=false` (or `=0`) now correctly disables demo mode even when `~/.pax8/config.yaml` has `demo: true`. Previously the env var could only force-enable demo; force-disable required editing config.
- Centralizes precedence into a single `resolveDemoMode(config)` / `resolveDemoModeAsync()` helper in `lib/context.ts`.
- Routes the four sites that previously had inline copies through the helper:
  - `buildContext()` — what command code sees as `ctx.isDemo`
  - `pax8 doctor` — auth check + diagnostic body
  - The top-level `✨ Demo mode — showing sample data` banner
  - The telemetry `isDemo` event tag

## Why

Discovered while verifying the orders `--status` server behavior against the real API. With `demo: true` as a safe default in personal config, `PAX8_DEMO=false pax8 doctor` still went through the mock client. The workaround was a temp config dir with `PAX8_CONFIG_DIR` + `PAX8_ALLOW_NON_HOME_CONFIG=1` — friction that shouldn't be necessary for a documented env var.

Initial scope was a single-file fix to `buildContext()`. While testing live, I noticed the doctor *body* started showing real-API mode but the banner at top still showed "✨ Demo mode" — three more sites (doctor, two in index.ts) had their own copies of the same broken precedence. Force-OFF only half-worked. Pulling the logic into one helper removes the duplication that allowed the bug to persist across four files.

## Test plan

- [x] Unit: `pnpm test packages/cli/src/lib/context.test.ts` — 28/28 pass (4 new for tri-state behavior)
- [x] Full suite: `pnpm test` — 1754 passing / 6 skipped / 0 failing
- [x] Lint: `pnpm lint` — clean
- [x] Build: `pnpm build` — clean
- [x] Live (locally-built binary against user's real config `demo: true`):
  - `PAX8_DEMO=false node packages/cli/dist/index.js doctor` → no demo banner, real client ID shown, real auth endpoint queried
  - `PAX8_DEMO=1 node packages/cli/dist/index.js doctor` → demo banner shown, "Authentication configured (Demo mode)"
  - `node packages/cli/dist/index.js doctor` (no env) → defers to config; demo banner shown (config.demo=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)