### PR TITLE
feat(quotes): mirror line-item flag surface on quotes create shorthand (#426)

### DIFF
--- a/.changeset/quotes-create-line-item-flag-parity.md
+++ b/.changeset/quotes-create-line-item-flag-parity.md
@@ -1,0 +1,5 @@
+---
+"@pax8/cli": minor
+---
+
+**`pax8 quotes create` shorthand: full line-item flag parity (#426).** Mirrored every line-item flag from `pax8 quotes line-items add` onto the `quotes create --product` shorthand path so partners can pass `--price` and `--effective-date` (the two flags previously missing) and get the same line-item shape on the wire as the long-form two-step flow. Closes the Fred Lintz domain-review gap where the shorthand could silently produce line items with default pricing / effective-date when the partner expected explicit values. Added a parity test (`packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts`) that fails loudly if a future contributor adds a flag to `line-items add` without mirroring it. Construction logic is now shared via `packages/cli/src/commands/quotes/_shared.ts` (`buildLineItemPayload`) so both call sites produce identical payloads. No change to the empty-quote two-step path (`quotes create` without `--product` → `quotes line-items add` separately) — that flow continues to work exactly as today.

--- a/packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts
+++ b/packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts
@@ -1,0 +1,129 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCli } from "./test-utils.js";
+
+/**
+ * Regression guard for #426: `pax8 quotes create` is a shorthand that
+ * orchestrates `POST /v2/quotes` + `POST /v2/quotes/{id}/line-items` in one
+ * call. The shorthand must accept every line-item flag that
+ * `pax8 quotes line-items add` accepts — otherwise partners using the
+ * shorthand can silently produce line items missing `--billing-term`,
+ * `--price`, `--effective-date`, etc. (the kind of subtle wrongness Fred
+ * Lintz flagged on the domain review).
+ *
+ * "Parity" here means: every long flag declared on `quotes line-items add`
+ * also appears on `quotes create`. `create` is allowed to declare *extra*
+ * flags (notably `--company`, which `add` doesn't need because it takes
+ * the quote-id as a positional arg), but it must not be missing any.
+ *
+ * If you add a new line-item flag to `quotes line-items add`, you must
+ * also add it to `quotes create` (or this test fails). If you intentionally
+ * want a flag to live only on `add`, update the EXCLUDED_FROM_PARITY set
+ * below and explain why in a code comment.
+ */
+describe("pax8 quotes create / quotes line-items add flag parity (#426)", () => {
+  /**
+   * Flags declared on `line-items add` that intentionally don't appear on
+   * `quotes create`. Empty today — every line-item flag is mirrored. If
+   * you add an entry here, add a comment explaining why the asymmetry is
+   * justified (e.g. a flag that only makes sense post-creation).
+   */
+  const EXCLUDED_FROM_PARITY = new Set<string>([]);
+
+  /**
+   * Parse the `--help` output of a Commander command and return the set of
+   * long flags it declares (e.g. `--billing-term`, `--price`). We look only
+   * at the "Options:" section so help-footer mentions of other commands
+   * don't pollute the set.
+   */
+  function extractLongFlags(help: string): Set<string> {
+    // Commander prints options after a literal "Options:" header and ends
+    // the block on the next blank line + non-indented section (e.g. our
+    // help-text footer or "Examples:"). Find the Options: block and parse
+    // long flags from it.
+    const optionsIdx = help.indexOf("Options:");
+    if (optionsIdx < 0) {
+      throw new Error("Help output is missing an 'Options:' section");
+    }
+    const afterOptions = help.slice(optionsIdx + "Options:".length);
+    // The Options block ends at the next double-newline that isn't followed
+    // by an indented continuation line. The simplest heuristic: stop at the
+    // first line that starts a new top-level section (no leading whitespace
+    // and ends with `:` like `Examples:` or `Body shape (...)`).
+    const lines = afterOptions.split("\n");
+    const collected: string[] = [];
+    for (const line of lines) {
+      if (/^[A-Z][^\n]*:\s*$/.test(line) || /^[A-Z][^\n]+:\s/.test(line)) {
+        // New top-level section header (e.g. "Examples:", "Setting an
+        // expiration date:") — stop. Indented continuation lines inside
+        // the Options block always start with whitespace, so this only
+        // fires on real section breaks.
+        if (collected.length > 0) break;
+      }
+      collected.push(line);
+    }
+    const block = collected.join("\n");
+    const flags = new Set<string>();
+    // Match `--flag-name` at any position; restrict to the kebab-case form
+    // Commander emits. Skip `--help` since it's auto-added by Commander.
+    const re = /--([a-z][a-z0-9-]*)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(block)) !== null) {
+      const flag = `--${m[1]}`;
+      if (flag === "--help") continue;
+      flags.add(flag);
+    }
+    return flags;
+  }
+
+  it("`quotes create` accepts every line-item flag declared on `quotes line-items add`", async () => {
+    const [createHelp, addHelp] = await Promise.all([
+      runCli(["quotes", "create", "--help"]),
+      runCli(["quotes", "line-items", "add", "--help"]),
+    ]);
+
+    expect(createHelp.exitCode).toBe(0);
+    expect(addHelp.exitCode).toBe(0);
+
+    const createFlags = extractLongFlags(createHelp.stdout);
+    const addFlags = extractLongFlags(addHelp.stdout);
+
+    // Sanity: we should have parsed a non-trivial flag set out of `add`.
+    // If this assertion fails the extractor is broken and the parity check
+    // below would silently pass.
+    expect(addFlags.size).toBeGreaterThanOrEqual(4);
+    expect(addFlags.has("--product")).toBe(true);
+    expect(addFlags.has("--quantity")).toBe(true);
+    expect(addFlags.has("--billing-term")).toBe(true);
+
+    const missing = [...addFlags].filter(
+      (flag) => !EXCLUDED_FROM_PARITY.has(flag) && !createFlags.has(flag),
+    );
+
+    expect(
+      missing,
+      `quotes create is missing flags that quotes line-items add declares: ${missing.join(", ")}.\n`
+        + `Mirror these onto quotes create (see #426), or add to EXCLUDED_FROM_PARITY with a code comment.`,
+    ).toEqual([]);
+  });
+
+  it("`quotes create` and `quotes line-items add` agree on the well-known line-item flags", async () => {
+    // Belt-and-braces assertion: pin the concrete flag names so future
+    // refactors don't accidentally remove one. This is the contract Fred
+    // Lintz's domain-review comment called out.
+    const createHelp = await runCli(["quotes", "create", "--help"]);
+    expect(createHelp.exitCode).toBe(0);
+    const createFlags = extractLongFlags(createHelp.stdout);
+    for (const flag of [
+      "--product",
+      "--quantity",
+      "--billing-term",
+      "--price",
+      "--effective-date",
+    ]) {
+      expect(createFlags.has(flag), `quotes create is missing ${flag}`).toBe(true);
+    }
+  });
+});

