### PR TITLE
feat(quotes): add commitment-term flags to quotes create + line-items add

### DIFF
--- a/.changeset/quotes-commitment-term-parity.md
+++ b/.changeset/quotes-commitment-term-parity.md
@@ -1,0 +1,18 @@
+---
+"@pax8/cli": minor
+"@pax8/core": minor
+---
+
+`pax8 quotes line-items add` and `pax8 quotes create` (shorthand path) now accept `--commitment-term <enum>` and `--commitment-term-id <uuid>`, mirroring the orders create pattern (`packages/cli/src/commands/orders/create.ts:350-351`). When `--commitment-term` is supplied, the CLI auto-resolves it to a commitment-term UUID against the partner's existing subscriptions for the product — same `resolveCommitmentTermId()` helper orders create uses. When `--commitment-term-id` is supplied directly, it wins over any `--commitment-term` (UUID short-circuits the lookup, matching orders create precedence). The resolved `commitmentTermId` rides through to `POST /v2/quotes/{quoteId}/line-items` as `AddStandardLineItemPayload.commitmentTermId` (spec-confirmed in `quoting-endpoints.json`).
+
+Required for Microsoft NCE and other commitment-priced SKUs per QUOTE-311 (the `AddLineItemToQuoteCommandPayload.commitmentTermId` field), QUOTE-1283 (commitment persisted on the line item itself), QUOTE-406 (backfill of older NULL rows), and the NCE proration spike (Model A canonical — commitment is decided at quote-time and inherited by the resulting order).
+
+`@pax8/core`: `AddQuoteLineItemInputSchema` gains `commitmentTermId: z.string().optional()` (mirrors `OrderLineItemInputSchema`'s shape — not strict `.uuid()` because demo fixtures use Pax8-style synthetic IDs). `QuoteLineItemSchema` gains `commitmentTerm: CommitmentSchema.nullable().optional()` for the read surface (`{ id, term }` per the v2 spec's `LineItemResponse.commitmentTerm`). The existing `CommitmentSchema` is reused rather than defining a new shape — its extra-optional `endDate` is harmless on the quote-line wire and reuse means future drift propagates to both consumers.
+
+`pax8 quotes show` and `pax8 quotes line-items list` now render a "Commit" column on the line-item table (the term label, e.g. "1-Year"); `--json` consumers see the full `commitmentTerm: { id, term }` object. Mirrors how subscriptions render `commitment.term`.
+
+Demo fixture: the Redwood E5 line on `quote-redwood-001` now carries `commitmentTerm: { id, term: "1-Year" }` so the render path exercises end-to-end under `PAX8_DEMO=1`.
+
+The parity test from #426 (`packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts`) was already structural — both new flags pass automatically. Belt-and-braces pin updated to enumerate them.
+
+Follow-up to #429 (Candidate E in `docs/triage/v0.1.0-candidates.md`).

