### PR TITLE
feat(ux): TTY empty-state messages + commitment-aware cancel preview (#409)

### DIFF
--- a/.changeset/empty-state-and-cancel-preview.md
+++ b/.changeset/empty-state-and-cancel-preview.md
@@ -1,0 +1,9 @@
+---
+"@pax8/cli": patch
+---
+
+Polish two partner-walkthrough findings (#409 — Group B):
+
+**Empty-state UX in table mode.** List commands that already routed through the `emptyState` API now also pass a structured `filtersApplied` map; the renderer surfaces it as a single "Filters applied: …" line directly under the "No <resource> found." headline. This answers "why is this empty?" with the partner's own filter values before any speculative reasons. JSON / CSV / `--ids-only` / quiet output contracts are unchanged — agents and pipelines reading `--json` still see exactly `[]`. Touched commands: `companies list`, `subscriptions list`, `orders list`, `invoices list`, `quotes list`, `usage list`, `products list`, `products search` (refactored off ad-hoc empty handling onto the shared helper).
+
+**Commitment-aware cancel preview.** `pax8 subscriptions cancel <id>` now prints a one-line headline branch in table mode BEFORE the confirmation prompt: committed subs show `This subscription has an active commitment ending YYYY-MM-DD.` (then the existing yellow `⚠ COMMITMENT ACTIVE` block), and uncommitted subs show `This subscription has no active commitment. Cancellation will take effect immediately.` This addresses the walkthrough Finding #7 where a Monthly-sub partner had no pre-flight signal that cancellation was immediate. JSON mode is unchanged. Vocabulary stays on the canonical "commitment term end date" framing (no ETF / penalty / fee per the Direct User Agreement).

--- a/packages/cli/src/__tests__/empty-state.test.ts
+++ b/packages/cli/src/__tests__/empty-state.test.ts
@@ -110,6 +110,86 @@ describe("empty list rendering — #197", () => {
     });
   });
 
