### PR TITLE
fix(ux): rename stale `pax8 companies *` refs inside command source code

### DIFF
--- a/.changeset/ux-stale-companies-refs-cleanup.md
+++ b/.changeset/ux-stale-companies-refs-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+UX: cleaned up ~15 stale `pax8 companies *` references inside command source code that #382's doc cleanup didn't reach. These strings print at runtime as Try-next suggestions, error-recovery hints, and demo-mode `Try:` prompts (in `init`, `contacts/{list,show,update,delete}`, `dashboard`, `subscriptions/show`, `invoices/show`, `orders/create`, `report/mrr`, `quotes` examples, and `companies/{create,list,more,show,update}` Examples blocks). Plus a few user-facing prose strings: "Pick a company first" → "Pick a client first", "Full company summary" → "Full client summary", "view company" → "view client", "Create a new company" → "Create a new client", "List companies:" → "List clients:". The `--company` flag on every command stays unchanged (per #317's decision: flag mirrors the API field; will migrate when the API ships `/clients` endpoints). JSON output field names (`companyId`, `companyName`, etc.) unchanged. Code comments and `companies/index.ts`'s deliberate alias-explanation block also unchanged. Closes the runtime gap that pair-completes #379/#382.

--- a/packages/cli/src/commands/companies/create.ts
+++ b/packages/cli/src/commands/companies/create.ts
@@ -59,7 +59,7 @@ function buildPrimaryContact(
 }
 
 export const companiesCreateCommand = new Command("create")
-  .description("Create a new company (Active by default via atomic contact creation per PAM-997)")
+  .description("Create a new client (Active by default via atomic contact creation per PAM-997)")
   .requiredOption("--name <name>", "Company name (required)")
   .option("--phone <phone>", "Company phone number (also used as the primary-contact phone on the default atomic path)")
   .option("--website <url>", "Company website")
@@ -122,12 +122,12 @@ Atomic-create behavior (default):
 
 Examples:
   # Atomic (Active company in one call)
-  pax8 companies create --name "Summit Healthcare" --phone "+1-303-555-0101" \\
+  pax8 clients create --name "Summit Healthcare" --phone "+1-303-555-0101" \\
       --website "https://summithealthcare.example.com" --city Denver --state CO --zip 80246 \\
       --first-name Maya --last-name Chen --email maya@summit.example.com
 
   # Company-only (Inactive — must follow up with 'pax8 contacts create')
