### PR TITLE
feat(recommendations): add OE opportunityType axis + recommendations upsell

### DIFF
--- a/.changeset/recommendations-opportunity-type-axis.md
+++ b/.changeset/recommendations-opportunity-type-axis.md
@@ -1,0 +1,22 @@
+---
+"@pax8/core": minor
+"@pax8/cli": minor
+---
+
+**Recommendations (additive):** `pax8 recommendations` output now carries an `opportunityType` field alongside the existing `type`, using Pax8's canonical Opportunity Explorer 5-type taxonomy (`Upsell`, `Cross-sell`, `Add-on`, `Upgrade`, `Net-new`). Existing `type` field unchanged.
+
+Mapping:
+
+| Existing `type`              | Emitted `opportunityType` |
+|------------------------------|---------------------------|
+| `cross_sell` (active subs)   | `Cross-sell`              |
+| `cross_sell` (zero-sub cust) | `Net-new`                 |
+| `seat_gap`                   | `Upsell`                  |
+
+Zero-subscription companies now classify as `Net-new` instead of being silently routed through the `Cross-sell` rail — the closest existing surrogate for OE's `Net-new` motion, and the fix for surprise #7 in `docs/triage/recommendations-conformance.md`.
+
+Added `pax8 recommendations upsell --from-product <name> --to-product <name>` following the MCP "Proactive Upsell Opportunity Finder" composition pattern (Guide §3b): list every company on the source product who does not yet have the upsell target, with seats, current MRR, and contact details (`--with-contacts`). New exports from `@pax8/core`: `findUpsellCohort`, types `UpsellMatch`, `UpsellCohortReport`, `OpportunityType`.
+
+Full taxonomy alignment — retiring the CLI's security-centric 7-category product taxonomy in favor of Pax8's canonical STAX/PCM categories, and migrating `seat_gap` with an alias period — is deferred to v0.2 (#375), to align with whatever taxonomy OE's `GET /opportunities` API publishes when ARC-785 ships.
+
+Extends the disclosure-over-rewrite pattern from #298 (vocabulary alignment) and #299 (`mrrAtRisk` → `mrrRenewing` one-cycle alias). Cites Rovo research on PICS (4 executive categories) / STAX (8 L1 operational categories) / Taxonomy v2 (in flight, hierarchical L1/L2/L3) in the new STAX-divergence doc comment at the top of `packages/core/src/services/recommendations.ts` and in the v0.2 issue (#375).

--- a/docs/triage/recommendations-conformance.md
+++ b/docs/triage/recommendations-conformance.md
@@ -1,0 +1,238 @@
+# Triage — `pax8 recommendations` vs. Pax8 Opportunity Explorer (OE) canon
+
+**Status:** Originally a read-only audit (2026-05-11). The narrow, additive
+resolution ("Path B") for surprise #7 and the OE 5-type axis shipped in a
+follow-up PR: additive `opportunityType` field on every recommendation,
+zero-sub companies reclassified as `Net-new`, new `pax8 recommendations
+upsell --from-product --to-product` command, and the STAX-divergence doc
+comment at the top of `packages/core/src/services/recommendations.ts`. The
+retain-as-is items (7 product categories, `seat_gap` rename, `coverage: 'n/7'`
+migration) are tracked for v0.2 in #375.
+
+**Date:** 2026-05-11.
+
+This doc inventories the current CLI recommendations surface, classifies every category, rule, and term against Pax8's canonical Opportunity Explorer (OE) vocabulary, and enumerates **material surprises** the user should weigh before authorizing a rename/rewrite.
+
+---
+
+## 0. Canonical access — what I could and could not verify
+
+- **OE rules page** ([`https://pax8.atlassian.net/wiki/spaces/OE/pages/934674534/`](https://pax8.atlassian.net/wiki/spaces/OE/pages/934674534/)) — partner-portal gated; not fetched. **Canon claims below are reproduced from the prompt and from in-repo prior research (`docs/triage/mcp-use-case-alignment.md`, `docs/pm-review-response-2026-05.md`).** Where this audit cites "Pax8 canon" without a verifiable URL, treat as second-hand.
+- **Verified in-repo:** OE 5-type taxonomy (Upsell / Cross-Sell / Add-On / Upgrade / Net-New) is referenced at `docs/pm-review-response-2026-05.md:296` and `docs/triage/mcp-use-case-alignment.md:77,97`. Seat Utilization canonical name is referenced at `docs/triage/mcp-use-case-alignment.md:73,86`. ARC-785 / `GET /opportunities` is **not** referenced anywhere in this tree.
+
+---
+
+## 1. Current CLI surface
+
+### 1.1 Top-level commands
+
+| Surface | File:line | Description |
+|---|---|---|
+| `pax8 recommendations list` | `packages/cli/src/commands/recommendations/list.ts:59-310` | Read-only ranked list. Supports `--company`, `--priority`, `--type`, `--product`, `--include-all`, `--with-actions`, `--limit`, `--json`, `--csv`. |
+| `pax8 recommendations act` | `packages/cli/src/commands/recommendations/act.ts:157-334` | Write. Interactive multi-select picker → batched `orders.create`; `--yes` bypasses. |
+| `pax8 recs …` (alias) | `packages/cli/src/commands/recommendations/index.ts:11` | Shorthand for `recommendations`. |
+
+### 1.2 Cross-surface consumers (same engine)
+
+| Surface | File:line | What it reads |
+|---|---|---|
+| `pax8 companies list --coverage` | `packages/cli/src/commands/companies/list.ts:45,87,111-112,118-131,150-158` | Calls `getRecommendations()` then `getPortfolioCoverage()`. Surfaces `coverage` ("n/7"), `coveredCategories[]`, `missingCategories[]`, `estimatedUplift` — adds them to JSON output (lines 155-158) and table cells. |
+| `pax8 dashboard` | `packages/cli/src/commands/dashboard.ts:139-156,221-222,241-246,293-294,414-425,478-484` | Calls `getRecommendations()`, filters `priority === "high"`, renders Growth section, emits `highPriorityRecs` + `potentialMrrUplift` in JSON. Quick Actions reads `r.orderCommand`, `r.suggestedProducts`, `r.title`. |
+| Claude Skill tool | `packages/claude-skill/src/tools/recommendations.ts:9` | Tool description hardcodes `"type (cross-sell or seat-gap)"`. |
+
+### 1.3 Exported public API (`@pax8/core`)
+
+`packages/core/src/services/index.ts:9` re-exports: `getRecommendations`, `getPortfolioCoverage`, `categorizeProduct`, `ALL_CATEGORIES`, type `Recommendation`, type `RecommendationReport`, type `CompanyCoverage`, type `ProductCategory`. **All seven category strings are part of the type union and are reachable by `@pax8/core` consumers.**
+
+### 1.4 `Recommendation` JSON contract
+
+Type at `packages/core/src/services/recommendations.ts:229-249`. Fields: `companyId, companyName, type, priority, title, reason, suggestedProducts[], orderCommand, productAvailable, currentMrr, estimatedMrrUplift, targetSeats, estimateType`. Surfaced verbatim in `--json` (`list.ts:160`) and `--with-actions` (`list.ts:158`). Mirrored in `docs/domain-review.md:371`.
+
+---
+
+## 2. Current categories — classification vs. canon
+
+Defined at `packages/core/src/services/recommendations.ts:11-18` (type), `:25-54` (regex rules), `:56-64` (`ALL_CATEGORIES`).
+
+| # | Category string | Status vs. canon | Notes |
+|---|---|---|---|
+| C1 | `productivity` | ❓ Ambiguous | Not in the verifiable OE 5-type taxonomy (taxonomy is opportunity *types*, not product *categories*). Internal product-category vocabulary at Pax8 may differ; **canonical category list not in this repo.** Flag for triage. |
+| C2 | `email` | ❓ Ambiguous | Same as C1. |
+| C3 | `security` | ❓ Ambiguous | Same as C1. |
+| C4 | `endpoint_protection` | ❓ Ambiguous | Same as C1. |
+| C5 | `identity` | ❓ Ambiguous | Same as C1. |
+| C6 | `backup` | ❓ Ambiguous | Same as C1. |
+| C7 | `cloud_infrastructure` | ❓ Ambiguous | Same as C1. |
+
+**Key point:** the seven categories are **product-category labels**, not OE opportunity *types*. The OE 5-type taxonomy and the CLI's 7-category taxonomy are orthogonal axes. **A "rename categories to match OE" instruction would be a category error** unless OE itself publishes a canonical product-category list (no evidence in this tree).
+
+Pattern matches against product names are **single-rule, English-only, lossy** — `defender` matches both `security` and `endpoint_protection` (`:35,39`); `Microsoft Defender for Identity` would mis-categorize; `Acronis Cyber Backup` matches `backup` correctly but `Acronis Cyber Protect` (which includes endpoint) would only hit `backup` via `acronis`.
+
+---
+
+## 3. Current rules — classification vs. canon
+
+### 3.1 Opportunity types (`type` field, `recommendations.ts:232`)
+
+| Value | Status | Notes |
+|---|---|---|
+| `cross_sell` | ✏️ Naming drift | Maps to OE's **Cross-Sell** in name. Help text at `list.ts:78-83` already discloses the CLI collapses OE's Cross-Sell + Net-New + Add-On into this single label. So the **value name aligns**; the **semantic coverage is broader than canonical Cross-Sell**. |
+| `seat_gap` | ❌ Invented | Not in OE taxonomy. CLI heuristic. Help text at `list.ts:85-91` already discloses this. Not equivalent to canonical **Seat Utilization** (which is single-product), and not equivalent to OE's **Upsell** (which is in-product expansion). |
+
+### 3.2 Cross-sell rules (`recommendations.ts:89-146`)
+
+Shape: "if has category X but missing category Y → recommend product list Z."
+
+| # | Rule | File:line | Priority | Status vs. canon |
+|---|---|---|---|---|
+| R1 | productivity → backup | `:90-97` | high | ❓ Ambiguous — generic IT-stack heuristic. Likely sound regardless of OE; **canonical text on OE page not verified.** |
+| R2 | productivity → endpoint_protection | `:98-105` | high | ❓ Same as R1. |
+| R3 | productivity → identity | `:106-113` | high | ❓ Same as R1. |
+| R4 | email → security | `:114-121` | medium | ❓ Same as R1. |
+| R5 | cloud_infrastructure → backup | `:122-129` | medium | ❓ Same as R1. |
+| R6 | cloud_infrastructure → security | `:130-137` | medium | ❓ Same as R1. |
+| R7 | security → backup | `:138-145` | low | ❓ Same as R1. |
+
+**Hardcoded suggested product names** (`recommendations.ts:95,103,111,119,127,135,143`) include `"AvePoint Cloud Backup for Microsoft 365"`, `"Microsoft Defender for Office 365 (Plan 1) [New Commerce Experience]"`, `"Microsoft Entra ID P1 [New Commerce Experience]"`, `"CrowdStrike MSSP Complete Defend"`, `"SentinelOne Singularity Complete"`, `"Datto SaaS Protection"`, `"Veeam Backup"`, `"Mimecast"`, `"JumpCloud"` — these are SKU strings that will break on vendor rename (`docs/triage/mcp-use-case-alignment.md:103`).
+
+### 3.3 Seat-gap thresholds (`recommendations.ts:161-206`)
+
+| Threshold | Value | File:line | Status |
+|---|---|---|---|
+| Primary product min seats | ≥ 10 | `:184` | ❌ Invented |
+| Secondary coverage ratio | < 50% | `:191` | ❌ Invented |
+| Missing seats min | ≥ 10 | `:191` | ❌ Invented |
+| High-priority escalation | missing > 20 | `:509` | ❌ Invented |
+
+The 85% Seat Utilization target referenced in the prompt is **a single-product assigned-vs-purchased ratio**; it has no obvious mapping to this cross-product comparison. Different metric, different denominator.
+
+### 3.4 Other rule-ish constants
+
+| Item | File:line | Status |
+|---|---|---|
+| `RESTRICTED_PATTERNS` regex (non-profit/charity/GCC/education/government/AOS) | `:360` | ✅ Sound (commercial-only filter; defensible regardless of canon). |
+| Zero-subscription company flag | `:526-547` | ❓ CLI-invented "Net-New" surrogate; arguably maps to OE **Net-New**. Priority hardcoded `high`. |
+| Dedupe key | `:555` (`companyId:type:title`) | ❌ CLI-invented; tied to current `type` strings. |
+| Priority order | `:563` (`high=0, medium=1, low=2`) | ✅ Maps to OE priority canon (assumed). |
+| Estimate semantics | `:248,489,521` (`estimateType: "upper_bound"`) | ✅ Already disclaims it is **not** PMRR (`list.ts:93-97`). |
+
+---
+
+## 4. `seat_gap` references — exhaustive list
+
+| File | Line | Context |
+|---|---|---|
+| `packages/core/src/services/recommendations.ts` | `:232` | Type union member: `"cross_sell" \| "seat_gap"` (exported via `@pax8/core`) |
+| `packages/core/src/services/recommendations.ts` | `:508` | Sets `type: "seat_gap"` on synthesized rec |
+| `packages/core/src/services/recommendations.ts` | `:510-513` | Comment discussing disambiguation from Seat Utilization |
+| `packages/core/src/services/recommendations.ts` | `:554` | Dedupe comment ("For seat_gap, dedupe by company + product") |
+| `packages/core/src/services/recommendations.test.ts` | `:105` | Test: `r.type === "seat_gap"` |
+| `packages/cli/src/commands/recommendations/list.ts` | `:39` | Column formatter: `String(v) === "seat_gap" ? "Seat Gap" : "Cross-sell"` |
+| `packages/cli/src/commands/recommendations/list.ts` | `:63` | Help: `--type <type>` "(seat_gap or cross_sell)" |
+| `packages/cli/src/commands/recommendations/list.ts` | `:85-91` | Help-text disclaimer paragraph |
+| `packages/cli/src/commands/recommendations/act.ts` | `:153` | `rec.type === "seat_gap" ? "Bump" : "Add"` in picker label |
+| `packages/cli/src/commands/recommendations/filter.test.ts` | `:38,107-110` | Filter tests assert literal value |
+| `packages/claude-skill/src/tools/recommendations.ts` | `:9` | Skill tool description literal: `"seat-gap"` (hyphen variant) |
+| `packages/claude-skill/skill.md` | (implicit) | No literal `seat_gap`, but references the `--type` flag indirectly |
+| `docs/domain-review.md` | `:371` | Documents the type union |
+| `docs/triage/mcp-use-case-alignment.md` | `:73,86` | Triage doc already flags seat_gap divergence |
+| `docs/pm-review-response-2026-05.md` | `:245,296` | PM response acknowledges as CLI-invented |
+| `README.md` | `:478` | User-facing docs reference `seat_gap` |
+| `README.md` | `:475-482` | "Cross-product coverage gaps vs. Seat Utilization" section |
+| `CHANGELOG.md` | `:9,23` | Release notes disclaim |
+
+**Critical:** `seat_gap` is **part of the exported TypeScript type union** in `@pax8/core` (`recommendations.ts:232`, re-exported from `services/index.ts:9` and the package root `index.ts:228-236`). Renaming it is a **breaking API change** for any `@pax8/core` embedder.
+
+---
+
+## 5. Material surprises ⚠️
+
+These are the things that should give the user pause before authorizing a clean rename/rewrite. **This is the headline section.**
+
+### S1. The "all 7 categories are invented" framing is technically defensible but the right axis to fight on isn't categories — it's the conflation of two orthogonal taxonomies.
+
+OE's **5-type taxonomy** (Upsell / Cross-Sell / Add-On / Upgrade / Net-New) is opportunity *types* — what kind of motion this is. The CLI's **7-category taxonomy** is product *categories* — what kind of thing is being sold. **These are different axes.** A rename prompt that says "adopt OE's 5 types" does **not** tell you what to do with the 7 product categories. Pax8 likely has a canonical product-category list internally, but **no evidence of it exists in this tree** (`docs/triage/mcp-use-case-alignment.md:74` flags this exact gap as a "joint gap"). If you proceed without nailing this down, the rewrite will replace 7 invented categories with 7 newly-invented categories that just *look* more canonical.
+
+### S2. `seat_gap` is in the **exported public TypeScript type** of `@pax8/core`.
+
+`packages/core/src/services/recommendations.ts:232` declares `type: "cross_sell" | "seat_gap"`. That type is re-exported as `Recommendation` from the package root (`packages/core/src/index.ts:228-236`). **Embedders of `@pax8/core` will fail to compile if you rename it.** This is not just a CLI string — it is an SDK contract. The current prompt's framing as "rename" understates this. README at `README.md:274` explicitly markets `@pax8/core` as importable into "a portal feature, a Lambda, a dashboard, or your own tool."
+
+### S3. `seat_gap` is also part of the **`--json` output contract** of `pax8 recommendations list`.
+
+`list.ts:160` writes raw `Recommendation[]` to stdout. Agents and scripts (including the Claude skill at `packages/claude-skill/src/tools/recommendations.ts:9`) filter on `r.type === "seat_gap"`. Renaming changes downstream tooling behavior silently. The `CLAUDE.md` agent contract at the root already encodes `r.orderCommand` extraction; if you change `type`, you should also publish an alias period like the recent `mrrAtRisk → mrrRenewing` migration (see `CHANGELOG.md:23`, which kept both keys for one minor cycle).
+
+### S4. `pax8 dashboard` depends on the literal string `"high"` for priority filtering.
+
+`packages/cli/src/commands/dashboard.ts:222`: `recsReport.recommendations.filter((r) => r.priority === "high")`. The dashboard's "Growth Opportunities" section, JSON `highPriorityRecs` / `potentialMrrUplift` fields (`:293-294`), and Quick Actions block (`:415-424`) all consume `r.title`, `r.suggestedProducts`, `r.orderCommand`, `r.estimatedMrrUplift`. **A rewrite that changes the shape of `Recommendation`, the priority enum, or the title format silently changes the dashboard.** Not a blocker — but the rewrite spec needs to enumerate these fields as part of the contract surface, not just the categories.
+
+### S5. `pax8 companies list --coverage` exposes the **literal coverage string "n/7"** in JSON.
+
+`recommendations.ts:314`: `coverage: \`${coveredCategories.length}/${ALL_CATEGORIES.length}\``. That `7` is `ALL_CATEGORIES.length`. The output is surfaced verbatim in `companies/list.ts:155` as `row.coverage`. **If the category count changes (e.g. 7 → 5 or 7 → 9), every consumer parsing `"3/7"` as a fraction or denominator breaks.** This includes any external dashboard a partner has built on top. The `0/7` fallback for zero-sub companies is also hardcoded (`companies/list.ts:127`). Need a one-cycle alias period or a structural format like `{ covered: 3, total: 7 }`.
+
+### S6. The CLI already collapses OE's 5-type taxonomy into 2 types **with explicit help-text disclaimers**.
+
+`list.ts:77-91` discloses that `cross_sell` collapses Cross-Sell + Net-New + Add-On, and that `seat_gap` is a CLI heuristic. This was the resolution of #298 (`CHANGELOG.md:9`). **The framing "all 7 are invented, let's adopt canon" is partly already settled** — the maintainers already chose disclosure-over-rewrite and pinned the full migration to ARC-785 / issue #62. A rewrite now relitigates a recently-closed decision; before authorizing, the user should know which way #62 is currently leaning.
+
+### S7. Zero-subscription companies are silently emitted as `type: "cross_sell"` recs.
+
+`recommendations.ts:526-547` synthesizes a high-priority `cross_sell` rec for every company with no active subs, with empty `suggestedProducts`, null `orderCommand`, and `productAvailable: false`. **This is the closest existing surrogate for OE's "Net-New" type** and arguably should migrate there before anything else does. Currently it travels as `cross_sell` and gets filtered out of the actionable view because `productAvailable: false` (`list.ts:169`). Worth being deliberate about during the rewrite — it's a real opportunity type masquerading as a cross-sell.
+
+### S8. Hardcoded SKU strings are the real fragility, not the category names.
+
+`recommendations.ts:95,103,111,…` contain literal vendor SKU strings like `"Microsoft Defender for Office 365 (Plan 1) [New Commerce Experience]"`. These break silently on vendor rename. `docs/triage/mcp-use-case-alignment.md:103` already calls this out. **A rewrite focused on category/type names that doesn't also externalize the suggested-product list is fixing the cosmetic problem while leaving the real one in place.**
+
+### S9. The `seat_gap` heuristic uses `quantity` from `Subscription` as a coverage proxy.
+
+`recommendations.ts:181-203` treats *purchased quantity* as a proxy for *covered seats*. This is wrong for both the canonical Seat Utilization metric (which uses assigned seats, not purchased) **and** for cross-product gap detection (which assumes the same denominator applies — i.e. that 100 productivity seats means 100 humans, and 30 backup seats means 70 humans uncovered). It's a reasonable rough cut, but **it's epistemically the same kind of approximation the prompt's premise objects to in the canonical Seat Utilization comparison** — i.e. if you rename `seat_gap` to align with canon, the underlying logic still won't be canon-grade.
+
+### S10. The Claude Skill description hardcodes the hyphenated variant `"seat-gap"`.
+
+`packages/claude-skill/src/tools/recommendations.ts:9` says `"Returns type (cross-sell or seat-gap)"`. The actual JSON values are `cross_sell` and `seat_gap` (underscored). This is a pre-existing minor bug in the skill description, but a rewrite must touch this too or the new term won't match the description either.
+
+### S11. The `RESTRICTED_PATTERNS` filter has real business value and is non-obvious.
+
+`recommendations.ts:360`: `/non-profit|charity|gcc|education|faculty|student|government|\bAOS\b/i`. This silently skips SKUs that aren't orderable for commercial customers. A rewrite that doesn't preserve this regex will produce recs that error on submission. Important to carry forward.
+
+---
+
+## 6. Recommended action per finding
+
+| Item | Recommendation |
+|---|---|
+| C1–C7 (7 categories) | **Flag for discussion.** Do not rename until a canonical Pax8 product-category list is identified. If none exists, document this as a CLI-invented taxonomy and stop calling it a "rename" — it's a domain-modeling exercise. |
+| Type `cross_sell` | **Keep, document scope.** Name aligns with OE. Document (already done at `list.ts:78-83`) that scope is broader. |
+| Type `seat_gap` | **Two-cycle deprecation with alias**, mirroring the `mrrAtRisk → mrrRenewing` pattern (`CHANGELOG.md:23`). Don't hard-rename. The new name needs to be picked from canon, not invented (see S1) — `upsell`, `add_on`, `coverage_gap`, or a structural change all have different downstream implications. |
+| Type `cross_sell` for zero-sub companies | **Move to a new type (`net_new`?)** with a one-cycle alias if you adopt OE's Net-New. See S7. |
+| Cross-sell rules R1–R7 | **Keep, but externalize.** Move to a data file the user can override; if/when OE ships a canonical rule list, swap the data source. |
+| Seat-gap thresholds (50% / 10 seats / 20 high) | **Keep**, but expose as configuration. |
+| `RESTRICTED_PATTERNS` | **Keep verbatim.** Real business filter, non-canonical but correct. |
+| Hardcoded SKU names | **Replace with a vendor-canonical product-keyword list.** Decouple from current Pax8 catalog naming. Higher priority than the rename. |
+| `coverage: "n/7"` literal | **Add structured field** `{ covered, total }` alongside existing string; deprecate string after one cycle. |
+| Dashboard `priority === "high"` filter | **Keep**, but pin priority enum as part of the contract spec, not an implementation detail. |
+| Claude Skill description `"cross-sell or seat-gap"` | **Fix to underscored form** regardless of rewrite (pre-existing bug). |
+| `@pax8/core` type exports | **Treat as semver-major** if you remove `seat_gap` without alias. Add to the rewrite spec explicitly. |
+
+---
+
+## 7. If-we-proceed-as-spec'd: smooth vs. friction
+
+### Likely smooth
+
+- Adding canonical OE 5-type strings as new `type` values alongside the existing two (additive, non-breaking).
+- Adding new help-text disclaimers / renaming column headers (cosmetic, no contract impact).
+- Externalizing thresholds to env vars or config (additive).
+- Fixing the Claude Skill description hyphen bug.
+
+### Likely friction
+
+- **Hard-renaming `seat_gap` without an alias period** → breaks `@pax8/core` embedders (S2), `--json` consumers (S3), tests, agent prompts, and downstream tooling. Mirror the `mrrAtRisk → mrrRenewing` pattern.
+- **Changing the 7-category taxonomy** → silently changes `companies list --coverage` `n/7` denominator (S5), breaks any partner-built dashboard reading `coveredCategories[]` / `missingCategories[]`. Needs structured `{ covered, total }` migration.
+- **Replacing hardcoded suggested-product SKU strings** → larger refactor than the rename, but the real fragility (S8). Worth pairing with the rename.
+- **Adopting OE 5-type taxonomy without nailing the product-category axis** → ships a half-rewrite that still has the same epistemic mismatch (S1). Both axes need explicit canonical sources before authorizing.
+- **Relitigating #298** → the maintainers explicitly chose disclosure-over-rewrite three months ago (`CHANGELOG.md:9`, `docs/pm-review-response-2026-05.md:245`). The user should know they're reversing a recently-closed decision before authorizing (S6).
+
+---
+
+## 8. Bottom line for the authorizing user
+
+The premise "all 7 categories are invented; let's adopt OE canon" is **only partly right**: the type axis (`cross_sell`/`seat_gap`) has a clean OE mapping in name though not in scope; the category axis (`productivity`/`email`/...) does not appear to have a canonical Pax8 source in this tree, so any rename will trade one invented vocabulary for another unless a canonical source is produced. The biggest concrete risks are not invention — they are the public `@pax8/core` type export of `seat_gap`, the literal `"n/7"` coverage string in JSON, the dashboard's structural dependency on `priority === "high"`, and the hardcoded SKU strings that are a bigger fragility than the names. A "clean rename" is not actually clean — it's a semver-major API change for `@pax8/core` and a contract change for the `--json` surface. Recommend a two-cycle alias migration plus an explicit decision about the product-category axis before any code changes land.

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -176,6 +176,114 @@ describe("pax8 recommendations", () => {
         withCommand.every((r) => /--product\s+\S+/.test(r.orderCommand!)),
       ).toBe(true);
     });
+
+    // Path B (#375 precursor): every recommendation carries the additive
+    // `opportunityType` axis alongside the legacy `type`, using OE's
+    // canonical 5-type taxonomy. The legacy `type` is unchanged.
+    it("--json carries both legacy type and additive opportunityType (OE 5-type taxonomy)", async () => {
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
+      const data = JSON.parse(result.stdout) as Array<{
+        type: string;
+        opportunityType: string;
+      }>;
+      expect(data.length).toBeGreaterThan(0);
+      const allowed = new Set(["Upsell", "Cross-sell", "Add-on", "Upgrade", "Net-new"]);
+      for (const rec of data) {
+        expect(rec).toHaveProperty("type");
+        expect(rec).toHaveProperty("opportunityType");
+        expect(allowed.has(rec.opportunityType)).toBe(true);
+        // Mapping invariants (zero-sub → Net-new is asserted at the engine
+        // level; here we just check that seat_gap is always Upsell and
+        // cross_sell never becomes Add-on/Upgrade in the v0.x stopgap).
+        if (rec.type === "seat_gap") {
+          expect(rec.opportunityType).toBe("Upsell");
+        }
+        if (rec.type === "cross_sell") {
+          expect(["Cross-sell", "Net-new"]).toContain(rec.opportunityType);
+        }
+      }
+    });
+  });
+
+  describe("recommendations upsell", () => {
+    it("returns the upsell cohort as JSON by default", async () => {
+      const result = await runCliExpectSuccess([
+        "recommendations", "upsell",
+        "--from-product", "Microsoft 365 Business Basic",
+        "--to-product", "Microsoft 365 Business Premium",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout) as {
+        fromProduct: string;
+        toProduct: string;
+        matches: Array<{
+          companyName: string;
+          fromSeats: number;
+          fromMrr: number;
+          opportunityType: string;
+          contacts: Array<{ name: string; email: string }>;
+        }>;
+        totalFromMrr: number;
+        totalFromProductCompanies: number;
+        alreadyHaveToProduct: number;
+      };
+      expect(data.fromProduct).toBe("Microsoft 365 Business Basic");
+      expect(data.toProduct).toBe("Microsoft 365 Business Premium");
+      expect(Array.isArray(data.matches)).toBe(true);
+      // Demo data has companies on Basic without Premium → at least one match.
+      expect(data.matches.length).toBeGreaterThan(0);
+      for (const m of data.matches) {
+        expect(m.opportunityType).toBe("Upsell");
+        expect(m.fromSeats).toBeGreaterThan(0);
+        expect(Array.isArray(m.contacts)).toBe(true);
+      }
+    });
+
+    it("returns no matches when no company has the from-product", async () => {
+      const result = await runCliExpectSuccess([
+        "recommendations", "upsell",
+        "--from-product", "ThisProductDoesNotExistInDemoData99999",
+        "--to-product", "Microsoft 365 Business Premium",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout) as {
+        matches: unknown[];
+        totalFromProductCompanies: number;
+      };
+      expect(data.matches).toEqual([]);
+      expect(data.totalFromProductCompanies).toBe(0);
+    });
+
+    it("returns no matches when every from-product company already has to-product", async () => {
+      // Force the edge by passing the same product on both sides — every
+      // company on Premium trivially "already has" Premium, so the
+      // actionable cohort is empty even though the source cohort is not.
+      const result = await runCliExpectSuccess([
+        "recommendations", "upsell",
+        "--from-product", "Microsoft 365 Business Premium",
+        "--to-product", "Microsoft 365 Business Premium",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout) as {
+        matches: unknown[];
+        totalFromProductCompanies: number;
+        alreadyHaveToProduct: number;
+      };
+      expect(data.matches).toEqual([]);
+      expect(data.totalFromProductCompanies).toBeGreaterThan(0);
+      expect(data.alreadyHaveToProduct).toBe(data.totalFromProductCompanies);
+    });
+
+    it("errors when --from-product or --to-product is missing", async () => {
+      const result = await runCliExpectFailure([
+        "recommendations", "upsell",
+        "--from-product", "Microsoft 365 Business Basic",
+        "--json",
+      ]);
+      // Commander emits its own required-option message on stderr.
+      expect(result.stderr).toMatch(/--to-product|required/i);
+      expect(result.exitCode).not.toBe(0);
+    });
   });
 
   describe("recommendations act", () => {

--- a/packages/cli/src/commands/recommendations/index.ts
+++ b/packages/cli/src/commands/recommendations/index.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import { recommendationsListCommand } from "./list.js";
 import { recommendationsActCommand } from "./act.js";
+import { recommendationsUpsellCommand } from "./upsell.js";
 
 export function registerRecommendationsCommands(program: Command): void {
   const recommendations = new Command("recommendations")
@@ -12,6 +13,7 @@ export function registerRecommendationsCommands(program: Command): void {
 
   recommendations.addCommand(recommendationsListCommand);
   recommendations.addCommand(recommendationsActCommand);
+  recommendations.addCommand(recommendationsUpsellCommand);
 
   program.addCommand(recommendations);
 }

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -75,20 +75,28 @@ Examples:
   pax8 recommendations list --json
 
 Recommendation types:
+  Each recommendation carries TWO classification axes in --json output:
+  the legacy 'type' field (cross_sell | seat_gap) and the additive
+  'opportunityType' field with OE's canonical 5-type taxonomy (Upsell |
+  Cross-sell | Add-on | Upgrade | Net-new). Mapping:
+    type=cross_sell + active subs    → opportunityType=Cross-sell
+    type=cross_sell + zero-sub cust  → opportunityType=Net-new
+    type=seat_gap                    → opportunityType=Upsell
+
   cross_sell: gaps in a customer's stack where a complementary product
-  category is missing. Aligns with Pax8 Opportunity Explorer's Cross-Sell
-  category. The CLI currently collapses multiple OE opportunity types
-  (Cross-Sell + Net-New + Add-On) into this single label for v0.x; the
-  full taxonomy will be adopted when the first-party recommendations
-  API ships (#62).
+  category is missing. Aligns with Pax8 Opportunity Explorer's Cross-sell
+  category for active-sub customers, and Net-new for zero-sub customers
+  (carried on 'opportunityType'). The legacy 'type' field collapses both
+  motions onto 'cross_sell' for v0.x; the full taxonomy migration is
+  deferred to v0.2 (#375) and ARC-785.
 
   seat_gap: a CLI-invented heuristic that flags cross-product seat
   mismatches (e.g. 100 email seats but only 30 backup seats). Identifies
   coverage gaps across a customer's stack — NOT the same as Pax8's
   canonical Seat Utilization metric, which measures single-product
-  assigned-vs-purchased seats. Also not equivalent to OE's Upsell
-  opportunity type. seat_gap will likely be retired or remapped when
-  OE's first-party API ships.
+  assigned-vs-purchased seats. Closest OE surrogate is Upsell (carried
+  on 'opportunityType'); seat_gap will likely be retired or remapped
+  when OE's first-party API ships.
 
 Estimate semantics:
   estimatedMrrUplift is an upper-bound estimate (unit price × seat

--- a/packages/cli/src/commands/recommendations/upsell.ts
+++ b/packages/cli/src/commands/recommendations/upsell.ts
@@ -1,0 +1,222 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  ALL_SUBS_PAGE_SIZE,
+  ERROR_INVALID_INPUT,
+  findUpsellCohort,
+  type UpsellCohortReport,
+} from "@pax8/core";
+import { buildContext, warnIfTruncated } from "../../lib/context.js";
+import { output, type Column } from "../../lib/output.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { handleCommandError, CliError } from "../../lib/errors.js";
+import { formatCurrency, formatCompanyName } from "../../lib/formatters.js";
+import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
+import { replCmd } from "../../lib/confirm.js";
+
+const columns: Column[] = [
+  { key: "companyName", header: "Company", format: (v) => formatCompanyName(String(v)) },
+  { key: "fromSeats", header: "Seats" },
+  {
+    key: "fromMrr",
+    header: "Current MRR",
+    format: (v) => (v != null ? formatCurrency(v as number) : chalk.dim("—")),
+  },
+  {
+    key: "contactSummary",
+    header: "Contacts",
+    format: (v) => {
+      const s = String(v ?? "");
+      return s || chalk.dim("—");
+    },
+  },
+];
+
+export const recommendationsUpsellCommand = new Command("upsell")
+  .description("Find companies on one product who don't yet have a target upsell product")
+  .requiredOption("--from-product <name>", "The product the cohort already owns (e.g. 'Microsoft 365 Business Basic')")
+  .requiredOption("--to-product <name>", "The upsell target the cohort does NOT yet own (e.g. 'Microsoft 365 Business Premium')")
+  .option("--limit <number>", "Max rows to show in table (default 20)")
+  .option("--with-contacts", "Look up contacts for each matching company (extra API calls)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 recommendations upsell --from-product "Microsoft 365 Business Basic" --to-product "Microsoft 365 Business Premium"
+  pax8 recommendations upsell --from-product "Business Basic" --to-product "Business Premium" --with-contacts --json
+  pax8 recommendations upsell --from-product "Exchange Online (Plan 1)" --to-product "Exchange Online (Plan 2)" --json
+
+About this workflow:
+  This is the canonical Pax8 composition for the "proactive upsell" question
+  ("who's on product A but not yet on product B?") — equivalent to the
+  Pax8 MCP server's "Proactive Upsell Opportunity Finder" pattern
+  (Guide §3b), composed over get_subscriptions + get_companies (+ optional
+  get_contacts). Use it when you have a specific motion in mind (tier swap,
+  edition upgrade); use 'pax8 recommendations list' when you want the
+  engine to surface gaps for you.
+
+Output:
+  JSON (default for piped/non-TTY): { fromProduct, toProduct, matches[],
+  totalFromSeats, totalFromMrr, alreadyHaveToProduct,
+  totalFromProductCompanies }. Each match carries opportunityType="Upsell"
+  per Pax8 Opportunity Explorer's canonical 5-type taxonomy.`
+  )
+  .action(async (options, cmd) => {
+    const allOpts = cmd.optsWithGlobals();
+    const fromProduct = String(options.fromProduct ?? "").trim();
+    const toProduct = String(options.toProduct ?? "").trim();
+
+    if (!fromProduct || !toProduct) {
+      throw new CliError(
+        "Both --from-product and --to-product are required",
+        ["The upsell finder needs a source product (the one customers already have) and a target product (the upsell they don't yet have)."],
+        [
+          `Try: ${replCmd('pax8 recommendations upsell --from-product "Microsoft 365 Business Basic" --to-product "Microsoft 365 Business Premium"')}`,
+        ],
+        undefined,
+        ERROR_INVALID_INPUT,
+      );
+    }
+
+    const ctx = await buildContext(allOpts);
+    const spinner = createSpinner("Finding upsell cohort...").start();
+
+    try {
+      const [subsResult, companiesResult] = await Promise.all([
+        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, status: "Active" }),
+        ctx.api.companies.list({ size: 200 }),
+      ]);
+
+      warnIfTruncated(subsResult, ALL_SUBS_PAGE_SIZE);
+
+      const companyNames = new Map<string, string>();
+      for (const c of companiesResult.content) {
+        companyNames.set(c.id, c.name);
+      }
+
+      const subs = subsResult.content;
+      await enrichProductNames(ctx, subs);
+      enrichCompanyNames(companyNames, subs);
+
+      // Optionally fetch contacts for the matched cohort. We do this AFTER
+      // the cohort is computed so we only pay the per-company API cost on
+      // companies that actually qualify (`getContacts` is a per-company
+      // call, not a flat list).
+      const baseReport = findUpsellCohort(subs, fromProduct, toProduct, {
+        companies: companiesResult.content,
+      });
+
+      let report: UpsellCohortReport = baseReport;
+      if (options.withContacts && baseReport.matches.length > 0) {
+        const allContacts: Array<{ companyId: string; firstName?: string; lastName?: string; email?: string }> = [];
+        for (const match of baseReport.matches) {
+          try {
+            const contactsResult = await ctx.api.contacts.list(match.companyId, { size: 50 });
+            for (const c of contactsResult.content) {
+              allContacts.push({
+                companyId: match.companyId,
+                firstName: c.firstName,
+                lastName: c.lastName,
+                email: c.email,
+              });
+            }
+          } catch {
+            /* best effort — skip companies the partner can't read contacts for */
+          }
+        }
+        report = findUpsellCohort(subs, fromProduct, toProduct, {
+          companies: companiesResult.content,
+          contacts: allContacts,
+        });
+      }
+
+      spinner.stop();
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      if (ctx.outputFormat === "csv") {
+        const rows = report.matches.map((m) => ({
+          companyName: m.companyName,
+          fromSeats: m.fromSeats,
+          fromMrr: m.fromMrr,
+          contactSummary: m.contacts.map((c) => c.email).join("; "),
+        }));
+        output(rows, { format: "csv", columns });
+        return;
+      }
+
+      // Table mode
+      if (report.matches.length === 0) {
+        if (report.totalFromProductCompanies === 0) {
+          process.stderr.write(
+            chalk.yellow(`\n  No companies have an active subscription to "${fromProduct}".\n\n`) +
+              chalk.dim(`  Try a broader product name, or list what's actually in use:\n`) +
+              `    ${chalk.cyan(replCmd("pax8 subscriptions list --json --size 1000"))}\n\n`,
+          );
+        } else {
+          process.stderr.write(
+            chalk.green(
+              `\n  ✨ All ${report.totalFromProductCompanies} ${report.totalFromProductCompanies === 1 ? "company" : "companies"} on "${fromProduct}" already have "${toProduct}" — fully upgraded.\n\n`,
+            ),
+          );
+        }
+        return;
+      }
+
+      const requestedLimit = parseInt(options.limit, 10) || 20;
+      const limit = report.matches.length <= 25 ? report.matches.length : requestedLimit;
+      const displayed = report.matches.slice(0, limit).map((m) => ({
+        companyName: m.companyName,
+        fromSeats: m.fromSeats,
+        fromMrr: m.fromMrr,
+        contactSummary: options.withContacts
+          ? m.contacts.slice(0, 2).map((c) => c.email).join(", ") +
+            (m.contacts.length > 2 ? ` (+${m.contacts.length - 2} more)` : "")
+          : "",
+      }));
+
+      // Drop the contacts column if the user didn't ask for them.
+      const visibleColumns = options.withContacts ? columns : columns.filter((c) => c.key !== "contactSummary");
+      output(displayed, { format: "table", columns: visibleColumns });
+
+      if (report.matches.length > limit) {
+        process.stderr.write(
+          chalk.dim(`\n  Showing top ${limit} of ${report.matches.length} matches`) +
+            chalk.dim(` · use --limit ${report.matches.length} to see all\n`),
+        );
+      }
+
+      process.stderr.write(
+        chalk.dim(
+          `\n  ${report.matches.length} ${report.matches.length === 1 ? "company" : "companies"} on "${fromProduct}" without "${toProduct}"`,
+        ),
+      );
+      if (report.alreadyHaveToProduct > 0) {
+        process.stderr.write(
+          chalk.dim(` · ${report.alreadyHaveToProduct} already upgraded`),
+        );
+      }
+      if (report.totalFromMrr > 0) {
+        process.stderr.write(
+          chalk.green(` · ${formatCurrency(report.totalFromMrr)}/mo currently on source product`),
+        );
+      }
+      process.stderr.write("\n");
+
+      if (!options.withContacts) {
+        process.stderr.write(
+          chalk.dim(`\n  Add ${chalk.cyan("--with-contacts")} to pull contact emails per company.\n`),
+        );
+      }
+    } catch (error) {
+      await handleCommandError(error, spinner, "Failed to compute upsell cohort");
+    }
+  });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -227,6 +227,7 @@ export {
   getRecommendations,
   getPortfolioCoverage,
   categorizeProduct,
+  findUpsellCohort,
   ALL_CATEGORIES,
 } from "./services/recommendations.js";
 export type {
@@ -234,6 +235,9 @@ export type {
   RecommendationReport,
   CompanyCoverage,
   ProductCategory,
+  OpportunityType,
+  UpsellMatch,
+  UpsellCohortReport,
 } from "./services/recommendations.js";
 
 export {

--- a/packages/core/src/services/recommendations.test.ts
+++ b/packages/core/src/services/recommendations.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { getRecommendations } from "./recommendations.js";
+import { findUpsellCohort, getRecommendations } from "./recommendations.js";
 
 function makeSub(overrides: Record<string, unknown> = {}) {
   return {
@@ -146,6 +146,11 @@ describe("getRecommendations", () => {
     );
     expect(zeroSub).toBeDefined();
     expect(zeroSub!.type).toBe("cross_sell");
+    // Per the additive `opportunityType` axis (OE canon: 5 types), a
+    // zero-active-sub company is Net-new — there is no existing stack to
+    // cross-sell into. The legacy `type` stays `cross_sell` for one cycle;
+    // the full migration is deferred to v0.2 (#375).
+    expect(zeroSub!.opportunityType).toBe("Net-new");
     expect(zeroSub!.priority).toBe("high");
     expect(zeroSub!.companyName).toBe("Ghost Co");
     expect(zeroSub!.reason).toContain("no active subscriptions");
@@ -176,5 +181,167 @@ describe("getRecommendations", () => {
     ];
     const report = getRecommendations(subs, undefined, companies);
     expect(report.totalCompanies).toBe(3);
+  });
+
+  it("populates opportunityType on every recommendation per the OE 5-type taxonomy", () => {
+    // Build a portfolio that exercises all three emission paths:
+    //   - cross-sell rule (active subs, missing category)  → "Cross-sell"
+    //   - seat-gap heuristic (same-category seat mismatch) → "Upsell"
+    //   - zero-sub company                                  → "Net-new"
+    const subs = [
+      // Big M365 sub creates the productivity stack — triggers cross-sell rules.
+      makeSub({ companyId: "c1", companyName: "Has Productivity", quantity: 100, price: 22 }),
+      // Smaller same-category sub on the SAME company creates a seat-gap.
+      makeSub({
+        companyId: "c1", companyName: "Has Productivity",
+        productId: "p2", productName: "Microsoft 365 Business Basic [New Commerce Experience]",
+        quantity: 20, price: 6,
+      }),
+    ];
+    const companies = [
+      { id: "c1", name: "Has Productivity" },
+      { id: "c2", name: "Ghost Co" }, // zero-sub
+    ];
+    const report = getRecommendations(subs, undefined, companies);
+
+    // Every rec must carry an opportunityType drawn from the OE 5-type set.
+    const allowed = new Set(["Upsell", "Cross-sell", "Add-on", "Upgrade", "Net-new"]);
+    for (const rec of report.recommendations) {
+      expect(allowed.has(rec.opportunityType)).toBe(true);
+    }
+
+    // Mapping invariants per the doc-comment at the top of recommendations.ts:
+    //   cross_sell + has active subs    → Cross-sell
+    //   cross_sell + zero active subs   → Net-new
+    //   seat_gap                         → Upsell
+    for (const rec of report.recommendations) {
+      if (rec.type === "seat_gap") {
+        expect(rec.opportunityType).toBe("Upsell");
+      } else if (rec.type === "cross_sell" && rec.companyId === "c2") {
+        expect(rec.opportunityType).toBe("Net-new");
+      } else if (rec.type === "cross_sell") {
+        expect(rec.opportunityType).toBe("Cross-sell");
+      }
+    }
+
+    // Sanity: at least one of each path actually fired.
+    expect(report.recommendations.some((r) => r.opportunityType === "Cross-sell")).toBe(true);
+    expect(report.recommendations.some((r) => r.opportunityType === "Net-new")).toBe(true);
+    expect(report.recommendations.some((r) => r.opportunityType === "Upsell")).toBe(true);
+  });
+});
+
+describe("findUpsellCohort", () => {
+  function sub(overrides: Record<string, unknown>) {
+    return {
+      productId: "prod-x",
+      productName: "Microsoft 365 Business Basic [New Commerce Experience]",
+      quantity: 10,
+      price: 6,
+      status: "Active",
+      billingTerm: "Monthly",
+      ...overrides,
+    };
+  }
+
+  it("returns companies on from-product who lack to-product", () => {
+    const subs = [
+      // Wants: on Basic, not on Premium.
+      sub({ companyId: "c1", companyName: "Basic Only", quantity: 25, price: 6 }),
+      // Excluded: already on Premium.
+      sub({ companyId: "c2", companyName: "Already Upgraded", quantity: 50, price: 6 }),
+      sub({
+        companyId: "c2", companyName: "Already Upgraded",
+        productId: "prod-prem", productName: "Microsoft 365 Business Premium [New Commerce Experience]",
+        quantity: 50, price: 22,
+      }),
+      // Excluded: doesn't have the source product at all.
+      sub({
+        companyId: "c3", companyName: "Different Stack",
+        productId: "prod-other", productName: "Datto SaaS Protection",
+        quantity: 10, price: 5,
+      }),
+    ];
+    const report = findUpsellCohort(
+      subs,
+      "Microsoft 365 Business Basic",
+      "Microsoft 365 Business Premium",
+    );
+    expect(report.matches.length).toBe(1);
+    expect(report.matches[0].companyId).toBe("c1");
+    expect(report.matches[0].companyName).toBe("Basic Only");
+    expect(report.matches[0].fromSeats).toBe(25);
+    // 25 seats * $6 = $150/mo
+    expect(report.matches[0].fromMrr).toBe(150);
+    expect(report.matches[0].opportunityType).toBe("Upsell");
+    expect(report.alreadyHaveToProduct).toBe(1);
+    expect(report.totalFromProductCompanies).toBe(2);
+    expect(report.fromProduct).toBe("Microsoft 365 Business Basic");
+    expect(report.toProduct).toBe("Microsoft 365 Business Premium");
+  });
+
+  it("returns empty matches when no company has the from-product (edge: empty cohort)", () => {
+    const subs = [
+      sub({
+        companyId: "c1", companyName: "Only Other",
+        productId: "prod-other", productName: "Datto SaaS Protection",
+      }),
+    ];
+    const report = findUpsellCohort(subs, "Microsoft 365 Business Basic", "Microsoft 365 Business Premium");
+    expect(report.matches).toEqual([]);
+    expect(report.totalFromProductCompanies).toBe(0);
+    expect(report.alreadyHaveToProduct).toBe(0);
+  });
+
+  it("returns empty matches when every from-product company already has to-product (edge: fully upgraded)", () => {
+    const subs = [
+      sub({ companyId: "c1", companyName: "Co A" }),
+      sub({
+        companyId: "c1", companyName: "Co A",
+        productId: "prod-prem", productName: "Microsoft 365 Business Premium [New Commerce Experience]",
+        quantity: 10, price: 22,
+      }),
+      sub({ companyId: "c2", companyName: "Co B" }),
+      sub({
+        companyId: "c2", companyName: "Co B",
+        productId: "prod-prem", productName: "Microsoft 365 Business Premium [New Commerce Experience]",
+        quantity: 10, price: 22,
+      }),
+    ];
+    const report = findUpsellCohort(subs, "Microsoft 365 Business Basic", "Microsoft 365 Business Premium");
+    expect(report.matches).toEqual([]);
+    expect(report.totalFromProductCompanies).toBe(2);
+    expect(report.alreadyHaveToProduct).toBe(2);
+  });
+
+  it("attaches contact details when contacts are provided", () => {
+    const subs = [sub({ companyId: "c1", companyName: "Basic Only", quantity: 10, price: 6 })];
+    const report = findUpsellCohort(
+      subs,
+      "Microsoft 365 Business Basic",
+      "Microsoft 365 Business Premium",
+      {
+        contacts: [
+          { companyId: "c1", firstName: "Pat", lastName: "Lee", email: "pat@basic.example" },
+          { companyId: "c1", firstName: "Sam", lastName: "Lee", email: "sam@basic.example" },
+          // Different company — should not leak into c1's contact list.
+          { companyId: "other", email: "ghost@other.example" },
+        ],
+      },
+    );
+    expect(report.matches.length).toBe(1);
+    expect(report.matches[0].contacts).toEqual([
+      { name: "Pat Lee", email: "pat@basic.example" },
+      { name: "Sam Lee", email: "sam@basic.example" },
+    ]);
+  });
+
+  it("matches by partial product name (token-based)", () => {
+    const subs = [sub({ companyId: "c1", companyName: "Basic Only" })];
+    // Query with a partial name like "Business Basic" should still match
+    // "Microsoft 365 Business Basic [New Commerce Experience]".
+    const report = findUpsellCohort(subs, "Business Basic", "Business Premium");
+    expect(report.matches.length).toBe(1);
+    expect(report.matches[0].companyId).toBe("c1");
   });
 });

--- a/packages/core/src/services/recommendations.ts
+++ b/packages/core/src/services/recommendations.ts
@@ -1,6 +1,38 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * Recommendations engine — STAX / taxonomy divergence notice.
+ *
+ * The CLI's 7-category product taxonomy (`productivity`, `email`, `security`,
+ * `endpoint_protection`, `identity`, `backup`, `cloud_infrastructure`) does
+ * not match Pax8's canonical STAX taxonomy (8 L1 categories: Productivity,
+ * Infrastructure, Continuity, Security, Communications, Network, Operations,
+ * Network & Communications Commissioned). The CLI over-decomposes Security
+ * into 4 categories and omits Communications, Network, and Operations
+ * entirely. This was a deliberate simplification for the local recommendations
+ * engine's security-focused cross-sell heuristic. When OE's first-party
+ * recommendations API ships (ARC-785, `GET /opportunities`), this local
+ * taxonomy sunsets. Pax8's STAX taxonomy is itself being replaced by a new
+ * L1/L2/L3 hierarchical taxonomy (PCM team, Angelo Echtermeijer) — the CLI
+ * should align to whichever taxonomy the OE API uses at sunset time. See:
+ * Product Category (STAX) Layout, Product Taxonomy & Ontology PRD, and the
+ * v0.2 follow-up issue (#375).
+ *
+ * Separately from product categories, the `opportunityType` field on
+ * `Recommendation` carries OE's canonical 5-type opportunity taxonomy
+ * (`Upsell`, `Cross-sell`, `Add-on`, `Upgrade`, `Net-new`). It was added
+ * alongside (not replacing) the legacy `type` field, extending the
+ * disclosure-over-rewrite pattern from #298/#299. Mapping:
+ *   - `type: "cross_sell"` with at least one active sub → "Cross-sell"
+ *   - `type: "cross_sell"` for a zero-sub company        → "Net-new"
+ *   - `type: "seat_gap"`                                  → "Upsell"
+ *     (in-stack expansion of an existing product, closest OE surrogate for
+ *     the CLI's cross-product mismatch heuristic — still not equivalent to
+ *     Pax8's canonical Seat Utilization, which is single-product
+ *     assigned-vs-purchased.)
+ */
+
 import type { Subscription } from "../api/types.js";
 import { subscriptionMrr } from "./analytics.js";
 
@@ -226,10 +258,31 @@ type SubscriptionInput = Omit<Partial<Subscription>, "status" | "billingTerm"> &
   billingTerm?: string;
 };
 
+/**
+ * Pax8 Opportunity Explorer's canonical 5-type opportunity taxonomy.
+ * Source: OX Help Center. Added as an additive axis on every recommendation
+ * alongside the legacy `type` field, per the disclosure-over-rewrite pattern
+ * from #298/#299. The full taxonomy alignment (CLI 7 product categories vs
+ * STAX / PCM canon) is deferred to v0.2 (#375); this axis is the in-tree
+ * portion of that alignment that can ship without waiting on ARC-785.
+ */
+export type OpportunityType =
+  | "Upsell"
+  | "Cross-sell"
+  | "Add-on"
+  | "Upgrade"
+  | "Net-new";
+
 export interface Recommendation {
   companyId: string;
   companyName: string;
   type: "cross_sell" | "seat_gap";
+  /**
+   * Pax8 Opportunity Explorer canonical opportunity type. Additive axis —
+   * does not replace `type`. See the module-level doc comment for the
+   * mapping between `type` and `opportunityType`.
+   */
+  opportunityType: OpportunityType;
   priority: "high" | "medium" | "low";
   title: string;
   reason: string;
@@ -477,6 +530,10 @@ export function getRecommendations(
           companyId,
           companyName,
           type: "cross_sell",
+          // Company has at least one active sub (it matched at least one
+          // `ifHas` category), so the canonical OE motion is Cross-sell —
+          // adding a complementary product category to an existing stack.
+          opportunityType: "Cross-sell",
           priority: effectivePriority,
           title,
           reason: rule.reason,
@@ -506,6 +563,11 @@ export function getRecommendations(
         companyId,
         companyName,
         type: "seat_gap",
+        // Seat-gap is in-stack expansion of an existing product — the closest
+        // OE surrogate is Upsell. Still not equivalent to Pax8's canonical
+        // Seat Utilization (single-product assigned-vs-purchased); see #298
+        // and the module doc.
+        opportunityType: "Upsell",
         priority: gap.missingSeats > 20 ? "high" : "medium",
         // Wording disambiguates from Pax8's canonical "Seat Utilization"
         // metric, which is single-product assigned-vs-purchased. This
@@ -530,7 +592,17 @@ export function getRecommendations(
         recommendations.push({
           companyId: company.id,
           companyName: company.name,
+          // Legacy `type` stays `cross_sell` — this is the closest existing
+          // surrogate in the 2-value union. The full `seat_gap`/`cross_sell`
+          // → OE 5-type migration is deferred to v0.2 (#375). The new
+          // `opportunityType` axis carries the correct value today.
           type: "cross_sell",
+          // Zero active subs → no existing stack to cross-sell into.
+          // Canonical OE motion is Net-new. This corrects the surprise the
+          // triage doc surfaced (see surprise #7 in
+          // `docs/triage/recommendations-conformance.md`): the company was
+          // being labeled Cross-sell when there was nothing to cross from.
+          opportunityType: "Net-new",
           priority: "high",
           title: `No active subscriptions for ${company.name}`,
           reason: "This customer has no active subscriptions. Consider reaching out to discuss their needs.",
@@ -582,5 +654,215 @@ export function getRecommendations(
     companiesWithGaps,
     estimatedTotalMrrUplift,
     unmatchedProducts: [...unmatchedProducts],
+  };
+}
+
+// ─── Upsell Cohort Finder ───────────────────────────────────────────────────
+//
+// Composition over `get_subscriptions` + `get_companies` (+ optional
+// `get_contacts`) that answers a single question:
+//   "Which companies have product A but NOT product B?"
+//
+// Follows the MCP "Proactive Upsell Opportunity Finder" pattern (MCP Guide
+// 3b) — Pax8's canonical composition for the upsell workflow. The MCP server
+// composes this from get_subscriptions / get_companies / get_contacts; we
+// mirror it locally over the same inputs so it works under PAX8_DEMO=1 and
+// over the live API alike.
+//
+// This is intentionally distinct from `getRecommendations()`: the cross-sell
+// engine works on inferred product *categories*, while this finder works on
+// explicit product *identities* the user names on the command line. It is
+// the canonical Pax8 workflow when a partner has a specific upsell motion in
+// mind (e.g. "everyone on M365 Business Basic who doesn't have E3").
+
+export interface UpsellMatch {
+  companyId: string;
+  companyName: string;
+  /** The subscription(s) for the `--from-product` that qualify this company */
+  fromSubscriptions: Array<{
+    subscriptionId: string | undefined;
+    productId: string | undefined;
+    productName: string;
+    quantity: number;
+    price: number;
+    billingTerm: string;
+  }>;
+  /** Total seats currently on the `--from-product` (sum across qualifying subs) */
+  fromSeats: number;
+  /** Current MRR contribution from the `--from-product` subscriptions */
+  fromMrr: number;
+  /**
+   * Contact emails on file for the company, when contacts were supplied.
+   * Empty when no contacts were provided to the finder.
+   */
+  contacts: Array<{ name: string; email: string }>;
+  /**
+   * OE canonical opportunity type — always `"Upsell"` for this finder: the
+   * partner is moving an existing customer up a product tier, not adding a
+   * new category or net-new customer.
+   */
+  opportunityType: "Upsell";
+}
+
+export interface UpsellCohortReport {
+  fromProduct: string;
+  toProduct: string;
+  /** Companies that have `--from-product` and DO NOT have `--to-product`. */
+  matches: UpsellMatch[];
+  /** Total seats across all qualifying companies (sum of `fromSeats`). */
+  totalFromSeats: number;
+  /** Total MRR currently on the from-product across the cohort. */
+  totalFromMrr: number;
+  /**
+   * Companies excluded because they already have `--to-product` (counted but
+   * not listed, to keep the cohort focused on the *actionable* set).
+   */
+  alreadyHaveToProduct: number;
+  /** How many companies match `--from-product` at all (before exclusion). */
+  totalFromProductCompanies: number;
+}
+
+interface MinimalContact {
+  companyId: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+}
+
+/**
+ * Match a free-text product query against a subscription's product name.
+ *
+ * Honors the same case-insensitive substring + whole-word-token semantics the
+ * existing `recommendations` engine uses elsewhere. Callers can pass either an
+ * exact product name (`"Microsoft 365 Business Basic [New Commerce
+ * Experience]"`) or a partial keyword (`"Business Basic"`) — both work.
+ */
+function productNameMatches(subscriptionProductName: string, query: string): boolean {
+  if (!subscriptionProductName || !query) return false;
+  const name = subscriptionProductName.toLowerCase();
+  const q = query.toLowerCase();
+  if (name.includes(q)) return true;
+  // Token-based fallback: every word in the query must appear in the name.
+  const tokens = q.split(/\s+/).filter((t) => t.length > 2);
+  if (tokens.length === 0) return false;
+  return tokens.every((t) => name.includes(t));
+}
+
+/**
+ * Find companies that have `fromProduct` but not `toProduct`.
+ *
+ * Per the MCP "Proactive Upsell Opportunity Finder" pattern (Guide 3b), this
+ * composes over the three inputs a partner already has access to:
+ *   - `subscriptions` — the universe of active subscriptions
+ *   - `companies` — for name resolution + the no-active-sub cohort
+ *   - `contacts` (optional) — for follow-up routing
+ *
+ * Returns the cohort with seats, MRR, and contact details attached. The
+ * caller decides how to render it (table for humans, JSON for agents).
+ */
+export function findUpsellCohort(
+  subscriptions: SubscriptionInput[],
+  fromProduct: string,
+  toProduct: string,
+  options?: {
+    companies?: Array<{ id: string; name: string }>;
+    contacts?: MinimalContact[];
+  },
+): UpsellCohortReport {
+  const companyNames = new Map<string, string>();
+  if (options?.companies) {
+    for (const c of options.companies) companyNames.set(c.id, c.name);
+  }
+
+  // Group active subs by company; track whether each company has fromProduct
+  // and/or toProduct, and record the qualifying `from` subscriptions.
+  const byCompany = new Map<string, {
+    companyName: string;
+    hasFrom: boolean;
+    hasTo: boolean;
+    fromSubs: UpsellMatch["fromSubscriptions"];
+  }>();
+
+  for (const sub of subscriptions) {
+    if (sub.status !== "Active" || !sub.companyId) continue;
+    const productName = sub.productName ?? "";
+    const matchesFrom = productNameMatches(productName, fromProduct);
+    const matchesTo = productNameMatches(productName, toProduct);
+    if (!matchesFrom && !matchesTo) continue;
+
+    const companyName = sub.companyName ?? companyNames.get(sub.companyId) ?? sub.companyId;
+    const entry = byCompany.get(sub.companyId) ?? {
+      companyName,
+      hasFrom: false,
+      hasTo: false,
+      fromSubs: [],
+    };
+    if (matchesFrom) {
+      entry.hasFrom = true;
+      entry.fromSubs.push({
+        subscriptionId: sub.id,
+        productId: sub.productId,
+        productName,
+        quantity: sub.quantity ?? 0,
+        price: sub.price ?? 0,
+        billingTerm: sub.billingTerm ?? "Monthly",
+      });
+    }
+    if (matchesTo) {
+      entry.hasTo = true;
+    }
+    byCompany.set(sub.companyId, entry);
+  }
+
+  // Bucket contacts by company once, for O(n) lookup.
+  const contactsByCompany = new Map<string, Array<{ name: string; email: string }>>();
+  if (options?.contacts) {
+    for (const c of options.contacts) {
+      if (!c.email) continue;
+      const name = [c.firstName, c.lastName].filter(Boolean).join(" ").trim();
+      const list = contactsByCompany.get(c.companyId) ?? [];
+      list.push({ name: name || c.email, email: c.email });
+      contactsByCompany.set(c.companyId, list);
+    }
+  }
+
+  const matches: UpsellMatch[] = [];
+  let alreadyHaveToProduct = 0;
+  let totalFromProductCompanies = 0;
+
+  for (const [companyId, entry] of byCompany) {
+    if (!entry.hasFrom) continue;
+    totalFromProductCompanies++;
+    if (entry.hasTo) {
+      alreadyHaveToProduct++;
+      continue;
+    }
+    const fromSeats = entry.fromSubs.reduce((sum, s) => sum + (s.quantity || 0), 0);
+    const fromMrr = entry.fromSubs.reduce(
+      (sum, s) => sum + subscriptionMrr(s.price, s.quantity, s.billingTerm),
+      0,
+    );
+    matches.push({
+      companyId,
+      companyName: entry.companyName,
+      fromSubscriptions: entry.fromSubs,
+      fromSeats,
+      fromMrr: Number(fromMrr.toFixed(2)),
+      contacts: contactsByCompany.get(companyId) ?? [],
+      opportunityType: "Upsell",
+    });
+  }
+
+  // Sort by MRR descending so the highest-leverage targets float to the top.
+  matches.sort((a, b) => b.fromMrr - a.fromMrr);
+
+  return {
+    fromProduct,
+    toProduct,
+    matches,
+    totalFromSeats: matches.reduce((sum, m) => sum + m.fromSeats, 0),
+    totalFromMrr: Number(matches.reduce((sum, m) => sum + m.fromMrr, 0).toFixed(2)),
+    alreadyHaveToProduct,
+    totalFromProductCompanies,
   };
 }


### PR DESCRIPTION
## Summary

Path B from the `pax8 recommendations` conformance audit
(`docs/triage/recommendations-conformance.md`): narrow, additive alignment
with Pax8 Opportunity Explorer canon. Extends the disclosure-over-rewrite
pattern established by #298 (vocabulary alignment) and #299 (`mrrAtRisk` →
`mrrRenewing` one-cycle alias). Full taxonomy retirement is deferred to
v0.2 (#375).

- **Additive `opportunityType` axis on every recommendation** using OE's
  canonical 5-type taxonomy (`Upsell`, `Cross-sell`, `Add-on`, `Upgrade`,
  `Net-new`). The legacy `type` field is **unchanged**. Mapping:

  | Existing `type`              | Emitted `opportunityType` |
  |------------------------------|---------------------------|
  | `cross_sell` (active subs)   | `Cross-sell`              |
  | `cross_sell` (zero-sub cust) | `Net-new` *(fix)*         |
  | `seat_gap`                   | `Upsell`                  |

  The zero-sub remap is the fix for surprise #7 in the audit: zero-sub
  companies were silently traveling as `cross_sell` (with empty
  `suggestedProducts` and `productAvailable: false`) when the canonical
  OE motion is `Net-new` — there is no existing stack to cross-sell into.

- **New `pax8 recommendations upsell --from-product --to-product`** command
  follows the MCP "Proactive Upsell Opportunity Finder" pattern (Guide
  §3b): composes `get_subscriptions` + `get_companies` (+ optional
  `get_contacts`) to return every company on the source product who does
  not yet have the upsell target. Supports `--with-contacts` for contact
  enrichment and `--json` for agent consumption.

- **STAX-divergence doc comment** added verbatim at the top of
  `packages/core/src/services/recommendations.ts` citing Rovo research on
  PICS (4 executive categories), STAX (8 L1 operational categories), and
  the in-flight L1/L2/L3 taxonomy v2 (PCM team, Angelo Echtermeijer,
  POM-901). Notes that this local 7-category taxonomy sunsets when
  ARC-785 ships.

- **Triage doc** (`docs/triage/recommendations-conformance.md`) committed
  alongside the implementation, matching the shape of the other audit
  artifacts batch-committed in #372. Header updated to reflect that
  Path B has now shipped.

## New `@pax8/core` exports

- `findUpsellCohort(subscriptions, fromProduct, toProduct, { companies, contacts })`
- types `UpsellMatch`, `UpsellCohortReport`, `OpportunityType`

## Out of scope (deferred to v0.2 / #375)

- Retiring the security-centric 7 product categories (`productivity`,
  `email`, `security`, `endpoint_protection`, `identity`, `backup`,
  `cloud_infrastructure`) in favor of Pax8's canonical STAX/PCM
  categories. The mapping audit (CLI 7 → STAX 8) lives in the v0.2 issue.
- Renaming `seat_gap` with a one-cycle alias period, mirroring the
  `mrrAtRisk` → `mrrRenewing` precedent (#299, `CHANGELOG.md:23`).
- Migrating `coverage: "n/7"` (a literal string in
  `getPortfolioCoverage()` output) to a structured `{ covered, total }`
  shape.
- Fixing the pre-existing Claude Skill description hyphen/underscore
  mismatch (`packages/claude-skill/src/tools/recommendations.ts:9` says
  `"cross-sell or seat-gap"` while the actual JSON values are
  `cross_sell` and `seat_gap`). Flagged in the v0.2 issue as adjacent
  cleanup.

## Refs

- Triage doc: `docs/triage/recommendations-conformance.md` (in this PR)
- v0.2 follow-up issue: #375 (filed prior to this PR; cited in the
  changeset and the engine doc comment)
- Vocabulary-alignment precedent: #298, #299
- First-party API tracker: #62 (covered by ARC-785 in the v0.2 issue)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 1761 passed, 6 skipped (was 1751 passed before;
  +10 new tests covering opportunityType invariants, zero-sub Net-new
  fix, and the new `upsell` command happy path + edges)
- [x] `pnpm lint` clean
- [x] Schema invariant: every recommendation carries both `type` and
  `opportunityType`; `opportunityType` is drawn from the OE 5-type set.
- [x] Engine: zero-sub companies emit `opportunityType: "Net-new"`.
- [x] CLI: `pax8 recommendations list --json` includes both fields.
- [x] CLI: `pax8 recommendations upsell` happy path returns a non-empty
  cohort under `PAX8_DEMO=1`.
- [x] CLI: `pax8 recommendations upsell` returns `{ matches: [],
  totalFromProductCompanies: 0 }` when no company has `--from-product`.
- [x] CLI: `pax8 recommendations upsell` returns `{ matches: [],
  alreadyHaveToProduct: totalFromProductCompanies }` when every
  qualifying company already has `--to-product`.
- [x] CLI: `pax8 recommendations upsell` errors cleanly when
  `--to-product` is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)