### PR TITLE
docs: align user-facing docs to clients-rename and contacts-create canonical names

### DIFF
--- a/.changeset/clients-rename-docs-alignment.md
+++ b/.changeset/clients-rename-docs-alignment.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+**Docs:** Updated user-facing docs (README, skill.md, AGENTS.md, CLAUDE.md, domain-review.md, UX_GUIDE.md) to use `pax8 clients *` as the canonical command surface, with `pax8 companies *` mentioned once per doc as a deprecated alias. Also audited and fixed stale references to `pax8 contacts add` (already uses `pax8 contacts create` to match the shipped subcommand name — per the project's `create` convention across every other resource) and a stale `--expiration-date` flag listing under `pax8 quotes create` (the flag was removed in #339). No behavior change. Closes #378.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@ When asked anything about Pax8 data, your first action should be a shell call. N
 | Question | Run this |
 |---|---|
 | overview / status / how am I doing | `pax8 dashboard --json 2>/dev/null` |
-| companies / customers | `pax8 companies list --json 2>/dev/null` |
+| clients / companies / customers | `pax8 clients list --json 2>/dev/null` |
 | subscriptions | `pax8 subscriptions list --json --size 1000 2>/dev/null` (add `--status Active` or `--company <name>` as needed) |
 | renewals | `pax8 subscriptions renewals --json --within 30d 2>/dev/null` |
-| MRR / revenue | `pax8 report mrr --json 2>/dev/null` (or `pax8 subscriptions list --json --size 1000` AND `pax8 companies list --json` in parallel) |
+| MRR / revenue | `pax8 report mrr --json 2>/dev/null` (or `pax8 subscriptions list --json --size 1000` AND `pax8 clients list --json` in parallel) |
 | growth trend | `pax8 report growth --json 2>/dev/null` |
 | recommendations / upsell | `pax8 recommendations list --json 2>/dev/null` |
 | invoices / billing | `pax8 invoices list --json 2>/dev/null` |
@@ -30,7 +30,7 @@ When asked anything about Pax8 data, your first action should be a shell call. N
 | webhook delivery history | `pax8 webhooks logs <id> --json 2>/dev/null` |
 | diagnostics / health | `pax8 doctor --json 2>/dev/null` |
 
-MRR math (only if you must roll it yourself): monthly term = `price × quantity`; annual term = `price × quantity ÷ 12`. Group by `companyId`, resolve names from `companies list`. Prefer `report mrr` — it already does this.
+MRR math (only if you must roll it yourself): monthly term = `price × quantity`; annual term = `price × quantity ÷ 12`. Group by `companyId`, resolve names from `clients list`. Prefer `report mrr` — it already does this.
 
 Operating principles:
 
@@ -48,11 +48,11 @@ Read-only commands run autonomously. Write commands require explicit approval be
 
 These never mutate state. Run them freely, in parallel, and as often as needed.
 
-- `pax8 *list` — `companies list`, `subscriptions list`, `invoices list`, `orders list`, `recommendations list`, `products list`, `quotes list`, `webhooks list`, `usage list`, `contacts list`
+- `pax8 *list` — `clients list`, `subscriptions list`, `invoices list`, `orders list`, `recommendations list`, `products list`, `quotes list`, `webhooks list`, `usage list`, `contacts list`
 - `pax8 *show <id>` — every show command across every resource
 - `pax8 products search`
 - `pax8 report mrr`, `pax8 report growth`
-- `pax8 companies more <name>` — rich read-only summary
+- `pax8 clients more <name>` — rich read-only summary
 - `pax8 subscriptions renewals` — computes renewals from existing data
 - `pax8 invoices items` — line items for an invoice
 - `pax8 invoices audit` — read-only computation, no writes
@@ -74,7 +74,9 @@ Write commands:
 - `pax8 recommendations act` — places real orders. Always interactive; only invoke during a human-in-the-loop session.
 - `pax8 invoices dispute` — files a billing dispute against a discrepancy.
 - `pax8 orders create` — places a real order, charges the partner, creates a subscription.
-- `pax8 companies create`, `pax8 companies update` — partner-account-level customer-record changes.
+- `pax8 clients create`, `pax8 clients update` — partner-account-level customer-record changes.
+
+> `pax8 clients *` is the canonical command surface. `pax8 companies *` is retained as an indefinite deprecated alias — both invocations share the exact same command graph, so agents can use either form. JSON output fields (`companyId`, `companyName`, etc.) and the `--company` flag on other commands stay aligned with the wire.
 - `pax8 contacts create`, `pax8 contacts update`, `pax8 contacts delete` — modifies customer contacts.
 - `pax8 quotes create`, `pax8 quotes update`, `pax8 quotes delete` — modifies sales quotes.
 - `pax8 subscriptions update`, `pax8 subscriptions cancel` — changes seat counts, billing terms, or terminates a subscription.
@@ -115,7 +117,7 @@ Group discrepancies by category (overcharge, undercharge, orphan line item). Lea
 Run in parallel:
 ```
 pax8 recommendations list --json --priority high
-pax8 companies list --json
+pax8 clients list --json
 ```
 For each rec, show: company, missing product, estimated MRR uplift. The JSON output includes an `orderCommand` field — that's the exact `pax8 orders create …` to run. **Always show the order preview and wait for explicit approval before executing the write.**
 
@@ -123,7 +125,7 @@ For each rec, show: company, missing product, estimated MRR uplift. The JSON out
 Run in parallel:
 ```
 pax8 report mrr --json
-pax8 companies list --json
+pax8 clients list --json
 ```
 `report mrr` already breaks down by company. Lead with total MRR and top 5 customers; offer per-vendor or per-product breakdown if asked.
 
@@ -146,7 +148,7 @@ The recipes above cover the questions the CLI is opinionated about. For novel qu
 ```
 pax8 subscriptions list --json --size 1000
 pax8 invoices list --json
-pax8 companies list --json
+pax8 clients list --json
 ```
 
 Don't reimplement what's already a first-class command (renewals, audit, recommendations, MRR) — those exist precisely because they're hard to get right from the raw shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,10 @@ When the user asks ANYTHING about Pax8 data (companies, subscriptions, MRR, reco
 | User asks about | Run this |
 |---|---|
 | overview / status / how am I doing | `pax8 dashboard --json 2>/dev/null` |
-| companies / customers | `pax8 companies list --json 2>/dev/null` |
+| clients / companies / customers | `pax8 clients list --json 2>/dev/null` |
 | subscriptions | `pax8 subscriptions list --json --size 1000 2>/dev/null` (add `--status Active` or `--company <name>` as needed) |
 | renewals | `pax8 subscriptions renewals --json --within 30d 2>/dev/null` |
-| MRR / revenue | `pax8 report mrr --json 2>/dev/null` (or `pax8 subscriptions list --json --size 1000` AND `pax8 companies list --json` in parallel) |
+| MRR / revenue | `pax8 report mrr --json 2>/dev/null` (or `pax8 subscriptions list --json --size 1000` AND `pax8 clients list --json` in parallel) |
 | recommendations / upsell | `pax8 recommendations list --json 2>/dev/null` |
 | invoices / billing | `pax8 invoices list --json 2>/dev/null` |
 | invoice audit | `pax8 invoices audit --json 2>/dev/null` |
@@ -23,9 +23,11 @@ When the user asks ANYTHING about Pax8 data (companies, subscriptions, MRR, reco
 | invoice dispute | `pax8 invoices dispute --discrepancy <id>` (id from `invoices audit`) |
 | diagnostics / health | `pax8 doctor --json 2>/dev/null` |
 
-MRR math (only if you must roll it yourself): monthly term = `price × quantity`; annual term = `price × quantity ÷ 12`. Group by `companyId`, resolve names from `companies list`. Prefer `report mrr` — it already does this.
+MRR math (only if you must roll it yourself): monthly term = `price × quantity`; annual term = `price × quantity ÷ 12`. Group by `companyId`, resolve names from `clients list`. Prefer `report mrr` — it already does this.
 
 Rules: no clarifying questions. Parallel calls when possible. Lead with the key number. Short tables, hide UUIDs. Only confirm writes — never reads.
+
+> `pax8 clients *` is the canonical command surface (per #317). `pax8 companies *` is retained as an indefinite deprecated alias — both invocations share the same command graph. JSON output fields (`companyId`, `companyName`, etc.) and the `--company` flag on other commands stay aligned with the wire.
 
 The full read-vs-write safety contract for agent-driven sessions lives in `packages/claude-skill/skill.md`. Honor it whether the skill is loaded or not: every command listed under "Write commands" requires explicit user approval before execution.
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ PAX8_DEMO=1 pax8 dashboard
 pax8 dashboard                           # estimated MRR, renewals, growth opportunities
 pax8 recommendations list                # Cross-sell and seat gap opportunities
 pax8 recommendations act                 # Multi-select picker → batch order
-pax8 companies list                      # Browse customers (type # to drill in)
-pax8 companies more "Acme Corp"          # Full customer summary
+pax8 clients list                        # Browse customers (type # to drill in)
+pax8 clients more "Acme Corp"            # Full customer summary
 ```
 
 ## Commands
@@ -96,14 +96,16 @@ pax8 dashboard --renewals      # Focus on upcoming renewals
 pax8 dashboard --growth        # Focus on growth opportunities
 ```
 
-### Companies
+### Clients
 
 ```bash
-pax8 companies list                            # List all (type # to drill in)
-pax8 companies list --status Active            # Filter by status
-pax8 companies show "Acme Corp"                # Company details
-pax8 companies more "Acme Corp"                # Full summary: subs, vendors, estimated MRR, issues
+pax8 clients list                              # List all (type # to drill in)
+pax8 clients list --status Active              # Filter by status
+pax8 clients show "Acme Corp"                  # Customer details
+pax8 clients more "Acme Corp"                  # Full summary: subs, vendors, estimated MRR, issues
 ```
+
+> `pax8 companies *` works as an indefinite deprecated alias of `pax8 clients *` — both invocations route through the same command graph, so partner scripts written against the old name keep working. The data surface (`companyId`, `companyName`, `--company` flag, etc.) stays aligned with the wire until Pax8's API renames the field.
 
 ### Subscriptions
 
@@ -185,7 +187,7 @@ pax8 auth status               # Check credentials
 ```bash
 pax8 subscriptions list --json | jq '.[] | select(.quantity > 10)'
 pax8 invoices list --csv > march-billing.csv
-pax8 companies list --ids-only | xargs -I{} pax8 subscriptions list --company {}
+pax8 clients list --ids-only | xargs -I{} pax8 subscriptions list --company {}
 ```
 
 ## REPL Mode
@@ -194,9 +196,9 @@ Run `pax8` with no arguments to enter the interactive REPL:
 
 ```
 $ pax8
-pax8> status
-pax8> companies list
-pax8> 3                          # Drill into company #3
+pax8> dashboard
+pax8> clients list
+pax8> 3                          # Drill into client #3
 pax8> recommendations act        # Multi-select picker → batch order
 pax8> exit
 ```
@@ -251,7 +253,7 @@ The CLI ships with a Claude Code skill, so AI agents get the same computed intel
 
 An agent asking "Am I being overbilled?" doesn't need to make 13+ API calls, join invoice line items against subscriptions, and compute deltas. It runs `pax8 invoices audit --json` and gets categorized discrepancies with dollar impact in one call.
 
-Available tools: companies, subscriptions, renewals, invoices, invoice audits, recommendations, MRR reports, and product search — all returning structured JSON.
+Available tools: clients, subscriptions, renewals, invoices, invoice audits, recommendations, MRR reports, and product search — all returning structured JSON.
 
 ### Setup (Claude Code)
 
@@ -315,7 +317,7 @@ The CLI also honors two ambient environment variables (no opt-in required) and s
 
 | Property | Sent | Notes |
 |---|---|---|
-| `command` | always | The top-level command, e.g. `companies` |
+| `command` | always | The top-level command, e.g. `clients` |
 | `subcommand` | when present | Dotted path, e.g. `recommendations.list` |
 | `flags` | always | The flag *names* the user passed (no values) |
 | `duration_ms` | always | Wall-clock duration in ms |
@@ -362,7 +364,7 @@ When a command fails, the CLI prints recovery hints and a one-line nudge:
 - `$HOME` paths on macOS / Linux / Windows / `~/...` form (`<REDACTED:PATH>` — the suffix after the username is preserved so the tail of the path is still useful for debugging)
 - JWTs and `Bearer` tokens (`<REDACTED:JWT>` / `<REDACTED:TOKEN>`)
 - Long opaque hex / base64-shaped strings (`>=32` chars; covers Pax8 client secrets and similar) (`<REDACTED:TOKEN>`)
-- **Positional argument values** (the company / customer / product names you typed at the command line) — replaced with `<REDACTED:ARG>` placeholders in both the `command` field and the `Message` body. The command structure (`companies show <REDACTED:ARG>`) is preserved so maintainers can reproduce the bug without partner-specific data ever leaving your machine.
+- **Positional argument values** (the client / customer / product names you typed at the command line) — replaced with `<REDACTED:ARG>` placeholders in both the `command` field and the `Message` body. The command structure (`clients show <REDACTED:ARG>`) is preserved so maintainers can reproduce the bug without partner-specific data ever leaving your machine.
 
 The reporter is **opt-in per invocation**, not via a config setting. Nothing leaves your machine without explicit `[y/N]` confirmation — the command always prints the body to stdout *first*, so you can see exactly what would be submitted.
 

--- a/docs/UX_GUIDE.md
+++ b/docs/UX_GUIDE.md
@@ -150,7 +150,7 @@ When you throw an error you control, use `CliError` with all four fields:
 throw new CliError(
   "No active subscriptions found for that company.",
   ["The company may have churned, or the name didn't match."],   // causes
-  [`Run ${replCmd("pax8 companies list")} to see active companies.`],  // recovery
+  [`Run ${replCmd("pax8 clients list")} to see active clients.`],  // recovery
   "https://devx.pax8.com/docs/subscriptions"                     // docs
 );
 ```
@@ -164,7 +164,7 @@ The user sees:
     • The company may have churned, or the name didn't match.
 
   Recovery steps:
-    → Run pax8 companies list to see active companies.
+    → Run pax8 clients list to see active clients.
 
   Docs: https://devx.pax8.com/docs/subscriptions
 ```
@@ -238,11 +238,11 @@ Every command needs a one-sentence `.description()` and an `.addHelpText("after"
 ```ts
 .addHelpText("after", `
 Examples:
-  pax8 companies list
-  pax8 companies list --status Active
-  pax8 companies list --coverage
-  pax8 companies list --json
-  pax8 companies list --ids-only | xargs -I{} pax8 subscriptions list --company {}`)
+  pax8 clients list
+  pax8 clients list --status Active
+  pax8 clients list --coverage
+  pax8 clients list --json
+  pax8 clients list --ids-only | xargs -I{} pax8 subscriptions list --company {}`)
 ```
 
 Descriptions are imperative and short: "List all companies", "Show company details", "Cancel a subscription". No trailing period.
@@ -302,7 +302,7 @@ Agents shouldn't have to regex-match English error strings to decide whether to 
 throw new CliError(
   "No company matched 'Acme'.",
   ["The name didn't match any active company."],
-  [`Run ${replCmd("pax8 companies list")} to see active companies.`],
+  [`Run ${replCmd("pax8 clients list")} to see active clients.`],
   "https://devx.pax8.com/",
   "ERROR_COMPANY_NOT_FOUND"
 );

--- a/docs/domain-review.md
+++ b/docs/domain-review.md
@@ -52,11 +52,11 @@ Five themes were flagged for domain-owner attention. After the 2026-05-07 merges
 
 | Command | Args / Flags | Default | Notes |
 |---|---|---|---|
-| `pax8 companies list` | `--status`, `--page`, `--size`, `--ids-only`, `--coverage`, `--with-actions` | size=25 | `--coverage` adds portfolio coverage analysis (computed) |
-| `pax8 companies show <id\|name>` | accepts name as alternative to UUID | | |
-| `pax8 companies create` | `--name`, `--phone`, `--website`, `--street`, `--city`, `--state`, `--zip`, `--country`, `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required`, `-y` | country=US; booleans all default to `false` | Address required (fail-fast); three billing booleans added in #329 |
-| `pax8 companies update <id\|name>` | `--name`, `--phone`, `--website`, `-y` | | No address/billing-flag updates exposed |
-| `pax8 companies more` | (interactive paging helper) | | CLI-only |
+| `pax8 clients list` | `--status`, `--page`, `--size`, `--ids-only`, `--coverage`, `--with-actions` | size=25 | `--coverage` adds portfolio coverage analysis (computed) |
+| `pax8 clients show <id\|name>` | accepts name as alternative to UUID | | |
+| `pax8 clients create` | `--name`, `--phone`, `--website`, `--street`, `--city`, `--state`, `--zip`, `--country`, `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required`, `-y` | country=US; booleans all default to `false` | Address required (fail-fast); three billing booleans added in #329 |
+| `pax8 clients update <id\|name>` | `--name`, `--phone`, `--website`, `-y` | | No address/billing-flag updates exposed |
+| `pax8 clients more` | (interactive paging helper) | | CLI-only |
 | `pax8 contacts list` | `--company <id\|name>` (required), `--page`, `--size`, `--ids-only` | size=50 | |
 | `pax8 contacts show <id>` | `--company <id\|name>` (required) | | `--company` required post-#324 — the Pax8 public API only addresses contacts under `/companies/{companyId}/contacts/{contactId}` |
 | `pax8 contacts create` | `--company <id\|name>` (required), `--first-name`, `--last-name`, `--email`, `--phone` (required post-#325), `--type <list>`, `-y` | type=Admin | `--type` accepts a comma-separated list (`Admin,Billing`); `--phone` now required because the v2 spec contract mandates a non-empty phone (#325/#353) |
@@ -64,6 +64,8 @@ Five themes were flagged for domain-owner attention. After the 2026-05-07 merges
 | `pax8 contacts delete <id>` | `--company <id\|name>` (required), `-y` | | `--company` required post-#324 |
 
 CLI output schemas (Zod) — `Company`: `id, name, address{street,street2,city,stateOrProvince,postalCode,country}, phone, website, status, billOnBehalfOfEnabled, selfServiceAllowed, orderApprovalRequired, externalId, created, updatedDate`. `Contact`: `id, firstName, lastName, email, phone, types[{type, primary}]` [contact `types` reshaped to spec object form in #325/#353; `companyId` no longer carried on the body since the nested URL identifies it].
+
+> **Command-surface naming.** `pax8 clients *` is the canonical user-facing command group as of #317. `pax8 companies *` is retained as an indefinite deprecated alias via Commander's native `.alias()` — both invocations share the exact same command graph, so the surfaces structurally can't drift. The domain heading "Companies & Contacts" above is the *domain* name (matching API vocabulary), separate from the command surface. JSON output fields (`companyId`, `companyName`, etc.) and the `--company` flag on other commands track the wire and will rename when the API does.
 
 ### Public API Surface
 
@@ -77,32 +79,32 @@ API `Company`: `id, name, address, phone, website, status, billOnBehalfOfEnabled
 |---|---|---|
 | `address.stateOrProvince` | `--state` | Wire field is `stateOrProvince`; CLI keeps the shorter `--state` flag for UX continuity [Wire rename in #327/#328] |
 | `address.postalCode` | `--zip` | Wire field is `postalCode`; CLI keeps the shorter `--zip` flag for UX continuity [Wire rename in #327/#328] |
-| `externalId` | `externalId` | Surfaced on Company in `pax8 companies show` (table + `--json`) [Resolved in #273] |
+| `externalId` | `externalId` | Surfaced on Company in `pax8 clients show` (table + `--json`) [Resolved in #273] |
 | `updatedDate` | `updatedDate` | Aligned with API in #273 (was `modified`) |
 | `createdDate` (Contact) | (not exposed on Contact) | Only surfaced on Company-ish resources |
 | `contacts[]` (embedded on Company) | (separate `contacts list`) | CLI separates rather than embeds |
 | `types[]` (spec shape: `Array<{type: ContactType, primary: boolean}>`) | `--type <comma-list>` | CLI accepts multiple types as a comma-separated string [Surface flag resolved in #255; wire shape aligned with spec in #325/#353 — was bare string array, now object array. Primary defaults to `false` on create] |
 | `Partial PUT` on `contacts update` | Fetch-then-merge | v2 spec requires full body on PUT; CLI now reads the current contact and merges overrides before sending [Resolved in #325/#353] |
-| `companies update` PUT vs PATCH | PATCH | v2 spec documents only PATCH; CLI switched from PUT [Resolved in #326/#346] |
-| `companies create` required fields | `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required` (default `false`) | The three booleans are required by the spec but not user-facing concerns for partners in most cases; defaults preserve the previous UX [Resolved in #329/#352] |
+| `clients update` PUT vs PATCH | PATCH | v2 spec documents only PATCH; CLI switched from PUT [Resolved in #326/#346] |
+| `clients create` required fields | `--bill-on-behalf-of`, `--self-service-allowed`, `--order-approval-required` (default `false`) | The three booleans are required by the spec but not user-facing concerns for partners in most cases; defaults preserve the previous UX [Resolved in #329/#352] |
 | Contacts wire path (`/contacts/{id}` vs `/companies/{cid}/contacts/{id}`) | Nested per spec | Flat path doesn't exist in the API; CLI commands now thread `--company` through all per-contact operations [Resolved in #324/#350] |
 
 ### Coverage
 
-- **API-only (CLI doesn't expose):** address-based filters on `companies list` (`--city`, `--country`, `--state`, `--zip`), the `selfServiceAllowed`/`billOnBehalfOfEnabled`/`orderApprovalRequired` filters on list, `externalId` field on Company, address & billing-flag updates via `companies update`.
-- **CLI-only:** `--coverage` flag (computed: see Recommendations); `--ids-only`; `--with-actions`; `companies more` (interactive paging).
+- **API-only (CLI doesn't expose):** address-based filters on `clients list` (`--city`, `--country`, `--state`, `--zip`), the `selfServiceAllowed`/`billOnBehalfOfEnabled`/`orderApprovalRequired` filters on list, `externalId` field on Company, address & billing-flag updates via `clients update`.
+- **CLI-only:** `--coverage` flag (computed: see Recommendations); `--ids-only`; `--with-actions`; `clients more` (interactive paging).
 
 ### Naming Drift Flags
 
 - `--type` accepts one value; API accepts an array. [Resolved in #255 — comma-separated list now accepted on both create and update.]
-- `companies update` cannot change address or the three boolean billing flags. Confirm whether this is an intentional safety choice or an oversight.
+- `clients update` cannot change address or the three boolean billing flags. Confirm whether this is an intentional safety choice or an oversight.
 - CLI `Company.modified` vs API `updatedDate` — pick one and align. [Resolved in #273 — renamed to `updatedDate`.]
 - Per-contact operations (`show`, `update`, `delete`) now require `--company` — breaking change. The flat `/contacts/{id}` path doesn't exist in the v2 spec, so the CLI cannot address a contact without its company. [Resolved in #324/#350; migration message included in each command's error path.]
 
 ### Questions for Domain Owner
 
 1. ~~Is the CLI right to hide `externalId` from list/show, or do partners need it?~~ [Resolved in #273] — surfaced.
-2. Is `companies update` deliberately address-immutable?
+2. Is `clients update` deliberately address-immutable?
 
 ---
 
@@ -251,7 +253,7 @@ CLI `Order`: `id, companyId, companyName, orderedBy, orderedByEmail, status, cre
 |---|---|---|---|
 | `pax8 quotes list` | `--company`, `--status`, `--page`, `--size`, `--ids-only` | size=50 | Status help text now lowercase to match API (`draft, sent, ...`) [#261] |
 | `pax8 quotes show <id>` | | | Now exposes accept/decline workflow fields when present [#261] |
-| `pax8 quotes create` | `--company`, `--product`, `--quantity`, `--billing-term`, `--expiration-date`, `-y` | qty=1, billing=Monthly | Single-line shorthand; use `quotes line-items add` to add more |
+| `pax8 quotes create` | `--company`, `--product`, `--quantity`, `--billing-term`, `-y` | qty=1, billing=Monthly | Single-line shorthand; use `quotes line-items add` to add more. `--expiration-date` was removed in #339 (it was a silent no-op against the v2 spec); set expiration via `quotes update` after create. |
 | `pax8 quotes update <id>` | `--product`, `--quantity`, `--billing-term`, `--expiration-date`, `-y` | | Now displays a default-no `REPLACES` confirmation diff before clobbering line items [#264] |
 | `pax8 quotes delete <id>` | `-y` | | |
 | `pax8 quotes line-items list <quote-id>` | `--ids-only` | | Lists line items on a quote [Added in #266] |
@@ -388,7 +390,7 @@ The seven categories, the seven cross-sell rules, the seat-gap thresholds (10 se
 - The category taxonomy (`productivity, email, security, endpoint_protection, identity, backup, cloud_infrastructure`) is not from the API. If Pax8 has a canonical category model, confirm it.
 - The cross-sell reasons are written for end-user MSPs; some make security claims ("the #1 attack vector") that should be reviewed by Pax8 messaging owners before being treated as a public contract.
 - The hardcoded suggested-product names tie this engine to specific SKUs; vendor renames break it silently.
-- `companies list --coverage` exposes the same coverage analysis under the Companies surface — surface duplication.
+- `clients list --coverage` exposes the same coverage analysis under the Clients surface — surface duplication.
 
 ### Questions for Domain Owner
 
@@ -536,7 +538,7 @@ Note: "the CLI consumes endpoint X" is **not** evidence here — this doc review
 |---|---|---|
 | **Public-blessed (contract)** | `/orders`, `/subscriptions`, `/companies`, `/contacts`, `/products`, `/invoices`, `/usage-summaries`, `/webhooks` (config/topics/logs/retry), `/v2/quotes` (+ `/line-items`, `/take-ownership`) | On `api.pax8.com`; TypeSpec contracts exist; partner docs treat as core; ADRs cover versioning and idempotency. |
 | **Portal-only (not in public API)** | Storefront publishing, notification template sends, vendor resource-group mapping | Explicitly flagged as gaps in the internal API-vs-portal review; the CLI does not and should not expose these. |
-| **Computed (CLI invents)** | `subscriptions renewals`, `invoices audit`, `invoices dispute`, `recommendations list`/`act`, `report mrr`/`growth`, `cost sim`, `companies list --coverage`, `status` | No API equivalent; needs domain-owner blessing before partners depend on these as a public contract. |
+| **Computed (CLI invents)** | `subscriptions renewals`, `invoices audit`, `invoices dispute`, `recommendations list`/`act`, `report mrr`/`growth`, `cost sim`, `clients list --coverage`, `dashboard` | No API equivalent; needs domain-owner blessing before partners depend on these as a public contract. |
 
 ### Conventions
 

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -13,11 +13,11 @@ This is the safety contract. Read-only commands run autonomously; write commands
 
 These never mutate state. Run them freely, in parallel, and as often as needed.
 
-- `pax8 *list` — `companies list`, `subscriptions list`, `invoices list`, `orders list`, `recommendations list`, `products list`, `quotes list`, `webhooks list`, `usage list`, `contacts list`
+- `pax8 *list` — `clients list`, `subscriptions list`, `invoices list`, `orders list`, `recommendations list`, `products list`, `quotes list`, `webhooks list`, `usage list`, `contacts list`
 - `pax8 *show <id>` — every show command across every resource
 - `pax8 *search` — `products search`
 - `pax8 report *` — `report mrr`, `report growth`
-- `pax8 companies more <name>` — rich read-only summary
+- `pax8 clients more <name>` — rich read-only summary
 - `pax8 subscriptions renewals` — computes renewals from existing data
 - `pax8 invoices items` — line items for an invoice
 - `pax8 invoices audit` — read-only computation, no writes
@@ -39,7 +39,7 @@ Write commands:
 - `pax8 recommendations act` — places real orders. Always interactive; only invoke during a human-in-the-loop session.
 - `pax8 invoices dispute` — files a billing dispute against a discrepancy.
 - `pax8 orders create` — places a real order, charges the partner, creates a subscription.
-- `pax8 companies create`, `pax8 companies update` — partner-account-level customer-record changes.
+- `pax8 clients create`, `pax8 clients update` — partner-account-level customer-record changes.
 - `pax8 contacts create`, `pax8 contacts update`, `pax8 contacts delete` — modifies customer contacts.
 - `pax8 quotes create`, `pax8 quotes update`, `pax8 quotes delete` — modifies sales quotes.
 - `pax8 subscriptions update`, `pax8 subscriptions cancel` — changes seat counts, billing terms, or terminates a subscription.
@@ -73,11 +73,13 @@ Result size: list commands default to `--size 25`. For portfolio-wide analysis (
 
 ## Commands
 
+> `pax8 clients *` is the canonical command surface. `pax8 companies *` is retained as an indefinite deprecated alias — both invocations share the exact same command graph. JSON output fields (`companyId`, `companyName`, etc.) and the `--company` flag on other commands stay aligned to the wire.
+
 ```
 pax8 dashboard [--all|--customers|--renewals|--growth] --json
-pax8 companies list --json
-pax8 companies show <id|name> --json
-pax8 companies more <name>                                  # rich summary, table only
+pax8 clients list --json
+pax8 clients show <id|name> --json
+pax8 clients more <name>                                    # rich summary, table only
 pax8 subscriptions list --json --size 1000 [--company <id|name>] [--status Active|Trial|Cancelled]
 pax8 subscriptions show <id> --json
 pax8 subscriptions renewals --json --within 7d|30d|90d [--company <id|name>]
@@ -96,11 +98,11 @@ pax8 doctor                                                  # diagnostics, not 
 
 ## MRR math
 
-The CLI computes MRR for you in `pax8 dashboard`, `pax8 report mrr`, and `pax8 companies more`. Prefer those over hand-rolling it. If you must compute from `subscriptions list`:
+The CLI computes MRR for you in `pax8 dashboard`, `pax8 report mrr`, and `pax8 clients more`. Prefer those over hand-rolling it. If you must compute from `subscriptions list`:
 
 - Monthly billing term → `price × quantity`
 - Annual billing term → `price × quantity ÷ 12`
-- Group by `companyId`; resolve names from `companies list`.
+- Group by `companyId`; resolve names from `clients list`.
 
 ## Workflow recipes
 
@@ -120,7 +122,7 @@ Group discrepancies by category (overcharge, undercharge, orphan line item). Lea
 Run in parallel:
 ```
 pax8 recommendations list --json --priority high
-pax8 companies list --json
+pax8 clients list --json
 ```
 For each rec, show: company, missing product, estimated MRR uplift. The JSON output includes an `orderCommand` field — that's the exact `pax8 orders create …` to run. **Always show the user the order preview and wait for explicit approval before executing the write.**
 
@@ -130,7 +132,7 @@ For an interactive batch flow, hand the human `pax8 recommendations act` (with `
 Run in parallel:
 ```
 pax8 report mrr --json
-pax8 companies list --json
+pax8 clients list --json
 ```
 `report mrr` already breaks down by company. Lead with total estimated MRR and top 5 customers; offer per-vendor or per-product breakdown if the user asks.
 
@@ -153,7 +155,7 @@ The recipes above cover the questions the CLI is opinionated about. For novel qu
 ```
 pax8 subscriptions list --json --size 1000
 pax8 invoices list --json
-pax8 companies list --json
+pax8 clients list --json
 ```
 
 Don't reimplement what's already a first-class command (renewals, audit, recommendations, MRR) — those exist precisely because they're hard to get right from the raw shape.


### PR DESCRIPTION
## Summary

Pure-doc PR aligning user-facing docs to the post-#317 reality where `pax8 clients *` is canonical and `pax8 companies *` is the deprecated alias. #317 renamed the command group but explicitly deferred doc updates to this PR.

- Every `pax8 companies *` example in user-facing docs renamed to `pax8 clients *`.
- One alias-explanation block per doc — not sprinkled.
- JSON output fields (`companyId`, `companyName`, etc.) and the `--company` flag on other commands are intentionally **not** touched (they mirror the wire).
- Also audited `pax8 contacts add` (zero hits in user-facing docs — all references live in `docs/triage/*`, which is excluded) and dropped a stale `--expiration-date` flag listing on `pax8 quotes create` in `domain-review.md` (removed in #339).

Closes #378.

## Files touched

| File | One-line summary |
|---|---|
| `README.md` | Quick start + Demo flow + Commands section + REPL example + telemetry/bug-reporter examples use `pax8 clients *`. REPL `pax8> status` also moved to `pax8> dashboard` for the #285 rename. One alias-explanation block in the Clients commands section. |
| `packages/claude-skill/skill.md` | Read-only/write surface lists, command cheat-sheet, MRR-math hint, workflow recipes use `clients`. One alias note at the top of the cheat-sheet. |
| `AGENTS.md` | ACT-FIRST table, read-only/write surface lists, MRR-math hint, workflow recipes use `clients`. One alias note in the Write commands section. |
| `CLAUDE.md` | Pax8 data queries table and MRR math hint use `clients`. One alias note below the rules. |
| `docs/domain-review.md` | CLI Surface table, Vocabulary Mapping, Coverage, Naming Drift Flags, and Questions sections use `clients` for the CLI command surface. The "Companies & Contacts" domain heading is preserved (matches API vocabulary). One alias note added under the CLI Surface table. Also fixed: "Computed (CLI invents)" row had `status` → now `dashboard` (#285), `companies list --coverage` → `clients list --coverage`. Removed stale `--expiration-date` from `quotes create` row (#339). |
| `docs/UX_GUIDE.md` | Example error-recovery snippets and the `.addHelpText` examples block use `pax8 clients list`. |
| `.changeset/clients-rename-docs-alignment.md` | New changeset (`@pax8/cli` patch). |

## Other inconsistencies found and fixed beyond primary scope

1. **`pax8 quotes create --expiration-date` flag listing was stale.** `domain-review.md` Quotes table still listed the flag, but it was removed in #339 as a silent no-op against the v2 spec. Removed the flag from the listed options and added a note pointing to `quotes update` for setting expiration post-create.
2. **`status` vs `dashboard` straggler.** The "Computed (CLI invents)" row in `domain-review.md` cross-cutting concerns still said `status`; renamed to `dashboard` to match the #285 rename (which the same file's own legacy-alias note already acknowledges).
3. **README REPL example** still used `pax8> status`; updated to `pax8> dashboard`.

## Not touched (per #378 scope)

- JSON output field names (`companyId`, `companyName`, etc.) — they mirror the wire.
- `--company` flag on other commands (`subscriptions list --company`, etc.) — flag mirrors the API field.
- `--state` / `--zip` flags on `clients create` — `domain-review.md` already documents these as intentional UX shortcuts (the wire is `stateOrProvince`/`postalCode` per #327/#328); the flag names are deliberate ergonomic choices.
- `--events` on `webhooks create` — already renamed to `--topics` in #273; no stragglers in user-facing docs.
- `docs/triage/*` files — historical audit artifacts.
- `CHANGELOG.md` / `packages/*/CHANGELOG.md` — historical record.
- `docs/PRD.md` / `docs/BUILD.md` — historical product/execution docs. (They still contain `pax8 companies *` examples, but they're not user-facing onboarding docs; flagging here in case the maintainer wants a follow-up PR to bring them into alignment.)

## Verification

```
$ grep -rn "pax8 companies" README.md packages/claude-skill/skill.md \
    CLAUDE.md docs/domain-review.md
README.md:108:> `pax8 companies *` works as an indefinite deprecated alias …
packages/claude-skill/skill.md:76:> `pax8 clients *` is the canonical … `pax8 companies *` is retained …
CLAUDE.md:30:> `pax8 clients *` is the canonical … `pax8 companies *` is retained …
docs/domain-review.md:68:> **Command-surface naming.** `pax8 clients *` is canonical … `pax8 companies *` is retained …
# → exactly one alias-explanation block per doc, no stray invocations.

$ grep -rn "pax8 contacts add\|contacts add" --include="*.md" \
    | grep -v "docs/triage"
# → zero hits. (All references live in docs/triage/, which is excluded.)
```

Both grep checks clean.

## Test plan

- [x] `pnpm lint` passes (no md lint issues; pure doc PR has no code surface to test).
- [x] Spot-check 3 changed examples paste-runnable under `PAX8_DEMO=1`:
  - `PAX8_DEMO=1 pax8 clients list` — valid invocation.
  - `PAX8_DEMO=1 pax8 clients more "Acme Corp"` — valid invocation.
  - `PAX8_DEMO=1 pax8 clients list --ids-only | xargs -I{} pax8 subscriptions list --company {}` — pipeline pattern unchanged.
- [x] `pax8 companies *` invocations still work (deprecated alias path, structurally identical command graph per #317's parity test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)