### PR TITLE
feat(ux): number-pickable next-step affordances + workflow follow-ons

### DIFF
--- a/.changeset/ux-pickable-next-steps.md
+++ b/.changeset/ux-pickable-next-steps.md
@@ -1,0 +1,11 @@
+---
+"@pax8/cli": minor
+---
+
+UX: number-pickable next-step affordances across show/detail commands and `invoices audit`. Previously, "Try next:" blocks were emitted as plain `process.stderr.write` text — partners had to copy-paste the suggested command. This change converts those blocks to use `promptNextSteps({ renderList: true })`, so a partner can scan the numbered list, type a number, and drill in.
+
+Converted to pickable: `subscriptions show`, `invoices show`, `quotes show` (status-aware — Draft now leads with `quotes send`), `quotes send`, `quotes update` (newly added), `quotes line-items add`, `quotes line-items list`, `companies more`, `cost sim` (now also surfaces the affected subscription when present), `contacts create`, `contacts list`, `contacts show`, `orders show` (newly added), `products search`, `subscriptions cancel`, `recommendations upsell` (newly actionable — one `orders create` step per upsell match). `invoices audit` discrepancies are indexed 1-N in the rendered output and each becomes a pickable `dispute --discrepancy <id>` step, carrying the `--month` filter through when set.
+
+Placeholder-style entries (`pax8 X update <some-id> --y <n>`) are dropped from pickable lists wherever they appeared and replaced with affordance-pointer framing — short prose lines that name the capability without offering a literal command (e.g. "You can also adjust quantity or billing term — run `pax8 subscriptions update --help` for syntax"). The pickable list is the entry point a partner can drill into; the affordance pointer is what they read when the next step needs values they have to choose. A regression test (`packages/cli/src/__tests__/next-step-placeholders.test.ts`) prevents drift back to the placeholder pattern.
+
+Workflow follow-ons added: `quotes show` on a Draft surfaces `quotes send` as the first pickable step (was missing); `recommendations upsell` is now pickable across all listed matches with a parameterized `orders create` per row; `orders show` and `quotes update` gained Try-next blocks they didn't have before. List-style commands (`subscriptions list`, `invoices list`, `orders list`, `quotes list`) are deferred to #418 — they render tables and the drill-in design is a separate choice (extend the existing `_num`-column pattern from `clients list` / `recommendations list`).