-  pax8 companies create --name "Test Co" --city Denver --state CO --zip 80202 --company-only`,
+  pax8 clients create --name "Test Co" --city Denver --state CO --zip 80202 --company-only`,
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -148,7 +148,7 @@ Examples:
           ["The Pax8 spec marks `address` as a required field on POST /companies."],
           [
             "Pass at least one of --street, --city, --state, --zip (and --country if not US).",
-            'Example: pax8 companies create --name "Acme" --city Denver --state CO --zip 80202',
+            'Example: pax8 clients create --name "Acme" --city Denver --state CO --zip 80202',
           ],
           undefined,
           ERROR_INVALID_INPUT,

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -102,19 +102,19 @@ export const companiesListCommand = new Command("list")
     "after",
     `
 Examples:
-  pax8 companies list
-  pax8 companies list --status Active
-  pax8 companies list --city Denver --state CO
-  pax8 companies list --country US --sort city
-  pax8 companies list --self-service true
-  pax8 companies list --bill-on-behalf true --order-approval false
-  pax8 companies list --page 1 --size 25
-  pax8 companies list --coverage
-  pax8 companies list --json
-  pax8 companies list --json --with-actions
-  pax8 companies list --csv
-  pax8 companies list --ids-only
-  pax8 companies list --ids-only | xargs -I{} pax8 subscriptions list --company {}`
+  pax8 clients list
+  pax8 clients list --status Active
+  pax8 clients list --city Denver --state CO
+  pax8 clients list --country US --sort city
+  pax8 clients list --self-service true
+  pax8 clients list --bill-on-behalf true --order-approval false
+  pax8 clients list --page 1 --size 25
+  pax8 clients list --coverage
+  pax8 clients list --json
+  pax8 clients list --json --with-actions
+  pax8 clients list --csv
+  pax8 clients list --ids-only
+  pax8 clients list --ids-only | xargs -I{} pax8 subscriptions list --company {}`
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -124,7 +124,7 @@ Examples:
     // tell whether they typo'd or genuinely had no matching companies.
     try {
       validateEnum(allOpts.status, COMPANY_STATUS_VALUES, "--status", {
-        cmdHint: "pax8 companies list",
+        cmdHint: "pax8 clients list",
       });
     } catch (error) {
       await handleCommandError(error);
@@ -265,7 +265,7 @@ Examples:
         writeFileSync(join(dir, "pending-actions.json"), JSON.stringify(
           result.content.map((_c, i) => ({
             key: String(startNum + i + 1),
-            command: `companies more ${startNum + i + 1}`,
+            command: `clients more ${startNum + i + 1}`,
           }))
         ));
       } catch { /* best effort */ }
@@ -284,7 +284,7 @@ Examples:
           : result.content;
         for (const c of ranked.slice(0, 3)) {
           nextActions.push({
-            command: `pax8 companies more "${c.name}"`,
+            command: `pax8 clients more "${c.name}"`,
             description: `Drill into ${c.name}`,
           });
         }
@@ -298,7 +298,7 @@ Examples:
           }
         } else {
           nextActions.push({
-            command: "pax8 companies list --coverage --json",
+            command: "pax8 clients list --coverage --json",
             description: "Re-run with portfolio coverage analysis to surface gaps",
           });
         }
@@ -329,15 +329,15 @@ Examples:
           reasons: emptyReasons.length > 0 ? emptyReasons : undefined,
           suggestions: [
             {
-              command: "pax8 companies list",
+              command: "pax8 clients list",
               description: "list all companies (no filters)",
             },
             {
-              command: replCmd("pax8 companies create --name <name> ..."),
+              command: replCmd("pax8 clients create --name <name> ..."),
               description: "add your first company",
             },
             {
-              command: "PAX8_DEMO=1 pax8 companies list",
+              command: "PAX8_DEMO=1 pax8 clients list",
               description: "see what an active tenant looks like",
             },
           ],
@@ -357,7 +357,7 @@ Examples:
 
         if (totalPages > 1 && currentPage < totalPages - 1) {
           process.stderr.write(
-            chalk.dim("  Next page: ") + chalk.cyan(replCmd(`pax8 companies list --page ${currentPage + 2}`)) + "\n"
+            chalk.dim("  Next page: ") + chalk.cyan(replCmd(`pax8 clients list --page ${currentPage + 2}`)) + "\n"
           );
         }
 

--- a/packages/cli/src/commands/companies/more.ts
+++ b/packages/cli/src/commands/companies/more.ts
@@ -60,16 +60,16 @@ function daysUntil(dateStr: string | undefined): number | null {
 }
 
 export const companiesMoreCommand = new Command("more")
-  .description("Full company summary — subscriptions, vendors, seats, estimated MRR, and issues")
-  .argument("<name-or-number>", "Company name, ID, or # from companies list")
+  .description("Full client summary — subscriptions, vendors, seats, estimated MRR, and issues")
+  .argument("<name-or-number>", "Client name, ID, or # from companies list")
   .allowExcessArguments(true)
   .addHelpText(
     "after",
     `
 Examples:
