### PR TITLE
fix(ux): render numbered list before drill-in prompt in dashboard + renewals

### DIFF
--- a/.changeset/ux-numbered-quickactions-and-renewals.md
+++ b/.changeset/ux-numbered-quickactions-and-renewals.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+UX: `pax8 dashboard` Quick Actions and `pax8 subscriptions renewals` "Try next:" now render the numbered list before the drill-in prompt. Previously the dashboard printed "Quick Actions" then prompted "Type 1-5" with no visible 1-5 menu (the rows had been built internally but never rendered). The renewals "Try next:" block was static text with no interactive affordance. Both now share the same numbered + pickable pattern via `promptNextSteps({ renderList: true })`. Callers that already print a numbered table above the prompt (`recommendations list`, `companies list`, etc.) keep their existing headless behavior — the `renderList` flag is opt-in. The `subscriptions update <id> --quantity <n>` advisory in renewals remains as informational text below the pickable list since its placeholder argument can't be drilled into interactively.

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -432,7 +432,7 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
         if (quickActions.length > 0) {
           divider();
           out.write(chalk.bold("  Quick Actions\n\n"));
-          await promptNextSteps(quickActions);
+          await promptNextSteps(quickActions, { renderList: true });
         }
 
         if (alerts.length === 0 && quickActions.length === 0) {
@@ -499,7 +499,7 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
         if (allActions.length > 0) {
           divider();
           out.write(chalk.bold("  Quick Actions\n\n"));
-          await promptNextSteps(allActions);
+          await promptNextSteps(allActions, { renderList: true });
         }
       }
 

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -15,6 +15,7 @@ import {
 } from "../../lib/formatters.js";
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 function parseWithinDays(within: string): number {
   const match = within.match(/^(\d+)d$/);
@@ -223,13 +224,34 @@ JSON output (--json):
         process.stdout.write(chalk.dim("    • Cancel if the customer is churning\n"));
       }
 
-      // Show actionable commands for the most urgent items
+      // Show actionable commands for the most urgent item — numbered so
+      // partners and agents can drill in interactively via `promptNextSteps`.
+      // The `subscriptions update ... --quantity <n>` option carries a
+      // placeholder so we leave it off the pickable list (drilling into it
+      // would just hit a quantity-required error); it remains as advisory
+      // text in the renewals output above. See #379-area UX feedback.
       if (ctx.outputFormat === "table" && report.items.length > 0) {
         const top = report.items[0];
+        const steps: NextStep[] = [
+          {
+            key: "1",
+            label: `${chalk.cyan(`subscriptions show ${top.subscriptionId}`)}  ${chalk.dim("view details")}`,
+            command: ["subscriptions", "show", top.subscriptionId],
+          },
+          {
+            key: "2",
+            label: `${chalk.cyan(`companies more "${top.companyName}"`)}  ${chalk.dim("view company")}`,
+            command: ["companies", "more", top.companyName],
+          },
+        ];
         process.stderr.write(chalk.dim("\n  Try next:\n"));
-        process.stderr.write(`    ${chalk.cyan(`subscriptions show ${top.subscriptionId}`)}  ${chalk.dim("view details")}\n`);
-        process.stderr.write(`    ${chalk.cyan(`subscriptions update ${top.subscriptionId} --quantity <n>`)}  ${chalk.dim("adjust seats")}\n`);
-        process.stderr.write(`    ${chalk.cyan(`companies more "${top.companyName}"`)}  ${chalk.dim("view company")}\n`);
+        await promptNextSteps(steps, { renderList: true });
+        // Static advisory below the pickable list — the `--quantity <n>`
+        // command can't be picked interactively (needs a value), but the
+        // suggestion is still worth surfacing.
+        process.stderr.write(
+          `  ${chalk.dim("Or:")} ${chalk.cyan(`pax8 subscriptions update ${top.subscriptionId} --quantity <n>`)} ${chalk.dim("to adjust seats")}\n`,
+        );
       }
 
       process.stdout.write("\n");

