### PR TITLE
feat(ux): disclose CLI-local heuristic nature on `recommendations act --help`

### DIFF
--- a/.changeset/recommendations-act-heuristic-disclosure.md
+++ b/.changeset/recommendations-act-heuristic-disclosure.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": patch
+---
+
+UX: `pax8 recommendations act --help` now discloses the CLI-local heuristic nature of the recommendations it operates on. Previously the disclosure existed on `pax8 recommendations list` (STAX divergence, "seat_gap" heuristic framing, provisional engine status, ARC-785/#375 sunset) but not on `act` — partners running only `act --help` weren't shown that bulk action places real orders against CLI-side heuristics, not Pax8's canonical Opportunity Explorer. Mirrors the existing disclosure pattern; no flag or behavior changes.

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -297,6 +297,25 @@ describe("pax8 recommendations", () => {
       await fs.rm(tmpConfigDir, { recursive: true, force: true });
     });
 
+    // Disclosure parity with `recommendations list` (which already calls out
+    // the CLI-local engine, STAX divergence, provisional framing, and
+    // ARC-785/#375 sunset). Mirroring that disclosure onto `act` closes a
+    // gap Randall Ellis raised in the domain review: bulk order placement
+    // against a CLI-side heuristic deserves the same up-front disclosure as
+    // the list command it inherits from.
+    it("--help discloses the CLI-local heuristic nature and provisional engine status", async () => {
+      const result = await runCliExpectSuccess(["recommendations", "act", "--help"]);
+      // Names the local engine vs canonical OE
+      expect(result.stdout).toContain("CLI-side heuristics");
+      expect(result.stdout).toMatch(/canonical Opportunity Explorer|OE/);
+      // STAX divergence callout (consistent with `recommendations list --help`)
+      expect(result.stdout).toMatch(/STAX|seat_gap/);
+      // Provisional framing — names the OE first-party API + ARC-785/#375
+      expect(result.stdout).toMatch(/ARC-785|#375|first-party.*API/);
+      // Names that bulk action places REAL orders (not a dry run)
+      expect(result.stdout).toMatch(/REAL orders|orders API/);
+    });
+
     it("--yes places all recommendations without prompting", async () => {
       const result = await runCliExpectSuccess(
         ["recommendations", "act", "--company", "Bright Minds Academy", "--yes"],

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -159,7 +159,7 @@ function recLabel(rec: Recommendation): string {
 }
 
 export const recommendationsActCommand = new Command("act")
-  .description("Pick recommendations from a multi-select picker and place orders in a batch")
+  .description("Pick recommendations from a multi-select picker and place orders in a batch (uses CLI-side heuristics; see Notes below)")
   .option("--company <id|name>", "Filter to a specific company")
   .option("--product <name>", "Filter to a specific product (e.g. 'AvePoint', 'Entra')")
   .option("--priority <level>", "Filter by priority (high, medium, low)")
@@ -173,6 +173,32 @@ Examples:
   pax8 recommendations act --company "Summit Healthcare"
   pax8 recommendations act --priority high
   pax8 recommendations act --yes                    # non-interactive: place all
+
+Notes — what this command acts on:
+  The recommendations this command places orders against come from the
+  CLI's LOCAL recommendation engine, not Pax8's canonical Opportunity
+  Explorer (OE). The engine is provisional — it uses a CLI-local 7-category
+  product taxonomy (productivity, email, security, endpoint_protection,
+  identity, backup, cloud_infrastructure) and a "seat_gap" heuristic that
+  are NOT Pax8's canonical STAX taxonomy or Seat Utilization metric. See
+  the "Note on STAX divergence" section in 'pax8 recommendations list
+  --help' for the full breakdown of what's CLI-invented vs canonical.
+
+  estimatedMrrUplift on each recommendation is an upper-bound estimate
+  (unit price × seat count) and is NOT equivalent to Pax8's PMRR
+  (Potential MRR) metric. Treat order-placement decisions accordingly.
+
+  This local engine will be retired or remapped when OE's first-party
+  /opportunities API ships (ARC-785, #375).
+
+What this command does:
+  Bulk action submits REAL orders to Pax8 via the orders API — one POST
+  per recommendation in the selected set. In interactive (TTY) mode you
+  pick from a multi-select picker and confirm before submission. With
+  '--yes' or in non-interactive mode you opt in to skipping that gate;
+  every matching recommendation in the filtered set is ordered without
+  further prompting. Use the filter flags (--company, --product,
+  --priority) to constrain the set before passing '--yes'.
 
 Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.`
   )


### PR DESCRIPTION
## Summary

\`pax8 recommendations list --help\` already discloses the engine's CLI-local nature — seat_gap heuristic, 7-category taxonomy that's NOT STAX, upper-bound estimate that's NOT Pax8 PMRR, and provisional framing that sunsets with OE's first-party \`/opportunities\` API on ARC-785/#375. \`pax8 recommendations act --help\` said nothing about any of that — partners reading only the act help could place real orders against the local heuristic without ever seeing the disclosure that lives one command over.

This PR mirrors the disclosure pattern onto act's \`--help\`. No flag changes, no behavior changes.

## Why help-text disclosure, not a new flag

Randall Ellis flagged this on the domain review:

> "because these can be acted on in bulk against a local heuristic, might be worth adding an experimental flag."

Per the triage doc (\`docs/triage/v0.1.0-candidates.md\`, Candidate B), the existing \`-y\` opt-in already gates accidental bulk action adequately: TTY default is multi-select + confirm; non-TTY without \`--yes\` errors cleanly with guidance. Randall's underlying concern is **disclosure** of the heuristic nature, not an extra gate against bulk action. A new \`--experimental\` flag would duplicate the intent of \`--yes\` without naming the actual concern (the engine is CLI-invented, not Pax8 OE canonical).

The help-text mirror gets the disclosure in front of the partner the moment they read \`act --help\`, which is what was missing.

## What the new help text discloses

- CLI-side heuristics (not Pax8's canonical Opportunity Explorer)
- 7-category product taxonomy + seat_gap heuristic — explicitly NOT STAX or Seat Utilization
- estimatedMrrUplift is an upper-bound (unit price × seat count), NOT Pax8's PMRR
- Engine is provisional — retires when OE's first-party \`/opportunities\` API ships (ARC-785, #375)
- Bulk action submits REAL orders via the orders API (one POST per recommendation)
- Cross-references \`recommendations list --help\` for the full STAX-divergence breakdown

## Test

New subprocess assertion in \`packages/cli/src/__tests__/recommendations.test.ts\` confirming the disclosure appears in \`pax8 recommendations act --help\`:

- Names "CLI-side heuristics" + the canonical OE comparator
- Cites STAX divergence + seat_gap heuristic
- Cites ARC-785/#375 sunset
- Names "REAL orders" / orders API on bulk action

## Constraints honored

- No flag added.
- No behavior changes.
- No expansion of scope beyond Candidate B's help-text path.

## Test plan

- [x] Build clean
- [x] \`pnpm test\` — 1851 pass (was 1850; one new disclosure test)
- [x] \`pnpm lint\` clean
- [ ] Spot-check \`pax8 recommendations act --help\` in a terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)