### PR TITLE
feat(cli): rename companies command group to clients with deprecated alias (closes #317)

### DIFF
--- a/.changeset/clients-rename-with-alias.md
+++ b/.changeset/clients-rename-with-alias.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": minor
+---
+
+`pax8 companies *` renamed to `pax8 clients *` with `companies` retained as an indefinite deprecated alias via Commander's native `.alias()` mechanism. Both invocations route through the exact same Command graph and action handlers — there's structurally only one command graph, so the surfaces can't drift. Pax8 is structurally moving away from the COMPANY noun in API contracts (PAE-2054 governance, Client Archetype PRD, portal's "New Client Creation Form" GA, v2 quotes API `clientId`). The CLI command surface adopts the user-facing canonical noun now; JSON output fields (`companyId`, `companyName`, etc.) stay aligned with the current public API and will migrate when the API does. The `--company` flag on other commands (`subscriptions list`, `contacts list`, etc.) is unchanged — flag mirrors the API field, no rename until the API renames. Closes #317. Doc updates (README, skill.md, AGENTS.md, CLAUDE.md, domain-review.md) tracked separately under #378.

--- a/packages/cli/src/__tests__/clients-companies-parity.test.ts
+++ b/packages/cli/src/__tests__/clients-companies-parity.test.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCli } from "./test-utils.js";
+
+/**
+ * Regression guard for #317: `pax8 clients *` and `pax8 companies *` must
+ * resolve to the same Commander command graph. We use Commander's native
+ * `.alias()` mechanism in `packages/cli/src/commands/companies/index.ts`,
+ * which structurally guarantees a single set of action handlers — the
+ * tests below assert the *user-facing contract* (help output parity)
+ * stays in sync so a future refactor can't silently introduce drift.
+ */
+describe("pax8 clients / pax8 companies parity (#317)", () => {
+  // Subcommands that exist on the group today. If a new subcommand is added
+  // to clients/companies/index.ts, add it here too so the parity contract
+  // continues to hold.
+  const SUBCOMMANDS = ["list", "show", "create", "update", "more"];
+
+  /**
+   * Strip leading "Usage:" line and any volatile text so we compare the
+   * stable parts of `--help` output: options block, examples, etc.
+   * The "Usage:" line legitimately differs (one says `clients`, the other
+   * says `companies`), so we drop it.
+   */
+  function normalizeHelp(out: string): string {
+    return out
+      .split("\n")
+      .filter((line) => !line.startsWith("Usage:"))
+      .join("\n")
+      .replace(/\bcompanies\b/g, "<GROUP>")
+      .replace(/\bclients\b/g, "<GROUP>")
+      .trim();
+  }
+
+  it("`pax8 clients --help` and `pax8 companies --help` describe the same subcommands", async () => {
+    const clients = await runCli(["clients", "--help"]);
+    const companies = await runCli(["companies", "--help"]);
+
+    expect(clients.exitCode).toBe(0);
+    expect(companies.exitCode).toBe(0);
+
+    // Both should list every subcommand
+    for (const sub of SUBCOMMANDS) {
+      expect(clients.stdout, `clients --help missing ${sub}`).toMatch(
+        new RegExp(`\\b${sub}\\b`),
+      );
+      expect(companies.stdout, `companies --help missing ${sub}`).toMatch(
+        new RegExp(`\\b${sub}\\b`),
+      );
+    }
+  });
+
+  for (const sub of SUBCOMMANDS) {
+    it(`\`pax8 clients ${sub} --help\` matches \`pax8 companies ${sub} --help\``, async () => {
+      const clients = await runCli(["clients", sub, "--help"]);
+      const companies = await runCli(["companies", sub, "--help"]);
+
+      expect(clients.exitCode).toBe(0);
+      expect(companies.exitCode).toBe(0);
+
+      // The help output should be identical once the group-name token is
+      // normalized — if a flag is added to one but not the other, this
+      // assertion fails loudly.
+      expect(normalizeHelp(clients.stdout)).toBe(normalizeHelp(companies.stdout));
+    });
+  }
+
+  it("`pax8 --help` lists `clients` as the canonical command name", async () => {
+    const top = await runCli(["--help"]);
+    expect(top.exitCode).toBe(0);
+    // Commander prints aliases as "clients|companies" or similar. Either way,
+    // `clients` must appear as the canonical name.
+    expect(top.stdout).toMatch(/\bclients\b/);
+  });
+});

--- a/packages/cli/src/commands/companies/index.ts
+++ b/packages/cli/src/commands/companies/index.ts
@@ -8,14 +8,43 @@ import { companiesCreateCommand } from "./create.js";
 import { companiesUpdateCommand } from "./update.js";
 import { companiesMoreCommand } from "./more.js";
 