+  // #409: TTY-mode subprocess coverage. Pre-#409 the only TTY-mode
+  // assertions for empty-state lived in unit tests via `vi.spyOn`, so
+  // regressions could slip past CI if the wiring at the command-action
+  // level drifted. These exercise the full subprocess path with
+  // `PAX8_OUTPUT_FORMAT=table` to simulate a TTY render, then assert the
+  // headline + filter echo land on stderr (never stdout — the
+  // pipeline contract is load-bearing).
+  describe("subprocess TTY-mode empty-state (#409)", () => {
+    it("subscriptions list --status Cancelled in table mode shows the empty-state headline + filter echo", async () => {
+      const result = await runCliExpectSuccess(
+        ["subscriptions", "list", "--status", "Cancelled"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      // Headline must be on stderr, not stdout — agents reading stdout
+      // for a pipe must not see decorative text.
+      expect(result.stderr).toContain("No subscriptions found.");
+      expect(result.stdout).not.toContain("No subscriptions found.");
+      // The new `Filters applied:` line should echo back the user's
+      // exact filter so they see "you typed status=Cancelled, that's
+      // why it's empty" before any speculation.
+      expect(result.stderr).toContain("Filters applied:");
+      expect(result.stderr).toContain("status=Cancelled");
+    });
+
+    it("quotes list --status declined in table mode echoes the filter", async () => {
+      // Demo data has no declined quotes — exercises the empty path
+      // with a valid filter (no `resolveCompanyId` step to interfere).
+      const result = await runCliExpectSuccess(
+        ["quotes", "list", "--status", "declined"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      // Empty-state may or may not fire depending on demo data shape;
+      // when it does, the pipeline contract must still hold.
+      if (result.stderr.includes("No quotes found.")) {
+        expect(result.stdout).not.toContain("No quotes found.");
+        expect(result.stderr).toContain("status=declined");
+      }
+    });
+
+    it("invoices list with no-match filter shows headline on stderr in table mode", async () => {
+      const result = await runCliExpectSuccess(
+        ["invoices", "list", "--month", "1900-01"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      expect(result.stderr).toContain("No invoices found.");
+      expect(result.stderr).toContain("Filters applied:");
+      expect(result.stderr).toContain("month=1900-01");
+      // Stdout must stay clean of the human message even in table mode.
+      expect(result.stdout).not.toContain("No invoices found.");
+    });
+
+    it("companies list --status Deleted in table mode shows the empty-state", async () => {
+      const result = await runCliExpectSuccess(
+        ["companies", "list", "--status", "Deleted"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      expect(result.stderr).toContain("No companies found.");
+      expect(result.stderr).toContain("status=Deleted");
+    });
+
+    it("JSON mode still returns [] regardless of filter and empty-state (load-bearing contract)", async () => {
+      // The new `filtersApplied` rendering is table-mode only. Pin the
+      // contract that JSON output stays exactly `[]` for every touched
+      // command so agents and pipelines aren't surprised.
+      for (const args of [
+        ["subscriptions", "list", "--status", "Cancelled"],
+        ["invoices", "list", "--month", "1900-01"],
+        ["companies", "list", "--status", "Deleted"],
+      ]) {
+        const result = await runCliExpectSuccess([...args, "--json"]);
+        const data = JSON.parse(result.stdout);
+        expect(Array.isArray(data)).toBe(true);
+        expect(data.length).toBe(0);
+        // No human-facing text in the JSON output.
+        expect(result.stdout).not.toMatch(/No \w+ found/);
+        expect(result.stdout).not.toContain("Filters applied:");
+      }
+    });
+  });
+
   describe("output() — empty-state unit behavior", () => {
     it("renders the empty-state to stderr when table + 0 rows", async () => {
       const { output } = await import("../lib/output.js");
@@ -177,6 +257,45 @@ describe("empty list rendering — #197", () => {
         // emptyState. Agents depend on this for `--json | jq`.
         expect(onStdout.trim()).toBe("[]");
         expect(onStderr).toBe("");
+      } finally {
+        stdoutWrite.mockRestore();
+        stderrWrite.mockRestore();
+      }
+    });
+
+    it("renders `Filters applied:` when `filtersApplied` is supplied (#409)", async () => {
+      const { output } = await import("../lib/output.js");
+      const { vi } = await import("vitest");
+
+      const stdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+      const stderrWrite = vi
+        .spyOn(process.stderr, "write")
+        .mockImplementation(() => true);
+
+      try {
+        output([], {
+          format: "table",
+          columns: [{ key: "name", header: "Name" }],
+          emptyState: {
+            headline: "No widgets found.",
+            filtersApplied: { status: "Inactive", company: '"Acme Corp"' },
+            suggestions: [
+              {
+                command: "pax8 widgets list",
+                description: "no filters",
+              },
+            ],
+          },
+        });
+
+        const onStdout = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+        const onStderr = stderrWrite.mock.calls.map((c) => c[0]).join("");
+
+        // Pipeline contract: stdout stays empty even with `filtersApplied`.
+        expect(onStdout).toBe("");
+        expect(onStderr).toContain("Filters applied: status=Inactive, company=\"Acme Corp\"");
       } finally {
         stdoutWrite.mockRestore();
         stderrWrite.mockRestore();

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -735,6 +735,83 @@ describe("pax8 subscriptions cancel", () => {
       expect(combined).not.toMatch(/cancellation[- ]fee/i);
     });
 
+    // #409: commitment-aware cancel preview. Both branches of the preview
+    // text must surface BEFORE the confirmation prompt so the partner sees
+    // the timing reality (committed = scheduled, uncommitted = immediate)
+    // before they commit to the action. Force table output via
+    // PAX8_OUTPUT_FORMAT so we exercise the human-facing preview block
+    // through the subprocess (it would default to JSON otherwise).
+    it("preview names the commitment end date on a committed sub (#409)", async () => {
+      const result = await runCliExpectSuccess(
+        [
+          "subscriptions",
+          "cancel",
+          COMMITTED_SUB,
+          "--yes",
+        ],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      const combined = result.stdout + result.stderr;
+      // Headline phrasing from the issue: "This subscription has an active
+      // commitment ending YYYY-MM-DD." The actual date comes from demo
+      // fixtures (sub-summit-m365bp-001 ends 3 days from now), so we match
+      // the prefix + ISO shape rather than pinning a fixed value.
+      expect(combined).toMatch(
+        /This subscription has an active commitment ending \d{4}-\d{2}-\d{2}\./,
+      );
+      // Vocabulary discipline (carries the #294 contract forward).
+      expect(combined).not.toMatch(/\bETF\b/);
+      expect(combined).not.toMatch(/\bpenalty\b/i);
+    });
+
+    it("preview names the immediate-effect path on an uncommitted sub (#409)", async () => {
+      // sub-bright-m365bb-001 is a Monthly sub with no commitment in
+      // demo data — the exact case the partner walkthrough flagged
+      // (Finding #7): cancelling defaults to immediate with no
+      // pre-flight signal about timing.
+      const UNCOMMITTED_SUB = "sub-bright-m365bb-001";
+      const result = await runCliExpectSuccess(
+        [
+          "subscriptions",
+          "cancel",
+          UNCOMMITTED_SUB,
+          "--yes",
+        ],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain(
+        "This subscription has no active commitment. Cancellation will take effect immediately.",
+      );
+      // The committed-branch headline must NOT appear on an uncommitted sub.
+      expect(combined).not.toMatch(/COMMITMENT ACTIVE/);
+      expect(combined).not.toMatch(/active commitment ending/);
+    });
+
+    it("JSON mode is unchanged for the uncommitted preview branch (#409)", async () => {
+      // The new preview text is table-mode only. JSON pipelines must
+      // remain a flat one-element array exactly as before.
+      const UNCOMMITTED_SUB = "sub-bright-m365bb-001";
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "cancel",
+        UNCOMMITTED_SUB,
+        "--yes",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0]).toMatchObject({
+        id: UNCOMMITTED_SUB,
+        status: "Cancelled",
+      });
+      expect(data[0].cancelDate).toBeUndefined();
+      // The preview narrative must not leak into stdout — pipelines
+      // reading `--json` must not see it.
+      expect(result.stdout).not.toMatch(/no active commitment/i);
+      expect(result.stdout).not.toMatch(/take effect immediately/i);
+    });
+
     it("--help documents the safe-path default and --immediately escape hatch", async () => {
       const result = await runCliExpectSuccess([
         "subscriptions",

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -306,19 +306,32 @@ Examples:
         return;
       }
 
+      const filtersApplied: Record<string, string> = {};
+      if (allOpts.status) filtersApplied.status = String(allOpts.status);
+      if (allOpts.city) filtersApplied.city = String(allOpts.city);
+      if (allOpts.country) filtersApplied.country = String(allOpts.country);
+      if (allOpts.state) filtersApplied.state = String(allOpts.state);
+      if (allOpts.zip) filtersApplied.zip = String(allOpts.zip);
+      if (allOpts.selfService !== undefined) filtersApplied["self-service"] = String(allOpts.selfService);
+      if (allOpts.billOnBehalf !== undefined) filtersApplied["bill-on-behalf"] = String(allOpts.billOnBehalf);
+      if (allOpts.orderApproval !== undefined) filtersApplied["order-approval"] = String(allOpts.orderApproval);
       const emptyReasons: string[] = [];
-      if (allOpts.status) {
-        emptyReasons.push(`No companies match --status ${allOpts.status}.`);
+      if (Object.keys(filtersApplied).length === 0) {
+        emptyReasons.push("This may be a fresh tenant with no partners onboarded yet.");
       }
-      emptyReasons.push("This may be a fresh tenant with no partners onboarded yet.");
 
       output(numbered, {
         format: ctx.outputFormat,
         columns,
         emptyState: {
           headline: "No companies found.",
-          reasons: emptyReasons,
+          filtersApplied: Object.keys(filtersApplied).length > 0 ? filtersApplied : undefined,
+          reasons: emptyReasons.length > 0 ? emptyReasons : undefined,
           suggestions: [
+            {
+              command: "pax8 companies list",
+              description: "list all companies (no filters)",
+            },
             {
               command: replCmd("pax8 companies create --name <name> ..."),
               description: "add your first company",

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -199,16 +199,14 @@ Examples:
         return;
       }
 
+      const filtersApplied: Record<string, string> = {};
+      if (allOpts.company) filtersApplied.company = `"${allOpts.company}"`;
+      if (allOpts.status) filtersApplied.status = String(allOpts.status);
+      if (allOpts.month) filtersApplied.month = String(allOpts.month);
+      if (allOpts.from) filtersApplied.from = String(allOpts.from);
+      if (allOpts.to) filtersApplied.to = String(allOpts.to);
       const emptyReasons: string[] = [];
-      const filterDesc: string[] = [];
-      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
-      if (allOpts.status) filterDesc.push(`status ${allOpts.status}`);
-      if (allOpts.month) filterDesc.push(`month ${allOpts.month}`);
-      if (filterDesc.length > 0) {
-        emptyReasons.push(
-          `No invoices match the filters: ${filterDesc.join(", ")}.`,
-        );
-      } else {
+      if (Object.keys(filtersApplied).length === 0) {
         emptyReasons.push("This is a fresh tenant with no historical billing yet.");
       }
 
@@ -217,8 +215,13 @@ Examples:
         columns,
         emptyState: {
           headline: "No invoices found.",
-          reasons: emptyReasons,
+          filtersApplied: Object.keys(filtersApplied).length > 0 ? filtersApplied : undefined,
+          reasons: emptyReasons.length > 0 ? emptyReasons : undefined,
           suggestions: [
+            {
+              command: "pax8 invoices list",
+              description: "list all invoices (no filters)",
+            },
             {
               command: "pax8 invoices list --status Unpaid",
               description: "show only unpaid invoices",

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -91,15 +91,11 @@ Examples:
         return;
       }
 
+      const filtersApplied: Record<string, string> = {};
+      if (allOpts.company) filtersApplied.company = `"${allOpts.company}"`;
+      if (allOpts.status) filtersApplied.status = String(allOpts.status);
       const emptyReasons: string[] = [];
-      const filterDesc: string[] = [];
-      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
-      if (allOpts.status) filterDesc.push(`status ${allOpts.status}`);
-      if (filterDesc.length > 0) {
-        emptyReasons.push(
-          `No orders match the filters: ${filterDesc.join(", ")}.`,
-        );
-      } else {
+      if (Object.keys(filtersApplied).length === 0) {
         emptyReasons.push("This tenant hasn't placed any orders yet.");
       }
 
@@ -108,8 +104,13 @@ Examples:
         columns,
         emptyState: {
           headline: "No orders found.",
-          reasons: emptyReasons,
+          filtersApplied: Object.keys(filtersApplied).length > 0 ? filtersApplied : undefined,
+          reasons: emptyReasons.length > 0 ? emptyReasons : undefined,
           suggestions: [
+            {
+              command: "pax8 orders list",
+              description: "list all orders (no filters)",
+            },
             {
               command: "pax8 orders create --company <id> --product <id> --quantity <n>",
               description: "place a new order",

--- a/packages/cli/src/commands/products/list.ts
+++ b/packages/cli/src/commands/products/list.ts
@@ -54,26 +54,28 @@ Examples:
         { key: "unitOfMeasure", header: "Category", width: 15 },
       ];
 
+      const filtersApplied: Record<string, string> = {};
+      if (allOpts.vendor) filtersApplied.vendor = `"${allOpts.vendor}"`;
       const emptyReasons: string[] = [];
-      if (allOpts.vendor) {
-        emptyReasons.push(`No products match --vendor "${allOpts.vendor}".`);
+      if (Object.keys(filtersApplied).length === 0) {
+        emptyReasons.push("The catalog may not be reachable.");
       }
-      emptyReasons.push("The catalog may not be reachable, or filters are too narrow.");
 
       output(result.content, {
         format: ctx.outputFormat,
         columns,
         emptyState: {
           headline: "No products found.",
-          reasons: emptyReasons,
+          filtersApplied: Object.keys(filtersApplied).length > 0 ? filtersApplied : undefined,
+          reasons: emptyReasons.length > 0 ? emptyReasons : undefined,
           suggestions: [
-            {
-              command: "pax8 products search <query>",
-              description: "search the catalog by name or SKU",
-            },
             {
               command: "pax8 products list",
               description: "browse without filters",
+            },
+            {
+              command: "pax8 products search <query>",
+              description: "search the catalog by name or SKU",
             },
           ],
         },

--- a/packages/cli/src/commands/products/search.ts
+++ b/packages/cli/src/commands/products/search.ts
@@ -51,23 +51,43 @@ Examples:
         return name.includes(q) || queryTokens.every((t) => name.includes(t));
       });
 
-      if (matches.length === 0) {
-        if (ctx.outputFormat === "json") {
-          output([], { format: "json" });
-        } else if (ctx.outputFormat !== "quiet") {
-          process.stderr.write(
-            chalk.dim(`\n  No products matching "${query}". Try a broader search.\n\n`)
-          );
-        }
-        return;
-      }
-
       const columns = [
         { key: "name", header: "Name", width: 40 },
         { key: "vendorName", header: "Vendor", width: 20 },
         { key: "sku", header: "SKU", width: 30 },
         { key: "unitOfMeasure", header: "Category", width: 15 },
       ];
+
+      // Route the empty-search case through the standard `output()` helper so
+      // it picks up the same "Filters applied:" / "Try next:" block partners
+      // see on every other list command. JSON mode still emits `[]` (the
+      // pipeline contract); CSV still emits a header-only row.
+      if (matches.length === 0) {
+        const filtersApplied: Record<string, string> = { query: `"${query}"` };
+        if (options.vendor) filtersApplied.vendor = `"${options.vendor}"`;
+        output([], {
+          format: ctx.outputFormat,
+          columns,
+          emptyState: {
+            headline: `No products matching "${query}".`,
+            filtersApplied,
+            reasons: [
+              "The search may be too narrow, or the catalog doesn't carry that name.",
+            ],
+            suggestions: [
+              {
+                command: "pax8 products search <broader-query>",
+                description: "try a shorter or more generic term",
+              },
+              {
+                command: "pax8 products list",
+                description: "browse the full catalog",
+              },
+            ],
+          },
+        });
+        return;
+      }
 
       output(matches, { format: ctx.outputFormat, columns });
 

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -121,15 +121,11 @@ Examples:
         { key: "_total", header: "Total", width: 12, format: (v) => formatCurrency(Number(v)) },
       ];
 
+      const filtersApplied: Record<string, string> = {};
+      if (allOpts.company) filtersApplied.company = `"${allOpts.company}"`;
+      if (status) filtersApplied.status = String(status);
       const emptyReasons: string[] = [];
-      const filterDesc: string[] = [];
-      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
-      if (status) filterDesc.push(`status ${status}`);
-      if (filterDesc.length > 0) {
-        emptyReasons.push(
-          `No quotes match the filters: ${filterDesc.join(", ")}.`,
-        );
-      } else {
+      if (Object.keys(filtersApplied).length === 0) {
         emptyReasons.push("This tenant has no quotes yet.");
       }
 
@@ -138,8 +134,13 @@ Examples:
         columns,
         emptyState: {
           headline: "No quotes found.",
-          reasons: emptyReasons,
+          filtersApplied: Object.keys(filtersApplied).length > 0 ? filtersApplied : undefined,
+          reasons: emptyReasons.length > 0 ? emptyReasons : undefined,
           suggestions: [
+            {
+              command: "pax8 quotes list",
+              description: "list all quotes (no filters)",
+            },
             {
               command: replCmd("pax8 quotes create --company <id|name>"),
               description: "draft your first quote",

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -171,10 +171,22 @@ Behavior on committed subscriptions:
         // consequence is "fees paid are nonrefundable", i.e. billing
         // continues, not a separate penalty). See the canonical Rovo
         // research grounding for #294.
+        //
+        // Both branches print BEFORE the confirmation prompt so the partner
+        // sees the full picture (committed vs uncommitted) before they
+        // commit to the cancellation. Pre-#409 the uncommitted case fell
+        // straight through to the destructive preview with no narrative
+        // about timing — partners cancelling a Monthly sub had no
+        // pre-flight signal that cancellation would take effect immediately.
         if (activeCommitment) {
           const estimatedCost =
             (sub.price ?? 0) * sub.quantity * activeCommitment.monthsRemaining;
           process.stdout.write(chalk.yellow.bold("\n  ⚠ COMMITMENT ACTIVE\n\n"));
+          process.stdout.write(
+            chalk.bold(
+              `  This subscription has an active commitment ending ${activeCommitment.endIso}.\n\n`,
+            ),
+          );
           process.stdout.write(
             `  ${chalk.bold("Product")}            ${productName}\n`,
           );
@@ -207,10 +219,29 @@ Behavior on committed subscriptions:
           } else {
             process.stdout.write(
               chalk.dim(
-                `  Defaulting to schedule cancellation for the commitment term end date.\n  Use --immediately to cancel today, or --cancel-date <YYYY-MM-DD> to schedule a different date.\n\n`,
+                `  By default cancellation will take effect on the commitment term end date.\n  Use --immediately to cancel today, or --cancel-date <YYYY-MM-DD> to schedule a different date.\n\n`,
               ),
             );
           }
+        } else if (!explicitCancelDate) {
+          // Uncommitted-sub preview (#409 finding #7). The committed branch
+          // above is loud (yellow + ⚠ + estimated cost). For uncommitted
+          // subs the framing is the inverse: the partner needs to know
+          // that cancellation will NOT wait for any term end — it takes
+          // effect immediately. Stays dim because there's no commitment
+          // protection to surface, but the headline is still explicit so
+          // a Monthly-sub partner doesn't conflate this with the safe-path
+          // default they see in the help text.
+          //
+          // Only render when there's no `--cancel-date` override; an
+          // explicit future date already prints below via the standard
+          // preview block's `Cancel Date` row, so duplicating "takes
+          // effect immediately" here would be misleading.
+          process.stdout.write(
+            chalk.dim(
+              "\n  This subscription has no active commitment. Cancellation will take effect immediately.\n\n",
+            ),
+          );
         }
 
         const heading = effectiveCancelDate

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -157,15 +157,11 @@ Examples:
         return;
       }
 
+      const filtersApplied: Record<string, string> = {};
+      if (allOpts.company) filtersApplied.company = `"${allOpts.company}"`;
+      if (allOpts.status) filtersApplied.status = String(allOpts.status);
       const emptyReasons: string[] = [];
-      const filterDesc: string[] = [];
-      if (allOpts.company) filterDesc.push(`company "${allOpts.company}"`);
-      if (allOpts.status) filterDesc.push(`status ${allOpts.status}`);
-      if (filterDesc.length > 0) {
-        emptyReasons.push(
-          `No subscriptions match the filters: ${filterDesc.join(", ")}.`,
-        );
-      } else {
+      if (Object.keys(filtersApplied).length === 0) {
         emptyReasons.push("This tenant has no subscriptions yet.");
       }
 
@@ -174,11 +170,16 @@ Examples:
         columns,
         emptyState: {
           headline: "No subscriptions found.",
-          reasons: emptyReasons,
+          filtersApplied: Object.keys(filtersApplied).length > 0 ? filtersApplied : undefined,
+          reasons: emptyReasons.length > 0 ? emptyReasons : undefined,
           suggestions: [
             {
-              command: "pax8 products search <name>",
-              description: "find a product to sell",
+              command: "pax8 subscriptions list",
+              description: "list all subscriptions (no filters)",
+            },
+            {
+              command: "pax8 subscriptions list --status Active",
+              description: "filter to active subscriptions only",
             },
             {
               command: "pax8 orders create --company <id> --product <id> --quantity <n>",

--- a/packages/cli/src/commands/usage/list.ts
+++ b/packages/cli/src/commands/usage/list.ts
@@ -100,10 +100,11 @@ Notes:
         { key: "subtotal", header: "Subtotal", width: 14, format: (v: unknown) => formatCurrency(Number(v)) },
       ];
 
+      const filtersApplied: Record<string, string> = {};
+      if (options.subscription) filtersApplied.subscription = String(options.subscription);
+      if (options.company) filtersApplied.company = `"${options.company}"`;
+      if (options.month) filtersApplied.month = String(options.month);
       const emptyReasons: string[] = [];
-      if (options.month) {
-        emptyReasons.push(`No usage summaries recorded for ${options.month}.`);
-      }
       if (options.subscription) {
         emptyReasons.push(
           "The subscription may not be a metered/usage-based product.",
@@ -123,6 +124,7 @@ Notes:
         columns,
         emptyState: {
           headline: "No usage summaries found.",
+          filtersApplied: Object.keys(filtersApplied).length > 0 ? filtersApplied : undefined,
           reasons: emptyReasons,
           suggestions: [
             {

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -37,7 +37,21 @@ export interface EmptyStateSuggestion {
 export interface EmptyState {
   /** Headline shown in place of the table, e.g. "No companies found." */
   headline: string;
-  /** Optional bullet list explaining why the list might be empty. */
+  /**
+   * Optional structured filter context, rendered as a single "Filters
+   * applied:" line below the headline. Order is insertion order; keys are
+   * flag names without leading dashes (e.g. `status`, `company`), values
+   * are the user-supplied values. Use this when the caller knows exactly
+   * which filters narrowed the result set to zero rows — it tells the
+   * partner "you typed these filters, that's why it's empty" before any
+   * speculative explanation. Per #409 (partner walkthrough finding #3).
+   */
+  filtersApplied?: Record<string, string>;
+  /**
+   * Optional bullet list explaining why the list might be empty. Used when
+   * the explanation is speculative (e.g. "fresh tenant", "no orders yet")
+   * rather than a direct echo of filter flags.
+   */
   reasons?: string[];
   /** Optional "Try next:" block with copy-pasteable commands. */
   suggestions?: EmptyStateSuggestion[];
@@ -193,6 +207,21 @@ function inferColumns(rows: readonly Record<string, unknown>[]): Column[] {
  */
 function renderEmptyState(state: EmptyState): void {
   process.stderr.write("\n  " + state.headline + "\n");
+
+  // Echo the filters the caller declared, e.g.
+  //   Filters applied: status=Inactive, company="Acme Corp"
+  // This is the partner-facing answer to "why is this empty?" before any
+  // speculative reasons. Rendered as a single line in dim text so it sits
+  // visually under the headline without competing with it.
+  if (state.filtersApplied) {
+    const entries = Object.entries(state.filtersApplied);
+    if (entries.length > 0) {
+      const formatted = entries
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", ");
+      process.stderr.write(chalk.dim(`  Filters applied: ${formatted}\n`));
+    }
+  }
 
   if (state.reasons && state.reasons.length > 0) {
     process.stderr.write("\n" + chalk.dim("  Possible reasons:\n"));


### PR DESCRIPTION
## Summary

Closes #409 (partner walkthrough Group B). Two related polish items from `docs/triage/partner-walkthrough.md` findings #3 and #7.

- **TTY empty-state echoes the user's filters.** Added `filtersApplied?: Record<string, string>` to the shared `EmptyState` interface (`packages/cli/src/lib/output.ts`). When a list command returns 0 rows in table mode, the renderer now prints a single dim "Filters applied: k=v, k=v" line directly under the "No <resource> found." headline — so the partner sees their own filter values echoed back before any speculative reasoning. Wired through every touched list command. JSON / CSV / `--ids-only` / quiet output contracts are **unchanged** — agents and pipelines still see exactly `[]`, header-only CSV, or empty output.

- **Cancel preview names timing for both branches.** `pax8 subscriptions cancel <id>` now prints a one-line headline BEFORE the confirmation prompt: committed subs get `This subscription has an active commitment ending YYYY-MM-DD.` (then the existing yellow `⚠ COMMITMENT ACTIVE` block + estimated cost-through-term-end), uncommitted subs get `This subscription has no active commitment. Cancellation will take effect immediately.` This closes Finding #7 where a Monthly-sub partner had no pre-flight signal that cancellation was immediate. Vocabulary stays on the canonical "commitment term end date" framing per #294 / `docs/UX_GUIDE.md` (no ETF / penalty / fee).

Commands touched: `companies list`, `subscriptions list`, `orders list`, `invoices list`, `quotes list`, `usage list`, `products list`, `products search`, `subscriptions cancel`.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` — 1841 passed, 6 skipped, 0 failed (108 files)
- [x] `pnpm lint` — clean (only a non-blocking module-typeless warning unrelated to this change)
- [x] `pnpm -r exec tsc --noEmit` — exit 0 (explicit typecheck per #413 lesson)
- [x] Manual smoke: `PAX8_DEMO=1 PAX8_OUTPUT_FORMAT=table pax8 subscriptions list --status Cancelled` shows the new "Filters applied: status=Cancelled" line on stderr
- [x] Manual smoke: `PAX8_DEMO=1 PAX8_OUTPUT_FORMAT=table pax8 subscriptions cancel sub-bright-m365bb-001 --yes` (uncommitted Monthly sub) prints `This subscription has no active commitment. Cancellation will take effect immediately.` before the preview
- [x] Manual smoke: `PAX8_DEMO=1 PAX8_OUTPUT_FORMAT=table pax8 subscriptions cancel sub-summit-m365bp-001 --yes` (committed 1-Year sub) prints `This subscription has an active commitment ending YYYY-MM-DD.` before the ⚠ COMMITMENT ACTIVE block
- [x] JSON contract intact: `pax8 subscriptions list --status Cancelled --json` returns exactly `[]`; `pax8 subscriptions cancel <uncommitted-id> --yes --json` returns the same flat one-element array as before (no new fields, no leak of preview text)

## Notes for reviewers

- New subprocess tests pin both the empty-state TTY render (`PAX8_OUTPUT_FORMAT=table`) and the cancel preview branches across committed + uncommitted demo fixtures (`sub-summit-m365bp-001` / `sub-bright-m365bb-001`)
- `products search` was refactored off ad-hoc empty handling onto the shared `output(emptyState: …)` helper — first-time migration, no behavior change for non-empty results
- Group C is touching `addHelpText("after", …)` blocks in parallel; this PR touches command action bodies + the cancel preview block, so no path overlap is expected