--- a/packages/cli/src/__tests__/next-step-placeholders.test.ts
+++ b/packages/cli/src/__tests__/next-step-placeholders.test.ts
@@ -1,0 +1,166 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Static-source regression guard for the number-pickable next-step pattern.
+ *
+ * The PR that introduced this test converted ~12 plain-text "Try next:"
+ * blocks into pickable `promptNextSteps` lists. Pickable means: type a
+ * number, drill in. That contract breaks the moment a `NextStep.command`
+ * carries an unresolved placeholder like `<id>` or `<n>` — there's no
+ * value behind the placeholder for the child process to consume.
+ *
+ * This test parses every source file under `packages/cli/src/commands/`
+ * looking for two specific anti-patterns:
+ *
+ *   1. A `NextStep` `command:` array containing a token with `<...>`
+ *      placeholder syntax. This is the hard rule: pickable commands must
+ *      be fully resolved.
+ *
+ *   2. A `process.stderr.write(...)` line inside a `Try next:` block that
+ *      contains `<...>` placeholder syntax inside `chalk.cyan(replCmd(...))`.
+ *      Catches the legacy "copy-paste suggestion" pattern this PR removed.
+ *
+ * Affordance pointers (free-form prose telling the partner that a flag
+ * exists, e.g. "adjust quantity — run `subscriptions update --help`") are
+ * fine. They name a capability without offering a literal command, so
+ * placeholder syntax in `--help` text or feature descriptions doesn't
+ * trigger this guard.
+ */
+
+const COMMANDS_DIR = join(
+  process.cwd().endsWith("packages/cli") ? process.cwd() : join(process.cwd(), "packages/cli"),
+  "src/commands",
+);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const s = statSync(full);
+    if (s.isDirectory()) out.push(...walk(full));
+    else if (s.isFile() && name.endsWith(".ts") && !name.endsWith(".test.ts")) out.push(full);
+  }
+  return out;
+}
+
+const PLACEHOLDER_RE = /<[A-Za-z][A-Za-z0-9_| -]*>/;
+
+/**
+ * Find every NextStep object literal's `command:` array and return any
+ * tokens that contain placeholder syntax. We scan line-by-line: a line
+ * matching `command: [` starts an array we then walk until the matching
+ * `]`. Tokens are extracted from string literals — both `"..."` and
+ * template literals like `\`pax8 ... ${id}\``.
+ */
+function findPlaceholderCommandTokens(source: string): string[] {
+  const hits: string[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!/command:\s*\[/.test(lines[i])) continue;
+    // Accumulate the array body across lines until depth returns to 0.
+    let depth = 0;
+    let buf = "";
+    for (let j = i; j < lines.length; j++) {
+      for (const ch of lines[j]) {
+        if (ch === "[") depth++;
+        else if (ch === "]") depth--;
+        buf += ch;
+        if (depth === 0 && buf.includes("[")) break;
+      }
+      if (depth === 0 && buf.includes("[")) break;
+      buf += "\n";
+    }
+    // Pull out string literals from the array body. Look at quoted segments;
+    // template literals can also carry `${var}` which we treat as resolved.
+    const literalMatches = buf.match(/"[^"\n]*"|'[^'\n]*'|`[^`\n]*`/g) ?? [];
+    for (const lit of literalMatches) {
+      const inner = lit.slice(1, -1);
+      // Skip template-literal `${...}` interpolations — these ARE resolved
+      // at runtime, so an embedded `<foo>` inside `${someVar ?? "<…>"}` is
+      // an unusual edge case we accept.
+      if (PLACEHOLDER_RE.test(inner)) {
+        hits.push(inner);
+      }
+    }
+  }
+  return hits;
+}
+
+/**
+ * Find every `process.stderr.write(...)` call that follows a `Try next:`
+ * header in the same scope and contains `chalk.cyan(replCmd(...))` with a
+ * placeholder inside. This catches the legacy plain-text pattern this PR
+ * removed; future drift back to that pattern is what we want to prevent.
+ */
+function findPlaceholderTryNextSuggestions(source: string): string[] {
+  const hits: string[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!/Try next:/.test(lines[i])) continue;
+    // Walk forward up to 30 lines, stopping when we hit a closing brace
+    // at an outer indent or a blank-only stderr.write.
+    for (let j = i + 1; j < Math.min(i + 30, lines.length); j++) {
+      const line = lines[j];
+      if (/^\s*}\s*$/.test(line)) break;
+      // Look for a stderr.write that emits a suggestion line with cyan(replCmd(...))
+      if (/process\.stderr\.write\s*\([^)]*chalk\.cyan\s*\(\s*replCmd\s*\(/.test(line)) {
+        // Extract the replCmd argument string literal
+        const m = line.match(/replCmd\s*\(\s*(`[^`]*`|"[^"]*"|'[^']*')/);
+        if (m) {
+          const inner = m[1].slice(1, -1);
+          if (PLACEHOLDER_RE.test(inner)) {
+            hits.push(inner);
+          }
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+describe("next-step placeholder regression guard", () => {
+  it("NextStep `command:` arrays never carry `<placeholder>` tokens", () => {
+    const offenders: { file: string; tokens: string[] }[] = [];
+    for (const file of walk(COMMANDS_DIR)) {
+      const src = readFileSync(file, "utf8");
+      const tokens = findPlaceholderCommandTokens(src);
+      if (tokens.length > 0) {
+        offenders.push({ file: file.replace(process.cwd() + "/", ""), tokens });
+      }
+    }
+    expect(offenders, formatOffenders(offenders)).toEqual([]);
+  });
+
+  it("`Try next:` blocks never emit plain-text suggestions with `<placeholder>` syntax", () => {
+    const offenders: { file: string; tokens: string[] }[] = [];
+    for (const file of walk(COMMANDS_DIR)) {
+      const src = readFileSync(file, "utf8");
+      const tokens = findPlaceholderTryNextSuggestions(src);
+      if (tokens.length > 0) {
+        offenders.push({ file: file.replace(process.cwd() + "/", ""), tokens });
+      }
+    }
+    expect(offenders, formatOffenders(offenders)).toEqual([]);
+  });
+});
+
+function formatOffenders(
+  offenders: { file: string; tokens: string[] }[],
+): string {
+  if (offenders.length === 0) return "ok";
+  return (
+    "Found placeholder syntax in pickable next-step entries — these should " +
+    "either resolve the placeholder at runtime (pickable) or move out of the " +
+    '"Try next:" block into an affordance pointer ("run X --help for syntax"):\n' +
+    offenders
+      .map(
+        (o) => `  ${o.file}\n    ${o.tokens.map((t) => `→ ${t}`).join("\n    ")}`,
+      )
+      .join("\n")
+  );
+}

--- a/packages/cli/src/commands/companies/more.ts
+++ b/packages/cli/src/commands/companies/more.ts
@@ -19,6 +19,7 @@ import { resolveCompany } from "../../lib/resolve-company.js";
 import { replCmd } from "../../lib/confirm.js";
 import { enrichProductNames } from "../../lib/enrich-subscriptions.js";
 import { output, type Column } from "../../lib/output.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 
 interface SubSummary {
@@ -296,11 +297,34 @@ Examples:
         process.stdout.write(chalk.green("  ✓ No issues found\n\n"));
       }
 
+      // Pickable next steps. Every entry uses the resolved company name so
+      // partners can drill across the major surfaces (subscriptions,
+      // recommendations, invoices, orders) without retyping.
       if (ctx.outputFormat === "table") {
+        const steps: NextStep[] = [
+          {
+            key: "1",
+            label: `${chalk.cyan(replCmd(`pax8 subscriptions list --company "${company.name}"`))}  ${chalk.dim("all subscriptions")}`,
+            command: ["subscriptions", "list", "--company", company.name],
+          },
+          {
+            key: "2",
+            label: `${chalk.cyan(replCmd(`pax8 recommendations list --company "${company.name}"`))}  ${chalk.dim("growth opportunities")}`,
+            command: ["recommendations", "list", "--company", company.name],
+          },
+          {
+            key: "3",
+            label: `${chalk.cyan(replCmd(`pax8 invoices list --company "${company.name}"`))}  ${chalk.dim("billing history")}`,
+            command: ["invoices", "list", "--company", company.name],
+          },
+          {
+            key: "4",
+            label: `${chalk.cyan(replCmd(`pax8 orders list --company "${company.name}"`))}  ${chalk.dim("order history")}`,
+            command: ["orders", "list", "--company", company.name],
+          },
+        ];
         process.stderr.write(chalk.dim("  Try next:\n"));
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 recommendations list --company "${company.name}"`))}  ${chalk.dim("growth opportunities")}\n`);
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions list --company "${company.name}"`))}  ${chalk.dim("all subscriptions")}\n`);
-        process.stderr.write("\n");
+        await promptNextSteps(steps, { renderList: true });
       }
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/commands/contacts/create.ts
+++ b/packages/cli/src/commands/contacts/create.ts
@@ -12,6 +12,7 @@ import { confirm, replCmd } from "../../lib/confirm.js";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import type { CreateContactInput, ContactTypeKind } from "@pax8/core";
 
 const VALID_TYPES: ContactTypeKind[] = ["Admin", "Billing", "Technical"];
@@ -136,9 +137,20 @@ Notes:
       process.stdout.write(`  ${chalk.dim("Types:".padEnd(14))}${(contact.types ?? []).map((t) => t.type).join(", ")}\n`);
       process.stdout.write("\n");
 
+      const steps: NextStep[] = [
+        {
+          key: "1",
+          label: `${chalk.cyan(replCmd(`pax8 contacts list --company "${company.name}"`))}  ${chalk.dim("view all contacts at this client")}`,
+          command: ["contacts", "list", "--company", company.name],
+        },
+        {
+          key: "2",
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${company.name}"`))}  ${chalk.dim("view client summary")}`,
+          command: ["clients", "more", company.name],
+        },
+      ];
       process.stderr.write(chalk.dim("  Try next:\n"));
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts list --company "${company.name}"`))}  ${chalk.dim("view all contacts at this company")}\n`);
-      process.stderr.write("\n");
+      await promptNextSteps(steps, { renderList: true });
     } catch (error) {
       await handleCommandError(error, undefined, "Failed to create contact");
     }

--- a/packages/cli/src/commands/contacts/list.ts
+++ b/packages/cli/src/commands/contacts/list.ts
@@ -10,6 +10,7 @@ import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 export const contactsListCommand = new Command("list")
   .description("List contacts for a company")
@@ -99,14 +100,9 @@ Examples:
         emptyState: {
           headline: `No contacts found at ${company.name}.`,
           reasons: ["This company has no contacts recorded yet."],
-          suggestions: [
-            {
-              command: replCmd(
-                `pax8 contacts create --company "${company.name}" --email <email> --first-name <name> --last-name <name>`,
-              ),
-              description: "add a contact",
-            },
-          ],
+          // `contacts create` needs an email + first/last name that the
+          // user has to provide — surfaced as an affordance pointer below
+          // the headline instead of a copy-paste placeholder template.
         },
       });
 
@@ -115,10 +111,28 @@ Examples:
           chalk.dim(`\n  ${result.content.length} contacts at ${company.name}\n`)
         );
         const first = result.content[0];
+        // Pickable next steps. `contacts create` needs email + first/last
+        // name from the user, so it can't be drilled into by number;
+        // surfaced as an affordance pointer below the pickable list.
+        const steps: NextStep[] = [
+          {
+            key: "1",
+            label: `${chalk.cyan(replCmd(`pax8 contacts show ${first.id}`))}  ${chalk.dim("view contact details")}`,
+            command: ["contacts", "show", String(first.id)],
+          },
+          {
+            key: "2",
+            label: `${chalk.cyan(replCmd(`pax8 clients more "${company.name}"`))}  ${chalk.dim("view client summary")}`,
+            command: ["clients", "more", company.name],
+          },
+        ];
         process.stderr.write(chalk.dim("\n  Try next:\n"));
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts show ${first.id}`))}  ${chalk.dim("view contact details")}\n`);
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts create --company "${company.name}" --email <email> --first-name <name> --last-name <name>`))}  ${chalk.dim("add a contact")}\n`);
-        process.stderr.write("\n");
+        await promptNextSteps(steps, { renderList: true });
+        process.stderr.write(
+          chalk.dim(
+            `  Add another contact — run ${chalk.cyan(replCmd("pax8 contacts create --help"))} for syntax.\n\n`,
+          ),
+        );
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list contacts");

--- a/packages/cli/src/commands/contacts/show.ts
+++ b/packages/cli/src/commands/contacts/show.ts
@@ -10,6 +10,7 @@ import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
 import { replCmd } from "../../lib/confirm.js";
 import { resolveCompany } from "../../lib/resolve-company.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 export const contactsShowCommand = new Command("show")
   .description("Show contact details")
@@ -114,10 +115,33 @@ Notes:
       process.stdout.write(`  ${chalk.dim("Company ID:".padEnd(14))}${contact.companyId}\n`);
       process.stdout.write("\n");
 
+      // Pickable next steps. `contacts update` needs a new value the user
+      // has to provide (email, name, etc.), so it can't be drilled into by
+      // number — surfaced as an affordance pointer below the pickable list.
+      const steps: NextStep[] = [
+        {
+          key: "1",
+          label: `${chalk.cyan(replCmd(`pax8 contacts list --company "${company.name}"`))}  ${chalk.dim("see all contacts at this client")}`,
+          command: ["contacts", "list", "--company", company.name],
+        },
+        {
+          key: "2",
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${company.name}"`))}  ${chalk.dim("view client summary")}`,
+          command: ["clients", "more", company.name],
+        },
+        {
+          key: "3",
+          label: `${chalk.cyan(replCmd(`pax8 contacts delete ${contact.id} --company "${company.name}"`))}  ${chalk.dim("delete this contact")}`,
+          command: ["contacts", "delete", String(contact.id), "--company", company.name],
+        },
+      ];
       process.stderr.write(chalk.dim("  Try next:\n"));
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts update ${contact.id} --company "${company.name}" --email <new-email>`))}  ${chalk.dim("update this contact")}\n`);
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 contacts delete ${contact.id} --company "${company.name}"`))}  ${chalk.dim("delete this contact")}\n`);
-      process.stderr.write("\n");
+      await promptNextSteps(steps, { renderList: true });
+      process.stderr.write(
+        chalk.dim(
+          `  Update this contact — run ${chalk.cyan(replCmd("pax8 contacts update --help"))} for syntax.\n\n`,
+        ),
+      );
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to show contact");
     }

--- a/packages/cli/src/commands/cost/sim.ts
+++ b/packages/cli/src/commands/cost/sim.ts
@@ -22,6 +22,7 @@ import type { Subscription } from "@pax8/core";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 import { validateEnum } from "../../lib/validate.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 const BILLING_TERM_VALUES = BillingTermSchema.options as readonly BillingTerm[];
 
@@ -159,12 +160,15 @@ JSON output (--json):
         // simulate against an empty current state (i.e. add-new).
       }
 
-      // Resolve the "current" leg.
+      // Resolve the "current" leg. Track the matched subscription so the
+      // "Try next" block below can offer a pickable drill-in to it.
       let currentInput: SimulationInput["current"] | undefined;
+      let affectedSubscriptionId: string | undefined;
       if (allOpts.from) {
         // Explicit --from: resolve it as a separate product.
         const fromProduct = await resolveProduct(ctx, allOpts.from);
         const existing = pickCurrentSubscription(companySubs, fromProduct.id);
+        affectedSubscriptionId = existing?.id;
         const fromQty = allOpts.fromQuantity !== undefined
           ? parseInt(allOpts.fromQuantity, 10)
           : existing?.quantity ?? 0;
@@ -203,6 +207,7 @@ JSON output (--json):
       } else {
         // No --from: try to auto-detect a matching subscription on the proposed product.
         const existing = pickCurrentSubscription(companySubs, proposedProduct.id);
+        affectedSubscriptionId = existing?.id;
         if (existing && (existing.price !== undefined) && (existing.billingTerm !== undefined)) {
           currentInput = {
             productId: proposedProduct.id,
@@ -374,17 +379,47 @@ JSON output (--json):
         }
       }
 
-      // Suggested next step
+      // Pickable next steps. Place the change as an order is the headline
+      // action; viewing the affected subscription (if one exists) is the
+      // natural verification step.
+      const steps: NextStep[] = [
+        {
+          key: "1",
+          label: `${chalk.cyan(
+            replCmd(
+              `pax8 orders create --company "${company.name}" --product "${proposedProduct.name}" --quantity ${proposedQuantity} --billing-term ${result.proposed.billingTerm}`,
+            ),
+          )}  ${chalk.dim("place this change")}`,
+          command: [
+            "orders",
+            "create",
+            "--company",
+            company.name,
+            "--product",
+            proposedProduct.name,
+            "--quantity",
+            String(proposedQuantity),
+            "--billing-term",
+            result.proposed.billingTerm,
+          ],
+        },
+      ];
+      let nKey = 2;
+      if (affectedSubscriptionId) {
+        steps.push({
+          key: String(nKey++),
+          label: `${chalk.cyan(replCmd(`pax8 subscriptions show ${affectedSubscriptionId}`))}  ${chalk.dim("inspect the affected subscription")}`,
+          command: ["subscriptions", "show", affectedSubscriptionId],
+        });
+      }
+      steps.push({
+        key: String(nKey++),
+        label: `${chalk.cyan(replCmd(`pax8 clients more "${company.name}"`))}  ${chalk.dim("view client")}`,
+        command: ["clients", "more", company.name],
+      });
       process.stderr.write("\n");
       process.stderr.write(chalk.dim("  Try next:\n"));
-      process.stderr.write(
-        `    ${chalk.cyan(
-          replCmd(
-            `pax8 orders create --company "${company.name}" --product "${proposedProduct.name}" --quantity ${proposedQuantity} --billing-term ${result.proposed.billingTerm}`,
-          ),
-        )}  ${chalk.dim("place this change")}\n`,
-      );
-      process.stderr.write("\n");
+      await promptNextSteps(steps, { renderList: true });
     } catch (error) {
       spinner.stop();
       handleCommandError(error, undefined, "Cost simulation failed");

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -12,6 +12,7 @@ import { ALL_SUBS_PAGE_SIZE, auditInvoices } from "@pax8/core";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { discrepancyId } from "./dispute.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 export const invoicesAuditCommand = new Command("audit")
   .description("Audit invoices against active subscriptions")
@@ -173,9 +174,15 @@ JSON output (--json):
         `\n  ${chalk.yellow("⚠")} ${report.discrepancies.length} discrepancies found in ${monthLabel} invoices:\n\n`
       );
 
-      for (const d of stampedDiscrepancies) {
+      // Prefix each discrepancy with `N.` so the partner can read the
+      // pickable list below as a direct reference into this output (e.g.
+      // "type 3 to dispute discrepancy #3"). Keeps the existing single-id
+      // form in the `[…]` brackets so partners who copy-paste the id by
+      // hand can still locate it.
+      stampedDiscrepancies.forEach((d, i) => {
+        const idx = i + 1;
         process.stdout.write(
-          `  ${chalk.bold(d.companyName)} — ${d.productName}  ${chalk.dim(`[${d.discrepancyId}]`)}\n`
+          `  ${chalk.bold(`${idx}.`)} ${chalk.bold(d.companyName)} — ${d.productName}  ${chalk.dim(`[${d.discrepancyId}]`)}\n`
         );
 
         const deltaSign = d.delta > 0 ? "+" : "";
@@ -185,10 +192,10 @@ JSON output (--json):
             : `${formatCurrency(Math.abs(d.dollarImpact))} undercharge`;
 
         process.stdout.write(
-          `    Invoiced: ${formatQuantity(d.invoicedQuantity)}    Active: ${formatQuantity(d.activeQuantity)}    Δ ${deltaSign}${d.delta} (${impactLabel})\n`
+          `     Invoiced: ${formatQuantity(d.invoicedQuantity)}    Active: ${formatQuantity(d.activeQuantity)}    Δ ${deltaSign}${d.delta} (${impactLabel})\n`
         );
         process.stdout.write("\n");
-      }
+      });
 
       // Footer with totals
       process.stdout.write(chalk.dim("  ─────────────────────────────\n"));
@@ -207,15 +214,22 @@ JSON output (--json):
       );
       process.stdout.write("\n");
 
-      // Closed-loop hint: surface the dispute command so the partner can act
-      // on what the audit just found, without leaving the terminal.
+      // Closed-loop hint: every discrepancy becomes a pickable dispute
+      // entry. Partners can scan the indexed list above, type a number, and
+      // the dispute is drafted with the discrepancy id (and month, when
+      // filtering by month) carried through automatically.
       if (stampedDiscrepancies.length > 0) {
+        const monthArgs = options.month ? ["--month", options.month] : [];
+        const steps: NextStep[] = stampedDiscrepancies.map((d, i) => {
+          const command = ["invoices", "dispute", "--discrepancy", d.discrepancyId, ...monthArgs];
+          return {
+            key: String(i + 1),
+            label: `${chalk.cyan(replCmd(`pax8 invoices dispute --discrepancy ${d.discrepancyId}`))}  ${chalk.dim(`${d.companyName} — ${d.productName}`)}`,
+            command,
+          };
+        });
         process.stderr.write(chalk.dim("  Try next:\n"));
-        const first = stampedDiscrepancies[0];
-        process.stderr.write(
-          `    ${chalk.cyan(replCmd(`pax8 invoices dispute --discrepancy ${first.discrepancyId}`))}  ${chalk.dim("file a dispute draft")}\n`,
-        );
-        process.stderr.write("\n");
+        await promptNextSteps(steps, { renderList: true });
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to audit invoices");

--- a/packages/cli/src/commands/invoices/show.ts
+++ b/packages/cli/src/commands/invoices/show.ts
@@ -9,6 +9,7 @@ import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatCurrency, formatDate, formatStatus } from "../../lib/formatters.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 export const invoicesShowCommand = new Command("show")
   .description("Show invoice details")
@@ -62,12 +63,28 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Status:".padEnd(18))}${formatStatus(invoice.status)}\n`);
       process.stdout.write(`  ${chalk.dim("Total:".padEnd(18))}${formatCurrency(invoice.total)}\n`);
       process.stdout.write(`  ${chalk.dim("Balance:".padEnd(18))}${formatCurrency(invoice.balance)}\n`);
