### PR TITLE
fix(mock): add canonical timestamp fields to demo-data interfaces

### DIFF
--- a/.changeset/demo-data-canonical-timestamps.md
+++ b/.changeset/demo-data-canonical-timestamps.md
@@ -1,0 +1,9 @@
+---
+"@pax8/core": patch
+---
+
+Hotfix for typecheck regression introduced by #407. The timestamp standardization added canonical `createdAt` / `updatedAt` / `expiresAt` fields to the Zod schemas but didn't update the hand-coded interfaces in `packages/core/src/mock/demo-data.ts`. CLI command code (post-#407) reads `.createdAt` directly; TypeScript's union-narrowing across `Order | DemoOrder` (etc.) required the field on both sides, so accessing it failed with `Property 'createdAt' does not exist`. Main was broken on `pnpm -r exec tsc --noEmit` since #407 merged; `pnpm test` passed because vitest doesn't run that step.
+
+Fix: add canonical timestamp fields to all five demo-data interfaces (Company, Subscription, Order, Quote, Webhook), duplicate the 39 fixture records to carry both names, and ensure the four `create()` methods in `MockPax8Client` populate the new fields. Also normalize `quotes.update({ expiresOn })` to set BOTH `expiresOn` AND `expiresAt` so the schema preprocess doesn't revert user updates to the stored alias value.
+
+No public-API change. JSON output continues to emit both old and new names per #385.

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -52,8 +52,21 @@ export interface Company {
    * surfaced in #273 (fixes #5).
    */
   externalId?: string;
-  /** Mirrors the public `Company` schema field name. */
+  /**
+   * @deprecated Use `createdAt`. One-cycle alias preserved so existing
+   * `--json` consumers don't break; removal in v0.3.0. See #385.
+   */
   created: string;
+  /**
+   * Canonical timestamp (camelCase, past tense). Required so the demo
+   * fixture shape matches the Zod-inferred `Company` type, which keeps
+   * the `Company | DemoCompany` union narrowable across the CLI/mock
+   * boundary. Introduced as a hotfix after #385 (#407 missed updating
+   * the demo-data hand-coded interfaces).
+   */
+  createdAt: string;
+  /** Optional canonical updated-at; mirrors Zod `updatedAt`. */
+  updatedAt?: string;
   billingContact?: { firstName: string; lastName: string; email: string };
 }
 
