### PR TITLE
feat(companies): document multi-role primary assignment in companies create help text (#432)

### DIFF
--- a/.changeset/companies-create-multi-role-help.md
+++ b/.changeset/companies-create-multi-role-help.md
@@ -1,0 +1,7 @@
+---
+"@pax8/cli": patch
+---
+
+`pax8 clients create` (and its `pax8 companies create` alias) `--help` now documents that the supplied contact is implicitly assigned as primary on all three ContactType values (Admin, Billing, Technical) to satisfy activation, and points partners at `pax8 contacts update` / `pax8 contacts create --type` to re-split those roles afterward. README's Clients section gains a matching one-line note next to the `clients create` example.
+
+No behavior change — help-text + README only. Addresses Franco Aurieme's domain-review finding that the atomic-create path's implicit multi-role primary assignment (correct per `ContactService.accountHasAllPrimaryContacts`, shipped in #381) was invisible to partners who wanted different humans in different roles. Closes #432.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ pax8 clients list                              # List all (type # to drill in)
 pax8 clients list --status Active              # Filter by status
 pax8 clients show "Acme Corp"                  # Customer details
 pax8 clients more "Acme Corp"                  # Full summary: subs, vendors, Pax8 monthly cost, issues
+pax8 clients create --name "Acme" --city Denver --state CO --zip 80202 --phone "+1-303-555-0101" --first-name Maya --last-name Chen --email maya@acme.example.com --yes
 ```
+
+> **Note:** The single contact you supply on `clients create` is set as primary on all three types (Admin, Billing, Technical). Split roles afterward via `pax8 contacts update` or additional `pax8 contacts create --type` calls.
 
 > `pax8 companies *` works as an indefinite deprecated alias of `pax8 clients *` — both invocations route through the same command graph, so partner scripts written against the old name keep working. The data surface (`companyId`, `companyName`, `--company` flag, etc.) stays aligned with the wire until Pax8's API renames the field.
 

--- a/packages/cli/src/__tests__/companies.test.ts
+++ b/packages/cli/src/__tests__/companies.test.ts
@@ -597,5 +597,37 @@ describe("pax8 companies", () => {
       expect(result.stdout).toContain("--phone");
       expect(result.stdout).toContain("Examples:");
     });
+
+    // #432: Franco Aurieme's domain-review finding. The atomic-create path
+    // implicitly assigns the supplied contact as primary Admin/Billing/
+    // Technical to satisfy activation. Partners need to discover that they
+    // can re-split those roles afterward — pin the Note block in --help so
+    // a future help-text refactor can't quietly drop it.
+    it("create --help documents the multi-role primary assignment (#432)", async () => {
+      const result = await runCliExpectSuccess([
+        "companies",
+        "create",
+        "--help",
+      ]);
+      expect(result.stdout).toMatch(/primary Admin, Billing, and Technical/i);
+      expect(result.stdout).toContain("pax8 contacts update");
+      expect(result.stdout).toContain("pax8 contacts create --type");
+    });
+
+    // #432: same assertion through the `clients` invocation path. The alias
+    // is wired via Commander's `.alias()` so both surfaces share one command
+    // graph (see clients-companies-parity.test.ts), but pin the user-facing
+    // contract here too so a regression that breaks alias inheritance fails
+    // loudly on the canonical surface.
+    it("`clients create --help` inherits the multi-role Note via the alias (#432)", async () => {
+      const result = await runCliExpectSuccess([
+        "clients",
+        "create",
+        "--help",
+      ]);
+      expect(result.stdout).toMatch(/primary Admin, Billing, and Technical/i);
+      expect(result.stdout).toContain("pax8 contacts update");
+      expect(result.stdout).toContain("pax8 contacts create --type");
+    });
   });
 });

--- a/packages/cli/src/commands/companies/create.ts
+++ b/packages/cli/src/commands/companies/create.ts
@@ -127,7 +127,13 @@ Examples:
       --first-name Maya --last-name Chen --email maya@summit.example.com
 
   # Company-only (Inactive — must follow up with 'pax8 contacts create')
-  pax8 clients create --name "Test Co" --city Denver --state CO --zip 80202 --company-only`,
+  pax8 clients create --name "Test Co" --city Denver --state CO --zip 80202 --company-only
+
+Note:
+  The contact you provide is assigned as primary Admin, Billing, and Technical
+  to activate the company. To split these roles to different contacts, use
+  'pax8 contacts update' or create additional contacts with
+  'pax8 contacts create --type' after company creation.`,
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();


### PR DESCRIPTION
## Summary

Closes #432. Addresses Franco Aurieme's domain-review finding on Companies & Contacts:

> "When a partner supplies a single contact on companies create, the CLI assigns them as primary Admin, Billing, and Technical to satisfy activation. Worth a help-text line so partners know they can split those roles out afterward via contacts update or additional contacts create calls if they want different people in each role."

The implicit assign-all-three behavior is correct per Vinton Lee's confirmation that `ContactService.accountHasAllPrimaryContacts` requires primary Admin + Billing + Technical for `Active` — the design shipped in #381 is the only path to Active-on-first-call with a single contact. The gap was discoverability: partners who DO want different humans in different roles had no in-CLI signal that it was possible.

This PR is **documentation-only on help text + README + tests**. No code-logic changes.

## What changed

- **`packages/cli/src/commands/companies/create.ts`** — added a Note block to the `addHelpText("after", ...)` block, after the existing Examples. Mirrors the prose tone and single-quoted command-snippet convention used elsewhere in that block.
- **`README.md`** — added a `pax8 clients create` example to the Clients section (none existed) and a one-line Note immediately below explaining the multi-role assignment + how to re-split. Kept it tight; didn't restructure the section.
- **`packages/cli/src/__tests__/companies.test.ts`** — two new subprocess tests asserting `pax8 companies create --help` and `pax8 clients create --help` both contain the canonical "primary Admin, Billing, and Technical" fragment plus the `pax8 contacts update` / `pax8 contacts create --type` action hints. The second test pins alias inheritance through Commander's `.alias()` (PR #379 wiring).
- **`.changeset/companies-create-multi-role-help.md`** — `@pax8/cli` patch.

## Verification

Both help-text surfaces show the Note:
- `PAX8_DEMO=1 node packages/cli/dist/index.js companies create --help` ✓
- `PAX8_DEMO=1 node packages/cli/dist/index.js clients create --help` ✓

The `clients` alias inherits the help text correctly via Commander's `.alias()` in `packages/cli/src/commands/companies/index.ts` (per #379 wiring). No additional wiring needed — both invocations share one command graph by construction. The existing `clients-companies-parity.test.ts` (#317) continues to pass and structurally guarantees the surfaces stay in sync.

Build / test / lint / tsc all green:

- `pnpm build` — all 3 packages built clean
- `pnpm test` — 111 test files / 1874 tests pass (6 skipped, 0 failed), including the two new `#432` assertions and the parity matrix
- `pnpm lint` — clean
- `pnpm -r exec tsc --noEmit` — clean

Notes this closes Franco's review thread on Companies & Contacts.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` (1874 pass)
- [x] `pnpm lint`
- [x] `pnpm -r exec tsc --noEmit`
- [x] Manual `--help` verification on both `companies create` and `clients create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)