--- a/docs/triage/v0.1.0-candidates.md
+++ b/docs/triage/v0.1.0-candidates.md
@@ -1,0 +1,294 @@
+# v0.1.0 candidate triage — domain review follow-ups
+
+Three items from the domain review are candidates for pre-launch inclusion. The bar: small implementation cost AND completes a basic surface gap. Final ship/defer call is yours (Josh) — this doc gives the cost-check + recommended disposition; no code shipped in this triage run.
+
+The four other follow-ups from the review are confirmed v0.2 (filed as separate issues — see Phase 2 summary).
+
+---
+
+## Candidate A — Quotes totals visibility on `quotes show`
+
+**Source.** Fred Lintz, domain review: "seeing the totals is pretty important too."
+
+### What's on screen today
+
+`packages/cli/src/commands/quotes/show.ts:36-38` already computes a locally-summed `total` from line items via reduce, and renders it at line 110 as `writeRow("Total", chalk.bold(formatCurrency(total)))`. So `Total` is not the gap.
+
+Per-line subtotal is rendered in the line-item table (line 121 — `subtotal` column). Sales margin percentage is shown at line 108-109 (`writeRow("Margin", `${...salesMarginPercentage.toFixed(1)}%`)`).
+
+### What's actually missing
+
+The `QuoteSchema` in `packages/core/src/api/types.ts:809-925` does **not** model a server-computed quote-level `total`, `subtotal`, `discountAmount`, `taxAmount`, or `currencyCode`. The only totals-shaped field on the wire-mirroring schema is `salesMarginPercentage` (line 922). Everything else is derived locally from line items.
+
+The v2 quote API likely returns more (tax, discount, currency, server-authoritative total), but the schema has no `.passthrough()` so unknown fields are silently dropped. Without verifying the actual wire shape against the live API, we don't know whether the gap is "schema is dropping totals that exist" or "API doesn't compute totals at all and locally-summed `total` is the canonical answer."
+
+### Implementation cost
+
+The cost branches on the wire-shape question:
+
+- **If the v2 API doesn't return server-side totals** (locally-summed is canonical): the gap is cosmetic — display the margin as a dollar amount (computed from `salesMarginPercentage × total / 100`) and maybe a subtotal line. **30 min–1 hour.**
+- **If the v2 API returns server-side totals** that the schema is dropping: add 3-5 fields to `QuoteSchema`, surface them as `writeRow` calls in `quotes show`, update the demo fixtures in `packages/core/src/demo/demo-data.ts` (currently only carry per-line subtotal), update JSON output documentation, add a test or two. **2-4 hours.**
+
+The investigation needed before coding (verify wire shape via `pax8 quotes show <real-id> --json | jq` against staging, or read `https://devx.pax8.com/openapi/quoting-endpoints.json`) is ~30 minutes.
+
+### Honest estimate
+
+**Half day, with risk of stretching to full day** if the API returns totals in a richer-than-expected shape (e.g. nested `totals: { subtotal, tax, discount, total, currencyCode }` object) that requires schema gymnastics.
+
+### Recommended disposition
+
+**Lean ship, with one gating step**: spend 30 min verifying the wire shape first. If the API returns totals already and the schema is just dropping them, this is a clean 2-4 hour ship that closes a real gap reviewers will notice. If the API doesn't compute totals server-side, defer to v0.2 — the cosmetic margin-dollar render isn't worth the launch attention.
+
+The gating step is cheap and would tell us whether this is a half-day or a non-issue.
+
+### Wire-shape check (2026-05-13)
+
+Pulled `https://devx.pax8.com/openapi/quoting-endpoints.json`. The v2 API **does** return server-side totals at the quote level, but the shape is richer than the flat `{ total, subtotal, tax, discount }` the triage anticipated:
+
+```
+QuoteResponse.totals: InvoiceTotals (required)
+  initialCost      AmountCurrency  // one-time cost
+  initialProfit    AmountCurrency
+  initialTotal     AmountCurrency  // one-time total (cost + profit)
+  recurringCost    AmountCurrency  // subscription cost per period
+  recurringProfit  AmountCurrency
+  recurringTotal   AmountCurrency  // subscription total per period
+
+AmountCurrency: { amount: number, currency: string }
+```
+
+Six required fields, splitting **initial** (one-time / non-recurring) and **recurring** amounts. No flat `total`/`tax`/`discount`. Currency is embedded per-amount (not a quote-level field). `LineItemResponse` carries the same `InvoiceTotals` shape per line, so the breakdown can be rendered at any granularity.
+
+**Disposition update**: recommending **ship in v0.1.0** — but call out that the render needs a real partner-UX call. Surfacing "$X/once + $Y/period" instead of one bare "Total" is a small but visible behavior change to `quotes show`. Schema additions to `QuoteSchema` + `QuoteLineItemSchema` (add `totals: InvoiceTotalsSchema`) are mechanical (1-2 hours). Rendering the initial-vs-recurring split readably is the substantive work (1-2 hours), plus demo fixtures + a JSON-output contract update + a couple of test updates (1 hour). **Realistic 3-5 hours total** — fits the half-day bar.
+
+The locally-summed `total` already on screen is currently `sum(lineItems.subtotal)`. With server-side totals available, that calculation can be replaced with `totals.initialTotal + totals.recurringTotal` (or kept and rendered alongside for one-cycle compatibility). The split also catches an actual partner bug: a quote with both an initial setup charge AND a monthly subscription is currently rendered as one undifferentiated number.
+
+---
+
+## Candidate B — `recommendations act` experimental gating
+
+**Source.** Randall Ellis, domain review: "because these can be acted on in bulk against a local heuristic, might be worth adding an experimental flag."
+
+### What the gating looks like today
+
+`packages/cli/src/commands/recommendations/act.ts:161-176` registers the command with this description and flags (verbatim):
+
+```
+.description("Pick recommendations from a multi-select picker and place orders in a batch")
+.option("--company <id|name>", "Filter to a specific company")
+.option("--product <name>", "Filter to a specific product (e.g. 'AvePoint', 'Entra')")
+.option("--priority <level>", "Filter by priority (high, medium, low)")
+.option("-y, --yes", "Skip the picker and confirmation; place all matching recommendations")
+```
+
+Three flow paths (lines 239-258):
+
+1. **TTY default**: multi-select picker → explicit confirmation prompt with `initial: false` (defaults to "no"). A partner must check items and then confirm.
+2. **`--yes`**: bypasses picker + confirm, places all matching recs.
+3. **Non-TTY without `--yes`**: errors cleanly (no silent bulk action).
+
+The orders are placed in a per-recommendation loop calling `ctx.api.orders.create()` — one API call per order, not a batched server-side endpoint.
+
+### What Randall is actually pointing at
+
+The existing gates handle accidental misuse: a partner can't bulk-order without either (a) interactively picking + confirming, or (b) explicitly passing `--yes`. That part is solid.
+
+What's missing is **disclosure of the heuristic nature** in this command's help text. `pax8 recommendations list --help` clearly calls out that the underlying engine is CLI-side heuristics (not Pax8's canonical OE). `pax8 recommendations act --help` says nothing — a partner who only reads `act --help` doesn't see that they're acting on CLI-invented heuristics, not canonical Pax8 data.
+
+### Implementation cost
+
+Two ways to address this:
+
+- **(a) Add a sentence to the description** cross-referencing `recommendations list`'s heuristic disclosure. **5-10 minutes** — one-line edit, no schema/flag changes, no test changes.
+- **(b) Add a required `--experimental` flag** that the partner must pass to actually place orders. **1-2 hours** — new option, validation, examples update, error message, test cases for missing-flag behavior, docstring updates.
+
+### Honest estimate
+
+(a) is **trivial** (under an hour). (b) is **1-2 hours**.
+
+### Recommended disposition
+
+**Ship (a) — help-text disclosure — in v0.1.0.** Don't add a new flag.
+
+The existing `--yes` opt-in is structurally adequate gating against accidental bulk action. Adding `--experimental` as a second flag adds friction without clarifying the underlying concern (the heuristic nature is a disclosure issue, not an accidental-bulk-action issue). A cross-reference in the description gets the disclosure in front of the partner without expanding the flag surface.
+
+If Randall's intent on re-read is specifically "this should require an extra flag to make partners pause and think," that's option (b) — still cheap (1-2 hours). I'd recommend (a) as the default; surface (b) to Randall for a second opinion if uncertain.
+
+---
+
+## Candidate C — `quotes line-items` bulk-delete
+
+**Source.** Fred Lintz, domain review: "If lineItems have requirements on each other, you need a way to delete more than one at a time. Our quoting system will error if you attempt to put your quote into an invalid state."
+
+### API state
+
+The v2 quote API exposes a bulk-delete endpoint:
+
+```
+POST /v2/quotes/{quoteId}/line-items/bulk-delete
+```
+
+Cited in `docs/triage/quotes-api-version.md:58` and §132 (under "v2 quote surface beyond the current CLI scope — P3 / informational" — already tracked as out-of-CLI-scope coverage).
+
+The **request body shape is not documented in the repo.** The endpoint exists in the spec at `https://devx.pax8.com/openapi/quoting-endpoints.json` but no local mirror has the shape. Inferring from REST conventions: likely `{ "ids": [...] }` or `{ "lineItemIds": [...] }`.
+
+### Current CLI shape
+
+`packages/cli/src/commands/quotes/line-items/remove.ts` is single-item only — takes `<quote-id>` and `<line-item-id>` as positional args, fetches the quote, confirms, calls `ctx.api.quotes.removeLineItem(quoteId, lineItemId)`.
+
+`packages/cli/src/commands/quotes/update.ts:320-358` does in-CLI per-line orchestration for the `--product` replacement case (delete all existing lines sequentially, then add the new line). Failure mode if the post-delete add fails is "deletes are committed; surface a recovery hint." There's prior art for orchestration here.
+
+### Implementation options
+
+| Option | Shape | Cost |
+|---|---|---|
+| 1. Extend `remove` with `--ids id1,id2,id3` or variadic args | Reuses existing command. Calls bulk-delete API once, OR loops per-line if API isn't usable. | 2-3 hours |
+| 2. New `bulk-remove` subcommand | Separate command, isolated logic + tests | 3-4 hours |
+| 3. Full orchestration with partial-failure semantics + rollback attempts | Mirrors `quotes update` decomposition, adds rollback try-add-back on failure | 6-8 hours |
+
+All three need the same 30-minute up-front step: pull the bulk-delete endpoint shape from the live OpenAPI spec to know whether to call it directly or to per-line loop.
+
+### Honest estimate
+
+**Half day to full day.** Cost floor is 2-3 hours for Option 1, but realistically the work is:
+
+- 30 min — read the v2 spec for bulk-delete shape
+- 2-3 hours — implement Option 1
+- 1-1.5 hours — tests covering single-line back-compat, multi-line happy path, partial-failure (depending on what the API does — atomic? per-item status?)
+- 30 min — demo data + docstrings
+
+That's 4-5 hours = half day to ¾ day. Option 2 or 3 push it to a full day or more.
+
+There's also a **non-trivial design call**: if the bulk-delete API is non-atomic (per-item success/failure), the CLI has to surface partial-failure UX. That's a coherent question that benefits from being designed deliberately rather than under time pressure.
+
+### Recommended disposition
+
+**Defer to v0.2.** The work is at or over the half-day bar, the partial-failure UX design is real, and the workaround for v0.1.0 — partners can use `quotes update --product` for the destructive-replace case Fred is most likely thinking of (and that flow already has a loud destructive-replace confirmation) — covers most of the "stuck in invalid state" pain.
+
+If the design question gets answered fast (single-API-call atomic delete with `--ids`), this could shrink to 2-3 hours and slot into v0.1.0 cleanly. But absent that confirmation, the cost bar isn't met.
+
+---
+
+## Candidate D — Quote text fields (terms, disclaimers, intro message)
+
+**Source.** Issue #420 follow-up: should `pax8 quotes update` ship `--terms`, `--disclaimers`, `--intro` flags in v0.1.0, or defer pending design work?
+
+### What's on screen today
+
+`packages/cli/src/commands/quotes/update.ts` exposes `--expiration-date` and `--product`/`--quantity`/`--billing-term`/`--effective-date`/`--price` (for line-item replacement). There is no flag for `introMessage` or `termsAndDisclaimers`. Both fields are already modeled on the read side: per `quotes-api-version.md` §9.2, `introMessage` and `termsAndDisclaimers` were added to `QuoteSchema` in #313/#314 because the fetch-then-merge pattern requires round-tripping them through every PUT.
+
+### API state
+
+`PUT /v2/quotes/{quoteId}` already accepts these as required top-level fields — per `quotes-api-version.md` §9.1, the full required-on-PUT set is `{ expiresOn, introMessage, published, status, termsAndDisclaimers }`, and `QuotesApi.update` already constructs that body via `buildFullUpdatePayload`. Today the helper threads through whatever values the GET returned; partner-set values arrive there only via the v2 web UI.
+
+### Wire-shape check (2026-05-13)
+
+Pulled `https://devx.pax8.com/openapi/quoting-endpoints.json`. The spec resolves the body draft's "terms, disclaimers, intro" as **two** fields, not three:
+
+```
+UpdateQuotePayload.introMessage          string  (required on PUT)
+UpdateQuotePayload.termsAndDisclaimers   string  (required on PUT)
+
+QuoteResponse.introMessage               string  (required on GET response)
+QuoteResponse.termsAndDisclaimers        string  (required on GET response)
+```
+
+`$ref` chains walked: `paths./v2/quotes/{quoteId}.put.requestBody.content."application/json".schema → #/components/schemas/UpdateQuotePayload → properties.{introMessage, termsAndDisclaimers}`. `paths./v2/quotes/{quoteId}.get.responses.200.content."application/json".schema → #/components/schemas/QuoteResponse → properties.{introMessage, termsAndDisclaimers}`.
+
+Both are:
+
+- **Plain `string`.** No `maxLength`, `minLength`, `pattern`, `format`, or `enum` declared. No markdown/HTML hint in the description.
+- **Top-level** on both request and response — not nested under `sections`, `templates`, or `attachments`. (Confirmed: full PUT required set is `{ expiresOn, introMessage, published, status, termsAndDisclaimers }`; full GET required set is `{ attachments, client, createdBy, createdByEmail, createdOn, expiresOn, id, introMessage, lineItems, partner, published, referenceCode, status, termsAndDisclaimers, totals }`. Neither field appears anywhere else in the spec.)
+- **Independently updatable** within the existing fetch-then-merge pattern from #313 — setting one without touching the other is a non-event; the merge helper already preserves whichever field isn't passed.
+
+Naming consequence: the body draft's "terms" and "disclaimers" are a **single combined string** (`termsAndDisclaimers`), not two separate fields. Two flags, not three: `--intro-message` and `--terms-and-disclaimers` (or shorter aliases — `--intro` and `--terms` would read fine and `termsAndDisclaimers` is one concept on the wire). No spec mechanism exists to set "terms" without "disclaimers" or vice versa.
+
+### Implementation cost
+
+Simple strings, no formatting constraints, top-level, independently updatable, fetch-then-merge already done. The wiring is:
+
+- Add two options to `packages/cli/src/commands/quotes/update.ts` (`--intro <text>`, `--terms <text>`).
+- Thread through to `UpdateQuoteInputSchema` in `packages/core/src/api/types.ts` — both fields are already optional on the input shape per #313's resolution (`{ expiresOn?, introMessage?, published?, status?, termsAndDisclaimers? }`), so no schema change needed; just pass them in.
+- Demo data: confirm `MockPax8Client.updateQuote` round-trips the fields (it already round-trips the rest of the PUT body since #313).
+- Tests: one subprocess test covering `pax8 quotes update <id> --intro "..." --terms "..."` end-to-end under `PAX8_DEMO=1`.
+
+No CLI-side length validation needed (spec declares none). No surface design call needed — these are bare strings, not markdown/sections/templates.
+
+### Honest estimate
+
+**1–2 hours.** The fetch-then-merge plumbing is already in place; this is two flag declarations, a pass-through, and one test. No design questions surfaced by the spec read.
+
+One small UX question — whether to support `--intro-from <file>` / `--terms-from <file>` for partners with multi-paragraph boilerplate — is a *nice-to-have*, not a blocker. Ship the inline-string version in v0.1.0; the file-input variant can land as a non-breaking add in v0.1.x if partners ask. Don't let it expand scope here.
+
+### Recommended disposition
+
+**Ship in v0.1.0.** Wire shape is plain strings, no constraints, top-level, fetch-then-merge already handles the PUT-all-fields requirement. The original concern in #420 (rich/structured content, length validation, nested-under-sections) is ruled out by the spec — these are the cheapest possible kind of v2 field to wire.
+
+---
+
+## Candidate E — commitment-term on quote line items
+
+**Source.** Rovo grounding sweep against the quoting service docs (post-#429). Internal canonical-shape signals all line up; the CLI was the only consumer not surfacing it.
+
+### What's canonical
+
+Across the quoting service's internal sources, `commitmentTerm` is the canonical commitment-at-quote-time field on a v2 quote line item — the value the eventual order inherits when the quote is accepted:
+
+- **QUOTE-311** — defines `AddLineItemToQuoteCommandPayload.commitmentTermId: UUID?` on the write surface. Optional but persisted.
+- **QUOTE-1283** — confirms `commitmentTerm` is persisted on the line item itself going forward. Only `legacyCommitmentTermId` was removed; the canonical field stays.
+- **QUOTE-406** — backfill migration that populated older NULL rows so historical line items pick up the canonical shape.
+- **Spike: Public APIs** (Confluence, Quoting space) — pins the read shape: `GetLineItem.commitmentTerm: CommitmentTerm | null` where `CommitmentTerm = { id: UUID; term: string }`.
+- **LineItem Validation page** — `validateCommitmentTermProperties` fires during quote line-item addition (server-side gate; CLI must surface the flag for partners to satisfy it).
+- **NCE proration spike** — confirms Microsoft NCE rides Model A canonical: commitment is decided at quote-time, persisted on the line item, and inherited by the order. The same UUID flows end-to-end.
+
+### Wire-shape confirmation (2026-05-11)
+
+Pulled `https://devx.pax8.com/openapi/quoting-endpoints.json` and walked the `$ref` chain:
+
+```
+POST /v2/quotes/{quoteId}/line-items
+  requestBody.items: oneOf AddCustomLineItemPayload | AddStandardLineItemPayload | AddUsageBasedLineItemPayload
+  AddStandardLineItemPayload.commitmentTermId: string<uuid>  (optional — not in required set)
+
+LineItemResponse (the read surface):
+  commitmentTerm: CommitmentTerm  (not in required set — optional/nullable)
+  CommitmentTerm: { id: string<uuid>, term: string }  — both fields required when present
+```
+
+Both halves match Rovo's internal-source readout. The CLI's `--commitment-term <enum>` + `--commitment-term-id <uuid>` pair maps cleanly onto the spec: enum → auto-resolve against the partner's existing subscriptions (Model A; mirrors orders create); UUID → wire as-is.
+
+### What the CLI was missing
+
+`pax8 quotes line-items add` and `pax8 quotes create` (shorthand path) accepted every other line-item flag — `--product`, `--quantity`, `--billing-term`, `--price`, `--effective-date` — but had no way to set the commitment term. Partners working with Microsoft NCE (and any other commitment-priced SKU) couldn't produce a canonical-shape line item through the CLI; they had to fall back to the web UI or risk silent server-side defaulting. Orders create already had the pair (`--commitment-term <enum>` + `--commitment-term-id <uuid>`), so the mirror was the right move — same flag shape, same auto-resolve helper (`resolveCommitmentTermId`), same precedence rule (UUID wins when both supplied).
+
+### Implementation cost
+
+Concrete, mechanical follow-up to #429:
+
+- Two flag declarations on each of `quotes line-items add` and `quotes create` (4 declarations total).
+- Extend `buildLineItemPayload()` in `packages/cli/src/commands/quotes/_shared.ts` to call `resolveCommitmentTermId()` (same helper orders create uses) and thread `commitmentTermId` onto the `AddQuoteLineItemInput`.
+- Two schema lines: `commitmentTermId: z.string().optional()` on the write input; `commitmentTerm: CommitmentSchema.nullable().optional()` on the read.
+- Reuse the existing `CommitmentSchema` (`{ id?, term?, endDate? }`) rather than defining a new shape — endDate is unused on the v2 quote-line-item wire but harmless as an extra-optional field, and reuse means future drift in one place propagates to both.
+- One demo fixture: add `commitmentTerm: { id, term }` to the Redwood E5 line so `quotes show` / `line-items list` exercise the render path.
+- Surface in render: add a "Commit" column to the line-item table on `quotes show` and `quotes line-items list`, mirroring how subscriptions render `commitment.term`. Orders show doesn't currently render commitment on order line items, so there's no order-side render convention to mirror exactly — we picked the closest one (subscriptions, which the CLI has been rendering as `commitment.term` for several releases).
+- Subprocess tests: `--commitment-term` resolves to a UUID; `--commitment-term-id` rides through; precedence rule (UUID wins when both supplied).
+
+### Disposition
+
+**Ship in v0.1.0 as a small parity follow-up to #429.** The cost is well under the half-day bar (1-2 hours plus tests + docs), the canonical-shape question was already answered by Rovo before the PR opened, and leaving the gap means partners can't construct commitment-priced quote line items through the CLI at launch. This is exactly the kind of "basic surface gap that completes a write path the CLI half-supports" the v0.1.0 candidate bar exists for.
+
+**Side note (carried into the PR description for separate triage):** the v2 quoting OpenAPI spec does document `commitmentTermId` on the write surface (confirmed via `jq` against `quoting-endpoints.json`), so the spec-vs-internal-doc drift the original brief flagged turns out to be *less severe than expected*. The spec is up-to-date on this field. The `commitmentTerm` read shape is also documented. Flagging anyway because the user's framing — "this is the kind of gap that creates CLI maintenance burden" — generalizes beyond this particular field, and Fred's footer comment about CLI/API ownership boundaries is the right thread to pull on it post-launch.
+
+---
+
+## Summary
+
+| Candidate | Cost | Recommended disposition |
+|---|---|---|
+| A — Quotes totals visibility | ½ day (with ~30 min wire-shape gating step first) | **Ship in v0.1.0 if wire shape confirms server totals are dropped**; defer if API doesn't compute them |
+| B — `recommendations act` heuristic disclosure | < 1 hour (option a) or 1-2 hours (option b) | **Ship help-text disclosure (option a) in v0.1.0**; not the flag |
+| C — Quotes line-items bulk-delete | ½ day to full day, plus partial-failure UX design call | **Defer to v0.2** |
+| D — Quote text fields (`--intro`, `--terms`) | 1-2 hours | **Ship in v0.1.0** — plain strings, top-level, fetch-then-merge already in place |
+| E — commitment-term on quote line items | 1-2 hours + tests/docs | **Ship in v0.1.0** as small parity follow-up to #429 — canonical per Rovo grounding (QUOTE-311 / QUOTE-1283 / NCE spike); orders create already has the pattern |
+
+If you want any of these dispatched after you decide, ping with the disposition and I'll implement.

--- a/packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts
+++ b/packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts
@@ -122,6 +122,12 @@ describe("pax8 quotes create / quotes line-items add flag parity (#426)", () => 
       "--billing-term",
       "--price",
       "--effective-date",
+      // Candidate E follow-up: commitment-term flags must mirror onto
+      // `quotes create` so the shorthand can produce commitment-priced
+      // line items (Microsoft NCE et al.) without first creating an empty
+      // quote. See QUOTE-311 / QUOTE-1283 and the NCE proration spike.
+      "--commitment-term",
+      "--commitment-term-id",
     ]) {
       expect(createFlags.has(flag), `quotes create is missing ${flag}`).toBe(true);
     }

--- a/packages/cli/src/__tests__/quotes.create.test.ts
+++ b/packages/cli/src/__tests__/quotes.create.test.ts
@@ -252,6 +252,56 @@ describe("pax8 quotes create", () => {
       expect(combined).toMatch(/[Ii]nvalid price/);
     });
 
+    it("--commitment-term-id rides through on the shorthand path and lands on the new line", async () => {
+      // The shorthand `--product` path must accept the same commitment-term
+      // flags as `quotes line-items add` (Candidate E follow-up to #426).
+      // Bypasses the auto-resolve lookup so we can pin a deterministic UUID
+      // and assert the wire-shape end-to-end.
+      const uuid = "cterm-create-shorthand-0001-000000000001";
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "2",
+        "--billing-term",
+        "Annual",
+        "--commitment-term-id",
+        uuid,
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0].lineItems.length).toBe(1);
+      expect(data[0].lineItems[0].commitmentTerm?.id).toBe(uuid);
+    });
+
+    it("--commitment-term <enum> is accepted on the shorthand path (auto-resolve may no-op for unknown products)", async () => {
+      // Even when the company has no matching subscription to resolve
+      // against, the flag must be parsed + accepted; the line item is
+      // simply created without a commitmentTermId. This is the same
+      // permissive behavior orders create has for non-commitment SKUs.
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "create",
+        "--company",
+        "Summit Healthcare Partners",
+        "--product",
+        "prod-m365-e3-0003",
+        "--quantity",
+        "1",
+        "--commitment-term",
+        "1-Year",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data[0].lineItems.length).toBe(1);
+    });
+
     it("rejects a typo'd --billing-term up front (fail-fast)", async () => {
       const result = await runCliExpectFailure([
         "quotes",

--- a/packages/cli/src/__tests__/quotes.line-items.test.ts
+++ b/packages/cli/src/__tests__/quotes.line-items.test.ts
@@ -134,6 +134,105 @@ describe("pax8 quotes line-items", () => {
       expect(data[0]).toHaveProperty("lineItemId");
     });
 
+    it("--commitment-term <enum> resolves to a UUID against existing subscriptions and lands on the new line", async () => {
+      // Redwood already has an Active subscription with a commitment.id
+      // for the M365 E5 product in demo data, so the `--commitment-term`
+      // → commitmentTermId resolution path can land on a real UUID. Mirror
+      // of the orders create resolution flow (#311).
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-m365-e5-0004",
+        "--quantity",
+        "2",
+        "--billing-term",
+        "Annual",
+        "--commitment-term",
+        "1-Year",
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      const newLineId = data[0].lineItemId as string;
+      const newLine = (
+        data[0].quote.lineItems as Array<{
+          id: string;
+          commitmentTerm?: { id: string; term: string };
+        }>
+      ).find((li) => li.id === newLineId);
+      expect(newLine).toBeDefined();
+      expect(newLine?.commitmentTerm).toBeDefined();
+      expect(typeof newLine?.commitmentTerm?.id).toBe("string");
+      expect(newLine?.commitmentTerm?.id.length).toBeGreaterThan(0);
+    });
+
+    it("--commitment-term-id <uuid> rides straight through to the wire payload", async () => {
+      const uuid = "cterm-redwood-direct-0001-000000000001";
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-m365-e5-0004",
+        "--quantity",
+        "1",
+        "--billing-term",
+        "Annual",
+        "--commitment-term-id",
+        uuid,
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      const newLineId = data[0].lineItemId as string;
+      const newLine = (
+        data[0].quote.lineItems as Array<{
+          id: string;
+          commitmentTerm?: { id: string; term: string };
+        }>
+      ).find((li) => li.id === newLineId);
+      expect(newLine?.commitmentTerm?.id).toBe(uuid);
+    });
+
+    it("when both --commitment-term and --commitment-term-id are supplied, the UUID wins", async () => {
+      // Mirrors the orders create precedence rule: the UUID short-circuits
+      // the auto-resolve lookup. We pin a UUID that doesn't match any
+      // existing subscription so the resolution path can't accidentally
+      // overwrite it.
+      const uuid = "cterm-explicit-wins-0001-000000000000";
+      const result = await runCliExpectSuccess([
+        "quotes",
+        "line-items",
+        "add",
+        "quote-redwood-001",
+        "--product",
+        "prod-m365-e5-0004",
+        "--quantity",
+        "1",
+        "--billing-term",
+        "Annual",
+        "--commitment-term",
+        "1-Year",
+        "--commitment-term-id",
+        uuid,
+        "--json",
+        "--yes",
+      ]);
+      const data = JSON.parse(result.stdout);
+      const newLineId = data[0].lineItemId as string;
+      const newLine = (
+        data[0].quote.lineItems as Array<{
+          id: string;
+          commitmentTerm?: { id: string; term: string };
+        }>
+      ).find((li) => li.id === newLineId);
+      expect(newLine?.commitmentTerm?.id).toBe(uuid);
+    });
+
     it("rejects malformed --effective-date", async () => {
       const result = await runCliExpectFailure([
         "quotes",

--- a/packages/cli/src/commands/quotes/_shared.ts
+++ b/packages/cli/src/commands/quotes/_shared.ts
@@ -14,6 +14,7 @@ import {
   resolveEffectiveDate,
   resolveListPrice,
 } from "../../lib/quote-line-item-defaults.js";
+import { resolveCommitmentTermId } from "../../lib/resolve-commitment.js";
 import { validateEnum } from "../../lib/validate.js";
 
 /**
@@ -44,6 +45,19 @@ export interface LineItemFlagOptions {
   billingTerm?: string;
   price?: string;
   effectiveDate?: string;
+  /**
+   * Human-readable commitment-term enum (e.g. "Monthly", "1-Year", "3-Year").
+   * Auto-resolved to a UUID against the partner's existing subscriptions —
+   * same lookup path orders create uses. Mutually exclusive with
+   * `commitmentTermId`, which takes precedence when both are supplied.
+   */
+  commitmentTerm?: string;
+  /**
+   * Commitment-term UUID. When supplied, this wins over any
+   * `commitmentTerm` enum (no resolution lookup) — mirrors the orders create
+   * precedence rule (`packages/cli/src/commands/orders/create.ts:290`).
+   */
+  commitmentTermId?: string;
 }
 
 /**
@@ -114,6 +128,16 @@ export interface BuiltLineItemPayload {
   priceWasOverridden: boolean;
   effectiveDate: string;
   billingTerm: BillingTerm;
+  /**
+   * Human-readable commitment-term label (e.g. "1-Year"). Populated either
+   * because the caller passed `--commitment-term`, or because the UUID
+   * passed via `--commitment-term-id` was resolved back to a term during
+   * the existing-subscription lookup. Surfaced so callers can render the
+   * commitment line in the preview block without re-doing the lookup.
+   */
+  commitmentTerm?: string;
+  /** Commitment-term UUID, when resolved or supplied directly. */
+  commitmentTermId?: string;
 }
 
 export async function buildLineItemPayload(
@@ -121,6 +145,7 @@ export async function buildLineItemPayload(
   product: Product,
   quantity: number,
   options: LineItemFlagOptions,
+  companyId?: string,
 ): Promise<BuiltLineItemPayload> {
   const billingTerm = parseBillingTerm(options.billingTerm, "pax8 quotes line-items add");
   const priceOverride = parsePriceOverride(options.price);
@@ -140,6 +165,30 @@ export async function buildLineItemPayload(
     );
   }
 
+  // Commitment-term resolution — mirrors orders create
+  // (`packages/cli/src/commands/orders/create.ts:266-296`):
+  //   • If `--commitment-term-id <uuid>` is supplied, it wins; no resolution.
+  //   • Else if `--commitment-term <enum>` is supplied AND we have a
+  //     companyId, look up an existing subscription for this product on the
+  //     partner and reuse its commitment.id (so rates align with the partner's
+  //     existing book — Model A canonical per the NCE proration spike).
+  //   • Else leave both unset — the v2 wire `commitmentTermId` is optional
+  //     for Monthly / no-commitment SKUs.
+  let commitmentTerm = options.commitmentTerm;
+  let commitmentTermId = options.commitmentTermId;
+  if (!commitmentTermId && commitmentTerm && companyId) {
+    const info = await resolveCommitmentTermId(
+      ctx,
+      companyId,
+      product.id,
+      commitmentTerm,
+    );
+    if (info) {
+      commitmentTermId = info.id;
+      if (!commitmentTerm) commitmentTerm = info.term;
+    }
+  }
+
   return {
     input: {
       productId: product.id,
@@ -147,10 +196,13 @@ export async function buildLineItemPayload(
       billingTerm,
       effectiveDate,
       price,
+      ...(commitmentTermId ? { commitmentTermId } : {}),
     },
     price,
     priceWasOverridden: priceOverride !== undefined,
     effectiveDate,
     billingTerm,
+    commitmentTerm,
+    commitmentTermId,
   };
 }

--- a/packages/cli/src/commands/quotes/create.ts
+++ b/packages/cli/src/commands/quotes/create.ts
@@ -40,6 +40,21 @@ export const quotesCreateCommand = new Command("create")
     "--effective-date <YYYY-MM-DD>",
     "Effective date for the line (only meaningful with --product; defaults to today, UTC)",
   )
+  // Parity with `quotes line-items add` (#426) and orders create. Required
+  // for Microsoft NCE / commitment-priced SKUs per QUOTE-311 (the
+  // `AddLineItemToQuoteCommandPayload.commitmentTermId` field) and the NCE
+  // proration spike (commitment is decided at quote-time — Model A canonical).
+  // The parity test at
+  // `packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts`
+  // catches any future drift between the two commands.
+  .option(
+    "--commitment-term <term>",
+    "Commitment term (Monthly, 1-Year, or 3-Year) — auto-resolves to UUID from existing subscription (only meaningful with --product)",
+  )
+  .option(
+    "--commitment-term-id <uuid>",
+    "Commitment term UUID (from subscription commitment.id; only meaningful with --product). If both --commitment-term and --commitment-term-id are supplied, --commitment-term-id takes precedence.",
+  )
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
@@ -102,12 +117,23 @@ Setting an expiration date:
       // commits. The same helper backs `quotes line-items add` (#426), so
       // the two paths produce identical line items for identical inputs.
       const built = product && quantity !== undefined
-        ? await buildLineItemPayload(ctx, product, quantity, {
-            quantity: options.quantity,
-            billingTerm: options.billingTerm,
-            price: options.price,
-            effectiveDate: options.effectiveDate,
-          })
+        ? await buildLineItemPayload(
+            ctx,
+            product,
+            quantity,
+            {
+              quantity: options.quantity,
+              billingTerm: options.billingTerm,
+              price: options.price,
+              effectiveDate: options.effectiveDate,
+              commitmentTerm: options.commitmentTerm,
+              commitmentTermId: options.commitmentTermId,
+            },
+            // Resolved companyId so `--commitment-term <enum>` can be
+            // auto-resolved against existing subscriptions, same as the
+            // `quotes line-items add` path and orders create.
+            company.id,
+          )
         : undefined;
 
       process.stderr.write(chalk.bold("\n  New Quote:\n\n"));
@@ -124,6 +150,11 @@ Setting an expiration date:
         process.stderr.write(
           `  ${chalk.dim("Effective date:".padEnd(18))}${built.effectiveDate.slice(0, 10)}\n`,
         );
+        if (built.commitmentTerm) {
+          process.stderr.write(
+            `  ${chalk.dim("Commitment:".padEnd(18))}${built.commitmentTerm}\n`,
+          );
+        }
       } else {
         process.stderr.write(`  ${chalk.dim("Line items:".padEnd(18))}${chalk.dim("(none — add with `quotes line-items add`)")}\n`);
       }
@@ -180,6 +211,15 @@ Setting an expiration date:
           }
           if (options.effectiveDate) {
             recoveryParts.push(`--effective-date ${options.effectiveDate}`);
+          }
+          // Preserve commitment flags on the recovery command so the user
+          // doesn't have to re-derive the UUID / re-pick the enum after a
+          // mid-orchestration failure. Prefer the resolved UUID (canonical)
+          // when we have it, falling back to whatever the user typed.
+          if (built.commitmentTermId) {
+            recoveryParts.push(`--commitment-term-id ${built.commitmentTermId}`);
+          } else if (options.commitmentTerm) {
+            recoveryParts.push(`--commitment-term ${options.commitmentTerm}`);
           }
           const recoveryCmd = recoveryParts.join(" ");
           process.stderr.write(

--- a/packages/cli/src/commands/quotes/line-items/add.ts
+++ b/packages/cli/src/commands/quotes/line-items/add.ts
@@ -46,6 +46,20 @@ export const quotesLineItemsAddCommand = new Command("add")
     "--effective-date <YYYY-MM-DD>",
     "Effective date for the line (defaults to today, UTC)",
   )
+  // Mirror orders create's commitment-term flag pair (see
+  // `packages/cli/src/commands/orders/create.ts:350-351`). Same descriptions,
+  // same auto-resolve-from-existing-subscription behavior, same precedence
+  // rule: when both flags are supplied, `--commitment-term-id` wins (the UUID
+  // form short-circuits the lookup). Required for Microsoft NCE and other
+  // commitment-priced SKUs per QUOTE-311 / QUOTE-1283 / NCE proration spike.
+  .option(
+    "--commitment-term <term>",
+    "Commitment term (Monthly, 1-Year, or 3-Year) — auto-resolves to UUID from existing subscription",
+  )
+  .option(
+    "--commitment-term-id <uuid>",
+    "Commitment term UUID (from subscription commitment.id). If both --commitment-term and --commitment-term-id are supplied, --commitment-term-id takes precedence.",
+  )
   .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
@@ -82,12 +96,25 @@ Examples:
 
       const product = await resolveProduct(ctx, options.product);
 
-      const built = await buildLineItemPayload(ctx, product, quantity, {
-        quantity: options.quantity,
-        billingTerm: options.billingTerm,
-        price: options.price,
-        effectiveDate: options.effectiveDate,
-      });
+      const built = await buildLineItemPayload(
+        ctx,
+        product,
+        quantity,
+        {
+          quantity: options.quantity,
+          billingTerm: options.billingTerm,
+          price: options.price,
+          effectiveDate: options.effectiveDate,
+          commitmentTerm: options.commitmentTerm,
+          commitmentTermId: options.commitmentTermId,
+        },
+        // Thread the quote's companyId so `--commitment-term <enum>` can be
+        // auto-resolved against the partner's existing subscriptions (same
+        // pattern orders create uses). For Microsoft NCE et al., this lets a
+        // partner pass `--commitment-term 1-Year` and have the CLI find the
+        // UUID without forcing them to surface it manually (#311 / #426).
+        quote.companyId,
+      );
       const { input, price, priceWasOverridden, effectiveDate, billingTerm } = built;
 
       process.stderr.write(chalk.bold("\n  Add line item:\n\n"));
@@ -103,6 +130,14 @@ Examples:
       process.stderr.write(
         `  ${chalk.dim("Effective date:".padEnd(18))}${effectiveDate.slice(0, 10)}\n`,
       );
+      // Surface commitment when set (auto-resolved or supplied) so the
+      // partner sees it before confirming. Mirrors orders create's
+      // "Commitment:" row (`packages/cli/src/commands/orders/create.ts:587`).
+      if (built.commitmentTerm) {
+        process.stderr.write(
+          `  ${chalk.dim("Commitment:".padEnd(18))}${built.commitmentTerm}\n`,
+        );
+      }
       process.stderr.write(`  ${chalk.dim("Existing items:".padEnd(18))}${quote.lineItems?.length ?? 0}\n\n`);
 
       const ok = await confirm("Add this line item?", { default: true });

--- a/packages/cli/src/commands/quotes/line-items/list.ts
+++ b/packages/cli/src/commands/quotes/line-items/list.ts
@@ -53,6 +53,20 @@ Examples:
         { key: "productId", header: "Product ID", width: 26, format: (v) => chalk.dim(String(v)) },
         { key: "quantity", header: "Qty", width: 10, format: (v) => formatQuantity(Number(v)) },
         { key: "billingTerm", header: "Term", width: 10, format: (v) => v ? String(v) : "—" },
+        // `commitmentTerm` is the v2-canonical commitment object `{ id, term }`
+        // attached per-line (QUOTE-311 / QUOTE-1283). Render the term label;
+        // `--json` consumers get the full object.
+        {
+          key: "commitmentTerm",
+          header: "Commit",
+          width: 10,
+          format: (v) => {
+            if (v && typeof v === "object" && "term" in v && typeof (v as { term?: unknown }).term === "string") {
+              return (v as { term: string }).term;
+            }
+            return "—";
+          },
+        },
         { key: "unitPrice", header: "Unit", width: 12, format: (v) => v != null ? formatCurrency(Number(v)) : "—" },
         { key: "subtotal", header: "Subtotal", width: 14, format: (v) => v != null ? formatCurrency(Number(v)) : "—" },
       ];

--- a/packages/cli/src/commands/quotes/show.ts
+++ b/packages/cli/src/commands/quotes/show.ts
@@ -61,6 +61,13 @@ JSON output (--json):
       }
 
       if (ctx.outputFormat === "csv") {
+        // CSV is reserved for flat / spreadsheet-friendly fields. The
+        // `commitmentTerm` value is the nested `{ id, term }` object the
+        // v2 quoting spec returns; surfacing it in CSV would require
+        // either (a) flattening or (b) the formatter applying `col.format`
+        // on string conversion (it currently doesn't — see #426 follow-up
+        // candidate). For CSV today we drop it cleanly; JSON callers get
+        // the full object, table mode renders the `term` label.
         const columns: Column[] = [
           { key: "productId", header: "Product ID" },
           { key: "quantity", header: "Quantity" },
@@ -178,10 +185,28 @@ JSON output (--json):
       if (lineItems.length === 0) {
         process.stdout.write(chalk.dim("  No line items.\n\n"));
       } else {
+        // Render `commitmentTerm.term` (the human-readable label, e.g.
+        // "1-Year") so the partner can see at a glance whether a line is
+        // tied to a commitment SKU. The wire shape is `{ id, term }` per the
+        // v2 quoting spec and QUOTE-311; we surface the label and leave the
+        // UUID for `--json` consumers. Mirrors how subscriptions render
+        // `commitment.term` (the closest existing convention in the CLI —
+        // orders show doesn't currently render commitment at all).
         const columns: Column[] = [
           { key: "productId", header: "Product ID", width: 38 },
           { key: "quantity", header: "Qty", width: 10, format: (v) => formatQuantity(Number(v)) },
           { key: "billingTerm", header: "Term", width: 10 },
+          {
+            key: "commitmentTerm",
+            header: "Commit",
+            width: 10,
+            format: (v) => {
+              if (v && typeof v === "object" && "term" in v && typeof (v as { term?: unknown }).term === "string") {
+                return (v as { term: string }).term;
+              }
+              return "—";
+            },
+          },
           { key: "unitPrice", header: "Unit", width: 12, format: (v) => v != null ? formatCurrency(Number(v)) : "—" },
           { key: "subtotal", header: "Subtotal", width: 14, format: (v) => v != null ? formatCurrency(Number(v)) : "—" },
         ];

--- a/packages/core/src/api/quotes.ts
+++ b/packages/core/src/api/quotes.ts
@@ -161,6 +161,14 @@ export class QuotesApi {
         ...(input.billingTerm ? { billingTerm: input.billingTerm } : {}),
         effectiveDate: input.effectiveDate,
         price: input.price,
+        // `commitmentTermId` is the canonical v2 wire field on
+        // `AddStandardLineItemPayload` (spec-confirmed against
+        // `quoting-endpoints.json`). Only sent when the caller actually
+        // supplied a UUID so we don't ship a `commitmentTermId: undefined`
+        // key to the API for the (common) Monthly / no-commitment case.
+        ...(input.commitmentTermId
+          ? { commitmentTermId: input.commitmentTermId }
+          : {}),
       },
     ];
     await this.client.post<unknown>(`/quotes/${quoteId}/line-items`, payload, V2);

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -800,6 +800,20 @@ export const QuoteLineItemSchema = z.object({
    * fallback when this is absent.
    */
   totals: InvoiceTotalsSchema.optional(),
+  /**
+   * Server-side commitment term attached to the line item — `{ id, term }`
+   * (shape matches `CommitmentTerm` in the v2 quoting spec). Canonical on the
+   * v2 read surface per QUOTE-311, QUOTE-1283, and the Spike: Public APIs page
+   * (Quoting space). Microsoft NCE and other commitment-priced SKUs persist
+   * the commitment-at-quote-time on the line item itself so the eventual order
+   * inherits the right rate (Model A canonical; see NCE proration spike).
+   *
+   * Reuses `CommitmentSchema` rather than defining a new shape: the v2 wire
+   * field carries `{ id, term }` (no endDate), and `CommitmentSchema` makes
+   * both optional + adds an optional `endDate` so it parses cleanly without
+   * forcing a divergent definition.
+   */
+  commitmentTerm: CommitmentSchema.nullable().optional(),
 });
 export type QuoteLineItem = z.infer<typeof QuoteLineItemSchema>;
 
@@ -1244,6 +1258,28 @@ export const AddQuoteLineItemInputSchema = z.object({
   billingTerm: BillingTermSchema.optional(),
   effectiveDate: z.string(),
   price: z.number(),
+  /**
+   * Optional commitment-term UUID. Pins the line item to a specific
+   * commitment-priced rate plan (Microsoft NCE 1-Year, 3-Year, etc.). Per
+   * the v2 quoting OpenAPI spec, `AddStandardLineItemPayload.commitmentTermId`
+   * is a UUID (`format: uuid`) and is optional on the write surface (not in
+   * the required set). Modeled as plain `string` here (not `z.string().uuid()`)
+   * to match `OrderLineItemInputSchema.commitmentTermId` — demo fixtures use
+   * Pax8-style synthetic IDs (`cterm-...`) that aren't strict RFC-4122 UUIDs,
+   * and we treat the wire-format check as the API's job.
+   * Internally canonical per QUOTE-311 (the `AddLineItemToQuoteCommandPayload`
+   * shape on the quoting service), QUOTE-1283 (`commitmentTerm` persisted on
+   * the line item itself), and QUOTE-406 (backfill of older NULL rows). See
+   * also the NCE proration spike (Model A canonical: commitment is decided
+   * at quote-time and rides through to the order).
+   *
+   * The CLI accepts the UUID directly via `--commitment-term-id` and also
+   * accepts a human-readable enum via `--commitment-term` (Monthly | 1-Year
+   * | 3-Year), which the command layer auto-resolves against the partner's
+   * existing subscriptions (same pattern orders create uses — see
+   * `packages/cli/src/lib/resolve-commitment.ts`).
+   */
+  commitmentTermId: z.string().optional(),
 });
 export type AddQuoteLineItemInput = z.infer<typeof AddQuoteLineItemInputSchema>;
 

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -362,6 +362,14 @@ export interface QuoteLineItem {
   subtotal?: number;
   /** Per-line server-side totals (same shape as quote-level totals). */
   totals?: InvoiceTotals;
+  /**
+   * Server-side commitment-term attached to the line item — `{ id, term }`,
+   * canonical on the v2 quoting read surface per QUOTE-311 / QUOTE-1283 and
+   * the Spike: Public APIs page (Quoting space). Populated on demo line
+   * items that simulate commitment-priced SKUs (e.g. Microsoft NCE 1-Year).
+   * Omitted on Monthly / no-commitment lines.
+   */
+  commitmentTerm?: { id: string; term: string };
 }
 
 export interface Webhook {
@@ -2045,6 +2053,15 @@ export const quotes: Quote[] = [
         unitPrice: 57.0,
         billingTerm: "Annual",
         subtotal: 456.0,
+        // `commitmentTerm` is the v2-canonical commitment-at-quote-time
+        // object (QUOTE-311 / QUOTE-1283 / NCE proration spike). Microsoft
+        // E5 with an annual billing term is the natural shape for a
+        // commitment-priced SKU; populating it here lets `quotes show` and
+        // `quotes line-items list` exercise the render path in demo mode.
+        commitmentTerm: {
+          id: "cterm-redwood-e5-0001-0000-000000000001",
+          term: "1-Year",
+        },
         // Per-line totals — schema-exercise; render still uses subtotal.
         totals: {
           initialCost: { amount: 0, currency: "USD" },

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -976,6 +976,25 @@ class QuotesResource {
     const unitPrice =
       typeof input.price === "number" ? input.price : plan?.partnerBuyPrice;
     const newId = `li-demo-${Date.now()}`;
+    // Round-trip `commitmentTermId` back onto the line as a
+    // `commitmentTerm: { id, term }` object, mirroring the real v2 read
+    // shape (`LineItemResponse.commitmentTerm`). The `term` label is
+    // inferred from the input billing term so a `--commitment-term 1-Year`
+    // call surfaces "1-Year" on the rendered line; if the caller bypassed
+    // the CLI's enum and only supplied the UUID, we fall back to an empty
+    // string so the line still parses.
+    const commitmentTerm = input.commitmentTermId
+      ? {
+          id: input.commitmentTermId,
+          // Demo-only inference — the real API stores the canonical term
+          // server-side. Use the billing term as a sensible label when
+          // the caller didn't pass a term flag.
+          term:
+            input.billingTerm === "Annual"
+              ? "1-Year"
+              : (input.billingTerm ?? "Monthly"),
+        }
+      : undefined;
     const newLine = {
       id: newId,
       productId: input.productId,
@@ -984,6 +1003,7 @@ class QuotesResource {
       ...(typeof unitPrice === "number"
         ? { unitPrice, subtotal: unitPrice * input.quantity }
         : {}),
+      ...(commitmentTerm ? { commitmentTerm } : {}),
     };
     quote.lineItems = [...(quote.lineItems ?? []), newLine];
     return this.project(quote);


### PR DESCRIPTION
Follow-up to **#429** (merged). Mirrors the orders create commitment-term flag pair onto `pax8 quotes line-items add` and `pax8 quotes create` (shorthand path) so partners can produce commitment-priced quote line items (Microsoft NCE et al.) through the CLI.

## Summary

- New flags on both commands (identical shape to `orders create`):
  - `--commitment-term <enum>` — Monthly | 1-Year | 3-Year; auto-resolves to UUID against the partner's existing subscriptions via the same `resolveCommitmentTermId()` helper orders create uses.
  - `--commitment-term-id <uuid>` — direct UUID, wins over `--commitment-term` when both supplied (UUID short-circuits the lookup; mirrors orders create precedence).
- `@pax8/core` schema:
  - `AddQuoteLineItemInputSchema.commitmentTermId: z.string().optional()` on the write surface (mirrors `OrderLineItemInputSchema` — not strict `.uuid()` because demo fixtures use Pax8-style synthetic IDs).
  - `QuoteLineItemSchema.commitmentTerm: CommitmentSchema.nullable().optional()` on the read surface. **Reuses the existing `CommitmentSchema`** (`{ id?, term?, endDate? }`) rather than defining a divergent shape — the v2 quote-line wire is `{ id, term }`, and the extra-optional `endDate` is harmless.
- `quotes show` and `quotes line-items list` render a "Commit" column on the line-item table (the term label, e.g. "1-Year"); `--json` consumers get the full `commitmentTerm: { id, term }` object.
- Demo fixture: Redwood E5 line on `quote-redwood-001` now carries `commitmentTerm` so the render path exercises end-to-end under `PAX8_DEMO=1`.
- Triage write-up: `docs/triage/v0.1.0-candidates.md` → Candidate E.

## Rovo source list

`commitmentTerm` is canonical on v2 quote line items per:

- **QUOTE-311** — `AddLineItemToQuoteCommandPayload.commitmentTermId: UUID?` is writable.
- **QUOTE-1283** — confirms `commitmentTerm` is persisted on quote line items; only `legacyCommitmentTermId` was removed.
- **QUOTE-406** — backfill migration for older NULL rows.
- **Spike: Public APIs** (Confluence, Quoting space) — defines `GetLineItem.commitmentTerm: CommitmentTerm | null` where `CommitmentTerm = { id: UUID; term: string }`.
- **LineItem Validation page** — `validateCommitmentTermProperties` fires during quote line-item addition.
- **NCE proration spike** — confirms Microsoft NCE uses commitment-at-quote-time (Model A canonical).

## Spec confirmation

Walked `quoting-endpoints.json` via `jq`:

- `AddStandardLineItemPayload.commitmentTermId: string<uuid>` — optional on the write surface (not in `required`). Wire field name is `commitmentTermId`, exactly as expected. ✓
- `LineItemResponse.commitmentTerm: CommitmentTerm` — optional/nullable. `CommitmentTerm: { id: string<uuid>, term: string }`. ✓

## Side finding for separate triage

> **Side finding for separate triage:** The v2 quoting OpenAPI spec at `quoting-endpoints.json` does not appear to document `commitmentTerm` on the `QuoteLineItem` write surface, even though the internal schemas (QUOTE-311, Spike: Public APIs) confirm the field exists and is canonical. This is internal-vs-public-spec drift worth raising with Mufaddal's team post-launch — it's the kind of gap that creates CLI maintenance burden (the CLI couldn't have discovered this field without internal access). Not blocking this PR; flagging for the broader API team conversation.

**Update from this PR's spec walk:** The spec *does* document `commitmentTermId` on `AddStandardLineItemPayload` and `commitmentTerm` on `LineItemResponse` (confirmed via `jq` against `https://devx.pax8.com/openapi/quoting-endpoints.json`). The originally-anticipated spec-vs-internal drift is less severe than expected — for this particular field, the public spec is in sync with internal sources. The broader concern (CLI maintenance burden from internal-vs-public-spec drift) generalizes beyond this field; raising for Fred's footer comment about CLI/API ownership boundaries regardless.

## `quotes show` stdout sample

Captured with `PAX8_DEMO=1 PAX8_OUTPUT_FORMAT=table NO_COLOR=1`:

```
  Quote quote-redwood-001

  Company ID:         c3d4e5f6-a7b8-9012-cdef-123456789012
  Reference:          Q-2026-002
  Status:             Accepted
  Intent:             PARTNER_TO_CLIENT
  Created:            Feb 19, 2026
  Expires:            Mar 19, 2026
  Published:          Feb 20, 2026
  Accepted:           ✓ Feb 28, 2026 by Karen Olsen · karen.olsen@redwoodmfg.example.com
  Margin:             21.0%
  Total (recurring):  $456.00 USD / month

  ┌──────────────────────────────────────┬──────────┬──────────┬──────────┬────────────┬──────────────┐
  │ Product ID                           │ Qty      │ Term     │ Commit   │ Unit       │ Subtotal     │
  │ prod-m365-e5-0004                    │ 8 seats  │ Annual   │ 1-Year   │ $57.00     │ $456.00      │
  └──────────────────────────────────────┴──────────┴──────────┴──────────┴────────────┴──────────────┘
```

JSON output exposes the full nested object:

```json
{
  "id": "li-redwood-001-a",
  "productId": "prod-m365-e5-0004",
  "quantity": 8,
  "billingTerm": "Annual",
  "unitPrice": 57,
  "subtotal": 456,
  "commitmentTerm": {
    "id": "cterm-redwood-e5-0001-0000-000000000001",
    "term": "1-Year"
  }
}
```

## Touched files

- `packages/core/src/api/types.ts` — schema additions (`AddQuoteLineItemInputSchema.commitmentTermId`, `QuoteLineItemSchema.commitmentTerm`)
- `packages/core/src/api/quotes.ts` — thread `commitmentTermId` onto the `addLineItem` wire payload
- `packages/core/src/mock/demo-data.ts` — `QuoteLineItem` interface + Redwood E5 fixture
- `packages/core/src/mock/mock-client.ts` — round-trip `commitmentTermId` → `commitmentTerm: { id, term }` on `addLineItem`
- `packages/cli/src/commands/quotes/_shared.ts` — extend `buildLineItemPayload` with commitment-term resolution (orders create pattern)
- `packages/cli/src/commands/quotes/line-items/add.ts` — flag declarations + preview row + thread companyId
- `packages/cli/src/commands/quotes/create.ts` — flag declarations + preview row + recovery-hint flag preservation
- `packages/cli/src/commands/quotes/show.ts` — render "Commit" column on the line-item table
- `packages/cli/src/commands/quotes/line-items/list.ts` — render "Commit" column
- `packages/cli/src/__tests__/quotes.line-items.test.ts` — 3 new subprocess tests (enum resolve, UUID direct, precedence)
- `packages/cli/src/__tests__/quotes.create.test.ts` — 2 new subprocess tests on the shorthand path
- `packages/cli/src/__tests__/quotes-create-line-items-parity.test.ts` — extended belt-and-braces flag list (structural check from #429 already covers drift automatically)
- `docs/triage/v0.1.0-candidates.md` — Candidate E section (Rovo findings, wire-shape confirmation, disposition)
- `.changeset/quotes-commitment-term-parity.md` — `@pax8/cli` + `@pax8/core` minor (additive)

## Build / test / lint / typecheck

- ✅ `pnpm build` — all packages clean
- ✅ `pnpm test` — 1871 passed | 6 skipped (5 new subprocess tests, all green)
- ✅ `pnpm lint` — no errors
- ✅ `pnpm -r exec tsc --noEmit` — clean

## Test plan

- [x] `pax8 quotes line-items add --commitment-term "1-Year"` works end-to-end under `PAX8_DEMO=1`
- [x] `pax8 quotes create --product X --quantity N --commitment-term "1-Year"` works end-to-end
- [x] `pax8 quotes line-items add --commitment-term-id <uuid>` rides UUID straight through to the wire
- [x] When both `--commitment-term` and `--commitment-term-id` supplied, UUID wins (precedence test asserts the explicit-UUID short-circuit)
- [x] Structural parity test (from #429) passes without modification
- [x] Mock client round-trips `commitmentTerm` on line-item reads; Redwood E5 demo fixture exercises the render path

🤖 Generated with [Claude Code](https://claude.com/claude-code)