### PR TITLE
fix(orders): drop Status column; mark --status as documented no-op

### DIFF
--- a/.changeset/orders-list-drop-status-column.md
+++ b/.changeset/orders-list-drop-status-column.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+`pax8 orders list` no longer renders an `Status` column in the default table output. Wire-level testing against the real Pax8 API on 2026-05-11 confirmed (a) the `Order` schema has no `status` field on `GET /orders` or `GET /orders/{id}`, and (b) the server silently ignores `?status=` (every value, including bogus ones like `NotAStatus`, returns the full unfiltered set). The column previously rendered a gray em-dash for every row against real prod data; the `--status` flag is retained as a documented no-op for backwards compatibility with partner scripts. Help text and the inline source comment now reflect the verified behavior, and `docs/triage/orders-status-server-behavior.md` captures the methodology. Tracking eventual API-side resolution in #369.

--- a/packages/cli/src/__tests__/orders.test.ts
+++ b/packages/cli/src/__tests__/orders.test.ts
@@ -157,17 +157,16 @@ describe("pax8 orders", () => {
       expect(result.stdout).toContain("--page");
     });
 
-    // #250: the public Pax8 OpenAPI does not declare `Order.status` nor a
-    // `status` query parameter on `GET /orders`. The help text must NOT
-    // present the observed values as if they were a documented contract.
-    it("--status help honestly flags that the field is not in the public OpenAPI (#250)", async () => {
+    // Help text must disclose two facts about --status now:
+    //   (a) the field isn't in the public OpenAPI (#250 contract)
+    //   (b) the server silently ignores the filter — verified 2026-05-11
+    //       against the real API; see docs/triage/orders-status-server-behavior.md.
+    // The flag itself is retained so existing partner scripts keep working.
+    it("--status help honestly flags that the field is not in the public OpenAPI and the server ignores it", async () => {
       const result = await runCliExpectSuccess(["orders", "list", "--help"]);
-      // The flag itself remains so existing partner scripts keep working.
       expect(result.stdout).toContain("--status");
-      // The help text MUST disclose that the field is not in the spec.
-      // Match either phrasing variant to keep the assertion flexible
-      // without losing the contract.
-      expect(result.stdout).toMatch(/not in public OpenAPI|observed|undocumented/i);
+      expect(result.stdout).toMatch(/not\s+in\s+public\s+OpenAPI|observed|undocumented/i);
+      expect(result.stdout).toMatch(/no-op|ignores|silently dropped/i);
       // Bare-list framing (pre-#250) must not regress.
       expect(result.stdout).not.toMatch(
         /Filter by status \(Completed, Processing, Failed, PendingManual\)/

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -9,7 +9,7 @@ import { CliError, handleCommandError, timeoutRecoverySteps } from "../../lib/er
 import { buildContext } from "../../lib/context.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { output, type Column } from "../../lib/output.js";
-import { formatStatus, formatDate } from "../../lib/formatters.js";
+import { formatDate } from "../../lib/formatters.js";
 import { enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 
 const columns: Column[] = [
@@ -17,22 +17,25 @@ const columns: Column[] = [
   { key: "companyName", header: "Company" },
   { key: "orderedBy", header: "Ordered By" },
   { key: "createdDate", header: "Date", format: (v) => formatDate(String(v)) },
-  { key: "status", header: "Status", format: (v) => formatStatus(String(v)) },
   { key: "lineItems", header: "Items", format: (v) => String(Array.isArray(v) ? v.length : 0) },
 ];
 
 export const ordersListCommand = new Command("list")
   .description("List orders")
   .option("--company <id|name>", "Filter by company ID or name")
-  // Honesty note (#250): the public Pax8 OpenAPI does NOT document a `status`
-  // field on `Order` nor a `status` query parameter on `GET /orders`. The
-  // values below are observed in real API responses (and mirrored by the demo
-  // fixtures) but are NOT part of the published contract — they may change
-  // without notice. The flag is kept so partner scripts that already use it
-  // don't break; see docs/triage/api-version-audit/orders-status-enum.md.
+  // Verified 2026-05-11 against the real API (docs/triage/orders-status-server-behavior.md):
+  // the public Pax8 OpenAPI does NOT document a `status` field on `Order` or
+  // a `status` query parameter on `GET /orders`, AND the server silently
+  // ignores `?status=` — every value (including bogus ones like `NotAStatus`)
+  // returns the full unfiltered set. The flag is kept so partner scripts that
+  // already depend on it don't break, but it is a no-op until the Pax8 Orders
+  // team surfaces a real status field (tracked in #369). The default table
+  // output previously rendered a `Status` column that always showed `—` for
+  // prod data; it has been dropped here. JSON output continues to include
+  // `status` when the demo client emits it, for backwards compatibility.
   .option(
     "--status <status>",
-    "Filter by status (observed: Completed, Processing, Failed, PendingManual; not in public OpenAPI)"
+    "No-op: server ignores filter; field not in public OpenAPI (see #369)"
   )
   .option("--page <number>", "Page number", "1")
   .option("--size <number>", "Page size", "25")


### PR DESCRIPTION
## Summary

- Drop the `Status` column from `pax8 orders list` default table output (it rendered a gray `—` for every row against real prod data)
- Reword `--status` flag help to a documented no-op
- Update the inline `#250` honesty comment with verified server behavior
- Update the help-text regression test to assert both (a) "not in public OpenAPI" and (b) "no-op / ignores"
- `--status` flag itself is kept for backwards compat with partner scripts

## Why

Verified 2026-05-11 against the real API:

1. `Order` schema has no `status` field on `GET /orders` or `GET /orders/{id}` (verified keys: `companyId, createdDate, id, isScheduled, lineItems, orderedBy, orderedByUserEmail, orderedByUserId`).
2. The server silently ignores `?status=` — seven tested values, including a deliberately-invalid `NotAStatus`, all returned identical `totalElements=4721` on the test partner account.

The PR #360 disclaimer was technically correct ("not in OpenAPI") but understated the situation — the field doesn't exist anywhere in API responses and the filter is a silent no-op. The `Status` column showing `—` for every row gave a false sense of completeness.

Methodology recorded in `docs/triage/orders-status-server-behavior.md`. Tracking eventual Orders-team resolution in #369.

## Test plan

- [x] Unit: `pnpm test packages/cli/src/__tests__/orders.test.ts` — 35/35 pass (1 updated to match new wording)
- [x] Full suite: `pnpm test` — 1750 passing / 6 skipped / 0 failing
- [x] Lint: `pnpm lint` — clean
- [x] Build: `pnpm build` — clean
- [ ] Live: re-run `pax8 orders list` against the real API once Auth0 backend recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)