-      // Next steps
+      // Pickable next steps. Drill in by typing 1, 2, ... — every entry has
+      // its arguments resolved from the invoice already loaded above.
       if (ctx.outputFormat === "table") {
+        const steps: NextStep[] = [
+          {
+            key: "1",
+            label: `${chalk.cyan(replCmd(`pax8 invoices items ${invoice.id}`))}  ${chalk.dim("view line items")}`,
+            command: ["invoices", "items", "--invoice-id", invoice.id],
+          },
+          {
+            key: "2",
+            label: `${chalk.cyan(replCmd(`pax8 clients more "${invoice.companyName}"`))}  ${chalk.dim("view client")}`,
+            command: ["clients", "more", String(invoice.companyName)],
+          },
+          {
+            key: "3",
+            label: `${chalk.cyan(replCmd(`pax8 invoices audit --company "${invoice.companyName}"`))}  ${chalk.dim("audit this client's invoices")}`,
+            command: ["invoices", "audit", "--company", String(invoice.companyName)],
+          },
+        ];
         process.stderr.write(chalk.dim("  Try next:\n"));
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 invoices items ${invoice.id}`))}  ${chalk.dim("view line items")}\n`);
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 companies more "${invoice.companyName}"`))}  ${chalk.dim("view company")}\n`);
-        process.stderr.write("\n");
+        await promptNextSteps(steps, { renderList: true });
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to show invoice");

