### PR TITLE
fix(integration): isolate per-worker cache; add orders v1 smoke + --status pin

### DIFF
--- a/.changeset/integration-harness-cache-fix.md
+++ b/.changeset/integration-harness-cache-fix.md
@@ -1,0 +1,9 @@
+---
+"@pax8/core": patch
+---
+
+`FileCache` now honors `PAX8_CONFIG_DIR` (via `getConfigDir()`) instead of hardcoding `~/.pax8/cache`. The hardcoded path meant any caller that used the documented `PAX8_CONFIG_DIR` escape hatch got an inconsistent cache root, and the integration test harness in particular was unable to isolate per-worker caches — a `[pax8] CACHE HIT` from a previous test served stale data on rerun.
+
+Behavior change is purely additive: if you don't set `PAX8_CONFIG_DIR`, `getConfigDir()` still returns `~/.pax8`, so the cache stays at `~/.pax8/cache`. Callers passing an explicit `cacheDir` to the `FileCache` constructor are unaffected.
+
+Also adds `e2e/integration/orders.integration.test.ts` (orders v1 smoke + the `--status` no-op pin per #369) and updates the harness to (a) force `PAX8_DEMO=false` so a developer's `demo: true` config can't false-green integration runs, and (b) point each worker at a throwaway `PAX8_CONFIG_DIR` so the cache fix actually isolates per-worker.

--- a/e2e/integration/harness.ts
+++ b/e2e/integration/harness.ts
@@ -63,8 +63,10 @@
  */
 
 import { execFile } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { promisify } from "node:util";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe } from "vitest";
 
@@ -107,6 +109,30 @@ export const describeIntegration: typeof describe = HAS_CREDENTIALS
   ? describe
   : describe.skip;
 
