### PR TITLE
fix(quotes): align Zod schema to spec's nested client object

### DIFF
--- a/.changeset/quotes-schema-client-flatten.md
+++ b/.changeset/quotes-schema-client-flatten.md
@@ -1,0 +1,9 @@
+---
+"@pax8/core": patch
+---
+
+Align the `QuoteSchema` Zod parser with the v2 quoting API's nested `client` object so `pax8 quotes list` / `quotes show` return a usable `companyId` against the real API. Closes #384 (block-launch finding from `docs/triage/partner-readiness-audit/01-api-conformity-reads.md`).
+
+Pre-fix, `GET /v2/quotes` returned `{ client: { id, isShadowCompany, name } }` per `quoting-endpoints.json → components.schemas.QuoteResponse`, but `QuoteSchema` expected a flat `companyId: z.string()`. Zod's default behavior dropped the unknown `client` key, leaving `companyId` undefined on every parsed row when run against the real API. Demo mode masked this because the demo `Quote` fixture carried a flat `companyId` directly.
+
+`QuoteSchema` now `preprocess`es the wire payload to flatten `client.id → companyId` and surfaces `client.name` / `client.isShadowCompany` as flat optional `clientName` / `clientIsShadow` aliases. Demo data (`packages/core/src/mock/demo-data.ts`) now emits the spec's nested `client: {...}` shape and the `MockPax8Client` routes quote reads through `QuoteSchema.parse` — so the demo path exercises the same flattening as the real wire and demo mode stops masking the bug. The legacy flat shape (used by the `QuotesApi` unit-test fixtures) still parses cleanly because the preprocess passes through unchanged when no nested `client` is present.

--- a/e2e/integration/quotes.integration.test.ts
+++ b/e2e/integration/quotes.integration.test.ts
@@ -35,6 +35,25 @@ describeIntegration("quotes (v2)", () => {
       // Empty-portfolio sandboxes are valid here; the load-bearing assertion
       // is the wire URL above.
       expect(Array.isArray(data) || typeof data === "object").toBe(true);
+
+      // #384: assert at least one row carries a non-empty `companyId` when
+      // the sandbox has any quotes. Pre-#384, `companyId` was undefined on
+      // every row because the Zod schema expected a flat `companyId` while
+      // the v2 API returns `client: {id, ...}` nested — the unknown key
+      // was silently dropped and the required `companyId` parse failed (or
+      // landed as undefined depending on permissiveness). The schema now
+      // preprocesses `client.id → companyId` so partners get a usable ID
+      // back. Empty-portfolio sandboxes still skip the assertion.
+      const rows = Array.isArray(data)
+        ? data
+        : Array.isArray((data as { content?: unknown[] }).content)
+          ? (data as { content: unknown[] }).content
+          : [];
+      if (rows.length > 0) {
+        const first = rows[0] as { companyId?: unknown };
+        expect(typeof first.companyId).toBe("string");
+        expect((first.companyId as string).length).toBeGreaterThan(0);
+      }
     },
     60_000,
   );