--- a/packages/cli/src/commands/orders/show.ts
+++ b/packages/cli/src/commands/orders/show.ts
@@ -9,6 +9,8 @@ import { buildContext } from "../../lib/context.js";
 import { output, type Column } from "../../lib/output.js";
 import { formatStatus, formatDate, formatCurrency } from "../../lib/formatters.js";
 import { enrichProductNames } from "../../lib/enrich-subscriptions.js";
+import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 const lineItemColumns: Column[] = [
   { key: "productName", header: "Product" },
@@ -124,6 +126,32 @@ Examples:
         process.stdout.write(chalk.dim(`  Line Items (${lineItems.length}):\n\n`));
         output(lineItems, { format: "table", columns: lineItemColumns });
         process.stdout.write("\n");
+      }
+
+      // Pickable next steps. From an order detail view, the natural moves
+      // are: see the resulting subscription(s) on the customer, look at
+      // the client summary, and check what else this client has ordered.
+      const companyId = order.companyId ?? "";
+      if (companyId) {
+        const steps: NextStep[] = [
+          {
+            key: "1",
+            label: `${chalk.cyan(replCmd(`pax8 subscriptions list --company "${order.companyName ?? companyId}"`))}  ${chalk.dim("see the resulting subscriptions")}`,
+            command: ["subscriptions", "list", "--company", String(order.companyName ?? companyId)],
+          },
+          {
+            key: "2",
+            label: `${chalk.cyan(replCmd(`pax8 clients more "${order.companyName ?? companyId}"`))}  ${chalk.dim("view client")}`,
+            command: ["clients", "more", String(order.companyName ?? companyId)],
+          },
+          {
+            key: "3",
+            label: `${chalk.cyan(replCmd(`pax8 orders list --company "${order.companyName ?? companyId}"`))}  ${chalk.dim("other orders on this client")}`,
+            command: ["orders", "list", "--company", String(order.companyName ?? companyId)],
+          },
+        ];
+        process.stderr.write(chalk.dim("  Try next:\n"));
+        await promptNextSteps(steps, { renderList: true });
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to show order");

--- a/packages/cli/src/commands/products/search.ts
+++ b/packages/cli/src/commands/products/search.ts
@@ -8,6 +8,7 @@ import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 export const productsSearchCommand = new Command("search")
   .description("Search products by name")
@@ -95,11 +96,26 @@ Examples:
         process.stderr.write(chalk.dim(`\n  ${matches.length} products\n`));
         if (matches.length > 0) {
           const first = matches[0] as Record<string, unknown>;
+          // Pickable next step: drill into the top match. `orders create`
+          // needs --company (a value the user has to choose) so it can't be
+          // pickable — surfaced as an affordance pointer below.
+          const steps: NextStep[] = [
+            {
+              key: "1",
+              label: `${chalk.cyan(replCmd(`pax8 products show ${String(first.id)}`))}  ${chalk.dim("view details & pricing")}`,
+              command: ["products", "show", String(first.id)],
+            },
+          ];
           process.stderr.write(chalk.dim("\n  Try next:\n"));
-          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 products show ${first.id}`))}  ${chalk.dim("view details & pricing")}\n`);
-          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders create --product <id> --company <id> --quantity <n>`))}  ${chalk.dim("place an order")}\n`);
+          await promptNextSteps(steps, { renderList: true });
+          process.stderr.write(
+            chalk.dim(
+              `  Place an order — run ${chalk.cyan(replCmd("pax8 orders create --help"))} for syntax.\n\n`,
+            ),
+          );
+        } else {
+          process.stderr.write("\n");
         }
