### PR TITLE
docs(cli): document JSON output shape in --help on commands with nested responses (#396)

### DIFF
--- a/.changeset/json-output-shape-in-help.md
+++ b/.changeset/json-output-shape-in-help.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+**Docs / help text:** Added `JSON output (--json):` sections to `--help` on commands with nested or computed response shapes — `pax8 cost sim`, `pax8 dashboard` (and the `status` alias), `pax8 recommendations list`, `pax8 invoices audit`, `pax8 subscriptions renewals`, `pax8 report mrr`, `pax8 report growth`. Partners parsing `--json` no longer have to run a command to discover its shape; the contract is pinned in `--help`. Renewals and dashboard call out the deprecated `mrrAtRisk` / `arrAtRisk` aliases (per #299) and dashboard calls out the deprecated `createdDate` alias (per #385). Also expanded the README "Metric definitions" section with an explicit STAX taxonomy divergence subsection (CLI 7-category taxonomy and `seat_gap` heuristic vs. canonical STAX / Seat Utilization) and a mapping table — disclosure that previously lived only in `--help` and the module docstring, neither of which `--json` consumers see. Closes #396. No behavior change.

--- a/README.md
+++ b/README.md
@@ -489,6 +489,48 @@ distinct from Pax8's canonical "Seat Utilization" metric, which measures
 single-product assigned-vs-purchased seats. The CLI's heuristic is a coverage
 signal across the customer's stack, not a utilization rate within one product.
 
+### Recommendations taxonomy vs. STAX
+
+`pax8 recommendations list` emits a `type` field with the CLI's local product
+taxonomy alongside an `opportunityType` field with OE's canonical 5-type
+taxonomy. Two things diverge from Pax8's canonical models — partners parsing
+`--json` should know about both:
+
+1. **Product categories.** The recommendations engine bins products into a
+   local 7-category taxonomy (`productivity`, `email`, `security`,
+   `endpoint_protection`, `identity`, `backup`, `cloud_infrastructure`) that
+   does **not** match Pax8's canonical STAX taxonomy (8 L1 categories:
+   Productivity, Infrastructure, Continuity, Security, Communications,
+   Network, Operations, Network & Communications Commissioned). The CLI
+   over-decomposes Security into four buckets and omits Communications,
+   Network, and Operations entirely. The simplification was deliberate for
+   the local security-focused cross-sell heuristic.
+
+2. **`seat_gap` heuristic.** The CLI's `seat_gap` type flags **cross-product**
+   seat mismatches (e.g. 100 email seats but only 30 backup seats). It is
+   **not** Pax8's canonical Seat Utilization metric, which is a
+   single-product assigned-vs-purchased rate. The closest OE-canonical
+   surrogate is `Upsell` — carried on the additive `opportunityType` field.
+
+| CLI category (`type` / module taxonomy) | Closest Pax8 / OE concept | Notes |
+| --- | --- | --- |
+| `productivity` | STAX L1 *Productivity* | Aligned |
+| `email`, `security`, `endpoint_protection`, `identity` | STAX L1 *Security* (+ *Productivity* for email) | CLI over-decomposes STAX *Security* into four buckets |
+| `backup` | STAX L1 *Continuity* | Aligned |
+| `cloud_infrastructure` | STAX L1 *Infrastructure* | Aligned |
+| (no CLI category) | STAX L1 *Communications* / *Network* / *Operations* | Not currently produced by the engine |
+| `type: "seat_gap"` | OE `opportunityType: "Upsell"` (closest), NOT Seat Utilization | Cross-product coverage signal, not a utilization rate |
+| `type: "cross_sell"` + active subs | OE `opportunityType: "Cross-sell"` | Both carried on the record |
+| `type: "cross_sell"` + zero-sub company | OE `opportunityType: "Net-new"` | Both carried on the record |
+
+Both the CLI's product taxonomy and the `seat_gap` heuristic will sunset when
+Pax8's first-party Opportunity Explorer API ships (ARC-785, `GET /opportunities`).
+The local taxonomy is replaced at that point — tracked under
+[#375](https://github.com/pax8labs/pax8-cli/issues/375). The module docstring
+at `packages/core/src/services/recommendations.ts` carries the same disclosure
+for in-IDE readers; this README section is the canonical version for partners
+who only see `--json` output.
+
 ## Documentation
 
 - [Credential Setup Guide](docs/credential-setup.md)

--- a/packages/cli/src/__tests__/help-json-output.test.ts
+++ b/packages/cli/src/__tests__/help-json-output.test.ts
@@ -1,0 +1,122 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Verifies the "JSON output (--json):" sections added to addHelpText("after")
+ * on commands with nested/computed response shapes (#396 — widened scope from
+ * the partner walkthrough). Partners parsing `--json` need the contract
+ * pinned in --help so they don't have to run the command to discover the shape.
+ *
+ * No code logic changes — pure docs/help-text. We assert the section header
+ * appears AND that specific load-bearing field names are mentioned, including
+ * deprecation notes on dual-emitted aliases (mrrAtRisk, createdDate).
+ */
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess } from "./test-utils.js";
+
+describe("JSON output shape documented in --help (#396)", () => {
+  describe("pax8 cost sim --help", () => {
+    it("documents the simulation result shape", async () => {
+      const { stdout } = await runCliExpectSuccess(["cost", "sim", "--help"]);
+      expect(stdout).toContain("JSON output");
+      // Key top-level fields
+      expect(stdout).toContain("companyName");
+      expect(stdout).toContain("current");
+      expect(stdout).toContain("proposed");
+      expect(stdout).toContain("delta");
+      expect(stdout).toContain("nextActions");
+    });
+  });
+
+  describe("pax8 dashboard --help", () => {
+    it("documents the multi-section snapshot shape", async () => {
+      const { stdout } = await runCliExpectSuccess(["dashboard", "--help"]);
+      expect(stdout).toContain("JSON output");
+      expect(stdout).toContain("topCustomers");
+      expect(stdout).toContain("renewals");
+      expect(stdout).toContain("mrrRenewing");
+      // Deprecated aliases must be called out
+      expect(stdout).toContain("mrrAtRisk");
+      expect(stdout).toContain("DEPRECATED");
+      // #385 dual-emit
+      expect(stdout).toContain("createdAt");
+      expect(stdout).toContain("createdDate");
+    });
+  });
+
+  describe("pax8 recommendations list --help", () => {
+    it("documents the Recommendation shape and STAX divergence", async () => {
+      const { stdout } = await runCliExpectSuccess([
+        "recommendations",
+        "list",
+        "--help",
+      ]);
+      expect(stdout).toContain("JSON output");
+      expect(stdout).toContain("orderCommand");
+      expect(stdout).toContain("estimatedMrrUplift");
+      expect(stdout).toContain("opportunityType");
+      // STAX divergence cross-link
+      expect(stdout).toContain("STAX");
+    });
+  });
+
+  describe("pax8 invoices audit --help", () => {
+    it("documents the discrepancy array shape", async () => {
+      const { stdout } = await runCliExpectSuccess([
+        "invoices",
+        "audit",
+        "--help",
+      ]);
+      expect(stdout).toContain("JSON output");
+      expect(stdout).toContain("discrepancies");
+      expect(stdout).toContain("discrepancyId");
+      expect(stdout).toContain("dollarImpact");
+      expect(stdout).toContain("netImpact");
+    });
+  });
+
+  describe("pax8 subscriptions renewals --help", () => {
+    it("documents both canonical and deprecated renewal field names", async () => {
+      const { stdout } = await runCliExpectSuccess([
+        "subscriptions",
+        "renewals",
+        "--help",
+      ]);
+      expect(stdout).toContain("JSON output");
+      // Canonical fields (#298)
+      expect(stdout).toContain("mrrRenewing");
+      expect(stdout).toContain("arrRenewing");
+      // Deprecated aliases must be present with deprecation note
+      expect(stdout).toContain("mrrAtRisk");
+      expect(stdout).toContain("arrAtRisk");
+      expect(stdout).toContain("DEPRECATED");
+    });
+  });
+
+  describe("pax8 report mrr --help", () => {
+    it("documents the totalMrr / companies shape", async () => {
+      const { stdout } = await runCliExpectSuccess(["report", "mrr", "--help"]);
+      expect(stdout).toContain("JSON output");
+      expect(stdout).toContain("totalMrr");
+      expect(stdout).toContain("projectedArr");
+      expect(stdout).toContain("companies");
+      expect(stdout).toContain("pctOfTotal");
+    });
+  });
+
+  describe("pax8 report growth --help", () => {
+    it("documents the months / growth shape", async () => {
+      const { stdout } = await runCliExpectSuccess([
+        "report",
+        "growth",
+        "--help",
+      ]);
+      expect(stdout).toContain("JSON output");
+      expect(stdout).toContain("months");
+      expect(stdout).toContain("growthPercent");
+      expect(stdout).toContain("averageGrowthPercent");
+      expect(stdout).toContain("overallGrowthPercent");
+    });
+  });
+});

--- a/packages/cli/src/commands/cost/sim.ts
+++ b/packages/cli/src/commands/cost/sim.ts
@@ -76,7 +76,39 @@ Examples:
   pax8 cost sim --company "Bright Minds Academy" --product "M365 Business Premium" --from "M365 Business Basic" --quantity 25
 
   # Add a brand-new product (no current subscription)
-  pax8 cost sim --company "Coastline Legal Group" --product "AvePoint Cloud Backup" --quantity 30 --json`,
+  pax8 cost sim --company "Coastline Legal Group" --product "AvePoint Cloud Backup" --quantity 30 --json
+
+JSON output (--json):
+  {
+    "companyName": string,
+    "companyId": string,
+    "current": {                          // null on add-new (no existing sub)
+      "productName": string,
+      "billingTerm": "Monthly" | "Annual",
+      "quantity": number,
+      "unitPrice": number,
+      "monthly": number,                  // normalized monthly cost
+      "annual": number                    // normalized annual cost
+    } | null,
+    "proposed": {                         // same shape as "current"
+      "productName": string,
+      "billingTerm": "Monthly" | "Annual",
+      "quantity": number,
+      "unitPrice": number,
+      "monthly": number,
+      "annual": number
+    },
+    "delta": {
+      "monthly": number,                  // proposed.monthly − current.monthly
+      "annual": number,                   // proposed.annual − current.annual
+      "perSeat": number                   // per-seat monthly delta
+    },
+    "notes": string[],                    // human-readable caveats (e.g. SKU swap, term change)
+    "nextActions": [{                     // ready-to-run follow-up commands
+      "command": string,                  // e.g. "pax8 orders create --company ..."
+      "description": string
+    }]
+  }`,
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -529,7 +529,45 @@ Examples:
   pax8 ${name} --all
   pax8 ${name} --customers
   pax8 ${name} --renewals --growth
-  pax8 ${name} --json`,
+  pax8 ${name} --json
+
+JSON output (--json):
+  {
+    "totalCompanies": number,
+    "activeSubscriptions": number,
+    "companiesWithActiveSubs": number,
+    "totalSeats": number,
+    "mrr": number,                        // estimated MRR across active subs
+    "arr": number,                        // mrr × 12
+    "topCustomers": [{
+      "name": string,
+      "mrr": number,
+      "seats": number,
+      "subscriptions": number
+    }],
+    "renewalsNext30Days": number,
+    "urgentRenewals": number,             // renewals within 14d
+    "mrrRenewing": number,                // canonical key (#298)
+    "mrrAtRisk": number,                  // DEPRECATED alias of mrrRenewing — removed in a future minor
+    "renewals": [{
+      "companyName": string,
+      "productName": string,
+      "daysUntilRenewal": number,
+      "mrrRenewing": number,
+      "mrrAtRisk": number                 // DEPRECATED alias
+    }],
+    "highPriorityRecs": number,
+    "potentialMrrUplift": number,         // sum of estimatedMrrUplift for high-priority recs
+    "activeTrials": number,
+    "recentOrders": [{
+      "companyName": string,
+      "status": string,
+      "createdAt": string,                // ISO-8601 (canonical, #385)
+      "createdDate": string,              // DEPRECATED alias — removed in v0.3.0
+      "lineItems": [{ "productName": string, "quantity": number }]
+    }],
+    "nextActions": [{ "command": string, "description": string }]
+  }`,
     )
     .action(async (options: { all?: boolean; customers?: boolean; renewals?: boolean; growth?: boolean }, c: Command) => {
       if (name === "status") {

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -29,7 +29,28 @@ Examples:
 Note: this audit compares the partner's invoiced charges against their
 current active subscriptions (a partner-side reconciliation). It is not
 the same as Pax8's internal vendor reconciliation, which compares
-vendor-billed amounts against Pax8's records (vendor-side).`
+vendor-billed amounts against Pax8's records (vendor-side).
+
+JSON output (--json):
+  Returns a single-element array (legacy shape) wrapping the audit report:
+
+  [{
+    "discrepancies": [{
+      "companyId": string,
+      "companyName": string,
+      "productName": string,
+      "invoicedQuantity": number,
+      "activeQuantity": number,
+      "delta": number,                    // invoicedQuantity − activeQuantity
+      "dollarImpact": number,             // positive = overcharge, negative = undercharge
+      "type": "overcharge" | "undercharge" | "unexpected",
+      "discrepancyId": string             // stable id — pass to "pax8 invoices dispute --discrepancy <id>"
+    }],
+    "totalOvercharge": number,
+    "totalUndercharge": number,
+    "netImpact": number,
+    "nextActions": [{ "command": string, "description": string }]
+  }]`
   )
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -110,7 +110,38 @@ Estimate semantics:
   estimatedMrrUplift is an upper-bound estimate (unit price × seat
   count). It is NOT equivalent to Pax8's PMRR (Potential MRR) metric,
   which uses ML-based seat estimation. Use it as a directional ceiling,
-  not a forecast.`
+  not a forecast.
+
+JSON output (--json):
+  Default: a flat array of Recommendation objects. With --with-actions,
+  wrapped as { recommendations, nextActions, unmatchedProducts }.
+
+  Recommendation = {
+    "companyId": string,
+    "companyName": string,
+    "type": "seat_gap" | "cross_sell",   // CLI-local taxonomy; see Recommendation types above
+    "opportunityType": "Upsell" | "Cross-sell" | "Add-on" | "Upgrade" | "Net-new",
+                                          // OE canonical 5-type taxonomy (additive, mapped from "type")
+    "priority": "high" | "medium" | "low",
+    "title": string,
+    "reason": string,
+    "suggestedProducts": string[],        // human-readable product names
+    "orderCommand": string | null,        // ready-to-run "pax8 orders create ..." command;
+                                          // null if no orderable product matched in your catalog
+    "productAvailable": boolean,          // true when orderCommand resolves to a real product
+    "currentMrr": number,                 // company's current MRR (context)
+    "estimatedMrrUplift": number,         // upper-bound — see Estimate semantics above; NOT Pax8 PMRR
+    "targetSeats": number,
+    "estimateType": "upper_bound"
+  }
+
+  Note on STAX divergence: the CLI uses a local 7-category product
+  taxonomy (productivity, email, security, endpoint_protection,
+  identity, backup, cloud_infrastructure) and a "seat_gap" heuristic
+  that are NOT Pax8's canonical STAX taxonomy or Seat Utilization
+  metric. See "Metric definitions" in README.md and the module
+  docstring at packages/core/src/services/recommendations.ts. Will
+  sunset when OE's first-party /opportunities API ships (ARC-785, #375).`
   )
   .allowExcessArguments(true)
   .action(async (options, cmd) => {

--- a/packages/cli/src/commands/report/growth.ts
+++ b/packages/cli/src/commands/report/growth.ts
@@ -28,7 +28,20 @@ Metric definitions:
   metric taxonomy.
 
   ARR (Annual Recurring Revenue): MRR × 12. The yearly equivalent of MRR,
-  used to measure long-term financial health.`)
+  used to measure long-term financial health.
+
+JSON output (--json):
+  {
+    "months": [{
+      "month": string,                    // YYYY-MM
+      "mrr": number,                      // invoiced MRR for that month
+      "delta": number,                    // mrr − previous month's mrr
+      "growthPercent": number             // delta / previous mrr × 100 (one decimal)
+    }],
+    "averageGrowthPercent": number,       // mean of per-month growthPercent
+    "overallGrowthPercent": number,       // first → last month percentage change
+    "nextActions": [{ "command": string, "description": string }]
+  }`)
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();
     const ctx = await buildContext(globalOpts);

--- a/packages/cli/src/commands/report/mrr.ts
+++ b/packages/cli/src/commands/report/mrr.ts
@@ -27,7 +27,20 @@ Metric definitions:
   metric taxonomy.
 
   ARR (Annual Recurring Revenue): MRR × 12. The yearly equivalent of MRR,
-  used to measure long-term financial health.`)
+  used to measure long-term financial health.
+
+JSON output (--json):
+  {
+    "totalMrr": number,                   // sum of estimated MRR across active subs
+    "projectedArr": number,               // totalMrr × 12
+    "companies": [{
+      "name": string,
+      "activeSubs": number,
+      "mrr": number,
+      "pctOfTotal": number                // percentage of totalMrr (one decimal)
+    }],
+    "nextActions": [{ "command": string, "description": string }]
+  }`)
   .action(async (_options, command) => {
     const globalOpts = command.optsWithGlobals();
     const ctx = await buildContext(globalOpts);

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -75,7 +75,32 @@ Metric definitions:
   metric taxonomy.
 
   ARR (Annual Recurring Revenue): MRR × 12. The yearly equivalent of MRR,
-  used to measure long-term financial health.`
+  used to measure long-term financial health.
+
+JSON output (--json):
+  Default: a flat array of Renewal objects. With --with-actions,
+  wrapped as { renewals, nextActions }.
+
+  Renewal = {
+    "subscriptionId": string,
+    "companyId": string,
+    "companyName": string,
+    "productName": string,
+    "quantity": number,
+    "renewalDate": string,                // YYYY-MM-DD
+    "billingTerm": string,
+    "price": number,
+    "mrrRenewing": number,                // canonical key (#298)
+    "mrrAtRisk": number,                  // DEPRECATED alias of mrrRenewing — removed in a future minor
+    "arrRenewing": number,                // canonical key (#298)
+    "arrAtRisk": number,                  // DEPRECATED alias of arrRenewing — removed in a future minor
+    "daysUntilRenewal": number
+  }
+
+  The mrrAtRisk / arrAtRisk aliases are dual-emitted alongside the canonical
+  mrrRenewing / arrRenewing fields for one minor version cycle so existing
+  scripts don't break. Migrate to the renewing-named fields; the at-risk
+  names will be removed in a future minor version (see #299).`
   )
   .action(async (options, cmd) => {
     const allOpts = cmd.optsWithGlobals();


### PR DESCRIPTION
## Summary

- Adds `JSON output (--json):` sections to `addHelpText("after", ...)` on the seven commands whose `--json` responses are nested or computed. Partners parsing `--json` no longer have to run the command to discover its shape — the contract is pinned in `--help`.
- Expands the README "Metric definitions" section with a new "Recommendations taxonomy vs. STAX" subsection plus a CLI-category → STAX/OE mapping table. The recommendations engine's local 7-category taxonomy and `seat_gap` heuristic diverge from canonical STAX / Seat Utilization, but the disclosure previously lived only in `--help` and the module docstring — neither of which `--json` consumers see.
- Calls out the dual-emitted deprecated aliases inline in `--help`: `mrrAtRisk` / `arrAtRisk` on `subscriptions renewals` and `dashboard` (per #299), and `createdDate` on `dashboard` (per #385). Migration timing matches the existing disclosure-over-rewrite pattern.

Closes #396 (widened scope per the partner-walkthrough comment thread). References `docs/triage/partner-walkthrough.md` finding #6 (Group C of the partner-walkthrough plan).

## Commands documented (7)

- `pax8 cost sim` — `{ companyName, current, proposed, delta, notes, nextActions }`
- `pax8 dashboard` (and the deprecated `status` alias) — multi-section snapshot; dual-emit deprecations called out
- `pax8 recommendations list` — `Recommendation` shape + STAX divergence cross-link
- `pax8 invoices audit` — single-element array wrapping the audit report
- `pax8 subscriptions renewals` — canonical `mrrRenewing` / `arrRenewing` AND deprecated `mrrAtRisk` / `arrAtRisk`
- `pax8 report mrr` — `totalMrr` / `companies[]` / `pctOfTotal`
- `pax8 report growth` — `months[]` / `averageGrowthPercent` / `overallGrowthPercent`

Simple list commands returning flat arrays (`orders list`, `clients list`, `subscriptions list`, etc.) were intentionally left alone — they don't benefit from a shape sketch.

## Constraints honored

- **Docs / help-text only.** No code logic changes. Only `addHelpText`, README, the new test file, and the changeset.
- **No JSON contract changes.** The disclosure-over-rewrite pattern stays intact; renewals continues to dual-emit both naming generations.
- **Group B coordination.** Group B is touching empty-state rendering (`packages/cli/src/lib/output.ts`) and the cancel preview. This PR touches only `addHelpText("after", ...)` blocks, README, and a new test file — no overlap.

## Test plan

- [x] `pnpm build` — passes (core + cli + claude-skill).
- [x] `pnpm test` — 109 files / 1839 passed / 6 skipped. New `packages/cli/src/__tests__/help-json-output.test.ts` (7 subprocess assertions) is included.
- [x] `pnpm lint` — clean.
- [x] `pnpm -r exec tsc --noEmit` — clean.
- [x] Spot-checked the rendered `--help` for each of the seven commands; shape sketches read naturally in a terminal.

## Changeset

`.changeset/json-output-shape-in-help.md` — `@pax8/cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)