--- a/packages/cli/src/lib/next-step.ts
+++ b/packages/cli/src/lib/next-step.ts
@@ -13,19 +13,41 @@ export interface NextStep {
 }
 
 /**
- * Prompt the user to drill into a numbered row from the most-recent table.
- * Only interactive in TTY mode. Skips silently when piped.
+ * Prompt the user to drill into a numbered option. Only interactive in TTY
+ * mode. Skips silently when piped.
  *
- * The table itself is the menu — every row already shows its index in the
- * `#` column — so we don't re-print each option here. We just show one
- * concise hint with a representative example, then read input.
+ * Two rendering modes, controlled by `options.renderList`:
+ *
+ *   1. **Headless** (default — `renderList` false or absent): the caller
+ *      is responsible for printing the menu, typically as a numbered table
+ *      above this prompt. Used by `recommendations list`, `companies list`,
+ *      etc. — every row already shows its index in the `#` column, so we
+ *      don't re-print each option, just show one concise drill-in hint.
+ *
+ *   2. **Embedded list** (`renderList: true`): no table above. We print
+ *      every step as `  N. label` before the prompt so the user has
+ *      something to pick from. Used by `dashboard` (Quick Actions block)
+ *      and `subscriptions renewals` (`Try next:` block).
  */
-export async function promptNextSteps(steps: NextStep[]): Promise<void> {
+export async function promptNextSteps(
+  steps: NextStep[],
+  options?: { renderList?: boolean },
+): Promise<void> {
   if (!process.stdin.isTTY) return;
   if (steps.length === 0) return;
 
+  // Embedded-list mode: print each option before the prompt. Otherwise the
+  // prompt below references a "1-N" range with no visible menu (the bug
+  // the dashboard's Quick Actions block hit pre-this-fix).
+  if (options?.renderList) {
+    for (const step of steps) {
+      process.stderr.write(`  ${chalk.dim(`${step.key}.`)} ${step.label}\n`);
+    }
+    process.stderr.write("\n");
+  }
+
   // Pick a sample row to illustrate "what does typing a number do?"
-  // First row is representative for any list-style table.
+  // First row is representative for any list-style menu.
   const sample = steps[0];
   const max = steps[steps.length - 1].key;
 


### PR DESCRIPTION
## What this fixes

Two related UX bugs surfaced during this morning's testing:

1. **`pax8 dashboard` Quick Actions** prompted \"Type 1-5 to drill in\" but never rendered the 1-5 menu. The rows were built internally and handed to \`promptNextSteps\`, which assumed a numbered table above (true for \`recommendations list\` / \`companies list\` callers, false for dashboard).
2. **`pax8 subscriptions renewals` \"Try next:\"** printed three suggestion lines with no numbers and no prompt — not interactively pickable.

## How

Extended \`promptNextSteps\` with an opt-in \`renderList: true\` option that prints each step as \`  N. label\` before the drill-in hint. Default behavior unchanged (headless — table is the menu), so \`recommendations list\` / \`companies list\` keep their existing rendering.

- **Dashboard**: both Quick Actions sites opt in to \`renderList: true\`. The two existing call sites cover the default and the \`--all\` variant.
- **Renewals**: replaced the static stderr \"Try next:\" block with \`promptNextSteps([show, companies more], { renderList: true })\`. The \`subscriptions update <id> --quantity <n>\` suggestion can't be picked interactively (placeholder arg), so it stays as informational \`Or:\` text below the pickable list.

## Test plan

- [x] \`pnpm build && pnpm test && pnpm lint\` all green (1848 passed / 6 skipped)
- [ ] Manual TTY check: \`pax8 dashboard\` now shows numbered Quick Actions; typing a number drills in correctly
- [ ] Manual TTY check: \`pax8 subscriptions renewals\` now shows numbered Try next; typing 1 or 2 drills in

## Notes

- Changeset entry: \`@pax8/cli\` patch
- Other commands with \"Try next:\" hints (\`invoices/audit\`, \`invoices/show\`, \`quotes/send\`, etc.) **not migrated** — they're outside this UX feedback's scope and the static suggestions still read fine where there's nothing meaningful to pick interactively. Worth a follow-up audit but not in this PR.