### PR TITLE
docs(README): show 2>/dev/null pattern for clean JSON in pipes (#410)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ pax8 invoices list --csv > march-billing.csv
 pax8 clients list --ids-only | xargs -I{} pax8 subscriptions list --company {}
 ```
 
+**Piping JSON to other tools.** Banners and spinners go to stderr; redirect for clean JSON:
+
+```bash
+pax8 subscriptions list --json 2>/dev/null | jq '.[].id'
+pax8 dashboard --json 2>/dev/null > today.json
+```
+
 ## REPL Mode
 
 Run `pax8` with no arguments to enter the interactive REPL:


### PR DESCRIPTION
## Summary

Partner walkthrough flagged that banners and spinners appear to "leak" into `--json` output. Verification (`pax8 ... --json 2>/dev/null`) confirmed banners and spinners already route to stderr correctly — they only appear interleaved when both streams render to the same terminal. The implementation is correct; the README just didn't show partners how to use the stdout/stderr split when piping.

Adds a short note + two examples adjacent to the existing `--json` documentation in the Output Formats section. No code changes; UX_GUIDE.md §3 already covers the rule in depth (no edit needed there).

Closes #410. Context: `docs/triage/partner-walkthrough.md`.

## Test plan

- [x] Confirmed `PAX8_DEMO=1 node packages/cli/dist/index.js subscriptions list --json 2>/dev/null | head -3` produces clean JSON with no banner or spinner output
- [x] `pnpm lint` passes
- [x] Docs-only change — no build/test required, no changeset needed