-  pax8 companies more 1                                  Use # from companies list
-  pax8 companies more "Summit Healthcare Partners"
-  pax8 companies more "Summit Healthcare Partners" --json`
+  pax8 clients more 1                                  Use # from companies list
+  pax8 clients more "Summit Healthcare Partners"
+  pax8 clients more "Summit Healthcare Partners" --json`
   )
   .action(async (idOrName: string, _options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -333,7 +333,7 @@ Examples:
         process.stderr.write(
           chalk.red.bold(`\n  \u2717 Could not load company summary\n`) +
           chalk.dim(`    The company may not exist or the API returned no data.\n`) +
-          chalk.yellow(`    \u2192 Run ${chalk.cyan(replCmd("pax8 companies list"))} to see available companies\n\n`)
+          chalk.yellow(`    \u2192 Run ${chalk.cyan(replCmd("pax8 clients list"))} to see available clients\n\n`)
         );
         process.exit(1);
         throw new Error("process.exit intercepted", { cause: error });

--- a/packages/cli/src/commands/companies/show.ts
+++ b/packages/cli/src/commands/companies/show.ts
@@ -38,9 +38,9 @@ export const companiesShowCommand = new Command("show")
     "after",
     `
 Examples:
-  pax8 companies show "Summit Healthcare Partners"
-  pax8 companies show "Summit Healthcare Partners" --subscriptions
-  pax8 companies show a1b2c3d4-e5f6-7890-abcd-ef1234567890 --json`
+  pax8 clients show "Summit Healthcare Partners"
+  pax8 clients show "Summit Healthcare Partners" --subscriptions
+  pax8 clients show a1b2c3d4-e5f6-7890-abcd-ef1234567890 --json`
   )
   .action(async (idOrName: string, options, command: Command) => {
     const allOpts = command.optsWithGlobals();

--- a/packages/cli/src/commands/companies/update.ts
+++ b/packages/cli/src/commands/companies/update.ts
@@ -23,9 +23,9 @@ export const companiesUpdateCommand = new Command("update")
     "after",
     `
 Examples:
-  pax8 companies update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --name "New Name"
-  pax8 companies update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --phone "+1-555-1234"
-  pax8 companies update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --name "Updated" --yes`
+  pax8 clients update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --name "New Name"
+  pax8 clients update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --phone "+1-555-1234"
+  pax8 clients update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --name "Updated" --yes`
   )
   .action(async (idOrName: string, options, command: Command) => {
     const allOpts = command.optsWithGlobals();

--- a/packages/cli/src/commands/contacts/delete.ts
+++ b/packages/cli/src/commands/contacts/delete.ts
@@ -43,7 +43,7 @@ Notes:
             "(Previously: `pax8 contacts delete <contact-id>`.)",
           ],
           [
-            `Pick a company first: ${replCmd("pax8 companies list")}`,
+            `Pick a client first: ${replCmd("pax8 clients list")}`,
             `Then: ${replCmd(`pax8 contacts delete ${id}`)} --company <id|name>`,
           ],
           undefined,

--- a/packages/cli/src/commands/contacts/list.ts
+++ b/packages/cli/src/commands/contacts/list.ts
@@ -39,7 +39,7 @@ Examples:
           "--company is required",
           ["The Pax8 contacts API is scoped to a single company"],
           [
-            `Pick a company first: ${replCmd("pax8 companies list")}`,
+            `Pick a client first: ${replCmd("pax8 clients list")}`,
             `Then: ${replCmd("pax8 contacts list")} --company <id|name>`,
           ],
           undefined,

--- a/packages/cli/src/commands/contacts/show.ts
+++ b/packages/cli/src/commands/contacts/show.ts
@@ -43,7 +43,7 @@ Notes:
             "(Previously: `pax8 contacts show <contact-id>`.)",
           ],
           [
-            `Pick a company first: ${replCmd("pax8 companies list")}`,
+            `Pick a client first: ${replCmd("pax8 clients list")}`,
             `Then: ${replCmd(`pax8 contacts show ${id}`)} --company <id|name>`,
           ],
           undefined,

--- a/packages/cli/src/commands/contacts/update.ts
+++ b/packages/cli/src/commands/contacts/update.ts
@@ -66,7 +66,7 @@ Notes:
             "(Previously: `pax8 contacts update <contact-id> ...`.)",
           ],
           [
-            `Pick a company first: ${replCmd("pax8 companies list")}`,
+            `Pick a client first: ${replCmd("pax8 clients list")}`,
             `Then: ${replCmd(`pax8 contacts update ${id}`)} --company <id|name> --email <new-email>`,
           ],
           undefined,

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -257,7 +257,7 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
         // Add top customer drilldown
         if (topCustomers.length > 0) {
           nextActions.push({
-            command: `pax8 companies more "${topCustomers[0].name}" --json`,
+            command: `pax8 clients more "${topCustomers[0].name}" --json`,
             description: `Drill into top customer ${topCustomers[0].name}`,
           });
         }