-        process.stderr.write("\n");
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to search products");

--- a/packages/cli/src/commands/quotes/line-items/add.ts
+++ b/packages/cli/src/commands/quotes/line-items/add.ts
@@ -12,6 +12,7 @@ import { resolveProduct } from "../../../lib/resolve-product.js";
 import { invalidateCacheAfterWrite } from "../../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../../lib/signals.js";
 import { formatQuantity, formatCurrency as formatPrice } from "../../../lib/formatters.js";
+import { promptNextSteps, type NextStep } from "../../../lib/next-step.js";
 import {
   BillingTermSchema,
   ERROR_INVALID_INPUT,
@@ -205,9 +206,26 @@ Examples:
       process.stdout.write(`  ${chalk.dim("Total lines:".padEnd(16))}${updated.lineItems?.length ?? 0}\n`);
       process.stdout.write("\n");
 
+      // Pickable next steps after a successful line-item add.
+      const steps: NextStep[] = [
+        {
+          key: "1",
+          label: `${chalk.cyan(replCmd(`pax8 quotes show ${updated.id}`))}  ${chalk.dim("review the updated quote")}`,
+          command: ["quotes", "show", String(updated.id)],
+        },
+        {
+          key: "2",
+          label: `${chalk.cyan(replCmd(`pax8 quotes line-items list ${updated.id}`))}  ${chalk.dim("see all line items")}`,
+          command: ["quotes", "line-items", "list", String(updated.id)],
+        },
+        {
+          key: "3",
+          label: `${chalk.cyan(replCmd(`pax8 quotes send ${updated.id}`))}  ${chalk.dim("send the quote to the customer")}`,
+          command: ["quotes", "send", String(updated.id)],
+        },
+      ];
       process.stderr.write(chalk.dim("  Try next:\n"));
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items list ${updated.id}`))}  ${chalk.dim("see all line items")}\n`);
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes send ${updated.id}`))}  ${chalk.dim("send the quote to the customer")}\n\n`);
+      await promptNextSteps(steps, { renderList: true });
     } catch (error) {
       await handleCommandError(error, undefined, "Failed to add line item");
     }

--- a/packages/cli/src/commands/quotes/line-items/list.ts
+++ b/packages/cli/src/commands/quotes/line-items/list.ts
@@ -9,6 +9,7 @@ import { createSpinner } from "../../../lib/spinner.js";
 import { handleCommandError } from "../../../lib/errors.js";
 import { formatCurrency, formatQuantity } from "../../../lib/formatters.js";
 import { replCmd } from "../../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../../lib/next-step.js";
 
 export const quotesLineItemsListCommand = new Command("list")
   .description("List the line items on a quote")
@@ -77,12 +78,37 @@ Examples:
         process.stderr.write(
           chalk.dim(`\n  ${lineItems.length} line item${lineItems.length === 1 ? "" : "s"} on quote ${quote.id}\n`),
         );
-        process.stderr.write(chalk.dim("\n  Try next:\n"));
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items add ${quote.id} --product <id|name> --quantity <n>`))}  ${chalk.dim("add another line item")}\n`);
-        if (lineItems[0]?.id) {
-          process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes line-items remove ${quote.id} ${lineItems[0].id}`))}  ${chalk.dim("remove a line item")}\n`);
+        // Pickable next steps. `quotes line-items add` needs --product +
+        // --quantity values the user has to choose, so it can't be drilled
+        // into by number — surfaced as an affordance pointer below.
+        const steps: NextStep[] = [
+          {
+            key: "1",
+            label: `${chalk.cyan(replCmd(`pax8 quotes show ${quote.id}`))}  ${chalk.dim("review the quote (total, status)")}`,
+            command: ["quotes", "show", quote.id],
+          },
+        ];
+        let n = 2;
+        const firstWithId = lineItems.find((li) => Boolean(li.id));
+        if (firstWithId?.id) {
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 quotes line-items remove ${quote.id} ${firstWithId.id}`))}  ${chalk.dim("remove this line item")}`,
+            command: ["quotes", "line-items", "remove", quote.id, firstWithId.id],
+          });
         }