--- a/packages/cli/src/__tests__/quotes.create.test.ts
+++ b/packages/cli/src/__tests__/quotes.create.test.ts
@@ -142,6 +142,136 @@ describe("pax8 quotes create", () => {
     });
   });
 
+  describe("line-item flag parity (#426)", () => {
+    // Each newly-supported flag on the shorthand `quotes create` path
+    // must actually apply to the line item that gets appended. Without
+    // these tests, the parity check at
+    // `quotes-create-line-items-parity.test.ts` would pin the *flag
+    // surface* but not catch a regression where a flag is declared yet
+    // silently dropped on the way to the line-item POST.
+
+    it("--price flows through to the appended line item's unitPrice", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "2",
+        "--billing-term",
+        "Monthly",
+        "--price",
+        "77.77",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data[0].lineItems.length).toBe(1);
+      // Demo client persists unitPrice on the line; this is the regression
+      // pin for "shorthand silently used the list price instead of --price."
+      expect(data[0].lineItems[0].unitPrice).toBe(77.77);
+    });
+
+    it("--billing-term Annual produces a line item with billingTerm: \"Annual\"", async () => {
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "5",
+        "--billing-term",
+        "Annual",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0].lineItems.length).toBe(1);
+      expect(data[0].lineItems[0].billingTerm).toBe("Annual");
+    });
+
+    it("--effective-date YYYY-MM-DD is accepted and the line item is created", async () => {
+      // The demo client doesn't always echo effectiveDate, but the flag
+      // must be accepted end-to-end (parsed, validated, sent on the wire).
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "1",
+        "--effective-date",
+        "2026-06-15",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0].lineItems.length).toBe(1);
+    });
+
+    it("rejects malformed --effective-date with the same error shape as line-items add", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "1",
+        "--effective-date",
+        "06/15/2026",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/effective-date/i);
+    });
+
+    it("rejects negative --price with the same error shape as line-items add", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "1",
+        "--price",
+        "-5",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/[Ii]nvalid price/);
+    });
+
+    it("rejects a typo'd --billing-term up front (fail-fast)", async () => {
+      const result = await runCliExpectFailure([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "1",
+        "--billing-term",
+        "Annualy",
+        "--yes",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/billing-term/);
+      expect(combined).toMatch(/Annualy/);
+    });
+  });
+
   describe("partial-failure recovery hint (#311)", () => {
     // The shorthand path is two wire calls (POST /v2/quotes, then
     // POST /v2/quotes/{id}/line-items). If the second succeeds-but-fails

--- a/packages/cli/src/commands/quotes/_shared.ts
+++ b/packages/cli/src/commands/quotes/_shared.ts
@@ -1,0 +1,156 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  BillingTermSchema,
+  ERROR_INVALID_INPUT,
+  type AddQuoteLineItemInput,
+  type BillingTerm,
+  type Product,
+} from "@pax8/core";
+import { CliError } from "../../lib/errors.js";
+import type { CommandContext } from "../../lib/context.js";
+import {
+  resolveEffectiveDate,
+  resolveListPrice,
+} from "../../lib/quote-line-item-defaults.js";
+import { validateEnum } from "../../lib/validate.js";
+
+/**
+ * Shared helpers for the line-item construction path that both
+ * `quotes line-items add` and the `quotes create` shorthand use (#426).
+ *
+ * The two commands share the same wire-level operation
+ * (`POST /v2/quotes/{id}/line-items`) and must accept the same flag surface
+ * — anything `line-items add` understands, the shorthand needs to mirror so
+ * partners don't unknowingly produce incomplete line items (Fred Lintz
+ * domain-review finding).
+ *
+ * The actual flag declarations stay on each command (so each command's
+ * `--help` is self-documenting), but the validation + payload build live
+ * here. The parity test at
+ * `packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts`
+ * guards the user-facing contract.
+ */
+
+export const BILLING_TERM_VALUES = BillingTermSchema.options as readonly BillingTerm[];
+
+/**
+ * Raw flag options as they come off Commander — all strings (or undefined),
+ * since Commander hands us untyped values. Shared by both call sites.
+ */
+export interface LineItemFlagOptions {
+  quantity?: string;
+  billingTerm?: string;
+  price?: string;
+  effectiveDate?: string;
+}
+
+/**
+ * Parsed, validated quantity. Centralized so both commands surface the
+ * same error shape (#426).
+ */
+export function parseQuantity(raw: string | undefined): number {
+  const quantity = parseInt(raw ?? "1", 10);
+  if (isNaN(quantity) || quantity <= 0) {
+    throw new CliError(
+      `Invalid quantity: "${raw}"`,
+      ["Quantity must be a positive integer"],
+      undefined,
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return quantity;
+}
+
+/**
+ * Parse and validate `--price` if supplied. Returns `undefined` when the
+ * caller didn't pass the flag so the default-price lookup can run.
+ */
+export function parsePriceOverride(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new CliError(
+      `Invalid price: "${raw}"`,
+      ["Price must be a non-negative number"],
+      undefined,
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Validate `--billing-term` against the enum and return the canonical
+ * value. Reuses `validateEnum()` (#412) so a typo fails before any
+ * network call.
+ */
+export function parseBillingTerm(
+  raw: string | undefined,
+  cmdHint: string,
+): BillingTerm {
+  const value = raw ?? "Monthly";
+  validateEnum(value, BILLING_TERM_VALUES, "--billing-term", { cmdHint });
+  return value as BillingTerm;
+}
+
+/**
+ * Build the `AddQuoteLineItemInput` payload from the parsed flag values
+ * plus a resolved product. Encapsulates the "default to list price if
+ * `--price` not supplied" lookup and the "no list price available" error
+ * — the wire-shape contract that #312 pinned and #426 mirrors onto
+ * `quotes create`.
+ *
+ * Returns the input plus the effective price + whether it was an override,
+ * so callers can render the same preview line ("(override)" vs "(list)")
+ * without duplicating the logic.
+ */
+export interface BuiltLineItemPayload {
+  input: AddQuoteLineItemInput;
+  price: number;
+  priceWasOverridden: boolean;
+  effectiveDate: string;
+  billingTerm: BillingTerm;
+}
+
+export async function buildLineItemPayload(
+  ctx: CommandContext,
+  product: Product,
+  quantity: number,
+  options: LineItemFlagOptions,
+): Promise<BuiltLineItemPayload> {
+  const billingTerm = parseBillingTerm(options.billingTerm, "pax8 quotes line-items add");
+  const priceOverride = parsePriceOverride(options.price);
+  const effectiveDate = resolveEffectiveDate(options.effectiveDate);
+  const price = priceOverride ?? (await resolveListPrice(ctx, product.id, billingTerm));
+
+  if (price === undefined) {
+    throw new CliError(
+      `No list price found for "${product.name}" at billing term "${billingTerm}"`,
+      [
+        "Pass --price <number> to set the per-unit price explicitly",
+        "Try a different --billing-term (Monthly or Annual)",
+      ],
+      undefined,
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+
+  return {
+    input: {
+      productId: product.id,
+      quantity,
+      billingTerm,
+      effectiveDate,
+      price,
+    },
+    price,
+    priceWasOverridden: priceOverride !== undefined,
+    effectiveDate,
+    billingTerm,
+  };
+}

--- a/packages/cli/src/commands/quotes/create.ts
+++ b/packages/cli/src/commands/quotes/create.ts
@@ -6,26 +6,21 @@ import chalk from "chalk";
 import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
-import { handleCommandError, CliError } from "../../lib/errors.js";
+import { handleCommandError } from "../../lib/errors.js";
 import { confirm, replCmd } from "../../lib/confirm.js";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
-import { formatQuantity } from "../../lib/formatters.js";
+import { formatQuantity, formatCurrency as formatPrice } from "../../lib/formatters.js";
+import type { CreateQuoteInput } from "@pax8/core";
 import {
-  resolveEffectiveDate,
-  resolveListPrice,
-} from "../../lib/quote-line-item-defaults.js";
-import { BillingTermSchema, ERROR_INVALID_INPUT } from "@pax8/core";
-import type {
-  CreateQuoteInput,
-  AddQuoteLineItemInput,
-  BillingTerm,
-} from "@pax8/core";
-import { validateEnum } from "../../lib/validate.js";
-
-const BILLING_TERM_VALUES = BillingTermSchema.options as readonly BillingTerm[];
+  BILLING_TERM_VALUES,
+  buildLineItemPayload,
+  parseBillingTerm,
+  parsePriceOverride,
+  parseQuantity,
+} from "./_shared.js";
 
 export const quotesCreateCommand = new Command("create")
   .description("Create a new quote (empty, or with a single line item via --product)")
@@ -37,6 +32,14 @@ export const quotesCreateCommand = new Command("create")
     `Billing term — one of ${BILLING_TERM_VALUES.join(" | ")} (only meaningful with --product; default Monthly)`,
     "Monthly",
   )
+  .option(
+    "--price <number>",
+    "Per-unit price for the line (only meaningful with --product; defaults to the product's list price for the chosen billing term)",
+  )
+  .option(
+    "--effective-date <YYYY-MM-DD>",
+    "Effective date for the line (only meaningful with --product; defaults to today, UTC)",
+  )
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
@@ -47,6 +50,10 @@ Body shape (POST /v2/quotes):
   Passing --product orchestrates both steps for you; without it, an empty
   draft quote is created (the natural shape for the v2 surface).
 
+  When --product is supplied, every line-item flag accepted by
+  \`pax8 quotes line-items add\` is also accepted here and applied to the
+  appended line item — including --price and --effective-date.
+
 Examples:
   # Empty quote — canonical v2 shape. Add line items separately.
   pax8 quotes create --company "Summit Healthcare Partners"
@@ -55,6 +62,8 @@ Examples:
   # Shorthand: create quote + add a single line item in one command.
   pax8 quotes create --company "Summit Healthcare Partners" --product "Microsoft 365 E3" --quantity 10
   pax8 quotes create --company a1b2c3d4 --product prod-m365-e3-0003 --quantity 5 --billing-term Annual
+  pax8 quotes create --company a1b2c3d4 --product prod-m365-e3-0003 --quantity 5 --price 22.50
+  pax8 quotes create --company a1b2c3d4 --product prod-m365-e3-0003 --quantity 5 --effective-date 2026-06-01
 
 Setting an expiration date:
   POST /v2/quotes does not accept an expiration date. To set or change a
@@ -63,14 +72,15 @@ Setting an expiration date:
   )
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();
-    // Fail-fast on typo'd `--billing-term` BEFORE buildContext / any
-    // network call (#408). Only enforced when --product is set; otherwise
-    // billingTerm is unused by the create path.
-    if (typeof options.product === "string" && options.product.length > 0) {
+    const hasProduct = typeof options.product === "string" && options.product.length > 0;
+
+    // Fail-fast on typo'd `--billing-term` and bad `--price` BEFORE
+    // buildContext / any network call (#408, #426). Only enforced when
+    // --product is set; otherwise the line-item flags are ignored.
+    if (hasProduct) {
       try {
-        validateEnum(options.billingTerm, BILLING_TERM_VALUES, "--billing-term", {
-          cmdHint: "pax8 quotes create",
-        });
+        parseBillingTerm(options.billingTerm, "pax8 quotes create");
+        parsePriceOverride(options.price);
       } catch (error) {
         await handleCommandError(error);
       }
@@ -78,30 +88,42 @@ Setting an expiration date:
     const ctx = await buildContext(globalOpts);
 
     try {
-      // Quantity is only meaningful when --product is supplied, but if either
-      // is set we validate the integer up-front so the user sees the error
-      // before the company-resolve round trip.
-      const hasProduct = typeof options.product === "string" && options.product.length > 0;
-      const quantity = hasProduct ? parseInt(options.quantity, 10) : undefined;
-      if (hasProduct && (quantity === undefined || isNaN(quantity) || quantity <= 0)) {
-        throw new CliError(
-          `Invalid quantity: "${options.quantity}"`,
-          ["Quantity must be a positive integer"],
-          undefined,
-          undefined,
-          ERROR_INVALID_INPUT,
-        );
-      }
+      // Quantity is only meaningful when --product is supplied. When it is,
+      // validate the integer up-front so the user sees the error before the
+      // company-resolve round trip.
+      const quantity = hasProduct ? parseQuantity(options.quantity) : undefined;
 
       const company = await resolveCompany(ctx, options.company);
       const product = hasProduct ? await resolveProduct(ctx, options.product) : undefined;
 
+      // Build the line-item payload up-front when --product is supplied so
+      // any validation error (bad billing term, unresolvable list price)
+      // surfaces in the preview rather than after the quote-create POST
+      // commits. The same helper backs `quotes line-items add` (#426), so
+      // the two paths produce identical line items for identical inputs.
+      const built = product && quantity !== undefined
+        ? await buildLineItemPayload(ctx, product, quantity, {
+            quantity: options.quantity,
+            billingTerm: options.billingTerm,
+            price: options.price,
+            effectiveDate: options.effectiveDate,
+          })
+        : undefined;
+
       process.stderr.write(chalk.bold("\n  New Quote:\n\n"));
       process.stderr.write(`  ${chalk.dim("Company:".padEnd(18))}${company.name}\n`);
-      if (product && quantity !== undefined) {
+      if (product && quantity !== undefined && built) {
         process.stderr.write(`  ${chalk.dim("Product:".padEnd(18))}${product.name}\n`);
         process.stderr.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(quantity)}\n`);
-        process.stderr.write(`  ${chalk.dim("Billing Term:".padEnd(18))}${options.billingTerm}\n`);
+        process.stderr.write(`  ${chalk.dim("Billing Term:".padEnd(18))}${built.billingTerm}\n`);
+        process.stderr.write(
+          `  ${chalk.dim("Unit price:".padEnd(18))}${formatPrice(built.price)}${
+            built.priceWasOverridden ? chalk.dim(" (override)") : chalk.dim(" (list)")
+          }\n`,
+        );
+        process.stderr.write(
+          `  ${chalk.dim("Effective date:".padEnd(18))}${built.effectiveDate.slice(0, 10)}\n`,
+        );
       } else {
         process.stderr.write(`  ${chalk.dim("Line items:".padEnd(18))}${chalk.dim("(none — add with `quotes line-items add`)")}\n`);
       }
@@ -131,40 +153,11 @@ Setting an expiration date:
       // fails the quote is already created server-side — surface the new ID
       // prominently with a recovery hint so the user can retry the add
       // manually instead of losing the quote.
-      if (product && quantity !== undefined) {
-        const billingTerm = options.billingTerm as BillingTerm;
-        // The v2 line-items POST requires `effectiveDate` and `price` per
-        // #312. The shorthand uses sensible defaults: today (UTC) and the
-        // product's `suggestedRetailPrice` for the chosen billing term.
-        // Partners needing custom pricing or a different effective date can
-        // create the empty quote and use `pax8 quotes line-items add` with
-        // the explicit `--price` / `--effective-date` flags.
-        const effectiveDate = resolveEffectiveDate(undefined);
-        const price = await resolveListPrice(ctx, product.id, billingTerm);
-        if (price === undefined) {
-          throw new CliError(
-            `No list price available for ${product.name} (${billingTerm})`,
-            [
-              "The shorthand needs a default price to populate the line item.",
-              `Try: pax8 quotes create --company "${options.company}" (creates empty quote),`,
-              `then: pax8 quotes line-items add <quote-id> --product "${options.product}" --quantity ${quantity} --price <number>`,
-            ],
-            undefined,
-            undefined,
-            ERROR_INVALID_INPUT,
-          );
-        }
-        const lineInput: AddQuoteLineItemInput = {
-          productId: product.id,
-          quantity,
-          billingTerm,
-          effectiveDate,
-          price,
-        };
+      if (product && quantity !== undefined && built) {
         const lineSpin = createSpinner("Adding line item...").start();
         const doneLine = markWriteInFlight("quotes");
         try {
-          quote = await ctx.api.quotes.addLineItem(quote.id, lineInput);
+          quote = await ctx.api.quotes.addLineItem(quote.id, built.input);
           doneLine();
           lineSpin.succeed("Line item added");
         } catch (err) {
@@ -173,8 +166,22 @@ Setting an expiration date:
 
           // Quote create succeeded — surface the ID prominently so the user
           // can recover, then re-throw so the error envelope/exit-code path
-          // still fires. Partial-failure recovery hint per #311.
-          const recoveryCmd = `pax8 quotes line-items add ${quote.id} --product ${options.product} --quantity ${quantity}`;
+          // still fires. Partial-failure recovery hint per #311. The
+          // recovery command mirrors every flag the user passed so they can
+          // re-run without re-reading docs.
+          const recoveryParts = [
+            `pax8 quotes line-items add ${quote.id}`,
+            `--product ${options.product}`,
+            `--quantity ${quantity}`,
+            `--billing-term ${built.billingTerm}`,
+          ];
+          if (built.priceWasOverridden) {
+            recoveryParts.push(`--price ${built.price}`);
+          }
+          if (options.effectiveDate) {
+            recoveryParts.push(`--effective-date ${options.effectiveDate}`);
+          }
+          const recoveryCmd = recoveryParts.join(" ");
           process.stderr.write(
             chalk.yellow(
               `\n  ⚠ Quote ${chalk.bold(quote.id)} was created but the line-item add failed.\n`,

--- a/packages/cli/src/commands/quotes/line-items/add.ts
+++ b/packages/cli/src/commands/quotes/line-items/add.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { buildContext } from "../../../lib/context.js";
 import { output } from "../../../lib/output.js";
 import { createSpinner } from "../../../lib/spinner.js";
-import { handleCommandError, CliError } from "../../../lib/errors.js";
+import { handleCommandError } from "../../../lib/errors.js";
 import { confirm, replCmd } from "../../../lib/confirm.js";
 import { resolveProduct } from "../../../lib/resolve-product.js";
 import { invalidateCacheAfterWrite } from "../../../lib/invalidate-cache.js";
@@ -14,22 +14,19 @@ import { markWriteInFlight } from "../../../lib/signals.js";
 import { formatQuantity, formatCurrency as formatPrice } from "../../../lib/formatters.js";
 import { promptNextSteps, type NextStep } from "../../../lib/next-step.js";
 import {
-  BillingTermSchema,
-  ERROR_INVALID_INPUT,
-  type BillingTerm,
-  type AddQuoteLineItemInput,
-} from "@pax8/core";
-import {
-  resolveEffectiveDate,
-  resolveListPrice,
-} from "../../../lib/quote-line-item-defaults.js";
-import { validateEnum } from "../../../lib/validate.js";
-
-const BILLING_TERM_VALUES = BillingTermSchema.options as readonly BillingTerm[];
+  BILLING_TERM_VALUES,
+  buildLineItemPayload,
+  parseBillingTerm,
+  parsePriceOverride,
+  parseQuantity,
+} from "../_shared.js";
 
 // `resolveEffectiveDate` and `resolveListPrice` moved to
 // `packages/cli/src/lib/quote-line-item-defaults.ts` so #311's `quotes create`
-// two-call orchestration can reuse the same defaults.
+// two-call orchestration can reuse the same defaults. Per #426 the
+// `--price` / `--effective-date` flag wiring is also shared via
+// `packages/cli/src/commands/quotes/_shared.ts` so the shorthand and the
+// long-form path can't drift apart.
 
 export const quotesLineItemsAddCommand = new Command("add")
   .description("Add a line item to a quote")
@@ -65,43 +62,13 @@ Examples:
     const ctx = await buildContext(globalOpts);
 
     try {
-      // Fail-fast on typo'd `--billing-term` BEFORE any network call (#408).
-      validateEnum(options.billingTerm, BILLING_TERM_VALUES, "--billing-term", {
-        cmdHint: "pax8 quotes line-items add",
-      });
-
-      const quantity = parseInt(options.quantity, 10);
-      if (isNaN(quantity) || quantity <= 0) {
-        throw new CliError(
-          `Invalid quantity: "${options.quantity}"`,
-          ["Quantity must be a positive integer"],
-          undefined,
-          undefined,
-          ERROR_INVALID_INPUT,
-        );
-      }
-
-      // Resolve `--price` override if provided. Validate up-front so a bad
-      // value fails before any network/IO work.
-      let priceOverride: number | undefined;
-      if (options.price !== undefined) {
-        const parsed = Number(options.price);
-        if (!Number.isFinite(parsed) || parsed < 0) {
-          throw new CliError(
-            `Invalid price: "${options.price}"`,
-            ["Price must be a non-negative number"],
-            undefined,
-            undefined,
-            ERROR_INVALID_INPUT,
-          );
-        }
-        priceOverride = parsed;
-      }
-
-      // Resolve `--effective-date` override or default to today (UTC). The v2
-      // spec requires an ISO 8601 date-time; we accept the friendlier
-      // `YYYY-MM-DD` shape from the user and normalize to `T00:00:00Z`.
-      const effectiveDate = resolveEffectiveDate(options.effectiveDate);
+      // Pre-flight validation runs before any network call (#408, #426).
+      // The shared helpers validate `--billing-term`, `--quantity`, and
+      // `--price` so the shorthand path (`quotes create`) gets the same
+      // fail-fast behavior.
+      parseBillingTerm(options.billingTerm, "pax8 quotes line-items add");
+      parsePriceOverride(options.price);
+      const quantity = parseQuantity(options.quantity);
 
       const fetchSpinner = createSpinner("Fetching quote...").start();
       const quote = await ctx.api.quotes.get(quoteId);
@@ -115,26 +82,13 @@ Examples:
 
       const product = await resolveProduct(ctx, options.product);
 
-      // Resolve unit price: explicit `--price` wins; otherwise look up the
-      // product's list price (`suggestedRetailPrice`) for the chosen
-      // billing term. The lookup is best-effort and cached per command run,
-      // matching the convention used by `orders create` (#312).
-      const billingTerm = options.billingTerm as BillingTerm;
-      const price = priceOverride
-        ?? (await resolveListPrice(ctx, product.id, billingTerm));
-
-      if (price === undefined) {
-        throw new CliError(
-          `No list price found for "${product.name}" at billing term "${billingTerm}"`,
-          [
-            `Pass --price <number> to set the per-unit price explicitly`,
-            `Try a different --billing-term (Monthly or Annual)`,
-          ],
-          undefined,
-          undefined,
-          ERROR_INVALID_INPUT,
-        );
-      }
+      const built = await buildLineItemPayload(ctx, product, quantity, {
+        quantity: options.quantity,
+        billingTerm: options.billingTerm,
+        price: options.price,
+        effectiveDate: options.effectiveDate,
+      });
+      const { input, price, priceWasOverridden, effectiveDate, billingTerm } = built;
 
       process.stderr.write(chalk.bold("\n  Add line item:\n\n"));
       process.stderr.write(`  ${chalk.dim("Quote:".padEnd(18))}${quote.id} ${chalk.dim(`(${quote.status})`)}\n`);
@@ -143,7 +97,7 @@ Examples:
       process.stderr.write(`  ${chalk.dim("Billing term:".padEnd(18))}${billingTerm}\n`);
       process.stderr.write(
         `  ${chalk.dim("Unit price:".padEnd(18))}${formatPrice(price)}${
-          priceOverride !== undefined ? chalk.dim(" (override)") : chalk.dim(" (list)")
+          priceWasOverridden ? chalk.dim(" (override)") : chalk.dim(" (list)")
         }\n`,
       );
       process.stderr.write(
@@ -156,14 +110,6 @@ Examples:
         process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
         return;
       }
-
-      const input: AddQuoteLineItemInput = {
-        productId: product.id,
-        quantity,
-        billingTerm,
-        effectiveDate,
-        price,
-      };
 
       const spinner = createSpinner("Adding line item...").start();
       const done = markWriteInFlight("quotes");


### PR DESCRIPTION
## Summary

Closes #426. The `pax8 quotes create --company X --product Y` shorthand orchestrates `POST /v2/quotes` + `POST /v2/quotes/{id}/line-items` in one call, but previously accepted only `--quantity` and `--billing-term` from the line-item flag surface. `--price` and `--effective-date` were silently unreachable on this path, so partners using the shorthand could unknowingly produce line items with default pricing / effective-date when they expected explicit values — the subtle wrongness Fred Lintz flagged on the domain review (referenced in the issue body).

This PR mirrors the full flag surface so the shorthand and the long-form (`create` empty, then `line-items add`) produce identical line items for identical inputs, and adds a parity test that fails loudly on future drift.

### What changed

- **Flags added to `pax8 quotes create`:** `--price <number>` and `--effective-date <YYYY-MM-DD>` (2 net-new flags). Same descriptions, defaults, and validation as on `pax8 quotes line-items add`.
- **Shared payload builder:** `packages/cli/src/commands/quotes/_shared.ts` exports `buildLineItemPayload()` plus the underlying flag parsers (`parseQuantity`, `parsePriceOverride`, `parseBillingTerm`). Both `quotes create` and `quotes line-items add` now construct `AddQuoteLineItemInput` through this one code path — the parity test catches flag-surface drift; sharing the construction reduces the chance of construction-shape drift.
- **Pre-flight validation:** `--billing-term`, `--price`, `--quantity` are validated on both commands before any network call (preserves #408's fail-fast contract).
- **Recovery hint:** the partial-failure path on `quotes create` now mirrors every flag the user supplied so a copy-paste retry works without re-reading docs.
- **Help text:** `quotes create --help` lists the new flags and points at `quotes line-items add` as the canonical reference.

### Files touched

- `packages/cli/src/commands/quotes/create.ts` — wires new flags, calls shared builder, updates preview + recovery hint
- `packages/cli/src/commands/quotes/line-items/add.ts` — refactored to call the shared builder; behavior unchanged
- `packages/cli/src/commands/quotes/_shared.ts` (new) — `buildLineItemPayload()` + flag parsers
- `packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts` (new) — parity test, modeled on `clients-companies-parity.test.ts` (#379)
- `packages/cli/src/__tests__/quotes.create.test.ts` — subprocess tests that pin each new flag's effect on the appended line item
- `.changeset/quotes-create-line-item-flag-parity.md` — `@pax8/cli` minor (additive)

### Out of scope

- `quotes update --terms / --disclaimers` (#420) is intentionally deferred to v0.2 per the issue.
- No backwards-compat aliases (pre-v0.1.0).
- No change to the empty-quote two-step path (`create` without `--product`).

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` — 111 files / 1,858 tests passing (after clearing a full-disk environmental issue that was unrelated to this change; the cache.test.ts ENOSPC failures cleared once `~/.npm/_cacache` was pruned)
- [x] `pnpm lint` — passes
- [x] `pnpm -r exec tsc --noEmit` — passes (run explicitly per CLAUDE.md / #413)
- [x] New parity test asserts every long flag on `line-items add` appears on `create`
- [x] Subprocess tests pin `--price`, `--billing-term`, `--effective-date`, and the invalid-input error shapes
- [x] `pax8 quotes create --help` advertises the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)