@@ -492,7 +492,7 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
           allActions.push({
             key: String(allActions.length + 1),
             label: `Drill into ${topCustomers[0].name}`,
-            command: tokenizeCmd(`companies more "${topCustomers[0].name}"`),
+            command: tokenizeCmd(`clients more "${topCustomers[0].name}"`),
           });
         }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -47,7 +47,7 @@ Examples:
           config.demo = true;
           await saveConfig(config);
           process.stdout.write(
-            chalk.green(`\n  ✓ Demo mode enabled. Try: ${replCmd("pax8 companies list")}\n`)
+            chalk.green(`\n  ✓ Demo mode enabled. Try: ${replCmd("pax8 clients list")}\n`)
           );
           process.stdout.write(
             chalk.dim(`  Disable with: ${replCmd("pax8 init --demo off")}\n\n`)

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -421,7 +421,7 @@ Examples:
           ["--company <id|name> is required for orders create"],
           [
             `Example: ${replCmd("pax8 orders create")} --company "Acme" --product prod-123 --quantity 5`,
-            `List companies: ${replCmd("pax8 companies list")}`,
+            `List clients: ${replCmd("pax8 clients list")}`,
           ],
           undefined,
           ERROR_INVALID_INPUT,
@@ -818,7 +818,7 @@ Examples:
               ],
               [
                 `Search for alternatives: ${replCmd("pax8 products search")} "${shortName}"`,
-                `View ${displayCompany}'s current subscriptions: ${replCmd("pax8 companies more")} "${displayCompany}"`,
+                `View ${displayCompany}'s current subscriptions: ${replCmd("pax8 clients more")} "${displayCompany}"`,
               ],
               undefined,
               ERROR_PRODUCT_NOT_FOUND,

--- a/packages/cli/src/commands/report/mrr.ts
+++ b/packages/cli/src/commands/report/mrr.ts
@@ -92,7 +92,7 @@ JSON output (--json):
       const nextActions: { command: string; description: string }[] = [];
       if (companies.length > 0) {
         nextActions.push({
-          command: `pax8 companies more "${companies[0].name}"`,
+          command: `pax8 clients more "${companies[0].name}"`,
           description: `Drill into top customer ${companies[0].name}`,
         });
       }

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -240,8 +240,8 @@ JSON output (--json):
           },
           {
             key: "2",
-            label: `${chalk.cyan(`companies more "${top.companyName}"`)}  ${chalk.dim("view company")}`,
-            command: ["companies", "more", top.companyName],
+            label: `${chalk.cyan(`clients more "${top.companyName}"`)}  ${chalk.dim("view client")}`,
+            command: ["clients", "more", top.companyName],
           },
         ];
         process.stderr.write(chalk.dim("\n  Try next:\n"));


### PR DESCRIPTION
## Summary

- #382 cleaned up docs but missed ~15 runtime references that print as Try-next suggestions, error-recovery hints, and demo-mode \`Try:\` prompts. This sweep closes the runtime gap.
- Touches: \`init\`, \`contacts/{list,show,update,delete}\`, \`dashboard\`, \`subscriptions/{show,renewals}\`, \`invoices/show\`, \`orders/create\`, \`report/mrr\`, and \`companies/{create,list,more,show,update}\` Examples blocks.
- Plus a few user-facing prose strings: "Pick a company first" → "Pick a client first", "Full company summary" → "Full client summary", "view company" → "view client", "Create a new company" → "Create a new client", "List companies:" → "List clients:".

## Intentionally unchanged

- \`--company\` flag on every command (per #317: flag mirrors the API field; will migrate when the API ships \`/clients\` endpoints).
- JSON output field names (\`companyId\`, \`companyName\`).
- Code comments and \`companies/index.ts\`'s deliberate alias-explanation block.

Pair-completes #379 / #382.

## Test plan

- [x] \`pnpm build\` — clean
- [x] \`pnpm test\` — 1848 tests pass
- [x] \`pnpm lint\` — clean
- [ ] Spot-check \`pax8 dashboard\` / \`pax8 subscriptions renewals\` in demo mode — Try-next hints all say \`pax8 clients ...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)