### PR TITLE
fix(analytics): normalize 2-Year and 3-Year billing terms to monthly equivalent

### DIFF
--- a/packages/core/src/services/analytics.test.ts
+++ b/packages/core/src/services/analytics.test.ts
@@ -2,7 +2,92 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { computeMrr, computeGrowth } from "./analytics.js";
+import { computeMrr, computeGrowth, subscriptionMrr } from "./analytics.js";
+
+describe("subscriptionMrr", () => {
+  // 120 × 5 = 600 makes the normalization math visible for each term.
+  const PRICE = 120;
+  const QTY = 5;
+  const GROSS = PRICE * QTY; // 600
+
+  describe("canonical BillingTerm enum values", () => {
+    it("Monthly returns price × quantity", () => {
+      expect(subscriptionMrr(PRICE, QTY, "Monthly")).toBe(GROSS);
+    });
+
+    it("Annual returns price × quantity / 12", () => {
+      expect(subscriptionMrr(PRICE, QTY, "Annual")).toBe(GROSS / 12); // 50
+    });
+
+    it("2-Year returns price × quantity / 24", () => {
+      // Bug pre-fix: substring matching let "2-Year" fall through to the
+      // monthly default (returned 600). Correct value is 600 / 24 = 25.
+      expect(subscriptionMrr(PRICE, QTY, "2-Year")).toBe(GROSS / 24); // 25
+    });
+
+    it("3-Year returns price × quantity / 36", () => {
+      // Bug pre-fix: same fall-through as 2-Year (returned 600).
+      // Correct value is 600 / 36 ≈ 16.666…
+      expect(subscriptionMrr(PRICE, QTY, "3-Year")).toBeCloseTo(GROSS / 36, 10);
+    });
+
+    it("One-Time falls through to price × quantity (out of scope to re-define)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "One-Time")).toBe(GROSS);
+    });
+
+    it("Trial falls through to price × quantity (out of scope to re-define)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "Trial")).toBe(GROSS);
+    });
+
+    it("Activation falls through to price × quantity (out of scope to re-define)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "Activation")).toBe(GROSS);
+    });
+  });
+
+  describe("case-insensitive match", () => {
+    // The call sites used to lowercase before substring-matching; preserve
+    // tolerance for lowercased input so existing/loose callers keep working.
+    it("monthly (lowercased)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "monthly")).toBe(GROSS);
+    });
+
+    it("annual (lowercased)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "annual")).toBe(GROSS / 12);
+    });
+
+    it("2-year (lowercased)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "2-year")).toBe(GROSS / 24);
+    });
+
+    it("3-year (lowercased)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "3-year")).toBeCloseTo(GROSS / 36, 10);
+    });
+
+    it("ANNUAL (uppercased)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "ANNUAL")).toBe(GROSS / 12);
+    });
+  });
+
+  describe("default behavior for unknown / falsy terms", () => {
+    // `computeMrr` calls `subscriptionMrr(..., sub.billingTerm ?? "monthly")`
+    // — the `?? "monthly"` default plus the function's own tolerance must keep
+    // working so partners with stale or unrecognized term strings aren't
+    // silently zeroed out.
+    it("empty string treats as monthly (price × quantity)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "")).toBe(GROSS);
+    });
+
+    it("undefined (cast through string) treats as monthly", () => {
+      // Mirrors how callers funnel `sub.billingTerm ?? "monthly"` — but also
+      // exercise the function's internal `?? ""` guard against undefined.
+      expect(subscriptionMrr(PRICE, QTY, undefined as unknown as string)).toBe(GROSS);
+    });
+
+    it("unknown future enum value treats as monthly (preserves historical default)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "Quarterly")).toBe(GROSS);
+    });
+  });
+});
 
 describe("computeMrr", () => {
   it("should aggregate MRR by company", () => {

--- a/packages/core/src/services/analytics.ts
+++ b/packages/core/src/services/analytics.ts
@@ -28,16 +28,49 @@ export interface GrowthReport {
 
 /**
  * Calculate the Monthly Recurring Revenue for a single subscription.
- * Annual/yearly terms are divided by 12 to normalize to monthly.
+ *
+ * Pax8's `Subscription.billingTerm` is a closed enum (`BillingTermSchema`):
+ * `Monthly`, `Annual`, `2-Year`, `3-Year`, `One-Time`, `Trial`, `Activation`.
+ * Each multi-period term is divided down to its monthly equivalent. The match
+ * is case-insensitive against the canonical enum value so callers may pass
+ * lowercased / loosely-typed strings (the call sites in `computeMrr`,
+ * `cost-simulator`, etc. do this).
+ *
+ * `One-Time`, `Trial`, `Activation`, and unknown / falsy values fall through
+ * to `price × quantity` — preserving the pre-fix default. Reworking those
+ * semantics is a separate question (they aren't really "recurring") and is
+ * intentionally out of scope here.
+ *
+ * Historical note: the original implementation used substring matching on
+ * `annual` / `yearly`, which let `2-Year` and `3-Year` slide through to the
+ * `price × quantity` default — materially over-counting MRR for partners
+ * with NCE multi-year commitments. See PR #N (this commit) for context.
  *
  * This is the single source of truth for MRR calculation across the codebase.
  */
 export function subscriptionMrr(price: number, quantity: number, billingTerm: string): number {
-  const normalizedTerm = billingTerm.toLowerCase();
-  if (normalizedTerm.includes("annual") || normalizedTerm.includes("yearly")) {
-    return (price * quantity) / 12;
+  const gross = price * quantity;
+  const normalizedTerm = (billingTerm ?? "").toLowerCase();
+
+  switch (normalizedTerm) {
+    case "monthly":
+      return gross;
+    case "annual":
+      return gross / 12;
+    case "2-year":
+      return gross / 24;
+    case "3-year":
+      return gross / 36;
+    case "one-time":
+    case "trial":
+    case "activation":
+      return gross;
+    default:
+      // Unknown / falsy billingTerm: preserve historical behavior (treat as
+      // monthly) so callers passing `undefined`, `""`, or future enum values
+      // we don't yet recognize don't suddenly start under-reporting MRR.
+      return gross;
   }
-  return price * quantity;
 }
 
 export function computeMrr(subscriptions: AnalyticsSubscriptionInput[]): MrrReport {

--- a/packages/core/src/services/analytics.ts
+++ b/packages/core/src/services/analytics.ts
@@ -41,11 +41,6 @@ export interface GrowthReport {
  * semantics is a separate question (they aren't really "recurring") and is
  * intentionally out of scope here.
  *
- * Historical note: the original implementation used substring matching on
- * `annual` / `yearly`, which let `2-Year` and `3-Year` slide through to the
- * `price × quantity` default — materially over-counting MRR for partners
- * with NCE multi-year commitments. See PR #N (this commit) for context.
- *
  * This is the single source of truth for MRR calculation across the codebase.
  */
 export function subscriptionMrr(price: number, quantity: number, billingTerm: string): number {


### PR DESCRIPTION
## Summary

`subscriptionMrr` (the single source of truth for MRR in `@pax8/core`) used substring matching on `annual` / `yearly` to detect non-monthly billing terms. The Pax8 `BillingTerm` enum (`packages/core/src/api/types.ts:52-61`) also includes `2-Year` and `3-Year` (NCE multi-year commitments) — neither string contains `annual` or `yearly`, so both fell through to `price × quantity` and were counted as if they were monthly. That materially over-counts MRR for partners running NCE 2-year / 3-year deals — every multi-year sub was reported at 24×/36× its true monthly contribution.

The fix replaces the substring check with an explicit case-insensitive match on the canonical enum values:

| BillingTerm | Pre-fix | Post-fix |
|---|---|---|
| `Monthly`   | `gross`         | `gross` |
| `Annual`    | `gross / 12`    | `gross / 12` |
| `2-Year`    | `gross` (BUG)   | `gross / 24` |
| `3-Year`    | `gross` (BUG)   | `gross / 36` |
| `One-Time`  | `gross`         | `gross` (unchanged) |
| `Trial`     | `gross`         | `gross` (unchanged) |
| `Activation`| `gross`         | `gross` (unchanged) |

`One-Time` / `Trial` / `Activation` are intentionally left alone — treating those as monthly recurring is arguably wrong but is a separate semantics call out of scope here. Unknown / falsy `billingTerm` values (including `undefined` and `""` — relied on by `computeMrr`'s `sub.billingTerm ?? "monthly"` default) also fall through to the monthly default, preserving historical behavior for callers passing imperfectly-typed strings.

Example: `subscriptionMrr(120, 5, "3-Year")` now returns `16.666…` instead of `600`.

## Relationship to other in-flight work

`report mrr` / `report growth` are being removed in a concurrent PR (`chore(reporting): remove report mrr/growth and align vocabulary with Pax8-cost framing`). This fix lands separately because the **analytics engine** in `@pax8/core` is the durable, interface-agnostic asset (`packages/core/README.md`) and is what v0.2 reporting work will reuse via `subscriptionMrr` / `computeMrr`. Keeping the math correct is independent of which CLI surface exposes it.

`subscriptionMrr` is also called by `cost-simulator`, `recommendations`, `renewal-tracker`, and the CLI's `formatters.ts` — all of those silently benefit from the fix.

## Fixtures / expectations updated

None. No existing test in this repo asserted a specific MRR value for a `2-Year` / `3-Year` subscription (the demo data uses these terms but doesn't pin a numeric expectation to them), so no fixtures needed updating. All 1,886 pre-existing tests continue to pass.

## Test plan

- [x] Added unit tests in `packages/core/src/services/analytics.test.ts` covering every `BillingTerm` enum value with `price=120, quantity=5` (gross=600) so the normalization math is visible: `Monthly→600`, `Annual→50`, `2-Year→25`, `3-Year≈16.67`, `One-Time/Trial/Activation→600`.
- [x] Added lowercased-variant tests (`monthly`, `annual`, `2-year`, `3-year`, `ANNUAL`) — matches the realistic call-site input shape.
- [x] Added default-behavior tests for empty string, `undefined`, and an unknown future enum value (`Quarterly`) — all should fall back to monthly treatment so `computeMrr`'s `?? "monthly"` default keeps working and no caller is silently zeroed out.
- [x] `pnpm build` — clean.
- [x] `pnpm test` — 1,886 passed, 6 skipped, no regressions.
- [x] `pnpm lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)