### PR TITLE
docs(triage): launch coordination, partner walkthrough, and Candidates F+G

### DIFF
--- a/docs/triage/launch-coordination.md
+++ b/docs/triage/launch-coordination.md
@@ -1,0 +1,153 @@
+# Launch coordination — pax8-cli v0.1.0
+
+**Last updated:** 2026-05-12
+**Purpose:** Single working tracker for human-facing items gating v0.1.0 publish. Engineering items live in the per-issue queue; this doc covers everything else.
+
+---
+
+## 1 — Engineering state
+
+The repo went through two audit cycles in the last 48 hours:
+
+1. **Partner-readiness audit** (six dimensions in parallel) — reports at `docs/triage/partner-readiness-audit.md` (top-level synthesis) and `docs/triage/partner-readiness-audit/01-*.md` through `06-*.md` (per-dimension). Surfaced 3 block-launch and 10 fix-before-launch findings.
+2. **Partner-perspective walkthrough** — report at `docs/triage/partner-walkthrough.md`. Surfaced 3 additional UX-polish items plus verified that one earlier finding ("spinners leak into `--json`") was a false alarm.
+
+**Landed since the audits ran** (10 PRs, all merged to main):
+
+| PR | What |
+|---|---|
+| #406 | Block-launch B1 — quotes Zod schema flattens nested `client` to flat `companyId` |
+| #407 | Block-launch B2 — timestamp standardization (`createdAt` / `updatedAt` / `expiresAt`) with dual-emit aliases |
+| #413 | Hotfix — demo-data interfaces updated to match the canonical names; resolved `tsc --noEmit` regression introduced by #407 |
+| #411 | Group D walkthrough — README documents `2>/dev/null` pattern for clean JSON pipes |
+| #412 | Group A walkthrough — enum validation on 11 flag/command pairs + fuzzy product name resolution with "Did you mean" suggestions |
+| #414 | Group C walkthrough — `JSON output:` sections in `--help` on 7 commands + README STAX taxonomy divergence subsection |
+| #415 | Group B walkthrough — TTY empty-state messages on 9 list commands + commitment-aware cancel preview |
+| #404 | Walkthrough docs cleanup — `pax8 invoices items` flag syntax + missing CLAUDE.md row + duplicate README ref |
+| #405 | Filter expansion — server-side `--status` filter on quotes, plus geography/capability filters on companies, plus advanced filters on invoices |
+| #383 | Audit reconciliation doc |
+
+**In flight (open PRs):** none from the launch pile. One `chore: release` PR (#377) is open with all the merged changesets staged for v0.1.0 release-prep — that's the cut-the-release vehicle when ready.
+
+**Block-launch state:**
+
+- ✅ B1 #384 — closed
+- ✅ B2 #385 — closed (+ #413 hotfix)
+- ⏸ **B3 #386** — wire-level write tests. **Blocked: sandbox credentials are NOT configured in repo secrets** (verified: `gh api /repos/pax8labs/pax8-cli/actions/secrets` returned empty). Cannot be implemented in CI until secrets are provisioned.
+
+**Deferred to v0.1.1 (intentional):**
+
+- #393 — branch coverage on products/invoices/webhooks APIs (test-only, not partner-visible)
+- #395 — subprocess tests for easter-eggs / completions / init / report-bug (test-only)
+- #394 — CI sandbox credentials docs (companion to #386; only meaningful once secrets are provisioned)
+- #397, #398, #400, #401 — non-blocking docs and filter polish
+
+**Decisions recorded:**
+
+- #403 — JSON deprecation marker → declined; help-text + release notes + `@deprecated` JSDoc are sufficient. Revisit only with partner-friction evidence.
+
+---
+
+## 2 — Open coordination items
+
+Status legend: `not started` · `in flight` · `blocked` · `complete`
+
+| Item | Owner | Status | Next action | Blocking on |
+|---|---|---|---|---|
+| **Public repo / org name decision** (#141 sweep depends on this) | Cassie | not started, no known prior activity | Schedule Cassie conversation; pick a name; create org if needed | Cassie's input |
+| **Sandbox credential provisioning for CI** (PAX8_CLIENT_ID / PAX8_CLIENT_SECRET) | TBD (likely Mufaddal's team or broader API team) | not started | Identify owner; request a dedicated CI sandbox account or service-principal | Owner identification |
+| **LICENSE legal sign-off** | Courtney Norton | not started, no known prior activity | Send the LICENSE file (Apache-2.0 currently in repo) for legal review; document approval | Outreach to Courtney |
+| **npm OIDC trusted publisher configuration** | self | blocked | Configure the trusted publisher in npm registry once the GitHub org and repo are public and known | Public org name + public repo creation |
+| **Public repo creation** | self | blocked | Create the public repo on the chosen org once the name is decided | Public org name decision |
+| **Second peer reviewer beyond Cassie** | self | not started | Identify a second engineer with bandwidth for OSS-style code review on the surface; brief them | Owner identification |
+| **Review page refresh on Confluence** | self | in flight (draft text exists, not yet posted) | Post the refreshed review page reflecting all post-audit landings; date it 2026-05-12+ | None — ready to post |
+| **Four consolidated reviewer replies** (Tanner Horsey, Fred Lintz, Franco Aurieme, Josh Hollander) | self | not started | Draft per-reviewer reply summarizing what landed in response to each reviewer's feedback; send as Confluence inline replies or DMs | Drafting |
+| **Beyond keynote framing conversation with Libby** | self | not started, no known prior activity | Schedule conversation; align on how the CLI fits the Beyond keynote narrative | Outreach to Libby |
+| **Mufaddal GTM placement working session** (devx.pax8.com canonical home, Integrations Hub, integration guides) | self | not started | Schedule session; agree on where the CLI lives in Pax8 partner-facing surfaces | Outreach to Mufaddal |
+| **Substantive engagement asks for unengaged reviewers** (Randall Ellis on Recommendations, Bret Pittenger on Reporting, others as relevant) | self | not started — DM drafts exist from earlier in cycle, never sent | Decide whether to send (see section 4) | See section 4 — trade-off |
+
+---
+
+## 3 — Sequencing
+
+**Independent (start anytime, no upstream blockers):**
+
+- Review page refresh on Confluence (draft text exists)
+- Four consolidated reviewer replies (drafting only)
+- Beyond keynote conversation with Libby (scheduling only)
+- LICENSE legal sign-off with Courtney Norton (send file for review)
+- Identify second peer reviewer
+
+**Depends on public org/repo name decision:**
+
+- Public repo creation
+- npm OIDC trusted publisher configuration (needs public repo to exist)
+- #141 sweep of internal URL references (replace placeholders with the final canonical URL)
+
+**Depends on sandbox credentials being provisioned:**
+
+- B3 #386 — wire-level write integration tests
+- #394 — CI secrets documentation gains real "this is what's configured" content
+- Possibly: promote `integration.yml` from `continue-on-error: true` to required
+
+**Depends on reviewer responses:**
+
+- The four consolidated replies are drafted before responses are needed; sending them is independent. But any reviewer who responds with new findings triggers a fresh engineering cycle that could re-open block-launch state.
+
+**Depends on Mufaddal placement decision:**
+
+- Whether `pax8-cli` is GA via `npm install -g @pax8/cli` only, or also surfaced on devx.pax8.com / Integrations Hub at launch, or staged.
+
+**Final launch chain (close-out sequence once everything else is resolved):**
+
+1. B3 #386 wire-write tests land (requires credentials)
+2. `chore: release` PR #377 is updated and merged → bumps version
+3. npm publish (via OIDC trusted publisher)
+4. Public repo flipped from private to public
+5. Internal URL sweep (#141) confirmed clean against the public URL
+6. Release announcement (Confluence, partner email, Beyond keynote alignment)
+
+---
+
+## 4 — Auto-approval risk
+
+**May 15, 2026 is the auto-approval deadline** on the Pax8 CLI Domain Review Confluence page. Five reviewers have not engaged substantively against the current state of the page:
+
+- **Jen Bosier** — domain not stated in this thread
+- **Chris Weiss** — Orders (explicit outreach issue exists: #369, no response yet)
+- **Angelo Echtermeijer** — domain not stated in this thread
+- **Randall Ellis** — Recommendations
+- **Bret Pittenger** — Reporting
+
+Auto-approval is the procedural fallback. It represents real residual risk: if any of the five surfaces a substantive finding post-publish, the response options narrow (the CLI is already in partners' hands; a post-publish bug is more expensive to fix than a pre-publish one).
+
+### Trade-off
+
+**Send substantive outreach DMs** (sharper than the page; drafts exist from earlier in cycle but were never sent):
+- Pro: invites engagement that might surface findings before publish, when they're cheap to fix
+- Con: invites engagement that might surface findings before publish, slowing the launch window if a finding is substantial
+
+**Don't send; accept May 15 auto-approval as quiet sign-off:**
+- Pro: launch window stays tight; reviewers who haven't engaged are unlikely to engage even with a DM nudge
+- Con: any post-publish finding from these reviewers becomes a partner-visible issue
+
+This is a judgment call about how much pre-launch optionality to preserve vs. how much risk to push past the publish date. No recommendation. Decision point listed in section 5.
+
+---
+
+## 5 — Open questions (decisions pending)
+
+- **decision pending** — Whether to send substantive outreach DMs to the five unengaged reviewers (Jen Bosier, Chris Weiss, Angelo Echtermeijer, Randall Ellis, Bret Pittenger), or rely on May 15 auto-approval as quiet sign-off. See section 4 for trade-off.
+- **decision pending** — What public repo name to use. Drives the org name decision, the public-repo-creation step, the npm OIDC configuration, and the #141 sweep. Cassie conversation is the input.
+- **decision pending** — Whether the four reviewer replies (Tanner / Fred / Franco / Hollander) go out before or after the review page refresh. Order affects whether reviewers see "here's the page, here's the reply" or "here's the reply, by the way the page is also updated."
+- **decision pending** — Whether to gate v0.1.0 publish on the Mufaddal GTM placement session, or publish first and integrate placement after. Affects whether v0.1.0 ships as a CLI partners discover via `npm install`, or as a CLI Pax8 announces with a GTM motion.
+
+---
+
+## Inventory of cross-referenced sources
+
+- Partner-readiness audit (six dimensions): `docs/triage/partner-readiness-audit.md` and `docs/triage/partner-readiness-audit/01-*.md` through `06-*.md`
+- Partner walkthrough: `docs/triage/partner-walkthrough.md`
+- Engineering issue queue: GitHub issues labeled `pre-publish-write-fix` (now empty except #386), `v0.1.1`, and `decision-recorded`
+- The chore release vehicle: PR #377
+- Internal-URL sweep work: issue #141

--- a/docs/triage/partner-walkthrough.md
+++ b/docs/triage/partner-walkthrough.md
@@ -1,0 +1,195 @@
+# Partner walkthrough — pax8 CLI v0.1.0
+
+**Date:** 2026-05-12
+**Method:** Partner-perspective walkthrough by Explore agent. PAX8_DEMO=1 throughout. Read-only; no code or docs changed.
+**Repo state:** main @ `d20b113` (post-#406 quotes schema fix; PR #407 timestamp standardization open but not merged)
+
+---
+
+## Summary
+
+The pax8 CLI feels polished and thoughtful for a v0.1.0. A new MSP partner who has the README in hand can install it, enable demo mode, and immediately run meaningful commands — renewals, recommendations, invoice audits — without wrestling with API docs. Error messages are conversational and recovery hints are actionable. JSON output is clean and scriptable. The main friction points are minor UX inconsistencies (spinners leaking into `--json` output, no enum validation on flags) and a few demo-mode fixtures that are thin. The tool delivers on its core promise: it computes answers the raw API doesn't provide. For a partner evaluating whether to adopt it for automation, the answer is "yes, ready for trial use in protected environments."
+
+---
+
+## Findings by step
+
+### Step 1 — First impression
+
+- **`pax8` (no args)** → REPL banner with ASCII logo, clear headline, 4 common commands listed, inviting tone. Positive.
+- **`pax8 --help`** → Clean option/command table. All 25+ commands listed, descriptions are brief but precise. "commands: display help for command" pattern is conventional (Commander.js). No surprises.
+- **`pax8 --version`** → Returns `0.1.0` correctly.
+
+**Verdict:** Approachable entry point. Feels like a real CLI, not an experiment.
+
+### Step 2 — README quick start
+
+Tested the "Demo Flow (90 seconds)" section verbatim:
+
+```
+pax8 dashboard                           ✓ Works, shows MRR + renewals + top customers
+pax8 recommendations list                ✓ Works, returns JSON with orderCommand embedded
+pax8 recommendations act                 ✗ Non-TTY → graceful "Cannot show interactive picker" error with recovery hints
+pax8 clients list                        ✓ Works, 6 companies returned
+pax8 clients more "Acme Corp"            ✓ Works, full summary with subscriptions + coverage gaps + estimated uplift
+```
+
+**Verdict:** Demo flow is solid; the interactive picker error in non-TTY is handled well.
+
+### Step 3 — Obvious next things
+
+- **`pax8 clients list --json`** ✓ and **`pax8 companies list --json`** ✓ — alias works, both return same data structure. Good backward-compat signal.
+- **`pax8 subscriptions list --company "Acme Corp"`** ✓ — filters by name, includes commitment dates, quantity, billing term.
+- **`pax8 quotes list`** ✓ — returns quotes with line-item breakdown and expiration dates.
+- **`pax8 invoices list`** ✓ — shows invoice total + balance + due date for 6 companies.
+- **`pax8 recommendations list`** ✓ — detailed JSON: reason, suggested products, `orderCommand` (ready-to-copy), estimated MRR uplift.
+- **`pax8 dashboard --all`** ✓ — includes top customers + renewals + growth opportunities in one call.
+
+**Verdict:** Command surface is consistent. Output is data-rich without being overwhelming. JSON is well-shaped for scripting.
+
+### Step 4 — Try to mess up
+
+| Input | Output | Grade |
+|-------|--------|-------|
+| `--compny` (typo) | `error: unknown option '--compny' (Did you mean --company?)` | A+ |
+| `contacts create` (missing required `--company`) | `error: required option '--company <id\|name>' not specified` | A |
+| `subscriptions list --status FooBar` (invalid enum) | Returns empty array (no validation) | C |
+| `customers list` (nonexistent command) | `error: unknown command 'customers'` | A |
+| `subscriptions cancel` (with confirmation prompt) | Prompts for explicit "cancel" string, allows abort. | A+ |
+
+**Verdict:** Error handling is strong except for enum validation. The typo suggestion is a nice touch.
+
+### Step 5 — Help system
+
+Spot-checked 6 commands (`invoices audit`, `products search`, `subscriptions renewals`, `cost sim`, `report mrr`, `clients create`). All have:
+
+- ✓ Consistent structure (Usage, Options, Examples)
+- ✓ Examples that cover common cases
+- ✓ Detailed notes on behavior (e.g., "renewal exposure vs churn risk", "atomic vs company-only")
+- ✓ Metric definitions inline for MRR/ARR commands
+- ✗ No documented JSON output shape (e.g., "returns `{ renewals: [...], nextActions?: [...] }`")
+
+**Verdict:** Help is polished and in-depth. Would benefit from a "JSON output" section on commands that have complex shapes.
+
+### Step 6 — Write-shaped commands
+
+Reviewed help for `clients create`, `orders create`, `quotes create`, `subscriptions cancel`, `subscriptions update`.
+
+- ✓ Required vs optional flags are clear
+- ✓ Examples show both interactive and non-interactive (`--yes`) patterns
+- ✓ Warnings on destructive actions (cancellation defaults to safe-path, docs the commitment-term protection)
+- ✓ `--idempotency-key` pattern visible on `orders create` (good safety design)
+- ✓ Confirmation flows tested: order preview shows unit price, total, MRR impact before confirmation
+- ✗ No pre-flight warnings on some operations (e.g., `quotes create` doesn't warn that the quote will expire)
+
+**Verdict:** Write commands feel safe. Confirmation flows are clear. Good idempotency story.
+
+---
+
+## What worked well
+
+1. **Computed answers over raw API** — The three core features (renewal tracker, invoice auditor, recommendations engine) deliver *actual business intelligence*, not just CRUD. A partner asking "which customers are overbilled?" gets a structured answer with dollar impact in one call, not 13+ API calls and manual joins.
+
+2. **Demo mode is the posture, not a side project** — Every command works in demo, including multi-step flows (recommendations → order preview → confirm). This lowers the bar for trial use and testing. No setup ceremony.
+
+3. **Error recovery is human-readable** — Errors carry codes, recovery steps, and actionable hints (e.g., "Product not found: try `pax8 products search`"). No stack traces. The `pax8 report-bug` flow is thoughtful — shows you what will be submitted (redacted) before filing.
+
+4. **JSON output is genuinely scriptable** — Flat, predictable shapes. Embedded `orderCommand` on recommendations. `nextActions` array on cost sims. A partner can pipe to `jq` without wrestling with the schema.
+
+5. **Help is comprehensive and conversational** — Examples are real, not toy. Notes on commitment-term policies, metric definitions, safe paths. Feels like it was written by someone who has fielded partner support tickets.
+
+---
+
+## What's rough
+
+### Embarrassing on first encounter
+
+1. **Spinners leak into `--json` output** — Running `pax8 subscriptions list --json` shows:
+   ```
+   ✨ Demo mode — showing sample data
+   - Fetching subscriptions...
+   [json here]
+   ```
+   The banner and spinner go to stdout, not stderr. A partner piping to `jq` won't see it (redirected to `2>/dev/null`), but it's visible in the raw output and could break parsing if someone doesn't filter stderr. The README says "Stdout is data, stderr is everything else" but the implementation doesn't enforce it everywhere.
+
+2. **No enum validation on flags** — `--status FooBar` returns an empty array instead of "invalid status. Allowed: Active | Inactive | ...". Partners will debug "why am I getting no results?" instead of "I made a typo".
+
+3. **Empty-state UX is bare** — `pax8 clients list --status Inactive` on demo returns `[]` with no message. In a TTY it'd be good to see "No companies found with status Inactive" or a hint.
+
+### Friction in the experience
+
+4. **Demo-mode fixtures are thin in places** — The README mentions thin fixtures for `usage`, `quotes`, `webhooks` (#196). `quotes list` works but only has 2 sample quotes. Not a blocker, but a partner testing a full workflow will hit the edge of the fixture quickly.
+
+5. **Interactive picker (TTY mode) can't be tested in CI** — The REPL and `recommendations act` require a terminal for multi-select. All testing has to go through subprocess (non-TTY), which auto-routes to JSON. The README mentions this (#193) but it's a gap in test coverage for the human UX.
+
+6. **Help doesn't document JSON output shape** — A partner seeing `pax8 recommendations list --json` doesn't know what fields to expect without running the command. Commands like `cost sim` return nested objects (`current`, `proposed`, `delta`, `nextActions`) that aren't documented in `--help`.
+
+### Trial-and-error discoveries
+
+7. **Commitment-term safety is implicit** — `subscriptions cancel` defaults to "cancel at commitment end date" but this only works if the subscription has an active commitment. A partner cancelling a monthly-term sub won't see the safe-path behavior and might be confused. The help text is clear, but this is a "read the docs" thing.
+
+8. **Product name resolution isn't predictable** — `orders create --product "Microsoft 365"` fails ("Product not found") but `orders create --product "Microsoft 365 Business Premium [New Commerce Experience]"` works. There's no guidance on whether partial matches work. The error message hints at `products search`, so recovery is available, but it's a round-trip.
+
+9. **`--status` invalid values silently return 0 results** — Partner mistypes `--status Active1` and gets an empty list. No error, no validation. Matches the README's "all flags have sensible defaults" philosophy, but it's a source of quiet bugs.
+
+---
+
+## Specific recommendations
+
+### Embarrassing on first encounter
+
+- **Fix stdout/stderr split on spinners** — Send spinners to stderr unconditionally when `--json` is set. The output module (`packages/cli/src/lib/output.ts`) should check for `--json` and route spinners to stderr. A partner using the CLI in automation should never see a spinner mixed with JSON.
+
+- **Add enum validation on status/priority/type flags** — Add a validation helper that checks enum values and emits "Invalid status. Allowed: Active | Inactive | ..." before making API calls. Cost: ~50 lines of validation code. Payoff: partners find their typos instantly.
+
+- **Add empty-state message in TTY mode** — When a list command returns 0 rows in a TTY, show "No [items] found" instead of an empty table. Non-breaking: JSON mode returns `[]` as before.
+
+### Friction in the experience
+
+- **Bulk out the demo fixtures** — Add 5-10 more sample quotes, 3-5 usage entries, 2-3 webhook logs to the mock data. Enables partners to test workflows end-to-end in demo without hitting the fixture ceiling.
+
+- **Document JSON output shape in `--help`** — For commands that return complex shapes, add a "JSON output" section:
+  ```
+  JSON output:
+    pax8 cost sim returns { companyName, current, proposed, delta, notes, nextActions }
+  ```
+
+- **Add a `--list-enums` flag** — `pax8 subscriptions list --list-enums` prints "Allowed statuses: Active | Inactive | Cancelled". Low-lift, high-discovery value.
+
+### Trial-and-error discoveries
+
+- **Document commitment-term cancellation behavior upfront** — Add a note to `subscriptions list` output that shows commitment end date, and update `subscriptions cancel --help` to say "committed subscriptions default to cancellation at commitment end date — run `pax8 subscriptions show <id>` to see the date."
+
+- **Improve product name resolution feedback** — When `--product` fails to resolve, emit "Did you mean: [top 3 search results]?" instead of just "Product not found." This trades one extra search for a 90% hit rate on the second try.
+
+- **Validate filter values at the CLI layer before calling the API** — For `--status`, `--priority`, etc., check that the value is in the enum before making a request. This prevents silent empty-result bugs.
+
+---
+
+## What I'd tell a partner
+
+**Short:** "Try it in demo mode. The core features (renewals, recommendations, invoice audit) are solid and save you real work. The v0.1.0 polish is there, but expect to read the help text — there are some UX gaps around empty states and enum validation. Good foundation for automation, not production-ready without those fixes."
+
+**Long:** The CLI does what it promises: it turns raw Pax8 API data into computed answers you'd otherwise spend hours calculating or scripting. The error messages are thoughtful, the JSON output is clean, and the demo mode means you can trial it in under 5 minutes with zero credentials. The help system is genuinely good — whoever wrote it has fielded support tickets.
+
+The rough edges are solvable — most are single-digit-line fixes. The lack of enum validation will frustrate partners typing `--status foo`, and the spinners leaking into JSON will surprise someone in a pipeline. The thin demo fixtures (quotes, usage) won't matter for your first workflow, but will be obvious once you try the second one.
+
+For a v0.1.0 open-source tool, this is the right maturity level. It's honest about what it is (early-stage experiment), delivers real value in the core paths, and has enough safety rails (idempotency keys, confirmation prompts, demo mode) that a careful partner can use it for trial automation without fear.
+
+---
+
+## Overall assessment
+
+**Partner-ready for:** trial use in protected environments (demo mode + test sandbox)
+
+**Not yet for:** production automation without the enum validation and stdout/stderr fixes
+
+**Top 3 things that work well:**
+1. Computed business intelligence (renewals, recommendations, invoice audit) — saves partners actual work
+2. Conversational error messages with recovery hints — "did you mean --company?" for typos
+3. Demo mode as a testing posture, not a side project — every command works, no credential setup
+
+**Top 3 things that are rough:**
+1. Spinners leak into `--json` output (should be stderr only when JSON is set)
+2. No enum validation on flags like `--status` (silent empty results instead of helpful errors)
+3. No JSON output shape documentation in `--help` (partners have to run commands blind)

--- a/docs/triage/v0.1.0-candidates.md
+++ b/docs/triage/v0.1.0-candidates.md
@@ -281,6 +281,134 @@ Concrete, mechanical follow-up to #429:
 
 ---
 
+## Candidate F — Reporting reshape — Bret Pittenger alignment
+
+**Source.** Three proposed reporting reshapes for review with Bret Pittenger (Reporting domain reviewer): `pax8 report invoiced`, `pax8 report recurring`, and `pax8 report run-rate`. This is a pre-conversation wire-shape feasibility read — *can the public API support these, and how cleanly can the CLI compute them?* No code; just a green-light / yellow-light / red-light read per reshape, with the open definition questions Bret should answer before any of them gets built.
+
+Wire shape verified against the public Pax8 OpenAPI spec (`https://devx.pax8.com/openapi/partner-endpoints.json`, pulled 2026-05-15) for the `Invoice`, `InvoiceItem`, and `Subscription` schemas + their list endpoints' query params. The relevant local schemas are `InvoiceSchema` / `InvoiceItemSchema` / `SubscriptionSchema` in `packages/core/src/api/types.ts:666-700`, `:589-645`; the existing MRR math is `subscriptionMrr` / `computeMrr` in `packages/core/src/services/analytics.ts:35-91`.
+
+### Reshape 1 — `pax8 report invoiced` (sum of invoice line-item amounts by month, last N months)
+
+| | |
+|---|---|
+| **Endpoints needed** | `GET /invoices` (server-side `invoiceDateRangeStart` / `invoiceDateRangeEnd`, `companyId`, `status` filters, `size` up to 200) + `GET /invoices/{invoiceId}/items` (no filters; `size` up to 200, paginated) |
+| **Required fields on the wire** | **Yes.** Per spec `InvoiceItem` carries `subTotal`, `total`, `startPeriod` (yyyy-MM-dd), `endPeriod`, `currencyCode`, `productName`, `companyId`, `subscriptionId`, `type`, `term`. |
+| **Required fields modelled locally** | **Partial.** `InvoiceItemSchema` (`packages/core/src/api/types.ts:684-700`) currently models only `id`, `invoiceId`, `productId`, `subscriptionId`, `quantity`, `price`, `subTotal`, `companyId`, `productName`, `companyName`. Zod's default non-strict mode silently drops `type`, `term`, `startPeriod`, `endPeriod`, `total`, `chargeType`, `cost`, `costTotal`, `currencyCode`, `vendorName`, `billingFee`, `salesTax`, `rateType`, `sku`, `description`, `details`, `purchaseOrderNumber`, `externalId`, `billedByPax8`, `offeredBy`, `unitOfMeasure`. **Schema augmentation is the precondition for this command.** |
+| **Pagination / performance** | Real concern. There is no global items endpoint and no date filter on items — bucketing by month requires (1) listing invoices in the window (200/page), then (2) sequentially paginating items for *each* invoice (no batching). A partner with ~50 invoices/month × 12 months × ~100 items/invoice ≈ 600 invoice rows + 600+ item-page fetches, all sequential. Pax8 rate limit is 1,000 req/min, so a worst-case full-year roll-up is 1–2 min of wall time and could trip the limit on the largest partners. The aggregate-mode loop in `packages/core/src/api/invoices.ts:115-153` already does this fan-out, but for a small companyId filter; running it on the whole portfolio is the new shape. |
+| **Data-quality concern** | **`invoiceDate` vs. `startPeriod` is two different reports.** A January invoice routinely contains December's monthly subscription charge plus a February proration. "Sum line items by month" is ambiguous: bucket by `invoiceDate` (when it was billed) and you'll smear cross-period charges; bucket by `startPeriod` (which month the charge covers) and you get a partner-MRR-like waterfall. **Bret should pick the bucket key before we code** — they're not interchangeable and the difference shows up immediately on real data. |
+| **Effort** | **Medium.** ~50 lines of new analytics fn + new command + the schema augmentation above + demo fixture updates + tests. Bucketing-semantics conversation is the substantive part. **½ day to a full day.** |
+| **Light** | 🟡 Yellow — green on data availability, yellow on a definition call Bret needs to make first. |
+
+### Reshape 2 — `pax8 report recurring` (#1, filtered to recurring-coded line items)
+
+| | |
+|---|---|
+| **Endpoints needed** | Same as #1. |
+| **Required fields on the wire** | **Yes — and worth calling out explicitly because the brief flagged this as the load-bearing question.** Per spec, `InvoiceItem.type` is an enum: `subscription`, `prorate`, `one-time`, `service-charge`, `service-credit`, `payment-credit`, `invoice-credit`, `rebate`. Additionally `InvoiceItem.term` is an enum: `Monthly`, `Annual`, `2 Year`, `3 Year`, `Activation`, `One-Time`, `Trial`, `Arrears`, `Rebate`. The recurring-vs-non-recurring signal **is on the line item itself**, not derived from joining back to the subscription. Field name on the wire is **`term`** (not `billingTerm`) — distinct from `Subscription.billingTerm`'s spelling. Both fields are currently dropped by `InvoiceItemSchema`. |
+| **Pagination / performance** | Identical to #1. |
+| **Data-quality concern** | **Definition question for Bret: what counts as "recurring"?** Three reasonable definitions, all returning slightly different totals: (a) `type === 'subscription'`, (b) `term IN (Monthly, Annual, 2 Year, 3 Year)`, (c) the intersection of the two. A `prorate` line on a recurring product is "recurring revenue" in some books but "one-time" in others; same for `service-charge`. One-line implementation either way, but the answer changes which rows surface and how the total reconciles against Pax8's own canonical MRR. |
+| **Effort** | **Small once #1 ships** — same data-fetch path, just adds a filter predicate to the line-item reduce. **1–2 hours additional** on top of Reshape 1. |
+| **Light** | 🟡 Yellow — depends entirely on Reshape 1, plus the definition call above. |
+
+### Reshape 3 — `pax8 report run-rate` (sum of active subs × monthly-equivalent based on billing-term)
+
+| | |
+|---|---|
+| **Endpoints needed** | `GET /subscriptions` (server-side `status=Active`, `billingTerm`, `companyId`, `productId`, `sort`, `size` up to 200). |
+| **Required fields on the wire** | **Yes.** Per spec `Subscription` carries `price`, `quantity`, `billingTerm` (enum `Monthly`, `Annual`, `2-Year`, `3-Year`, `One-Time`, `Trial`, `Activation`), `status` (enum), `currencyCode`, plus `commitmentTerm` (read-only). All already modelled by `SubscriptionSchema` (`packages/core/src/api/types.ts:589-645`). |
+| **Existing logic** | **This is roughly what `report mrr` does today.** `computeMrr` (`packages/core/src/services/analytics.ts:43-91`) sums `subscriptionMrr(price, quantity, billingTerm)` over active subs (filtered client-side) and groups by company / product / vendor. `report mrr` (`packages/cli/src/commands/report/mrr.ts`) renders it and also exposes `projectedArr = totalMrr × 12`. |
+| **Latent bug worth flagging to Bret** | `subscriptionMrr` (`analytics.ts:35-41`) only normalizes `annual` / `yearly` → `/12`. **`2-Year` and `3-Year` fall through to the `price × quantity` branch** — i.e. treated as monthly. For partners with NCE 2-year / 3-year commitments this materially over-counts run-rate. The "run-rate" reframe is a good forcing function to fix this, but it should be fixed regardless (likely a separate v0.1.0 issue — wire-side enum is `2-Year` / `3-Year`, our normalization key only matches `annual`/`yearly` substrings). |
+| **Existing surface gap** | `SubscriptionsApi.list()` (`packages/core/src/api/subscriptions.ts:21-29`) doesn't yet thread `billingTerm` or sort through, even though the spec supports them server-side. Not a blocker — client-side filtering on `ALL_SUBS_PAGE_SIZE=1000` works — but a small ergonomic gap if run-rate ships with billing-term breakdowns. |
+| **Definition question for Bret** | **"Run-rate" is industry-ambiguous — monthly equivalent (≡ MRR) or annualized (≡ ARR)?** If monthly, the command is a rename of `report mrr` with the 2-Year/3-Year bug fix and no other delta. If annualized, it's `MRR × 12` — which `report mrr --json` already returns as `projectedArr`. Either way the new command is largely a help-text reframe + bug fix; the substantive work is fixing the term normalization. |
+| **Effort** | **Small.** Option (a) zero-code alias of `report mrr` with renamed output + clarifying help text + the bug fix: **2–3 hours.** Option (b) ship as new command with breakdowns by billing-term and an `--annualized` flag: **½ day.** The 2-Year / 3-Year normalization fix is ~10 lines and ships independently. |
+| **Light** | 🟢 Green on data and shape — this is repackaging existing logic. The 2-Year/3-Year normalization bug is the only real engineering work, and it should ship regardless of whether `run-rate` does. |
+
+### Summary table
+
+| Reshape | Endpoints | Wire fields | Local schema fields | Effort | Light |
+|---|---|---|---|---|---|
+| `report invoiced` | `/invoices` + `/invoices/{id}/items` | Yes | **Partial** — `InvoiceItemSchema` needs ~10 new fields | ½ day – 1 day | 🟡 — bucket-key definition call |
+| `report recurring` | Same | Yes (`type` + `term` on `InvoiceItem`) | Partial — same schema work as above | +1–2 h on top of `invoiced` | 🟡 — "what is recurring?" definition call |
+| `report run-rate` | `/subscriptions` | Yes | Yes — already modelled | 2–3 h (incl. 2-Year/3-Year normalization fix) | 🟢 — repackaging |
+
+### Recommended disposition
+
+- **`report run-rate`**: ship in v0.1.0 once Bret confirms monthly-vs-annualized framing. Pair with the 2-Year / 3-Year normalization fix in `subscriptionMrr` (ship separately if `run-rate` slips — the bug is independent and material).
+- **`report invoiced`**: defer to v0.2 unless Bret has a hard partner ask. Schema augmentation + bucketing-semantics conversation pushes it past the half-day bar this triage round is using.
+- **`report recurring`**: tied to `report invoiced` — defer to v0.2 with it. Once #1 lands the marginal cost is 1–2 hours, but shipping the filter without the underlying command is the wrong order.
+
+The pre-conversation deliverable for Bret is the three definition questions above (bucket key for `invoiced`, "what is recurring?" for `recurring`, monthly-vs-annualized for `run-rate`). The wire shape supports all three reshapes; the design decisions are where his domain authority is load-bearing.
+
+---
+
+## Candidate G — Reporting reshape — Pax8-cost-framed v0.1.0 commands
+
+**Source.** Reframing follow-up to Candidate F + Bret Pittenger's domain-review feedback. The three commands in F (`invoiced` / `recurring` / `run-rate`) leaned on partner-revenue framing that the underlying data doesn't honestly support — what we actually have is **Pax8 cost to the partner**, not partner-side revenue. This Candidate explores three replacement reporting shapes that are honest about that and can plausibly land in v0.1.0.
+
+Wire shape was verified against `https://devx.pax8.com/openapi/partner-endpoints.json` (pulled 2026-05-15, see Candidate F preamble). Key local references: `SubscriptionSchema` and `BillingTermSchema` in `packages/core/src/api/types.ts:589-645` / `:52-61`; the existing renewal logic in `packages/core/src/services/renewal-tracker.ts`; the analytics primitives in `packages/core/src/services/analytics.ts`. The enum-shaped `commitmentTermEndDate` is flattened onto `SubscriptionSchema` already (line 640), distinct from the nested `commitment` object — see the comment at types.ts:580 about why both surfaces exist.
+
+### Reshape 1 — `pax8 report subscriptions` (active subs grouped by vendor / product / customer with Pax8 cost)
+
+| | |
+|---|---|
+| **Endpoints needed** | `GET /subscriptions` (server-side `status=Active` filter, `page`/`size` up to 200, `companyId`, `productId`, `billingTerm`). To resolve vendor names, also `GET /products` (vendor is on the Product, not the Subscription — `vendorSubscriptionId` on Subscription is the *vendor's* identifier for the sub, not the vendor's name). |
+| **Required fields on the wire** | **Yes.** `Subscription` carries `price`, `quantity`, `billingTerm`, `status`, `companyId`, `productId`, `currencyCode`, `partnerCost`. Product carries vendor name. |
+| **Required fields modelled locally** | **Yes for subs, partial for the enrichment path.** `SubscriptionSchema` already models price/quantity/billingTerm/status/companyName/productName. Vendor enrichment exists in the analytics shape (`AnalyticsSubscriptionInput.vendorName` in `services/analytics.ts:6-9`) but is populated upstream — the same enrichment pattern `report mrr` used (`enrichCompanyNames`, `enrichProductNames` in `packages/cli/src/lib/`) needs a vendor variant if one doesn't exist. Worth a 10-minute check before estimating; it likely already exists since `computeMrr` already groups by vendor. |
+| **Pagination / performance** | Tractable. `ALL_SUBS_PAGE_SIZE = 1000` is the existing convention for fetch-all-subs reports (`packages/core/src/api/constants.ts:12`). For a partner with >1000 active subs the existing `warnIfTruncated` helper handles the overflow message. |
+| **Definition question** | Three groupings on one screen (vendor / product / customer) is a lot. Default view should pick one — probably vendor, since that's the dimension `dashboard` doesn't already give. `--by vendor|product|customer` flag for the others. |
+| **Effort** | **Small.** ~80 lines across new command, new analytics fn (or reuse `computeMrr` shape since the grouping logic is identical — only the label changes from "MRR" to "Pax8 cost"), tests, and demo-data assertions. **3–4 hours.** Half day with the vocabulary alignment in the help text. |
+| **Light** | 🟢 Green. Strictly repackaging existing logic with honest labels. The vocabulary-alignment PR (Candidate F follow-up: `chore(reporting): remove report mrr/growth and align vocabulary with Pax8-cost framing`) sets up the framing this command needs to slot into. |
+
+### Reshape 2 — `pax8 report renewals` (subs with `commitmentTermEndDate` within a window, Pax8 cost impact)
+
+| | |
+|---|---|
+| **Endpoints needed** | `GET /subscriptions` (same as #1). |
+| **Required fields on the wire** | **Yes.** Subscription's `commitmentTerm` object is read-only on the wire and is flattened locally to `commitmentTermEndDate` on `SubscriptionSchema` (`types.ts:640`). |
+| **Existing surface** | **This is partly repackaging, partly a definition call.** `pax8 subscriptions renewals --within 30d` already exists today (per `CLAUDE.md` routing table) and uses `getUpcomingRenewals` / `RenewalReport` from `packages/core/src/services/renewal-tracker.ts`. That service already computes "MRR renewing" via the same `subscriptionMrr` primitive — meaning the *aggregate Pax8-cost-at-risk* number is one line away. |
+| **What's net-new** | The shape of the existing command is per-subscription rows ("which subs renew in the next 30 days"); the proposed `report renewals` is aggregate ("how much Pax8 cost is locked into a renewal window"). Both are valid; they're different reports for different consumers (ops vs finance). |
+| **Decision needed before coding** | Two paths:<br>(a) Add `report renewals` as a roll-up shape (totals + breakdown by vendor / customer), keeping `subscriptions renewals` as the per-row view. The mental model becomes: `subscriptions renewals` = "list the subs," `report renewals` = "what does this cost me." Clean separation.<br>(b) Just add an `--aggregate` / `--summary` flag to the existing `subscriptions renewals`. Cheaper to ship but conflates two report shapes under one command.<br>Path (a) is what the user's brief is pointing at and matches the `report *` framing of the other two reshapes in this Candidate. |
+| **Pagination / performance** | Identical to #1. The `commitmentTermEndDate` filter is client-side (no server-side date filter on subscriptions in the spec). For a partner with thousands of subs this means fetching all and filtering locally — fine, same shape `subscriptions renewals` does today. |
+| **Effort** | **Small.** ~50 lines on top of existing renewal-tracker output: aggregate the per-row data into totals + group breakdowns, add a new command thin wrapper, tests. **2–3 hours.** The renewal-tracker primitive `computeMrrRenewing` already does the math — it just needs the rollup. |
+| **Light** | 🟢 Green on data + logic. The "new command vs. flag on existing command" call is the only real decision. |
+| **Note on the bug** | `subscriptionMrr` (the function `computeMrrRenewing` aliases to) currently mis-normalizes 2-Year / 3-Year — flagged in Candidate F. A concurrent PR (`fix(analytics): normalize 2-Year and 3-Year billing terms to monthly equivalent`) fixes it. Any renewal-cost-at-risk number this command surfaces will be wrong by the same factor until that lands. Sequencing: the analytics fix should ship first or alongside. |
+
+### Reshape 3 — `pax8 report concentration` (Pax8 spend concentration with percentages + top-N + cumulative share)
+
+| | |
+|---|---|
+| **Endpoints needed** | `GET /subscriptions` (same as #1). Same data shape, different reduce. |
+| **Required fields on the wire** | **Yes.** Same fields as Reshape 1. |
+| **Required fields modelled locally** | **Yes.** Same as Reshape 1 — no schema work. |
+| **What it computes** | For a chosen grouping dimension (default: customer; flag for product or vendor): per-group Pax8 cost, group's % of total, cumulative % across the sorted list, and a top-N cut. Classic Pareto / concentration view. |
+| **Why it's worth shipping** | This is the report that answers "if I lose customer X, what's the hit?" and "is my Pax8 spend dangerously concentrated?" It's the dimension `dashboard` and `report subscriptions` don't surface, and it's the smallest of the three to ship. |
+| **Pagination / performance** | Identical to #1. |
+| **Definition question** | What's "concentration"? Two reasonable conventions: (a) **Herfindahl-style** — sum of squared shares, one number; (b) **Pareto-style** — top-N rows + cumulative %, table shape. Most partners think Pareto, so default to (b) and treat HHI as an optional `--metric hhi` flag later if anyone asks. |
+| **Effort** | **Small.** ~50 lines: reuse `report subscriptions`'s data fetch + group function, add the sort + cumulative-share + top-N reduce + the `--top <n>` and `--by customer|product|vendor` flags. **2–3 hours.** |
+| **Light** | 🟢 Green. Smallest of the three. Pure aggregation on top of data Reshape 1 already pulls. |
+
+### Summary table
+
+| Reshape | Endpoints | Wire fields | Local schema | Effort | Light |
+|---|---|---|---|---|---|
+| `report subscriptions` | `/subscriptions` (+ `/products` for vendor enrichment) | Yes | Yes (verify vendor-enrichment helper exists) | 3–4 h | 🟢 |
+| `report renewals` (aggregate) | `/subscriptions` | Yes | Yes — `commitmentTermEndDate` already flattened | 2–3 h | 🟢 — `--aggregate` flag vs. new command is a design call |
+| `report concentration` | `/subscriptions` | Yes | Yes | 2–3 h | 🟢 |
+
+### Sequencing + recommended disposition
+
+All three are 🟢 green-light and total to ~½ – 1 day of implementation. Sequencing notes:
+
+1. **Land the vocabulary-alignment PR first** (`chore(reporting): remove report mrr/growth and align vocabulary with Pax8-cost framing`). All three new commands' help text and JSON output should use "Pax8 cost" framing from day one — shipping them on top of the old "MRR / revenue" labels would re-introduce the framing problem the vocab PR is removing.
+2. **Land the analytics fix second** (`fix(analytics): normalize 2-Year and 3-Year billing terms to monthly equivalent`). All three new commands sum `subscriptionMrr` outputs; until the fix lands, NCE multi-year subs are over-counted, and the totals on `report subscriptions` / `report renewals` / `report concentration` will be wrong by that same factor.
+3. **Ship the three new commands** in one PR (they share a data path) or two PRs (concentration depends on subscriptions; renewals is independent). One PR is cleaner — the new commands sit in `packages/cli/src/commands/report/` and share the fetch helper. **Estimated ½ – 1 day.**
+
+Decision needed from Josh: (a) confirm Path (a) vs. (b) for `report renewals` (new aggregate command vs. flag on existing), (b) confirm default grouping dimension for `report subscriptions` (vendor seems right) and `report concentration` (customer seems right). Other definition calls can be made in-implementation.
+
+If green-lit, dispatch as `feat(reporting): add report subscriptions / renewals / concentration` once the two predecessor PRs land. The triage round here only produces the feasibility read — no code shipped from this triage cycle.
+
+---
+
 ## Summary
 
 | Candidate | Cost | Recommended disposition |
@@ -290,5 +418,7 @@ Concrete, mechanical follow-up to #429:
 | C — Quotes line-items bulk-delete | ½ day to full day, plus partial-failure UX design call | **Defer to v0.2** |
 | D — Quote text fields (`--intro`, `--terms`) | 1-2 hours | **Ship in v0.1.0** — plain strings, top-level, fetch-then-merge already in place |
 | E — commitment-term on quote line items | 1-2 hours + tests/docs | **Ship in v0.1.0** as small parity follow-up to #429 — canonical per Rovo grounding (QUOTE-311 / QUOTE-1283 / NCE spike); orders create already has the pattern |
+| F — Reporting reshape (Bret Pittenger) | `run-rate` 2–3 h; `invoiced` ½–1 d; `recurring` +1–2 h on top of `invoiced` | **Reframed by Candidate G** — `run-rate` superseded by `report subscriptions`; `invoiced` / `recurring` deferred to v0.2 |
+| G — Pax8-cost-framed reporting commands | `report subscriptions` 3–4 h; `report renewals` 2–3 h; `report concentration` 2–3 h | **Ship all three in v0.1.0** after the vocab-alignment PR + 2-Year/3-Year analytics fix land. ~½–1 day total |
 
 If you want any of these dispatched after you decide, ping with the disposition and I'll implement.


### PR DESCRIPTION
## Summary

Two commits' worth of operational triage docs that have been living loose in the working tree, plus the feasibility reads from this week's reporting-domain review conversations.

- **`docs/triage/launch-coordination.md`** — working tracker for human-facing items gating v0.1.0 publish. Engineering state (10 landed PRs, B1/B2/B3 block-launch status), open coordination items (public org/repo name, sandbox credentials, LICENSE legal sign-off with Courtney Norton, second peer reviewer), sequencing dependencies, May 15 auto-approval risk read on five unengaged reviewers, and the live decision queue.
- **`docs/triage/partner-walkthrough.md`** — fresh-eyes partner-perspective trip report from an Explore-agent run against demo mode (main @ d20b113, post-#406, pre-#407-merge). Step-by-step UX findings; surfaced three follow-up items (spinners → \`--json\`, no enum validation, empty-state UX in TTY).
- **`docs/triage/v0.1.0-candidates.md`** — appended Candidates F and G:
  - **Candidate F** — Bret Pittenger reporting alignment. Wire-shape feasibility for \`report invoiced / recurring / run-rate\` against \`devx.pax8.com/openapi/partner-endpoints.json\`. \`run-rate\` 🟢, \`invoiced\` 🟡 (bucket-key definition call), \`recurring\` 🟡 (definition call). Flagged the 2-Year / 3-Year normalization bug in \`subscriptionMrr\` that #439 fixes.
  - **Candidate G** — Pax8-cost-framed v0.1.0 commands. Reframes Candidate F into three honestly-labeled commands sitting on top of the vocabulary-alignment + analytics-fix PRs (#440, #439) that ship first: \`report subscriptions\`, \`report renewals\`, \`report concentration\`. All three 🟢, ~½–1 day total.

## Why one PR

These are all triage docs and either operational state (#1, #2) or feasibility reads (#3) — neither is engineering work. Splitting into three PRs would be pure ceremony.

## Test plan

- [x] No code touched; \`pnpm test\` not relevant.
- [x] Visual diff confirms each addition is structured per existing triage conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)