### PR TITLE
docs: bundle audit-surfaced doc fixes (#391, #392, #402)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ When asked anything about Pax8 data, your first action should be a shell call. N
 | recommendations / upsell | `pax8 recommendations list --json 2>/dev/null` |
 | invoices / billing | `pax8 invoices list --json 2>/dev/null` |
 | invoice audit | `pax8 invoices audit --json 2>/dev/null` |
-| invoice line items | `pax8 invoices items <invoice-id> --json 2>/dev/null` |
+| invoice line items | `pax8 invoices items --invoice-id <invoice-id> --json 2>/dev/null` |
 | products / catalog | `pax8 products search "<query>" --json 2>/dev/null` |
 | cost sim / what-if / SKU swap / pricing change | `pax8 cost sim --company <name> --product <name> --quantity <n> --json 2>/dev/null` |
 | place an order | `pax8 orders create --company <id> --product <id> --quantity <n>` (confirm first) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,17 @@ When the user asks ANYTHING about Pax8 data (companies, subscriptions, MRR, reco
 | subscriptions | `pax8 subscriptions list --json --size 1000 2>/dev/null` (add `--status Active` or `--company <name>` as needed) |
 | renewals | `pax8 subscriptions renewals --json --within 30d 2>/dev/null` |
 | MRR / revenue | `pax8 report mrr --json 2>/dev/null` (or `pax8 subscriptions list --json --size 1000` AND `pax8 clients list --json` in parallel) |
+| growth trend | `pax8 report growth --json 2>/dev/null` |
 | recommendations / upsell | `pax8 recommendations list --json 2>/dev/null` |
 | invoices / billing | `pax8 invoices list --json 2>/dev/null` |
 | invoice audit | `pax8 invoices audit --json 2>/dev/null` |
+| invoice line items | `pax8 invoices items --invoice-id <invoice-id> --json 2>/dev/null` |
 | products / catalog | `pax8 products search "query" --json 2>/dev/null` |
 | cost sim / what if / pricing change / SKU swap | `pax8 cost sim --company <name> --product <name> --quantity <n> --json 2>/dev/null` |
 | place an order | `pax8 orders create --company <id> --product <id> --quantity <n>` (confirm first) |
 | act on a recommendation | Extract `orderCommand` from `pax8 recommendations list --json` and run it (confirm first), or use `pax8 recommendations act` for the interactive flow |
 | invoice dispute | `pax8 invoices dispute --discrepancy <id>` (id from `invoices audit`) |
+| webhook delivery history | `pax8 webhooks logs <id> --json 2>/dev/null` |
 | diagnostics / health | `pax8 doctor --json 2>/dev/null` |
 
 MRR math (only if you must roll it yourself): monthly term = `price × quantity`; annual term = `price × quantity ÷ 12`. Group by `companyId`, resolve names from `clients list`. Prefer `report mrr` — it already does this.

--- a/README.md
+++ b/README.md
@@ -486,7 +486,6 @@ signal across the customer's stack, not a utilization rate within one product.
 
 - [Credential Setup Guide](docs/credential-setup.md)
 - [Product Requirements](docs/PRD.md)
-- [Credential Setup Guide](docs/credential-setup.md)
 - [Build Prompt](docs/BUILD.md)
 - [Pax8 API Reference](https://devx.pax8.com/)
 

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -19,7 +19,7 @@ These never mutate state. Run them freely, in parallel, and as often as needed.
 - `pax8 report *` — `report mrr`, `report growth`
 - `pax8 clients more <name>` — rich read-only summary
 - `pax8 subscriptions renewals` — computes renewals from existing data
-- `pax8 invoices items` — line items for an invoice
+- `pax8 invoices items --invoice-id <id>` — line items for an invoice
 - `pax8 invoices audit` — read-only computation, no writes
 - `pax8 cost sim` — what-if pricing simulation, no writes
 - `pax8 dashboard`, `pax8 dashboard --all|--renewals|--growth`


### PR DESCRIPTION
## Summary

Bundles three docs-only fixes surfaced by the partner-readiness audit (dimension 03 — docs accuracy):

- **#391** — Fix `pax8 invoices items` syntax in `packages/claude-skill/skill.md` and `AGENTS.md`. The command takes `--invoice-id <id>` (flag), but both docs showed `pax8 invoices items <invoice-id>` (positional). Positional arg was silently ignored, returning ALL items — a silent data-correctness failure for agents.
- **#392** — Add `pax8 report growth` row to the `CLAUDE.md` command table (between MRR and recommendations). Also folded in two additional CLAUDE.md ↔ AGENTS.md row-gap fixes for the same class of issue: `invoice line items` and `webhook delivery history` rows that existed in AGENTS.md but were missing in CLAUDE.md.
- **#402** — Remove duplicated `[Credential Setup Guide](docs/credential-setup.md)` link in the README Documentation section.

Cross-reference: `docs/triage/partner-readiness-audit/03-docs-accuracy.md`.

## Test plan

- [x] docs-only — verified each command shown in the doc actually exists via `pax8 <cmd> --help` under `PAX8_DEMO=1`:
  - `pax8 invoices items --help` confirms `--invoice-id <id>` flag (no positional)
  - `pax8 report growth --help` confirms command exists
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `grep "pax8 invoices items <" *.md packages/**/*.md` shows zero remaining positional references in the user-facing docs (only references that remain are in the audit triage docs themselves, which describe the bug)