+/**
+ * Register the clients command group. `pax8 clients *` is the canonical
+ * user-facing surface; `pax8 companies *` is an indefinite deprecated
+ * alias registered via Commander's native `.alias()` mechanism so both
+ * invocations route through the exact same Command graph and action
+ * handlers — by construction, the surfaces cannot drift.
+ *
+ * Why "indefinite" rather than aggressive deprecation: Pax8 is structurally
+ * moving away from the COMPANY noun in API contracts (PAE-2054 governance,
+ * Client Archetype PRD, portal's "New Client Creation Form" GA, v2 quotes
+ * API `clientId`), but the public partner API hasn't shipped `/clients`
+ * endpoints yet. The CLI command surface adopts the canonical user-facing
+ * noun now; the data surface (JSON fields like `companyId`, `companyName`,
+ * `--company` flag on other commands) stays aligned with whatever the wire
+ * actually carries until the API renames. See #317.
+ */
 export function registerCompaniesCommands(program: Command): void {
-  const companies = new Command("companies").description("Manage companies");
+  const clients = new Command("clients")
+    .alias("companies")
+    .description("Manage clients (alias: companies, deprecated)")
+    .addHelpText(
+      "after",
+      `
+Note: \`pax8 companies\` is a deprecated alias for \`pax8 clients\`. Both work
+identically — the alias maps to the same Commander command graph, so there's
+no behavior drift. Pax8 is standardizing on "client" as the canonical
+user-facing noun (PAE-2054, Client Archetype PRD); the CLI tracks the
+human-facing term. JSON output fields and \`--company\` flags on other
+commands continue to mirror the public API and will migrate when the API
+ships \`/clients\` endpoints.`,
+    );
 
-  companies.addCommand(companiesListCommand);
-  companies.addCommand(companiesShowCommand);
-  companies.addCommand(companiesMoreCommand);
-  companies.addCommand(companiesCreateCommand);
-  companies.addCommand(companiesUpdateCommand);
+  clients.addCommand(companiesListCommand);
+  clients.addCommand(companiesShowCommand);
+  clients.addCommand(companiesMoreCommand);
+  clients.addCommand(companiesCreateCommand);
+  clients.addCommand(companiesUpdateCommand);
 
-  program.addCommand(companies);
+  program.addCommand(clients);
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -109,6 +109,16 @@ export type Address = z.infer<typeof AddressSchema>;
 
 // ─── Company ─────────────────────────────────────────────────────────────────
 
+/**
+ * `companyId` mirrors the public API's current field name. Pax8 is
+ * structurally moving away from the COMPANY noun in API contracts (per
+ * PAE-2054 governance rule and the Client Archetype PRD). The user-
+ * facing canonical term is `client`; the underlying API field name
+ * may eventually become `accountId` rather than `clientId`, per Pax8's
+ * account-archetype model. The CLI command surface uses `clients`
+ * today (per #317); the data surface stays aligned with whatever the
+ * wire actually carries.
+ */
 export const CompanySchema = z.object({
   id: z.string(),
   name: z.string(),


### PR DESCRIPTION
## Summary

`pax8 companies *` is now `pax8 clients *`. The previous name is retained indefinitely as a deprecated alias via Commander's native `.alias()` mechanism — both invocations route through the same Command graph, so the surfaces are structurally guaranteed not to drift.

## Why minor (not patch)

The canonical command name changes (user-facing surface). The `companies` invocation still works via the alias, but the canonical name is the change worth a minor bump.

## What landed

- **`packages/cli/src/commands/companies/index.ts`** — single Command graph, `.alias("companies")` on the group, deprecation note in `addHelpText`
- **`packages/core/src/api/types.ts`** — verbatim schema comment above `CompanySchema` documenting the COMPANY → CLIENT/ACCOUNT trajectory (PAE-2054 governance, Client Archetype PRD)
- **`packages/cli/src/__tests__/clients-companies-parity.test.ts`** — 7 regression tests: top-level help lists `clients` canonical; each subcommand's `--help` output is identical between the two invocation paths (any future drift fails loudly)
- **`.changeset/clients-rename-with-alias.md`** — `@pax8/cli` minor

## What I deliberately did NOT do

- Did not touch JSON output fields (`companyId`, `companyName`, etc.) — these mirror the wire
- Did not touch `--company` flag on other commands — same reason
- Did not update README / skill.md / AGENTS.md / CLAUDE.md / domain-review.md — deferred to **#378** (pure-doc follow-up) to keep this change reviewable

## Approach notes

The originally-dispatched agent went with a factory-pattern approach (`buildXxxCommand(groupName)`), which would have produced two parallel Command graphs with parameterized help-text examples. I reverted that and switched to Commander's native `.alias()` because:

1. It's genuinely thinner code (the user's brief said "thin alias mechanism")
2. Single command graph means structurally-guaranteed handler parity — there's literally only one definition
3. The parity test still proves help-output stability without requiring a custom factory

Trade-off accepted: `pax8 companies list --help` says "List all clients" (rather than "List all companies"). Acceptable — the alias note in the group help-text suffix explains this is the same command under a deprecated name.

## Verification

- `pnpm build` clean
- `pnpm test` — 1757 passed / 6 skipped (was 1750 — +7 from the new parity tests)
- `pnpm lint` clean
- Manual: `pax8 --help`, `pax8 clients --help`, `pax8 companies --help` all behave as documented

## Relates

- Closes #317
- Doc follow-up: #378