@@ -64,7 +77,12 @@ export interface Subscription {
   productName: string;
   quantity: number;
   startDate: string;
+  /**
+   * @deprecated Use `createdAt`. One-cycle alias; removal in v0.3.0. See #385.
+   */
   createdDate: string;
+  /** Canonical timestamp; mirrors Zod `Subscription.createdAt`. See #385. */
+  createdAt: string;
   billingStart: string;
   status: "Active" | "Trial" | "PendingManual" | "Cancelled" | "PendingCancel";
   price: number;
@@ -146,7 +164,12 @@ export interface Order {
   companyName: string;
   orderedBy: string;
   orderedByEmail: string;
+  /**
+   * @deprecated Use `createdAt`. One-cycle alias; removal in v0.3.0. See #385.
+   */
   createdDate: string;
+  /** Canonical timestamp; mirrors Zod `Order.createdAt`. See #385. */
+  createdAt: string;
   lineItems: OrderLineItem[];
   status: "Completed" | "Processing" | "Failed" | "PendingManual";
 }
@@ -238,10 +261,19 @@ export interface Quote {
     isShadowCompany?: boolean;
     name?: string;
   };
-  /** Mirrors the public quoting v2 API field name (was `createdDate`). */
+  /**
+   * @deprecated Use `createdAt`. One-cycle alias; removal in v0.3.0. See #385.
+   * Originally mirrored the public quoting v2 API field name.
+   */
   createdOn: string;
-  /** Mirrors the public quoting v2 API field name (was `expirationDate`). */
+  /** Canonical timestamp; mirrors Zod `Quote.createdAt`. See #385. */
+  createdAt: string;
+  /**
+   * @deprecated Use `expiresAt`. One-cycle alias; removal in v0.3.0. See #385.
+   */
   expiresOn?: string;
+  /** Canonical expiry timestamp; mirrors Zod `Quote.expiresAt`. See #385. */
+  expiresAt?: string;
   status: "Draft" | "Sent" | "Accepted" | "Declined";
   lineItems?: QuoteLineItem[];
 
@@ -301,7 +333,12 @@ export interface Webhook {
   url: string;
   status: "Active" | "Disabled";
   topics: string[];
+  /**
+   * @deprecated Use `createdAt`. One-cycle alias; removal in v0.3.0. See #385.
+   */
   createdDate: string;
+  /** Canonical timestamp; mirrors Zod `Webhook.createdAt`. See #385. */
+  createdAt: string;
   secret?: string;
   /** Human-friendly label (Pax8 webhook-manager v2.1+). */
   displayName?: string;
@@ -362,6 +399,7 @@ export const companies: Company[] = [
     // `externalId` surface introduced in #273 (fixes #5).
     externalId: "PSA-SUMMIT-1042",
     created: "2023-06-15",
+    createdAt: "2023-06-15",
     billingContact: {
       firstName: "Rachel",
       lastName: "Thornton",
@@ -386,6 +424,7 @@ export const companies: Company[] = [
     orderApprovalRequired: true,
     externalId: "PSA-COASTLINE-2018",
     created: "2024-01-10",
+    createdAt: "2024-01-10",
     billingContact: {
       firstName: "Marco",
       lastName: "Reyes",
@@ -410,6 +449,7 @@ export const companies: Company[] = [
     orderApprovalRequired: true,
     externalId: "PSA-REDWOOD-0517",
     created: "2022-09-01",
+    createdAt: "2022-09-01",
     billingContact: {
       firstName: "Karen",
       lastName: "Olsen",
@@ -434,6 +474,7 @@ export const companies: Company[] = [
     orderApprovalRequired: false,
     externalId: "PSA-BRIGHT-3304",
     created: "2025-03-20",
+    createdAt: "2025-03-20",
     billingContact: {
       firstName: "Lisa",
       lastName: "Cheng",
@@ -458,6 +499,7 @@ export const companies: Company[] = [
     orderApprovalRequired: false,
     externalId: "PSA-PINNACLE-7710",
     created: "2024-08-05",
+    createdAt: "2024-08-05",
     billingContact: {
       firstName: "David",
       lastName: "Nakamura",
@@ -487,6 +529,7 @@ export const companies: Company[] = [
     orderApprovalRequired: false,
     externalId: "PSA-ACME-0001",
     created: "2024-11-15",
+    createdAt: "2024-11-15",
     billingContact: {
       firstName: "Wile",
       lastName: "Coyote",
@@ -741,6 +784,7 @@ export const subscriptions: Subscription[] = [
     quantity: 85,
     startDate: "2025-03-26",
     createdDate: "2025-03-20",
+    createdAt: "2025-03-20",
     billingStart: "2025-03-26",
     status: "Active",
     price: 22.0,
@@ -759,6 +803,7 @@ export const subscriptions: Subscription[] = [
     quantity: 85,
     startDate: "2025-03-26",
     createdDate: "2025-03-20",
+    createdAt: "2025-03-20",
     billingStart: "2025-03-26",
     status: "Active",
     price: 3.0,
@@ -776,6 +821,7 @@ export const subscriptions: Subscription[] = [
     quantity: 85,
     startDate: "2025-03-26",
     createdDate: "2025-03-20",
+    createdAt: "2025-03-20",
     billingStart: "2025-03-26",
     status: "Active",
     price: 6.0,
@@ -795,6 +841,7 @@ export const subscriptions: Subscription[] = [
     quantity: 40,
     startDate: "2025-04-07",
     createdDate: "2025-04-01",
+    createdAt: "2025-04-01",
     billingStart: "2025-04-07",
     status: "Active",
     price: 36.0,
@@ -815,6 +862,7 @@ export const subscriptions: Subscription[] = [
     quantity: 40,
     startDate: "2025-04-07",
     createdDate: "2025-04-01",
+    createdAt: "2025-04-01",
     billingStart: "2025-04-07",
     status: "Active",
     price: 8.0,
@@ -834,6 +882,7 @@ export const subscriptions: Subscription[] = [
     quantity: 100,
     startDate: "2024-05-01",
     createdDate: "2024-04-25",
+    createdAt: "2024-04-25",
     billingStart: "2024-05-01",
     status: "Active",
     price: 36.0,
@@ -851,6 +900,7 @@ export const subscriptions: Subscription[] = [
     quantity: 50,
     startDate: "2024-05-01",
     createdDate: "2024-04-25",
+    createdAt: "2024-04-25",
     billingStart: "2024-05-01",
     status: "Active",
     price: 57.0,
@@ -868,6 +918,7 @@ export const subscriptions: Subscription[] = [
     quantity: 150,
     startDate: "2024-05-01",
     createdDate: "2024-04-25",
+    createdAt: "2024-04-25",
     billingStart: "2024-05-01",
     status: "Active",
     price: 4.0,
@@ -885,6 +936,7 @@ export const subscriptions: Subscription[] = [
     quantity: 150,
     startDate: "2024-05-01",
     createdDate: "2024-04-25",
+    createdAt: "2024-04-25",
     billingStart: "2024-05-01",
     status: "Active",
     price: 3.0,
@@ -902,6 +954,7 @@ export const subscriptions: Subscription[] = [
     quantity: 150,
     startDate: "2024-05-01",
     createdDate: "2024-04-25",
+    createdAt: "2024-04-25",
     billingStart: "2024-05-01",
     status: "Active",
     price: 6.0,
@@ -919,6 +972,7 @@ export const subscriptions: Subscription[] = [
     quantity: 150,
     startDate: "2024-08-01",
     createdDate: "2024-07-25",
+    createdAt: "2024-07-25",
     billingStart: "2024-08-01",
     status: "Active",
     price: 6.0,
@@ -936,6 +990,7 @@ export const subscriptions: Subscription[] = [
     quantity: 30,
     startDate: "2024-09-01",
     createdDate: "2024-08-28",
+    createdAt: "2024-08-28",
     billingStart: "2024-09-01",
     status: "Active",
     price: 8.5,
@@ -954,6 +1009,7 @@ export const subscriptions: Subscription[] = [
     quantity: 25,
     startDate: "2025-10-01",
     createdDate: "2025-09-28",
+    createdAt: "2025-09-28",
     billingStart: "2025-10-01",
     status: "Active",
     price: 6.0,
@@ -970,6 +1026,7 @@ export const subscriptions: Subscription[] = [
     quantity: 25,
     startDate: "2026-02-20",
     createdDate: "2026-02-18",
+    createdAt: "2026-02-18",
     billingStart: "2026-02-20",
     status: "Trial",
     price: 0.0,
@@ -988,6 +1045,7 @@ export const subscriptions: Subscription[] = [
     quantity: 15,
     startDate: "2025-04-01",
     createdDate: "2025-03-28",
+    createdAt: "2025-03-28",
     billingStart: "2025-04-01",
     status: "Active",
     price: 22.0,
@@ -1005,6 +1063,7 @@ export const subscriptions: Subscription[] = [
     quantity: 15,
     startDate: "2025-04-01",
     createdDate: "2025-03-28",
+    createdAt: "2025-03-28",
     billingStart: "2025-04-01",
     status: "Active",
     price: 3.0,
@@ -1022,6 +1081,7 @@ export const subscriptions: Subscription[] = [
     quantity: 15,
     startDate: "2025-04-01",
     createdDate: "2025-03-28",
+    createdAt: "2025-03-28",
     billingStart: "2025-04-01",
     status: "Active",
     price: 6.0,
@@ -1043,6 +1103,7 @@ export const subscriptions: Subscription[] = [
     quantity: 25,
     startDate: "2025-01-15",
     createdDate: "2025-01-10",
+    createdAt: "2025-01-10",
     billingStart: "2025-01-15",
     status: "Active",
     price: 22.0,
@@ -1060,6 +1121,7 @@ export const subscriptions: Subscription[] = [
     quantity: 25,
     startDate: "2025-01-15",
     createdDate: "2025-01-10",
+    createdAt: "2025-01-10",
     billingStart: "2025-01-15",
     status: "Active",
     price: 3.0,
@@ -1082,6 +1144,7 @@ export const subscriptions: Subscription[] = [
     quantity: 25,
     startDate: "2024-01-15",
     createdDate: "2024-01-10",
+    createdAt: "2024-01-10",
     billingStart: "2024-01-15",
     status: "Active",
     price: 6.0,
@@ -1540,6 +1603,7 @@ export const orders: Order[] = [
     orderedBy: "Rachel Thornton",
     orderedByEmail: "rachel.thornton@summithealthcare.example.com",
     createdDate: "2026-03-08",
+    createdAt: "2026-03-08",
     status: "Completed",
     lineItems: [
       {
@@ -1558,6 +1622,7 @@ export const orders: Order[] = [
     orderedBy: "Karen Olsen",
     orderedByEmail: "karen.olsen@redwoodmfg.example.com",
     createdDate: "2026-02-15",
+    createdAt: "2026-02-15",
     status: "Completed",
     lineItems: [
       {
@@ -1576,6 +1641,7 @@ export const orders: Order[] = [
     orderedBy: "David Nakamura",
     orderedByEmail: "david.nakamura@pinnaclefa.example.com",
     createdDate: "2026-01-28",
+    createdAt: "2026-01-28",
     status: "Processing",
     lineItems: [
       {
@@ -1601,6 +1667,7 @@ export const orders: Order[] = [
     orderedBy: "Marco Reyes",
     orderedByEmail: "marco.reyes@coastlinelegal.example.com",
     createdDate: "2025-04-01",
+    createdAt: "2025-04-01",
     status: "Completed",
     lineItems: [
       {
@@ -1626,6 +1693,7 @@ export const orders: Order[] = [
     orderedBy: "Lisa Cheng",
     orderedByEmail: "lisa.cheng@brightminds.example.com",
     createdDate: "2025-09-28",
+    createdAt: "2025-09-28",
     status: "Completed",
     lineItems: [
       {
@@ -1793,7 +1861,9 @@ export const quotes: Quote[] = [
     id: "quote-summit-001",
     client: { id: SUMMIT_ID, isShadowCompany: false, name: "Summit Healthcare Partners" },
     createdOn: "2026-03-10",
+    createdAt: "2026-03-10",
     expiresOn: "2026-04-10",
+    expiresAt: "2026-04-10",
     status: "Sent",
     referenceCode: "Q-2026-001",
     intentType: "PARTNER_TO_CLIENT",
@@ -1825,7 +1895,9 @@ export const quotes: Quote[] = [
     id: "quote-bright-001",
     client: { id: BRIGHT_ID, isShadowCompany: false, name: "Bright Minds Academy" },
     createdOn: "2026-03-05",
+    createdAt: "2026-03-05",
     expiresOn: "2026-04-05",
+    expiresAt: "2026-04-05",
     status: "Draft",
     intentType: "PARTNER_TO_CLIENT",
     published: false,
@@ -1858,7 +1930,9 @@ export const quotes: Quote[] = [
     id: "quote-acme-001",
     client: { id: ACME_ID, isShadowCompany: false, name: "Acme Corp" },
     createdOn: "2026-04-15",
+    createdAt: "2026-04-15",
     expiresOn: "2026-05-15",
+    expiresAt: "2026-05-15",
     status: "Draft",
     intentType: "PARTNER_TO_CLIENT",
     published: false,
@@ -1879,7 +1953,9 @@ export const quotes: Quote[] = [
     id: "quote-redwood-001",
     client: { id: REDWOOD_ID, isShadowCompany: false, name: "Redwood Manufacturing" },
     createdOn: "2026-02-20",
+    createdAt: "2026-02-20",
     expiresOn: "2026-03-20",
+    expiresAt: "2026-03-20",
     status: "Accepted",
     referenceCode: "Q-2026-002",
     intentType: "PARTNER_TO_CLIENT",
@@ -1909,7 +1985,9 @@ export const quotes: Quote[] = [
     id: "quote-coastline-001",
     client: { id: COASTLINE_ID, isShadowCompany: false, name: "Coastline Legal Group" },
     createdOn: "2026-02-12",
+    createdAt: "2026-02-12",
     expiresOn: "2026-03-12",
+    expiresAt: "2026-03-12",
     status: "Declined",
     referenceCode: "Q-2026-003",
     intentType: "PARTNER_TO_CLIENT",
@@ -1954,6 +2032,7 @@ export const webhooks: Webhook[] = [
       "subscription.cancelled",
     ],
     createdDate: "2025-06-01",
+    createdAt: "2025-06-01",
     secret: "whsec_demo_abc123",
     displayName: "Subscription events",
     contactEmail: "ops@example.com",
@@ -1967,6 +2046,7 @@ export const webhooks: Webhook[] = [
     status: "Active",
     topics: ["invoice.created", "invoice.paid"],
     createdDate: "2025-08-15",
+    createdAt: "2025-08-15",
     secret: "whsec_demo_def456",
     displayName: "Invoice events",
     contactEmail: "billing@example.com",
@@ -1980,6 +2060,7 @@ export const webhooks: Webhook[] = [
     status: "Disabled",
     topics: ["order.created", "order.completed"],
     createdDate: "2025-11-20",
+    createdAt: "2025-11-20",
     secret: "whsec_demo_ghi789",
     displayName: "Order events",
     contactEmail: "ops@example.com",

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -260,6 +260,7 @@ class CompaniesResource {
       selfServiceAllowed: data.selfServiceAllowed ?? false,
       orderApprovalRequired: data.orderApprovalRequired ?? false,
       created: new Date().toISOString().split("T")[0],
+      createdAt: new Date().toISOString().split("T")[0],
     };
     return withCompanyTimestampAliases(newCompany);
   }
@@ -664,6 +665,7 @@ class OrdersResource {
       orderedBy: "Demo User",
       orderedByEmail: "demo@example.com",
       createdDate: new Date().toISOString().split("T")[0],
+      createdAt: new Date().toISOString().split("T")[0],
       // Echo `lineItemNumber` back so callers can verify it was sent. Falls
       // back to 1-based array position when callers don't supply one — same
       // behavior `OrdersApi.create()` enforces on the real wire path (#331).
@@ -866,6 +868,7 @@ class QuotesResource {
         ...(clientName ? { name: clientName } : {}),
       },
       createdOn: new Date().toISOString().split("T")[0],
+      createdAt: new Date().toISOString().split("T")[0],
       status: "Draft",
       // Empty defaults for the two free-text fields the v2 read shape marks
       // required (#313). Real partners populate these via the marketplace UI
@@ -910,7 +913,13 @@ class QuotesResource {
     const quote = quotes.find((q) => q.id === id);
     if (!quote) throw notFound("Quote", id);
 
-    if (typeof data.expiresOn === "string") quote.expiresOn = data.expiresOn;
+    if (typeof data.expiresOn === "string") {
+      // Set BOTH names — without this, the stored `expiresAt` alias would
+      // win in the schema preprocess (it prefers the canonical name when
+      // both are present) and the user's update would silently revert.
+      quote.expiresOn = data.expiresOn;
+      quote.expiresAt = data.expiresOn;
+    }
     if (typeof data.introMessage === "string") quote.introMessage = data.introMessage;
     if (typeof data.published === "boolean") quote.published = data.published;
     if (typeof data.termsAndDisclaimers === "string") {
@@ -1050,6 +1059,7 @@ class WebhooksResource {
       status: "Active",
       topics: data.webhookTopics.map((t) => t.topic),
       createdDate: new Date().toISOString().split("T")[0],
+      createdAt: new Date().toISOString().split("T")[0],
       secret: `whsec_demo_${Date.now()}`,
       displayName: data.displayName,
     };


### PR DESCRIPTION
## Summary

**Hotfix for typecheck regression on main.** #407 (timestamp standardization) added canonical `createdAt` / `updatedAt` / `expiresAt` to the Zod schemas and updated CLI command code to read the new names, but missed updating the hand-coded interfaces in `packages/core/src/mock/demo-data.ts`. TypeScript's union-narrowing across `Order | DemoOrder` (and the same for the other four resource types) requires the field on both sides — so accessing `.createdAt` fails with `Property 'createdAt' does not exist on type 'Order'. Did you mean 'createdDate'?`.

**Main has been broken on `pnpm -r exec tsc --noEmit` since #407 merged.** `pnpm test` was passing because vitest doesn't run typecheck as a separate step. The bug surfaced visibly when PR #412's CI ran the full pipeline.

## What this PR does

- Adds canonical timestamp fields to all 5 demo-data interfaces (Company, Subscription, Order, Quote, Webhook). Marks the legacy names `@deprecated`; both names remain populated through the v0.3.0 deprecation window per #385.
- Duplicates 39 fixture records so both old and new field names appear.
- Patches the 4 `create()` methods in `MockPax8Client` to populate the new fields.
- Normalizes `quotes.update({ expiresOn })` to set **both** `expiresOn` AND `expiresAt` — without this, the schema preprocess (which prefers the canonical `expiresAt` when both are present) would revert user updates to the stored alias value. Caught by `mock-client-extended.test.ts:442` and `e2e/quotes-workflow.test.ts:149`.

## Why this PR is necessary right now

PR #412 (input validation) is blocked on this — its CI is red because the merged main has the typecheck regression. Landing this hotfix unblocks #412 and any other PR currently sitting on red CI for the same root cause.

## Test plan

- [x] `pnpm -r exec tsc --noEmit` — 0 errors (was 11)
- [x] `pnpm test` — 1807 passed, 6 skipped, 0 failed
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] Manual: `pax8 dashboard --json 2>/dev/null | jq '.recentOrders[0] | keys'` shows both `createdAt` and `createdDate`

## Scope discipline

No public-API change. JSON output continues to emit both old and new names per #385's deprecation policy. The legacy field names are still required on the interfaces (not optional) so existing test fixtures and external consumers see no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)