+// Per-worker temp config dir. Pax8Client's `FileCache` lives under
+// `<configDir>/cache/` with a 1-hour default TTL — re-running an
+// integration test within that window served a stale `[pax8] CACHE HIT`
+// instead of issuing a fresh wire call, which then made `expectWireUrl`
+// fail (no `[pax8] METHOD url=...` line was emitted on the cache hit
+// path). Isolating each worker's cache + config to a throwaway dir
+// guarantees every test exercises the wire and removes the
+// cross-invocation flakiness.
+//
+// Vitest forks a worker per file; each worker gets its own dir and its
+// own cleanup hook. No cross-worker contention.
+const TEST_CONFIG_DIR = HAS_CREDENTIALS
+  ? mkdtempSync(join(tmpdir(), "pax8-integration-"))
+  : "";
+if (TEST_CONFIG_DIR) {
+  process.on("exit", () => {
+    try {
+      rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+    } catch {
+      // best-effort; OS will reap /tmp eventually
+    }
+  });
+}
+
 export interface CliResult {
   stdout: string;
   stderr: string;
@@ -123,7 +149,26 @@ export interface CliResult {
 export async function runCliVerbose(args: string[]): Promise<CliResult> {
   try {
     const result = await exec("node", [CLI_PATH, "--verbose", ...args], {
-      env: { ...process.env, NO_COLOR: "1" },
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        // Force the real-API path. Without this, a developer with
+        // `demo: true` in `~/.pax8/config.yaml` would silently exercise
+        // `MockPax8Client` and the harness's wire assertions would all
+        // skip — false-green. The presence of `PAX8_CLIENT_ID` /
+        // `PAX8_CLIENT_SECRET` (which `describeIntegration` gates on) is
+        // the integration-test signal; demo config in the dev environment
+        // must not override that.
+        PAX8_DEMO: "false",
+        // Point at the per-worker throwaway config dir so every CLI
+        // invocation starts with a fresh `FileCache`. Without this, a
+        // previous test's response gets served from `~/.pax8/cache/`
+        // (1-hour default TTL) on rerun and `expectWireUrl` fails
+        // because cache hits don't emit the `[pax8] METHOD url=...`
+        // line the assertion grep depends on.
+        PAX8_CONFIG_DIR: TEST_CONFIG_DIR,
+        PAX8_ALLOW_NON_HOME_CONFIG: "1",
+      },
       timeout: 30_000,
       maxBuffer: 10 * 1024 * 1024,
     });

--- a/e2e/integration/orders.integration.test.ts
+++ b/e2e/integration/orders.integration.test.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Orders v1 wire smoke + `--status` no-op pin.
+ *
+ * The first test mirrors `companies.integration.test.ts`: it proves the
+ * CLI's orders surface still routes to `/v1/orders`. If a future refactor
+ * accidentally points orders at a different version segment, this catches
+ * it before partners do — same regression class as the #307 quotes bug.
+ *
+ * The second test pins the wire-level behavior verified against the real
+ * API on 2026-05-11 (see `docs/triage/orders-status-server-behavior.md`):
+ *
+ *   - The server silently ignores `?status=` (every value, including bogus
+ *     ones, returns the unfiltered set).
+ *   - The CLI still forwards the flag on the wire so existing partner
+ *     scripts don't break.
+ *
+ * If Pax8's Orders team ever lands real `status` filtering (tracked in
+ * #369), this test continues to pass — it only asserts the CLI forwards
+ * the parameter and the URL still resolves to `/v1/orders`, both of which
+ * remain true under real filtering. The actual ignored-vs-honored behavior
+ * is a server-side concern; we record it in the triage doc rather than
+ * re-asserting it on every test run.
+ */
+
+import { it, expect } from "vitest";
+import {
+  describeIntegration,
+  runCliVerbose,
+  expectExitZero,
+  expectWireUrl,
+} from "./harness.js";
+
+describeIntegration("orders (v1)", () => {
+  it(
+    "orders list --json hits /v1/orders and returns an array",
+    async () => {
+      const result = await runCliVerbose([
+        "orders",
+        "list",
+        "--json",
+        "--size",
+        "1",
+      ]);
+
+      expectExitZero(result);
+      expectWireUrl(result, {
+        method: "GET",
+        pathContains: "/v1/orders",
+        version: "v1",
+      });
+
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+    },
+    60_000,
+  );
+
+  it(
+    "orders list --status forwards the param on the wire (#369)",
+    async () => {
+      const result = await runCliVerbose([
+        "orders",
+        "list",
+        "--json",
+        "--size",
+        "1",
+        "--status",
+        "Completed",
+      ]);
+
+      expectExitZero(result);
+      expectWireUrl(result, {
+        method: "GET",
+        pathContains: "/v1/orders",
+        version: "v1",
+      });
+      // `--status` must reach the wire even though the server ignores it —
+      // dropping it client-side would surprise partner scripts that depend
+      // on the flag being forwarded for future-compat with PAM-side fixes.
+      expect(result.stderr).toMatch(
+        /\[pax8\]\s+GET\s+url=\S*[?&]status=Completed(&|\s|$)/,
+      );
+    },
+    60_000,
+  );
+});

--- a/packages/core/src/services/cache.ts
+++ b/packages/core/src/services/cache.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as fs from "node:fs/promises";
-import { homedir } from "node:os";
 import * as path from "node:path";
+import { getConfigDir } from "../config/loader.js";
 
 interface CacheEntry<T> {
   data: T;
@@ -11,7 +11,15 @@ interface CacheEntry<T> {
 }
 
 export class FileCache {
-  constructor(private cacheDir: string = path.join(homedir(), ".pax8", "cache")) {}
+  // Honor `PAX8_CONFIG_DIR` (via `getConfigDir()`) so the cache follows
+  // the config root. Previously hardcoded `~/.pax8/cache`, which meant
+  // integration tests and any caller using `PAX8_CONFIG_DIR` got a
+  // stale cross-invocation cache they couldn't redirect — surfaced
+  // when the integration suite hit `[pax8] CACHE HIT` on rerun and the
+  // wire-URL assertions had nothing to grep. Resolves on construction
+  // so each `FileCache` pins the dir it was built with (matches the
+  // prior behavior for callers that pass an explicit path).
+  constructor(private cacheDir: string = path.join(getConfigDir(), "cache")) {}
 
   private filePath(key: string): string {
     // Sanitize key to be safe as filename


### PR DESCRIPTION
## Summary

- **`FileCache` now honors `PAX8_CONFIG_DIR`** via `getConfigDir()` instead of hardcoding `~/.pax8/cache`. Latent bug — any caller using the documented `PAX8_CONFIG_DIR` escape hatch got a cache stuck at the wrong root.
- **Harness now forces `PAX8_DEMO=false`** so a developer's `demo: true` config can't silently exercise `MockPax8Client` and false-green the wire assertions.
- **Harness now mints a throwaway `PAX8_CONFIG_DIR`** per vitest worker so each test exercises a fresh cache and emits real `[pax8] METHOD url=...` lines.
- **Adds `orders.integration.test.ts`** — v1 smoke + `--status` no-op pin (#369).

## Why

Discovered while doing end-to-end verification of the bug-2 and bug-3 fixes against the real API. Re-running `pnpm test:integration` produced erratic results: the first run passed, subsequent runs failed with `No "[pax8] METHOD url=..." lines found on stderr`. The CLI was hitting cache instead of the wire, so the assertion grep had nothing to match.

The flakiness chain was:

1. The user's `~/.pax8/config.yaml` had `demo: true`, so the very first integration run skipped the wire entirely.
2. After forcing `PAX8_DEMO=false`, the first run hit the wire and seeded `~/.pax8/cache/`.
3. The harness already supported `PAX8_CONFIG_DIR`, but `FileCache` hardcoded `~/.pax8/cache` and ignored it — so isolating the config dir didn't isolate the cache.
4. On rerun within the 1-hour cache TTL, every test got `[pax8] CACHE HIT` and no wire log line, so `expectWireUrl` failed even though the CLI was behaving correctly.

Fixing FileCache to honor `getConfigDir()` is what actually closes the loop. The harness changes (force-demo-off + temp config dir per worker) are the wiring that exercises the fix.

## Behavior change for production users

Strictly additive. `getConfigDir()` returns `~/.pax8` when `PAX8_CONFIG_DIR` is unset, so the cache stays at `~/.pax8/cache` for everyone not opting into the env-var override.

## Orders integration test

Two assertions, both gated on `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET`:

1. **v1 smoke:** `orders list --json` hits `/v1/orders` (same shape as the existing companies smoke).
2. **`--status` pin (#369):** the CLI forwards `?status=Completed` on the wire even though the server ignores it. Pins the behavior verified against the real API on 2026-05-11 — see `docs/triage/orders-status-server-behavior.md`. If Pax8 ever lands real `status` filtering, this test still passes (it only checks the CLI's forward, not the server's response semantics).

## Test plan

- [x] Unit suite: `pnpm test` — 1750 passing / 6 skipped / 0 failing
- [x] Integration suite: `PAX8_CLIENT_ID=... PAX8_CLIENT_SECRET=... pnpm test:integration` — 6/7 pass
- [x] Build: `pnpm build` — clean
- [ ] CI: confirm credential-less CI still cleanly skips integration (gate-on-creds path)

The 1 failure in integration is `quotes list` returning HTTP 400 from the server on the test account — pre-existing, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)