-        process.stderr.write("\n");
+        steps.push({
+          key: String(n++),
+          label: `${chalk.cyan(replCmd(`pax8 quotes send ${quote.id}`))}  ${chalk.dim("send the quote to the customer")}`,
+          command: ["quotes", "send", quote.id],
+        });
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        await promptNextSteps(steps, { renderList: true });
+        process.stderr.write(
+          chalk.dim(
+            `  Add another line item — run ${chalk.cyan(replCmd("pax8 quotes line-items add --help"))} for syntax.\n\n`,
+          ),
+        );
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list line items");

--- a/packages/cli/src/commands/quotes/send.ts
+++ b/packages/cli/src/commands/quotes/send.ts
@@ -11,6 +11,7 @@ import { confirm, replCmd } from "../../lib/confirm.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 import { formatCurrency } from "../../lib/formatters.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import type { Quote } from "@pax8/core";
 
 /**
@@ -128,9 +129,34 @@ Note:
       }
       process.stdout.write("\n");
 
+      // Pickable next steps. The natural follow-on after `send` is to
+      // re-check the quote for the customer response and to surface the
+      // owning client. `webhooks list` (verify QUOTE.Accepted subscribers)
+      // is real-but-tangential — kept as an affordance pointer below
+      // rather than a pickable step the partner is unlikely to choose in
+      // this moment.
+      const companyId = (updated as Quote).companyId;
+      const steps: NextStep[] = [
+        {
+          key: "1",
+          label: `${chalk.cyan(replCmd(`pax8 quotes show ${updated.id}`))}  ${chalk.dim("view the live quote (check responses)")}`,
+          command: ["quotes", "show", String(updated.id)],
+        },
+      ];
+      if (companyId) {
+        steps.push({
+          key: "2",
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${companyId}"`))}  ${chalk.dim("view client")}`,
+          command: ["clients", "more", companyId],
+        });
+      }
       process.stderr.write(chalk.dim("  Try next:\n"));
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes show ${updated.id}`))}  ${chalk.dim("view the live quote")}\n`);
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 webhooks list`))}  ${chalk.dim("verify QUOTE.Accepted webhooks are configured")}\n\n`);
+      await promptNextSteps(steps, { renderList: true });
+      process.stderr.write(
+        chalk.dim(
+          `  Verify QUOTE.Accepted webhook delivery — run ${chalk.cyan(replCmd("pax8 webhooks list"))} to inspect subscribers.\n\n`,
+        ),
+      );
     } catch (error) {
       await handleCommandError(error, undefined, "Failed to send quote");
     }

--- a/packages/cli/src/commands/quotes/show.ts
+++ b/packages/cli/src/commands/quotes/show.ts
@@ -9,6 +9,7 @@ import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatDate, formatCurrency, formatQuantity } from "../../lib/formatters.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 export const quotesShowCommand = new Command("show")
   .description("Show quote details with line items")
@@ -123,10 +124,73 @@ Examples:
         output(lineItems, { format: ctx.outputFormat, columns });
       }
 
-      process.stderr.write(chalk.dim("\n  Try next:\n"));
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes update ${quote.id} --expiration-date <YYYY-MM-DD>`))}  ${chalk.dim("update this quote")}\n`);
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes delete ${quote.id}`))}  ${chalk.dim("delete this quote")}\n`);
-      process.stderr.write("\n");
+      // Pickable next steps. Status-dependent — the natural action varies
+      // by where the quote is in its lifecycle:
+      //   Draft  → `send` is the headline action; line-items add for
+      //            quotes that aren't ready yet; delete to abandon.
+      //   Sent   → `show` again to check responses; client view; delete.
+      //   Accepted → place the order; client view; delete is not surfaced.
+      // Other states fall through to the generic set.
+      if (ctx.outputFormat === "table") {
+        const steps: NextStep[] = [];
+        const status = quote.status;
+        let n = 1;
+        if (status === "Draft") {
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 quotes send ${quote.id}`))}  ${chalk.dim("send this quote to the customer")}`,
+            command: ["quotes", "send", quote.id],
+          });
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 quotes line-items list ${quote.id}`))}  ${chalk.dim("inspect line items")}`,
+            command: ["quotes", "line-items", "list", quote.id],
+          });
+        } else if (status === "Accepted") {
+          // Pax8 processes acceptance server-side — there's no CLI command
+          // that converts the quote into a CLI-side order. The natural
+          // follow-on is to verify the resulting order/subscription landed
+          // on the customer.
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 orders list --company "${quote.companyId}"`))}  ${chalk.dim("check the resulting order")}`,
+            command: ["orders", "list", "--company", quote.companyId],
+          });
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 subscriptions list --company "${quote.companyId}"`))}  ${chalk.dim("see the active subscription")}`,
+            command: ["subscriptions", "list", "--company", quote.companyId],
+          });
+        } else {
+          // Sent / Declined / Revoked / Expired — surface line items + client.
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 quotes line-items list ${quote.id}`))}  ${chalk.dim("inspect line items")}`,
+            command: ["quotes", "line-items", "list", quote.id],
+          });
+        }
+        steps.push({
+          key: String(n++),
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${quote.companyId}"`))}  ${chalk.dim("view client")}`,
+          command: ["clients", "more", quote.companyId],
+        });
+        // Delete stays accessible from non-Accepted states; once accepted it
+        // would orphan the downstream order and isn't a natural action.
+        if (status !== "Accepted") {
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 quotes delete ${quote.id}`))}  ${chalk.dim("delete this quote")}`,
+            command: ["quotes", "delete", quote.id],
+          });
+        }
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        await promptNextSteps(steps, { renderList: true });
+        process.stderr.write(
+          chalk.dim(
+            `  You can also change the expiration or replace line items — run ${chalk.cyan(replCmd("pax8 quotes update --help"))} for syntax.\n\n`,
+          ),
+        );
+      }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to show quote");
     }

--- a/packages/cli/src/commands/quotes/update.ts
+++ b/packages/cli/src/commands/quotes/update.ts
@@ -26,6 +26,7 @@ import type {
 } from "@pax8/core";
 import type { CommandContext } from "../../lib/context.js";
 import { validateEnum } from "../../lib/validate.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 const BILLING_TERM_VALUES = BillingTermSchema.options as readonly BillingTerm[];
 
@@ -377,6 +378,32 @@ Note:
       }
       process.stdout.write(`  ${chalk.dim("Items:".padEnd(14))}${updated.lineItems?.length ?? 0}\n`);
       process.stdout.write("\n");
+
+      // Pickable next steps after a successful update. `quotes show` is
+      // the standard verification path; `quotes send` is the natural
+      // follow-on for a Draft quote that's now ready.
+      const steps: NextStep[] = [
+        {
+          key: "1",
+          label: `${chalk.cyan(replCmd(`pax8 quotes show ${updated.id}`))}  ${chalk.dim("verify the updated quote")}`,
+          command: ["quotes", "show", String(updated.id)],
+        },
+      ];
+      let k = 2;
+      if (updated.status === "Draft") {
+        steps.push({
+          key: String(k++),
+          label: `${chalk.cyan(replCmd(`pax8 quotes send ${updated.id}`))}  ${chalk.dim("send to the customer")}`,
+          command: ["quotes", "send", String(updated.id)],
+        });
+      }
+      steps.push({
+        key: String(k++),
+        label: `${chalk.cyan(replCmd(`pax8 quotes line-items list ${updated.id}`))}  ${chalk.dim("inspect line items")}`,
+        command: ["quotes", "line-items", "list", String(updated.id)],
+      });
+      process.stderr.write(chalk.dim("  Try next:\n"));
+      await promptNextSteps(steps, { renderList: true });
     } catch (error) {
       await handleCommandError(error, undefined, "Failed to update quote");
     }

--- a/packages/cli/src/commands/recommendations/upsell.ts
+++ b/packages/cli/src/commands/recommendations/upsell.ts
@@ -16,6 +16,7 @@ import { handleCommandError, CliError } from "../../lib/errors.js";
 import { formatCurrency, formatCompanyName } from "../../lib/formatters.js";
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 const columns: Column[] = [
   { key: "companyName", header: "Company", format: (v) => formatCompanyName(String(v)) },
@@ -215,6 +216,30 @@ Output:
         process.stderr.write(
           chalk.dim(`\n  Add ${chalk.cyan("--with-contacts")} to pull contact emails per company.\n`),
         );
+      }
+
+      // Pickable next steps — one per displayed match, parameterized as a
+      // ready-to-place `orders create` against the `--to-product` target.
+      // `displayed` is what's actually on screen (respects --limit), so the
+      // 1-N indices line up with the table the partner just read.
+      const visibleMatches = report.matches.slice(0, limit);
+      if (visibleMatches.length > 0) {
+        const steps: NextStep[] = visibleMatches.map((m, i) => ({
+          key: String(i + 1),
+          label: `${chalk.cyan(replCmd(`pax8 orders create --company "${m.companyName}" --product "${toProduct}" --quantity ${m.fromSeats}`))}  ${chalk.dim(`upsell ${m.companyName} → ${toProduct}`)}`,
+          command: [
+            "orders",
+            "create",
+            "--company",
+            m.companyName,
+            "--product",
+            toProduct,
+            "--quantity",
+            String(m.fromSeats),
+          ],
+        }));
+        process.stderr.write(chalk.dim("\n  Try next:\n"));
+        await promptNextSteps(steps, { renderList: true });
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to compute upsell cohort");

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -12,6 +12,7 @@ import { confirmDestructive } from "../../lib/confirm.js";
 import { formatCurrency, formatQuantity, calculateMrr } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 
 /**
@@ -304,12 +305,30 @@ Behavior on committed subscriptions:
         );
       }
 
-      // Next steps
-      process.stderr.write(chalk.dim("\n  Try next:\n"));
+      // Pickable next steps. `orders create --product <name>` is the
+      // natural follow-on (order a replacement) but it needs the product
+      // name from the user, so it can't be drilled into by number —
+      // surfaced as an affordance pointer below.
       const coName = sub.companyName ?? sub.companyId;
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions list --company "${coName}"`))}  ${chalk.dim("remaining subscriptions")}\n`);
-      process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 orders create --company "${coName}" --product <name>`))}  ${chalk.dim("order a replacement")}\n`);
-      process.stderr.write("\n");
+      const steps: NextStep[] = [
+        {
+          key: "1",
+          label: `${chalk.cyan(replCmd(`pax8 subscriptions list --company "${coName}"`))}  ${chalk.dim("remaining subscriptions")}`,
+          command: ["subscriptions", "list", "--company", String(coName)],
+        },
+        {
+          key: "2",
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${coName}"`))}  ${chalk.dim("view client summary")}`,
+          command: ["clients", "more", String(coName)],
+        },
+      ];
+      process.stderr.write(chalk.dim("\n  Try next:\n"));
+      await promptNextSteps(steps, { renderList: true });
+      process.stderr.write(
+        chalk.dim(
+          `  Order a replacement — run ${chalk.cyan(replCmd("pax8 orders create --help"))} for syntax.\n\n`,
+        ),
+      );
     } catch (error) {
       // Wrap API rejections (vendor-specific commitment enforcement: NCE
       // 7-day window, Adobe renewal-only window, Azure Savings Plan

--- a/packages/cli/src/commands/subscriptions/show.ts
+++ b/packages/cli/src/commands/subscriptions/show.ts
@@ -15,6 +15,7 @@ import {
 } from "../../lib/formatters.js";
 import { enrichProductNames } from "../../lib/enrich-subscriptions.js";
 import { replCmd } from "../../lib/confirm.js";
+import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 
 const historyColumns: Column[] = [
   { key: "date", header: "Date", format: (v) => formatDate(String(v)) },
@@ -130,13 +131,38 @@ provisioning detail.`
         }
       }
 
-      // Next steps
+      // Pickable next steps. The `subscriptions update --quantity <n>` action
+      // is intentionally omitted from the pickable list — it needs a value
+      // the user has to choose, so it can't be drilled into by number.
+      // Surfaced as an affordance pointer below the list instead.
       if (ctx.outputFormat === "table") {
+        const companyLabel = sub.companyName ?? sub.companyId;
+        const steps: NextStep[] = [];
+        let n = 1;
+        if (!options.history) {
+          steps.push({
+            key: String(n++),
+            label: `${chalk.cyan(replCmd(`pax8 subscriptions show ${id} --history`))}  ${chalk.dim("view change history")}`,
+            command: ["subscriptions", "show", id, "--history"],
+          });
+        }
+        steps.push({
+          key: String(n++),
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${companyLabel}"`))}  ${chalk.dim("view client")}`,
+          command: ["clients", "more", String(companyLabel)],
+        });
+        steps.push({
+          key: String(n++),
+          label: `${chalk.cyan(replCmd(`pax8 subscriptions cancel ${id}`))}  ${chalk.dim("cancel this subscription")}`,
+          command: ["subscriptions", "cancel", id],
+        });
         process.stderr.write(chalk.dim("  Try next:\n"));
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions update ${id} --quantity <n>`))}  ${chalk.dim("change seats")}\n`);
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 subscriptions show ${id} --history`))}  ${chalk.dim("view changes")}\n`);
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 companies more "${sub.companyName ?? sub.companyId}"`))}  ${chalk.dim("view company")}\n`);
-        process.stderr.write("\n");
+        await promptNextSteps(steps, { renderList: true });
+        process.stderr.write(
+          chalk.dim(
+            `  You can also adjust quantity or billing term — run ${chalk.cyan(replCmd("pax8 subscriptions update --help"))} for syntax.\n\n`,
+          ),
+        );
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to show subscription");


### PR DESCRIPTION
## Summary

Brings the number-pickable next-step pattern to consistency across the CLI's show/detail surfaces. Before this PR, ~17 commands emitted "Try next:" suggestions as plain `process.stderr.write` text — partners had to copy-paste. After this PR, those are pickable lists rendered by `promptNextSteps({ renderList: true })`: scan the numbered list, type a number, drill in.

The substantive design call is the **placeholder/affordance split**: anywhere a pickable command would have required a user-supplied value (`<id>`, `<n>`, `<name>`), that entry is dropped from the pickable list and replaced with an affordance pointer — short prose that names the capability without offering a literal command. "You can also adjust quantity or billing term — run `pax8 subscriptions update --help` for syntax" is good; placeholder copy-paste templates are gone.

## What got pickable (Class 1 + 3)

| Command | Pickable entries |
|---|---|
| `subscriptions show` | view change history (when not already showing), view client, cancel — `update --quantity <n>` → affordance pointer |
| `invoices show` | view items, view client, audit this client |
| `invoices audit` | **every discrepancy** indexed 1-N → `dispute --discrepancy <id>` (carries `--month` through). Closes the audit→dispute loop. |
| `quotes show` | **status-aware**: Draft → `send` is headline, plus line-items list, delete; Accepted → `orders list --company`, `subscriptions list --company`; Sent/other → line-items list, client, delete |
| `quotes send` | view live quote, view client — `webhooks list` → affordance pointer |
| `quotes update` (new) | verify with `quotes show`, send (if Draft), inspect line items |
| `quotes line-items add` | review quote, list line items, send |
| `quotes line-items list` | review quote, remove first line, send — `line-items add <product> <qty>` → affordance pointer |
| `companies more` | subscriptions / recommendations / invoices / orders, all filtered to this client |
| `cost sim` | place change as order, **view affected subscription when one exists**, view client |
| `contacts create` | list contacts at client, view client summary |
| `contacts list` | view first contact, view client — `contacts create --email <…>` → affordance pointer |
| `contacts show` | list contacts at client, view client, delete this contact — `contacts update --email <…>` → affordance pointer |
| `orders show` (new) | resulting subscriptions, view client, other orders at this client |
| `products search` | view first match — `orders create --company <…>` → affordance pointer |
| `subscriptions cancel` | remaining subscriptions, view client — `orders create --product <name>` → affordance pointer |
| `recommendations upsell` | **per match** → `orders create --company <m.companyName> --product <toProduct> --quantity <m.fromSeats>`. Newly actionable; previously had no actionable next step. |

## Workflow follow-ons added (Class 2)

- `quotes show` on a Draft quote now leads with `quotes send` (was missing entirely)
- `recommendations upsell` is actionable for the first time — partners can drill from cohort match → place the order
- `orders show` and `quotes update` gained Try-next blocks they didn't have

## Surfaced by the regression test (not in original audit scope)

The placeholder-removal regression test (see "Tests" below) caught 4 additional files emitting the same anti-pattern this PR removes. Since they're identical-pattern instances, fixed them inline:

- `contacts/list.ts` — `contacts create --email <email> --first-name <name>` was a copy-paste template → affordance pointer
- `contacts/show.ts` — `contacts update <id> --email <new-email>` was a copy-paste template → affordance pointer
- `products/search.ts` — `orders create --product <id> --company <id> --quantity <n>` was a Try-next entry → affordance pointer
- `subscriptions/cancel.ts` — `orders create --product <name>` was a Try-next entry → affordance pointer

If those should have been deferred to a separate cleanup PR, happy to split them out — flagging since they're technically out of the original audit's scope.

## What got dropped

Placeholder-style entries that needed user input — moved out of pickable lists into affordance-pointer framing:

- `subscriptions update --quantity <n>` (from `subscriptions show`)
- `quotes update --expiration-date <YYYY-MM-DD>` (from `quotes show`)
- `quotes line-items add <quote-id> --product <…> --quantity <n>` (from `quotes line-items list`)
- `webhooks list` (from `quotes send` — real-but-tangential, surfaces as affordance pointer instead)
- `orders create --product <id> --company <id>` (from `products/search` empty-state)
- `orders create --product <name>` (from `subscriptions cancel`)
- `contacts create --email <email>` / `contacts update --email <…>` (from `contacts list` / `show`)

## Class 5 — Deliberate exclusions

List-style commands (`subscriptions list`, `invoices list`, `orders list`, `quotes list`) render full tables. Adding pickability is a separate design choice — extending the `_num`-column pattern from `clients list` / `recommendations list`, or adding a "Try next: drill into row N" block below. Filed as **#418** with the design-question writeup.

## Pattern reference

The pickable pattern already established (and now extended): `dashboard`, `recommendations list`, `subscriptions renewals`, `clients list`. Two flavors:
- **Pattern A** (renderList: true): `promptNextSteps(steps, { renderList: true })` prints the menu inline. Used for show/detail commands.
- **Pattern B** (numbered table above): caller prints a table with a `#` / `_num` column, then calls `promptNextSteps(steps)` without renderList. Used for list-style commands.

This PR uses Pattern A everywhere (show/detail commands). Phase 2 will introduce Pattern B for the four list commands above.

## Tests

- **New regression test**: `packages/cli/src/__tests__/next-step-placeholders.test.ts`. Scans every source file in `packages/cli/src/commands/` and fails if (a) any `NextStep.command` array carries a `<placeholder>` token, or (b) any `Try next:` block emits a stderr suggestion with placeholder syntax inside `chalk.cyan(replCmd(...))`. Prevents drift back to the copy-paste pattern this PR removes.
- **Existing suite**: 1850 tests pass. `pnpm build`, `pnpm lint` clean.

Subprocess assertions on the rendered pickable lists are intentionally absent: `promptNextSteps` short-circuits on non-TTY stdin (the agent/pipeline path), so subprocess tests with closed stdin can't observe the rendered menu. The regression test is the structural guarantee instead.

## What "feels designed" — verified

A partner navigating from `dashboard` → an entity → a workflow action no longer hits a copy-paste step on any of the touched commands. Open remaining gaps:

- List commands (filed as #418)
- Where a workflow genuinely requires user input (custom email, new quantity), those become affordance pointers rather than fake-pickable entries

## Test plan

- [x] `pnpm build` clean (core + cli)
- [x] `pnpm test` — 1850 pass, 6 skipped
- [x] `pnpm lint` clean
- [ ] Smoke test `pax8 invoices audit` in demo mode (TTY) — pick a discrepancy by number, confirm dispute drafts
- [ ] Smoke test `pax8 quotes show <draft-id>` — confirm `quotes send` is the first pickable entry
- [ ] Smoke test `pax8 recommendations upsell` — confirm each match is pickable to `orders create`
- [ ] Spot-check `pax8 subscriptions show <id>`, `pax8 invoices show <id>`, `pax8 orders show <id>` — confirm the pickable list renders and is drillable

🤖 Generated with [Claude Code](https://claude.com/claude-code)