--- a/packages/core/src/api/quotes.test.ts
+++ b/packages/core/src/api/quotes.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QuotesApi, buildFullUpdatePayload } from "./quotes.js";
+import { QuoteSchema } from "./types.js";
 import type { Pax8Client } from "./client.js";
 
 function createMockClient(): Pax8Client {
@@ -257,6 +258,84 @@ describe("QuotesApi", () => {
       },
       V2_OPTS,
     );
+  });
+});
+
+// ─── #384: nested-client wire-shape → flat companyId ──────────────────────────
+//
+// The v2 quoting API returns `client: {id, isShadowCompany, name}` per
+// `quoting-endpoints.json → components.schemas.QuoteResponse`. The CLI's
+// downstream code (table renderers, JSON output, filters) wants a flat
+// `companyId` field. `QuoteSchema` preprocesses the wire payload to flatten
+// `client.id → companyId` and surface `client.name` / `client.isShadowCompany`
+// as flat optional aliases. Pre-#384, the schema expected flat `companyId`
+// and silently dropped the nested `client` object — `companyId` parsed as
+// undefined against real API responses; demo mode (which carried a flat
+// `companyId` directly) masked the bug.
+describe("QuoteSchema (#384 nested client → flat companyId)", () => {
+  const baseQuoteFields = {
+    id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    createdOn: "2026-01-15T00:00:00Z",
+    status: "draft",
+    introMessage: "Hello partner.",
+    termsAndDisclaimers: "Standard terms.",
+    published: false,
+  } as const;
+
+  it("flattens nested wire `client.id` to flat `companyId`", () => {
+    const wire = {
+      ...baseQuoteFields,
+      client: {
+        id: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+        isShadowCompany: false,
+        name: "Acme Corp",
+      },
+    };
+    const parsed = QuoteSchema.parse(wire);
+    expect(parsed.companyId).toBe("b2c3d4e5-f6a7-8901-bcde-f12345678901");
+    expect(parsed.clientName).toBe("Acme Corp");
+    expect(parsed.clientIsShadow).toBe(false);
+    // The nested `client` object is consumed by the preprocess; the parsed
+    // output does not carry it through (z.object strips unknown keys).
+    expect("client" in parsed).toBe(false);
+  });
+
+  it("accepts the legacy flat shape (no nested client)", () => {
+    // The QuotesApi unit tests and historical demo fixtures hand `parse()`
+    // an already-flat object — the preprocess must pass these through
+    // unchanged so existing call sites keep working.
+    const flat = {
+      ...baseQuoteFields,
+      companyId: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+    };
+    const parsed = QuoteSchema.parse(flat);
+    expect(parsed.companyId).toBe("c3d4e5f6-a7b8-9012-cdef-123456789012");
+    expect(parsed.clientName).toBeUndefined();
+  });
+
+  it("nested `client.id` wins over an explicit flat `companyId` on the wire", () => {
+    // Defensive: if the API ever returned both shapes simultaneously
+    // (it doesn't today, but hedging against drift), the nested object is
+    // the authority — that's the spec-aligned field.
+    const wire = {
+      ...baseQuoteFields,
+      companyId: "ignore-me",
+      client: { id: "trust-me", isShadowCompany: false, name: "Wins" },
+    };
+    const parsed = QuoteSchema.parse(wire);
+    expect(parsed.companyId).toBe("trust-me");
+    expect(parsed.clientName).toBe("Wins");
+  });
+
+  it("tolerates a partial nested client (missing optional fields)", () => {
+    const wire = {
+      ...baseQuoteFields,
+      client: { id: "minimal-client-id" },
+    };
+    const parsed = QuoteSchema.parse(wire);
+    expect(parsed.companyId).toBe("minimal-client-id");
+    expect(parsed.clientName).toBeUndefined();
+    expect(parsed.clientIsShadow).toBeUndefined();
   });
 });
 

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -644,6 +644,23 @@ export const QuoteRespondedBySchema = z.object({
 export type QuoteRespondedBy = z.infer<typeof QuoteRespondedBySchema>;
 
 /**
+ * Wire shape for the nested `client` object on `GET /v2/quotes` /
+ * `GET /v2/quotes/{id}`. Per `quoting-endpoints.json` →
+ * `components.schemas.ClientDetails`, this is `{ id, isShadowCompany, name }`.
+ *
+ * The CLI surfaces these as flat fields (`companyId`, `clientIsShadow`,
+ * `clientName`) for ergonomic JSON output and downstream consumers that look
+ * up `companyId` directly. See `QuoteSchema`'s preprocess step for the
+ * flattening.
+ */
+export const QuoteClientSchema = z.object({
+  id: z.string(),
+  isShadowCompany: z.boolean().optional(),
+  name: z.string().optional(),
+});
+export type QuoteClient = z.infer<typeof QuoteClientSchema>;
+
+/**
  * Quote response body. The public quoting v2 endpoint returns the workflow
  * fields (`acceptedBy`, `declinedBy`, `respondedOn`, `revokedOn`,
  * `publishedOn`, `published`, `referenceCode`, `salesMarginPercentage`,
@@ -655,40 +672,90 @@ export type QuoteRespondedBy = z.infer<typeof QuoteRespondedBySchema>;
  * `changes_requested`, `pending`, `assigned`) but legacy demo data and the
  * test suite use the historical titlecase form. Forward-compat with new
  * statuses is also a goal.
+ *
+ * Wire-shape note (#384): the v2 quoting API returns `client: {id, ...}` as a
+ * nested object, not a flat `companyId`. We `preprocess` the raw payload to
+ * flatten `client.id → companyId` (and surface `client.name` / `client.
+ * isShadowCompany` as flat optional fields) before object validation. Demo
+ * data emits the same wire shape so demo and real-API output stay
+ * indistinguishable downstream. Legacy callers that hand-construct a flat
+ * `companyId` (older fixtures, the `QuotesApi` test mocks) still parse
+ * because the preprocess falls through to whatever's already on the input
+ * when `client` is absent.
  */
-export const QuoteSchema = z.object({
-  id: z.string(),
-  companyId: z.string(),
-  // Field names mirror the public quoting v2 API: `createdOn` and `expiresOn`.
-  // Earlier CLI versions exposed these as `createdDate` and `expirationDate`;
-  // renamed in #273 (fixes #8) to align `--json` output with the upstream
-  // contract. The `--expiration-date` CLI flag is unchanged — flag vocabulary
-  // and field vocabulary are intentionally separate concerns.
-  createdOn: z.string(),
-  expiresOn: z.string().optional(),
-  status: z.string(),
-  lineItems: z.array(QuoteLineItemSchema).optional(),
+export const QuoteSchema = z.preprocess(
+  (raw) => {
+    if (raw === null || typeof raw !== "object") return raw;
+    const r = raw as Record<string, unknown>;
+    // If wire has nested `client`, surface its fields as flat aliases.
+    // If `client` is absent (legacy flat input), pass through unchanged.
+    const client = r.client as
+      | { id?: string; isShadowCompany?: boolean; name?: string }
+      | undefined;
+    if (!client || typeof client !== "object") return raw;
+    const { client: _client, ...rest } = r;
+    void _client;
+    return {
+      ...rest,
+      // `client.id` wins over an explicit `companyId` — the wire is the
+      // authority. Falls through to existing `companyId` if `client.id` is
+      // missing (defensive; the spec marks it required).
+      companyId: client.id ?? r.companyId,
+      clientIsShadow:
+        typeof client.isShadowCompany === "boolean"
+          ? client.isShadowCompany
+          : r.clientIsShadow,
+      clientName:
+        typeof client.name === "string" ? client.name : r.clientName,
+    };
+  },
+  z.object({
+    id: z.string(),
+    companyId: z.string(),
+    /**
+     * Flattened from wire `client.name`. Optional because the spec marks it
+     * required on the nested object but legacy/demo inputs that bypass the
+     * preprocess (flat-shape) don't carry it.
+     */
+    clientName: z.string().optional(),
+    /**
+     * Flattened from wire `client.isShadowCompany`. Optional for the same
+     * reason as `clientName` — and because the field semantics (the client
+     * is a Pax8-internal shadow record vs. a partner-owned company) are
+     * informational, not load-bearing for any current CLI command.
+     */
+    clientIsShadow: z.boolean().optional(),
+    // Field names mirror the public quoting v2 API: `createdOn` and `expiresOn`.
+    // Earlier CLI versions exposed these as `createdDate` and `expirationDate`;
+    // renamed in #273 (fixes #8) to align `--json` output with the upstream
+    // contract. The `--expiration-date` CLI flag is unchanged — flag vocabulary
+    // and field vocabulary are intentionally separate concerns.
+    createdOn: z.string(),
+    expiresOn: z.string().optional(),
+    status: z.string(),
+    lineItems: z.array(QuoteLineItemSchema).optional(),
 
-  // The two free-text body fields the v2 quoting API marks as required on the
-  // `QuoteResponse` shape AND on the `PUT /v2/quotes/{quoteId}` request body.
-  // The CLI doesn't expose either as a user-settable flag today, but both must
-  // be modeled on the read shape so the fetch-then-merge in `update` /
-  // `setStatus` can round-trip the server-side values back without dropping
-  // them. See #313, #314 and `docs/triage/quotes-api-version.md` §9.1.
-  introMessage: z.string(),
-  termsAndDisclaimers: z.string(),
+    // The two free-text body fields the v2 quoting API marks as required on the
+    // `QuoteResponse` shape AND on the `PUT /v2/quotes/{quoteId}` request body.
+    // The CLI doesn't expose either as a user-settable flag today, but both must
+    // be modeled on the read shape so the fetch-then-merge in `update` /
+    // `setStatus` can round-trip the server-side values back without dropping
+    // them. See #313, #314 and `docs/triage/quotes-api-version.md` §9.1.
+    introMessage: z.string(),
+    termsAndDisclaimers: z.string(),
 
-  // Workflow fields (read-only visibility for the accept/decline lifecycle).
-  acceptedBy: QuoteRespondedBySchema.optional(),
-  declinedBy: QuoteRespondedBySchema.optional(),
-  respondedOn: z.string().optional(),
-  revokedOn: z.string().optional(),
-  publishedOn: z.string().optional(),
-  published: z.boolean().optional(),
-  referenceCode: z.string().optional(),
-  salesMarginPercentage: z.number().optional(),
-  intentType: z.string().optional(),
-});
+    // Workflow fields (read-only visibility for the accept/decline lifecycle).
+    acceptedBy: QuoteRespondedBySchema.optional(),
+    declinedBy: QuoteRespondedBySchema.optional(),
+    respondedOn: z.string().optional(),
+    revokedOn: z.string().optional(),
+    publishedOn: z.string().optional(),
+    published: z.boolean().optional(),
+    referenceCode: z.string().optional(),
+    salesMarginPercentage: z.number().optional(),
+    intentType: z.string().optional(),
+  }),
+);
 export type Quote = z.infer<typeof QuoteSchema>;
 
 // ─── Webhook ─────────────────────────────────────────────────────────────────

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -222,7 +222,22 @@ export interface UsageLine {
 
 export interface Quote {
   id: string;
-  companyId: string;
+  /**
+   * Nested client object — matches the wire shape of `GET /v2/quotes` per
+   * `quoting-endpoints.json → components.schemas.QuoteResponse` (#384).
+   *
+   * Demo data emits the spec's nested shape rather than a flat `companyId`
+   * so demo-mode parsing exercises the `QuoteSchema` preprocess that
+   * flattens `client.id → companyId`. Pre-#384 demo data carried a flat
+   * `companyId`, which masked the real-API mismatch and let `quotes list`
+   * pass demo tests while returning `undefined` `companyId` on the real
+   * wire.
+   */
+  client: {
+    id: string;
+    isShadowCompany?: boolean;
+    name?: string;
+  };
   /** Mirrors the public quoting v2 API field name (was `createdDate`). */
   createdOn: string;
   /** Mirrors the public quoting v2 API field name (was `expirationDate`). */
@@ -1776,7 +1791,7 @@ export const usageLines: UsageLine[] = [
 export const quotes: Quote[] = [
   {
     id: "quote-summit-001",
-    companyId: SUMMIT_ID,
+    client: { id: SUMMIT_ID, isShadowCompany: false, name: "Summit Healthcare Partners" },
     createdOn: "2026-03-10",
     expiresOn: "2026-04-10",
     status: "Sent",
@@ -1808,7 +1823,7 @@ export const quotes: Quote[] = [
   },
   {
     id: "quote-bright-001",
-    companyId: BRIGHT_ID,
+    client: { id: BRIGHT_ID, isShadowCompany: false, name: "Bright Minds Academy" },
     createdOn: "2026-03-05",
     expiresOn: "2026-04-05",
     status: "Draft",
@@ -1841,7 +1856,7 @@ export const quotes: Quote[] = [
     // count matches the existing count). The other Draft quote
     // (quote-bright-001) has 2 items and triggers the destructive path.
     id: "quote-acme-001",
-    companyId: ACME_ID,
+    client: { id: ACME_ID, isShadowCompany: false, name: "Acme Corp" },
     createdOn: "2026-04-15",
     expiresOn: "2026-05-15",
     status: "Draft",
@@ -1862,7 +1877,7 @@ export const quotes: Quote[] = [
   },
   {
     id: "quote-redwood-001",
-    companyId: REDWOOD_ID,
+    client: { id: REDWOOD_ID, isShadowCompany: false, name: "Redwood Manufacturing" },
     createdOn: "2026-02-20",
     expiresOn: "2026-03-20",
     status: "Accepted",
@@ -1892,7 +1907,7 @@ export const quotes: Quote[] = [
   },
   {
     id: "quote-coastline-001",
-    companyId: COASTLINE_ID,
+    client: { id: COASTLINE_ID, isShadowCompany: false, name: "Coastline Legal Group" },
     createdOn: "2026-02-12",
     expiresOn: "2026-03-12",
     status: "Declined",

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -30,19 +30,21 @@ import {
   type Contact,
   type UsageSummary,
   type UsageLine,
-  type Quote,
+  type Quote as DemoQuote,
   type Webhook,
   type WebhookLog,
   type WebhookTopicDefinition,
 } from "./demo-data.js";
 import { ApiError, NotFoundError } from "../api/errors.js";
-import type {
-  CreateOrderInput,
-  ProductPricing as ProductPricingPlans,
-  ProvisioningDetail as ProvisioningDetailType,
-  ProductDependency as ProductDependencyType,
-  AddQuoteLineItemInput,
-  QuoteStatusTransition,
+import {
+  QuoteSchema,
+  type CreateOrderInput,
+  type ProductPricing as ProductPricingPlans,
+  type ProvisioningDetail as ProvisioningDetailType,
+  type ProductDependency as ProductDependencyType,
+  type AddQuoteLineItemInput,
+  type QuoteStatusTransition,
+  type Quote,
 } from "../api/types.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -726,13 +728,29 @@ class UsageResource {
 }
 
 class QuotesResource {
+  /**
+   * Project a stored `DemoQuote` (wire-shape, with nested `client: {...}`)
+   * through `QuoteSchema` so demo-mode callers see the same canonical
+   * `Quote` (with flat `companyId`) the real API client returns after
+   * parsing. Demo data is wire-shape per #384 so the same Zod preprocess
+   * exercised against the real API runs in demo mode too — that's the
+   * point of the issue.
+   */
+  private project(q: DemoQuote): Quote {
+    return QuoteSchema.parse(q);
+  }
+
   async list(
     params?: ListParams & { companyId?: string; status?: string }
   ): Promise<PaginatedResponse<Quote>> {
     await randomDelay();
     let filtered = quotes;
     if (params?.companyId) {
-      filtered = filtered.filter((q) => q.companyId === params.companyId);
+      // Demo data stores the wire-shape nested `client.id` (#384). The
+      // CLI flag still resolves to a flat `companyId` query param on the
+      // public API — match by `client.id` here so the demo filter agrees
+      // with the wire-side filter the real API runs.
+      filtered = filtered.filter((q) => q.client.id === params.companyId);
     }
     if (params?.status) {
       // Mirror the real API's server-side filter (#387). Demo `Quote.status`
@@ -742,14 +760,15 @@ class QuotesResource {
       const s = params.status.toLowerCase();
       filtered = filtered.filter((q) => String(q.status).toLowerCase() === s);
     }
-    return paginate(filtered, params);
+    const page = paginate(filtered, params);
+    return { ...page, content: page.content.map((q) => this.project(q)) };
   }
 
   async get(id: string): Promise<Quote> {
     await randomDelay();
     const quote = quotes.find((q) => q.id === id);
     if (!quote) throw notFound("Quote", id);
-    return quote;
+    return this.project(quote);
   }
 
   /**
@@ -765,15 +784,22 @@ class QuotesResource {
    * is now strict — `{ clientId, quoteRequestId? }`.
    */
   async create(
-    data: { clientId?: string; quoteRequestId?: string } & Partial<Quote>,
+    data: { clientId?: string; quoteRequestId?: string; companyId?: string },
   ): Promise<Quote> {
     await randomDelay();
     const clientId = data.clientId ?? data.companyId ?? "";
-    const newQuote: Quote = {
+    const clientName = companies.find((c) => c.id === clientId)?.name;
+    const newQuote: DemoQuote = {
       id: `quote-demo-${Date.now()}`,
-      companyId: clientId,
+      // Wire-shape nested client per #384. Demo data stores the same shape
+      // the real /v2/quotes API returns; `QuoteSchema` flattens it on the
+      // way out (see `project()` above).
+      client: {
+        id: clientId,
+        isShadowCompany: false,
+        ...(clientName ? { name: clientName } : {}),
+      },
       createdOn: new Date().toISOString().split("T")[0],
-      ...(data.expiresOn ? { expiresOn: data.expiresOn } : {}),
       status: "Draft",
       // Empty defaults for the two free-text fields the v2 read shape marks
       // required (#313). Real partners populate these via the marketplace UI
@@ -790,7 +816,7 @@ class QuotesResource {
     // the `quotes create --product ...` shorthand path, which chains a
     // create + line-item add in a single command (#311).
     quotes.push(newQuote);
-    return newQuote;
+    return this.project(newQuote);
   }
 
   /**
@@ -826,7 +852,7 @@ class QuotesResource {
     }
     if (data.status) {
       const cap = data.status.charAt(0).toUpperCase() + data.status.slice(1);
-      const allowed: Record<string, Quote["status"]> = {
+      const allowed: Record<string, DemoQuote["status"]> = {
         Draft: "Draft",
         Sent: "Sent",
         Accepted: "Accepted",
@@ -834,7 +860,7 @@ class QuotesResource {
       };
       quote.status = allowed[cap] ?? quote.status;
     }
-    return quote;
+    return this.project(quote);
   }
 
   async delete(id: string): Promise<void> {
@@ -885,7 +911,7 @@ class QuotesResource {
         : {}),
     };
     quote.lineItems = [...(quote.lineItems ?? []), newLine];
-    return quote;
+    return this.project(quote);
   }
 
   async removeLineItem(quoteId: string, lineItemId: string): Promise<void> {


### PR DESCRIPTION
Closes #384. Block-launch finding per `docs/triage/partner-readiness-audit/01-api-conformity-reads.md`.

## Summary

- `GET /v2/quotes` returns `client: { id, isShadowCompany, name }` per `quoting-endpoints.json → components.schemas.QuoteResponse`. `QuoteSchema` expected a flat `companyId: z.string()`, so Zod silently dropped the nested `client` and every parsed row's `companyId` was undefined against the real API.
- `QuoteSchema` now preprocesses the wire payload to flatten `client.id → companyId` and surfaces `client.name` / `client.isShadowCompany` as flat `clientName` / `clientIsShadow` aliases.
- Demo data emits the spec's nested shape and `MockPax8Client` routes quote reads through `QuoteSchema.parse`, so demo mode now exercises the same flattening as the real wire (it previously masked the bug with a flat `companyId` fixture).
- Legacy flat inputs (`QuotesApi` unit-test fixtures) still parse — the preprocess is a no-op when `client` is absent.

## Test plan

- [x] `pnpm build` green
- [x] `pnpm test` green (1797 passed)
- [x] `pnpm lint` green
- [x] New unit tests in `packages/core/src/api/quotes.test.ts` pin the flattening (wire shape, legacy flat shape, nested-wins-over-flat, partial nested)
- [x] `e2e/integration/quotes.integration.test.ts` extended to assert a non-empty `companyId` per row when the sandbox has quotes
- [ ] Real-API smoke: `pax8 quotes list --json` returns rows with non-undefined `companyId` (manual / CI integration job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)