### PR TITLE
feat(report): reshape reporting surface to Pax8-cost framing per Bret Pittenger review

### DIFF
--- a/docs/triage/reporting-reshape-inventory.md
+++ b/docs/triage/reporting-reshape-inventory.md
@@ -1,0 +1,237 @@
+# Reporting / metrics surface inventory
+
+Companion document to the `feat/reporting-reshape` PR. Captures every
+existing reporting / metrics primitive in the codebase before the three
+new `pax8 report *` commands land, so reuse decisions are explicit and
+the v0.2 backlog has a clean reference.
+
+Scope: post-#440 (removal of `report mrr` / `report growth` + vocabulary
+alignment) and post-#439 (2-Year / 3-Year `BillingTerm` normalization
+fix). Both PRs are already merged on `main`; this PR builds on top.
+
+---
+
+## 1. `pax8 report *` command surface
+
+After #440 the `report/` directory was deleted entirely — parent command
+file, the two subcommand files (`mrr.ts`, `growth.ts`), and the
+subprocess test (`packages/cli/src/__tests__/report.test.ts`) all
+removed. `pax8 report` is **not registered** in
+`packages/cli/src/index.ts` today.
+
+This PR recreates `packages/cli/src/commands/report/index.ts` as a thin
+parent that registers three subcommands (`renewals`, `concentration`,
+`subscriptions`) and re-registers the parent in the root command file.
+
+---
+
+## 2. Renewal-tracking logic — reused by `report renewals`
+
+**Service:** `packages/core/src/services/renewal-tracker.ts`
+
+- `getUpcomingRenewals(subscriptions, withinDays): RenewalReport`
+  - Filters subscriptions by `commitmentTermEndDate` (or
+    `commitment.endDate` fallback) within the requested window.
+  - Skips subs with no commitment date (counted in
+    `RenewalReport.skippedNoDate`) — these are month-to-month and never
+    "renew" in the commitment sense.
+  - Per-row monthly cost is computed via `subscriptionMrr` from
+    `analytics.ts` (now correct for all `BillingTerm` enum values
+    post-#439).
+- `RenewalReport` shape:
+  - `items[]` (sorted by urgency, soonest first)
+  - `totalMrrRenewing` / `totalArrRenewing` (canonical, #298)
+  - `totalMrrAtRisk` / `totalArrAtRisk` (deprecated aliases — one cycle)
+  - `annualCount`, `monthlyCount`, `urgentCount` (<= 14d),
+    `skippedNoDate`
+- `RenewalItem` shape (per row):
+  - `subscriptionId`, `companyId`, `companyName`, `productName`,
+    `quantity`, `renewalDate` (Date), `billingTerm`, `price`,
+    `mrrRenewing` + deprecated `mrrAtRisk`, `arrRenewing` + deprecated
+    `arrAtRisk`, `daysUntilRenewal`.
+  - Notably **does not** carry `vendorName` — the existing surface only
+    needs product names. The new `report renewals` command adds vendor
+    via the `enrich-subscriptions` pattern.
+
+**CLI consumers today:**
+
+- `packages/cli/src/commands/subscriptions/renewals.ts` — primary
+  user-facing wrapper. Accepts `--within <Nd>` (period string parser),
+  `--company`, `--with-actions`. Emits flat array OR
+  `{ renewals, nextActions }` envelope depending on `--with-actions`.
+  Carries the standardized disclaimer footer.
+- `packages/cli/src/commands/dashboard.ts` — calls `getUpcomingRenewals`
+  with a hard-coded 30-day window for the dashboard alerts/quick-action
+  block.
+
+**Reuse decision for `report renewals`:**
+
+Call `getUpcomingRenewals` directly. Wrap the output in the new JSON
+shape (per-row `monthlyCost` as `AmountCurrency`, top-level
+`totalMonthlyCostExposure` as `AmountCurrency`, add `vendorName` via
+products enrichment, surface `commitmentTermEndDate` + `daysUntilEnd`
+instead of `renewalDate` + `daysUntilRenewal`). Do NOT alter
+`RenewalItem` itself — the subscriptions wrapper still emits the legacy
+`mrrRenewing` / `mrrAtRisk` shape and that's correct for that command.
+The new report command is a fresh surface with the post-#440 envelope
+shape.
+
+---
+
+## 3. Analytics primitives — reused by `report concentration` and `report subscriptions`
+
+**Service:** `packages/core/src/services/analytics.ts`
+
+- `subscriptionMrr(price, quantity, billingTerm): number` — single
+  source of truth for per-sub monthly cost.
+  - **#439 fix:** This function is now correct for **every value** in
+    the `BillingTermSchema` enum (`Monthly`, `Annual`, `2-Year`,
+    `3-Year`, `One-Time`, `Trial`, `Activation`). The 2-Year and 3-Year
+    cases divide by 24 / 36 respectively; previously these fell through
+    to the unknown-term default and were treated as `price x quantity`,
+    silently 24x / 36x overstating their monthly cost.
+  - `One-Time` / `Trial` / `Activation` still return `price x quantity`
+    by design (they aren't really recurring; reframing them is a
+    separate question).
+  - Unknown / falsy terms preserve the historical default of
+    `price x quantity`.
+- `computeMrr(subscriptions): MrrReport` — aggregator. Filters to
+  Active subs, groups by company / product / vendor, sums per-sub
+  monthly cost.
+- `computeGrowth(invoices, months): GrowthReport` — month-over-month
+  delta on invoice totals. **Not used by any CLI command after #440.**
+  Retained in `@pax8/core` for v0.2 reporting reuse.
+- `MrrReport` / `GrowthReport` types — exported but post-#440 not
+  consumed by CLI commands (only by `report mrr` / `report growth`,
+  both deleted).
+
+**Reuse decision:**
+
+- `report concentration` and `report subscriptions` call
+  `subscriptionMrr` directly per sub (not `computeMrr`). The grouping
+  semantics required are slightly different per command (concentration
+  needs share-percent + cumulative; subscriptions needs counts +
+  totalQuantity + annualCost), and re-rolling the per-sub fold is
+  cheaper than adapting `MrrReport`.
+- `computeMrr` / `computeGrowth` / `MrrReport` / `GrowthReport` stay
+  exported as-is from `@pax8/core`. v0.2 will revisit.
+
+---
+
+## 4. Cost simulation — unaffected, noted for completeness
+
+**Service:** `packages/core/src/services/cost-simulator.ts`
+
+- `simulateCostChange(...): SimulationResult` — `pax8 cost sim` backend.
+  Reuses `subscriptionMrr` for the per-sub monthly cost leg.
+- Shape is different from the new reporting commands (per-scenario
+  before/after, not per-entity rollup). No reuse opportunity for the
+  three new commands.
+
+---
+
+## 5. Invoice auditing — unaffected, noted for completeness
+
+**Service:** `packages/core/src/services/invoice-auditor.ts`
+
+- `auditInvoices(...): AuditReport` — `pax8 invoices audit` backend.
+  Compares per-invoice line items against active subscriptions and
+  surfaces overcharge / undercharge / unexpected discrepancies.
+- Per-invoice findings (`AuditReport.invoices[].discrepancies[]`) —
+  very different shape from the three new commands' per-entity rollup.
+- Noted because Bret Pittenger's canon-alignment work also touched this
+  surface and future invoice-line-item-based reporting (the `report
+  invoiced` / `report recurring` shapes from Candidate F) will likely
+  reuse the auditor's line-item correlation logic.
+
+---
+
+## 6. Recommendations — unaffected, noted for completeness
+
+**Service:** `packages/core/src/services/recommendations.ts`
+
+- `getRecommendations(...)`, `getPortfolioCoverage(...)`,
+  `findUpsellCohort(...)` — backends for `pax8 recommendations
+  list / act / upsell`.
+- All three reuse `subscriptionMrr` for `estimatedMrrUplift` (which is
+  partner-cost uplift, not partner-side resale revenue — Bret's review
+  flagged this terminology, hence #440 added explicit "Pax8 cost uplift"
+  language in the dashboard / recommendations help and JSON
+  descriptions).
+
+No direct reuse for the three new report commands.
+
+---
+
+## 7. Dashboard rollups — pattern reference for the new commands
+
+**Command:** `packages/cli/src/commands/dashboard.ts`
+
+Post-#440 `dashboard` emits `AmountCurrency` envelopes for every
+currency-bearing top-level field:
+
+- `monthlyCost` / `annualCost` — portfolio totals.
+- `topCustomers[].monthlyCost` — per-customer breakdown (top 5 by Pax8
+  monthly cost — same pattern `report concentration --by customer`
+  generalizes).
+- `potentialMonthlyUplift` — high-priority recommendation uplift.
+
+Currency-resolution rule: read from
+`activeSubs.find((s) => s.currencyCode)?.currencyCode ?? "USD"`. The new
+report commands follow the same convention. Mixed-currency portfolios
+are out of scope for v0.x.
+
+The dashboard also locks in the wire-side `mrrRenewing` / `mrrAtRisk`
+preservation rule — those fields are partner-side risk-framing on
+`RenewalReport`, not CLI-aggregated Pax8 cost, so they stay flat numbers
+(not wrapped in `AmountCurrency`). `report renewals` follows the same
+rule for its per-row `monthlyCost`: wrap aggregations in
+`AmountCurrency` envelopes, leave wire-side risk-framing fields flat.
+
+---
+
+## 8. Standardized disclaimer footer
+
+The exact string, applied verbatim via `.addHelpText("after", ...)`:
+
+```
+Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.
+```
+
+Footer is currently enforced on:
+
+- `pax8 dashboard`
+- `pax8 recommendations list / act / upsell`
+- `pax8 subscriptions renewals`
+- `pax8 clients more` (and the `companies more` alias)
+
+The three new commands in this PR (`report renewals`, `report
+concentration`, `report subscriptions`) extend the matrix to nine
+surfaces. The regression test in
+`packages/cli/src/__tests__/help-json-output.test.ts` already gates the
+existing seven; `report.test.ts` (recreated in this PR) gates the new
+three.
+
+---
+
+## 9. Deferred to v0.2
+
+Invoice-line-item-based reporting (Candidate F: `report invoiced` /
+`report recurring`) is **explicitly out of scope** for this PR. Gating
+questions surfaced in Bret Pittenger's canon-alignment work:
+
+- **Bucket-key choice** — `invoiceDate` (when Pax8 invoiced the
+  partner) versus `startPeriod` (the period the line was attributable
+  to). Pax8's canonical warehouse rolls by `startPeriod` with billing-
+  period amortization, which the CLI can't replicate from the public
+  API alone.
+- **Recurring filter** — Pax8's canon defines recurring by the
+  underlying product *type*, not by billing-term flags reachable from
+  the public API. The CLI can approximate (filter out `One-Time` /
+  `Activation` terms) but can't reach the canonical answer.
+
+Once those calls are made (likely in a v0.2 design doc with Bret),
+`report invoiced` and `report recurring` land. Until then,
+`@pax8/core`'s `computeMrr` / `computeGrowth` and the `invoice-auditor`
+service are the durable building blocks — the analytics engine stays;
+the CLI surface evolves.

--- a/packages/cli/src/__tests__/report.test.ts
+++ b/packages/cli/src/__tests__/report.test.ts
@@ -1,0 +1,499 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+
+// `pax8 report *` was reshaped in feat/reporting-reshape: the old
+// `report mrr` / `report growth` commands were deleted in #440
+// (misleading partner-revenue framing on Pax8-cost numbers), and
+// replaced by three honestly-framed commands. These tests gate the new
+// surface AND the regression of the old.
+
+const DISCLAIMER =
+  /Numbers shown are Pax8 cost — what Pax8 charges you\. For partner revenue \(what you charge your customers\), combine with sell-through pricing from your PSA\./;
+
+describe("pax8 report (parent)", () => {
+  it("lists exactly three subcommands and no mrr/growth references", async () => {
+    const { stdout } = await runCliExpectSuccess(["report", "--help"]);
+    expect(stdout).toContain("renewals");
+    expect(stdout).toContain("concentration");
+    expect(stdout).toContain("subscriptions");
+    // The two #440-removed subcommands must not appear anywhere in help.
+    expect(stdout).not.toMatch(/\bmrr\b/i);
+    expect(stdout).not.toMatch(/\bgrowth\b/i);
+  });
+
+  it("report mrr returns an unknown-command error", async () => {
+    const result = await runCli(["report", "mrr"]);
+    expect(result.exitCode).not.toBe(0);
+    const combined = (result.stderr + result.stdout).toLowerCase();
+    expect(combined).toMatch(/unknown command|invalid command|usage:/);
+  });
+
+  it("report growth returns an unknown-command error", async () => {
+    const result = await runCli(["report", "growth"]);
+    expect(result.exitCode).not.toBe(0);
+    const combined = (result.stderr + result.stdout).toLowerCase();
+    expect(combined).toMatch(/unknown command|invalid command|usage:/);
+  });
+});
+
+describe("pax8 report renewals", () => {
+  it("default --within 90 returns the canonical JSON shape", async () => {
+    const { stdout } = await runCliExpectSuccess(["report", "renewals", "--json"]);
+    const data = JSON.parse(stdout);
+    expect(data).toMatchObject({
+      windowDays: 90,
+      totalCount: expect.any(Number),
+    });
+    expect(Array.isArray(data.renewals)).toBe(true);
+    expect(data.totalMonthlyCostExposure).toMatchObject({
+      amount: expect.any(Number),
+      currency: expect.any(String),
+    });
+    // Every renewal row must carry the spec-mandated fields wrapped in
+    // AmountCurrency where applicable.
+    expect(data.renewals.length).toBeGreaterThan(0);
+    for (const r of data.renewals) {
+      expect(r).toHaveProperty("subscriptionId");
+      expect(r).toHaveProperty("companyId");
+      expect(r).toHaveProperty("companyName");
+      expect(r).toHaveProperty("productName");
+      expect(r).toHaveProperty("vendorName");
+      expect(r).toHaveProperty("quantity");
+      expect(r).toHaveProperty("commitmentTermEndDate");
+      expect(r).toHaveProperty("daysUntilEnd");
+      expect(r.monthlyCost).toMatchObject({
+        amount: expect.any(Number),
+        currency: expect.any(String),
+      });
+    }
+    expect(data.totalCount).toBe(data.renewals.length);
+  });
+
+  it("--within 30 narrows the window", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "30",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.windowDays).toBe(30);
+    for (const r of data.renewals) {
+      expect(r.daysUntilEnd).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it("--within 365 widens the window", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "365",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.windowDays).toBe(365);
+    expect(data.renewals.length).toBeGreaterThan(0);
+  });
+
+  it("--sort by-cost orders renewals by descending Pax8 monthly cost", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "180",
+      "--sort",
+      "by-cost",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.renewals.length).toBeGreaterThan(1);
+    for (let i = 1; i < data.renewals.length; i++) {
+      expect(data.renewals[i].monthlyCost.amount).toBeLessThanOrEqual(
+        data.renewals[i - 1].monthlyCost.amount,
+      );
+    }
+  });
+
+  it("--sort by-date orders renewals by ascending daysUntilEnd (default)", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "180",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    for (let i = 1; i < data.renewals.length; i++) {
+      expect(data.renewals[i].daysUntilEnd).toBeGreaterThanOrEqual(
+        data.renewals[i - 1].daysUntilEnd,
+      );
+    }
+  });
+
+  it("--vendor filters by vendor name", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "365",
+      "--vendor",
+      "Microsoft",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.renewals.length).toBeGreaterThan(0);
+    for (const r of data.renewals) {
+      expect(r.vendorName.toLowerCase()).toContain("microsoft");
+    }
+  });
+
+  it("--product filters by product name substring", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "365",
+      "--product",
+      "Defender",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    for (const r of data.renewals) {
+      expect(r.productName.toLowerCase()).toContain("defender");
+    }
+  });
+
+  it("--company filters by company", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "365",
+      "--company",
+      "Summit Healthcare Partners",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.renewals.length).toBeGreaterThan(0);
+    for (const r of data.renewals) {
+      expect(r.companyName).toBe("Summit Healthcare Partners");
+    }
+  });
+
+  it("rejects non-numeric --within", async () => {
+    const result = await runCliExpectFailure([
+      "report",
+      "renewals",
+      "--within",
+      "ninety",
+    ]);
+    expect(result.stderr.toLowerCase()).toContain("within");
+  });
+
+  it("accepts integer --within (no suffix required)", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "renewals",
+      "--within",
+      "60",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.windowDays).toBe(60);
+  });
+});
+
+describe("pax8 report concentration", () => {
+  for (const groupBy of ["customer", "vendor", "product"] as const) {
+    it(`--by ${groupBy} returns the canonical JSON shape`, async () => {
+      const { stdout } = await runCliExpectSuccess([
+        "report",
+        "concentration",
+        "--by",
+        groupBy,
+        "--json",
+      ]);
+      const data = JSON.parse(stdout);
+      expect(data.groupBy).toBe(groupBy);
+      expect(data.totalMonthlyCost).toMatchObject({
+        amount: expect.any(Number),
+        currency: expect.any(String),
+      });
+      expect(Array.isArray(data.concentration)).toBe(true);
+      expect(data.concentration.length).toBeGreaterThan(0);
+      for (const row of data.concentration) {
+        expect(row).toHaveProperty("rank");
+        expect(row).toHaveProperty("entityId");
+        expect(row).toHaveProperty("entityName");
+        expect(row).toHaveProperty("activeSubscriptionCount");
+        expect(row).toHaveProperty("sharePercent");
+        expect(row).toHaveProperty("cumulativeSharePercent");
+        expect(row.monthlyCost).toMatchObject({
+          amount: expect.any(Number),
+          currency: expect.any(String),
+        });
+      }
+    });
+  }
+
+  it("--top 5 limits results to at most 5 rows", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "concentration",
+      "--by",
+      "customer",
+      "--top",
+      "5",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.concentration.length).toBeLessThanOrEqual(5);
+  });
+
+  it("--threshold filters by share-percent", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "concentration",
+      "--by",
+      "customer",
+      "--threshold",
+      "10",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    for (const row of data.concentration) {
+      expect(row.sharePercent).toBeGreaterThan(10);
+    }
+  });
+
+  it("cumulativeSharePercent is monotonically non-decreasing and <= 100", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "concentration",
+      "--by",
+      "vendor",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    let prev = 0;
+    for (const row of data.concentration) {
+      expect(row.cumulativeSharePercent).toBeGreaterThanOrEqual(prev);
+      // Allow tiny floating-point overshoot (e.g. 100.01 from rounding).
+      expect(row.cumulativeSharePercent).toBeLessThanOrEqual(100.01);
+      prev = row.cumulativeSharePercent;
+    }
+  });
+
+  it("rank ordering reflects descending monthly cost", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "concentration",
+      "--by",
+      "customer",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    for (let i = 1; i < data.concentration.length; i++) {
+      expect(data.concentration[i].monthlyCost.amount).toBeLessThanOrEqual(
+        data.concentration[i - 1].monthlyCost.amount,
+      );
+    }
+    // Rank field is 1-based and sequential.
+    data.concentration.forEach((r: { rank: number }, i: number) => {
+      expect(r.rank).toBe(i + 1);
+    });
+  });
+
+  it("errors cleanly when --by is missing", async () => {
+    const result = await runCliExpectFailure(["report", "concentration"]);
+    expect(result.stderr.toLowerCase()).toContain("--by");
+  });
+
+  it("errors on invalid --by value", async () => {
+    const result = await runCliExpectFailure([
+      "report",
+      "concentration",
+      "--by",
+      "bogus",
+    ]);
+    expect(result.stderr.toLowerCase()).toContain("--by");
+  });
+});
+
+describe("pax8 report subscriptions", () => {
+  for (const groupBy of [
+    "customer",
+    "vendor",
+    "product",
+    "billing-term",
+  ] as const) {
+    it(`--by ${groupBy} returns the canonical JSON shape`, async () => {
+      const { stdout } = await runCliExpectSuccess([
+        "report",
+        "subscriptions",
+        "--by",
+        groupBy,
+        "--json",
+      ]);
+      const data = JSON.parse(stdout);
+      expect(data.groupBy).toBe(groupBy);
+      expect(data.totalActiveSubscriptions).toBeGreaterThan(0);
+      expect(data.totalMonthlyCost).toMatchObject({
+        amount: expect.any(Number),
+        currency: expect.any(String),
+      });
+      expect(Array.isArray(data.groups)).toBe(true);
+      expect(data.groups.length).toBeGreaterThan(0);
+      for (const g of data.groups) {
+        expect(g).toHaveProperty("groupName");
+        expect(g).toHaveProperty("subscriptionCount");
+        expect(g).toHaveProperty("totalQuantity");
+        expect(g.monthlyCost).toMatchObject({
+          amount: expect.any(Number),
+          currency: expect.any(String),
+        });
+        expect(g.annualCost).toMatchObject({
+          amount: expect.any(Number),
+          currency: expect.any(String),
+        });
+      }
+    });
+  }
+
+  it("--by billing-term groups Monthly / Annual / 2-Year / 3-Year separately", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "subscriptions",
+      "--by",
+      "billing-term",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    const groupNames = data.groups.map((g: { groupName: string }) => g.groupName);
+    expect(groupNames).toContain("Monthly");
+    expect(groupNames).toContain("Annual");
+    expect(groupNames).toContain("2-Year");
+    expect(groupNames).toContain("3-Year");
+  });
+
+  // Post-#439 normalization fix: 2-Year and 3-Year monthly cost MUST equal
+  // (price × quantity) / 24 and / 36 respectively. The demo fixture has a
+  // Coastline 2-Year M365 E3 (40 seats × $36 / 24 = $60/mo) and a Pinnacle
+  // 3-Year M365 E5 (15 seats × $57 / 36 = $23.75/mo).
+  it("--by billing-term 2-Year cost reflects post-#439 normalization (divide by 24)", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "subscriptions",
+      "--by",
+      "billing-term",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    const twoYear = data.groups.find(
+      (g: { groupName: string }) => g.groupName === "2-Year",
+    );
+    expect(twoYear).toBeDefined();
+    // Coastline's 40 × $36 / 24 = $60/mo. Allow a tiny rounding tolerance.
+    expect(twoYear.monthlyCost.amount).toBeCloseTo(60, 1);
+  });
+
+  it("--by billing-term 3-Year cost reflects post-#439 normalization (divide by 36)", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "subscriptions",
+      "--by",
+      "billing-term",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    const threeYear = data.groups.find(
+      (g: { groupName: string }) => g.groupName === "3-Year",
+    );
+    expect(threeYear).toBeDefined();
+    // Pinnacle's 15 × $57 / 36 = $23.75/mo.
+    expect(threeYear.monthlyCost.amount).toBeCloseTo(23.75, 1);
+  });
+
+  it("annualCost equals monthlyCost × 12 per group", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "subscriptions",
+      "--by",
+      "vendor",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    for (const g of data.groups) {
+      expect(g.annualCost.amount).toBeCloseTo(g.monthlyCost.amount * 12, 1);
+    }
+  });
+
+  it("--company filters subscriptions to that customer", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "subscriptions",
+      "--by",
+      "product",
+      "--company",
+      "Redwood Manufacturing",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.totalActiveSubscriptions).toBeGreaterThan(0);
+    // Redwood's portfolio is bounded — fewer subs than the whole portfolio.
+    expect(data.totalActiveSubscriptions).toBeLessThan(20);
+  });
+
+  it("--vendor filters to that vendor's products only", async () => {
+    const { stdout } = await runCliExpectSuccess([
+      "report",
+      "subscriptions",
+      "--by",
+      "product",
+      "--vendor",
+      "Microsoft",
+      "--json",
+    ]);
+    const data = JSON.parse(stdout);
+    expect(data.totalActiveSubscriptions).toBeGreaterThan(0);
+    // None of the resulting product groups should be a non-Microsoft
+    // product. Soft check via product name prefix to avoid coupling to
+    // vendor-resolution internals.
+    for (const g of data.groups) {
+      // Microsoft products in the demo catalog all start with "Microsoft "
+      // or "Exchange Online" — those are Microsoft as well.
+      expect(g.groupName).toMatch(/Microsoft|Exchange Online/);
+    }
+  });
+
+  it("errors on invalid --by value", async () => {
+    const result = await runCliExpectFailure([
+      "report",
+      "subscriptions",
+      "--by",
+      "bogus",
+    ]);
+    expect(result.stderr.toLowerCase()).toContain("--by");
+  });
+});
+
+describe("standardized Pax8-cost disclaimer footer", () => {
+  // The exact string is enforced verbatim across every command that
+  // surfaces partner-side Pax8 cost. The regex matches the same form
+  // help-json-output.test.ts uses for the seven already-shipped commands.
+  for (const argv of [
+    ["report", "renewals", "--help"],
+    ["report", "concentration", "--help"],
+    ["report", "subscriptions", "--help"],
+  ]) {
+    it(`appears on pax8 ${argv.slice(0, -1).join(" ")} --help`, async () => {
+      const { stdout } = await runCliExpectSuccess(argv);
+      expect(stdout).toMatch(DISCLAIMER);
+    });
+  }
+});

--- a/packages/cli/src/commands/report/concentration.ts
+++ b/packages/cli/src/commands/report/concentration.ts
@@ -1,0 +1,329 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import {
+  ALL_SUBS_PAGE_SIZE,
+  ERROR_INVALID_INPUT,
+  subscriptionMrr,
+  type AmountCurrency,
+  type Product,
+  type Subscription,
+} from "@pax8/core";
+import { buildContext } from "../../lib/context.js";
+import { output, type Column } from "../../lib/output.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { CliError, handleCommandError } from "../../lib/errors.js";
+import { formatCompanyName, formatCurrency } from "../../lib/formatters.js";
+import { enrichCompanyNames, enrichProductNames } from "../../lib/enrich-subscriptions.js";
+
+type GroupBy = "customer" | "vendor" | "product";
+
+interface ConcentrationOptions {
+  by?: string;
+  top?: string;
+  threshold?: string;
+}
+
+interface ConcentrationRow {
+  rank: number;
+  entityId: string;
+  entityName: string;
+  activeSubscriptionCount: number;
+  monthlyCost: AmountCurrency;
+  sharePercent: number;
+  cumulativeSharePercent: number;
+}
+
+function parseGroupBy(raw: string | undefined): GroupBy {
+  if (!raw) {
+    throw new CliError(
+      "--by is required for `pax8 report concentration`.",
+      undefined,
+      ["Use --by customer, --by vendor, or --by product."],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  const v = raw.toLowerCase();
+  if (v === "customer" || v === "vendor" || v === "product") return v;
+  throw new CliError(
+    `Invalid --by value: "${raw}".`,
+    undefined,
+    ["Use --by customer, --by vendor, or --by product."],
+    undefined,
+    ERROR_INVALID_INPUT,
+  );
+}
+
+function parsePositiveInt(raw: string | undefined, flag: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) {
+    throw new CliError(
+      `Invalid ${flag} value: "${raw}".`,
+      undefined,
+      [`${flag} must be a positive integer.`],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return n;
+}
+
+function parseThreshold(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || n > 100) {
+    throw new CliError(
+      `Invalid --threshold value: "${raw}".`,
+      undefined,
+      ["--threshold must be a percentage between 0 and 100 (e.g. --threshold 10)."],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return n;
+}
+
+const tableColumns: Column[] = [
+  { key: "rank", header: "#", format: (v) => String(v) },
+  {
+    key: "entityName",
+    header: "Entity",
+    format: (v) => formatCompanyName(String(v), 32),
+  },
+  {
+    key: "activeSubscriptionCount",
+    header: "Active subs",
+    format: (v) => String(v),
+  },
+  {
+    key: "monthlyCost",
+    header: "Pax8 monthly cost",
+    format: (v) => formatCurrency((v as AmountCurrency).amount),
+  },
+  {
+    key: "sharePercent",
+    header: "Share %",
+    format: (v) => `${(v as number).toFixed(1)}%`,
+  },
+  {
+    key: "cumulativeSharePercent",
+    header: "Cumulative %",
+    format: (v) => `${(v as number).toFixed(1)}%`,
+  },
+];
+
+export const reportConcentrationCommand = new Command("concentration")
+  .description(
+    "Pax8 spend concentration analysis. Shows where your Pax8 cost is concentrated across customers, vendors, or products — useful for risk modeling and capacity planning.",
+  )
+  .option("--by <customer|vendor|product>", "Concentration axis (required)")
+  .option("--top <n>", "Limit to the top N entities", "10")
+  .option(
+    "--threshold <pct>",
+    "Show entities representing more than this percent of total Pax8 cost (alternative to --top)",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 report concentration --by customer
+  pax8 report concentration --by vendor --top 5
+  pax8 report concentration --by product --threshold 5
+  pax8 report concentration --by customer --json
+
+JSON output (--json):
+  {
+    "groupBy": "customer" | "vendor" | "product",
+    "totalMonthlyCost": { "amount": number, "currency": string },
+    "concentration": [{
+      "rank": number,
+      "entityId": string,
+      "entityName": string,
+      "activeSubscriptionCount": number,
+      "monthlyCost": { "amount": number, "currency": string },
+      "sharePercent": number,
+      "cumulativeSharePercent": number
+    }]
+  }
+
+Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.`,
+  )
+  .action(async (options: ConcentrationOptions, cmd: Command) => {
+    const allOpts = cmd.optsWithGlobals();
+    const ctx = await buildContext(allOpts);
+    const spinner = createSpinner("Fetching subscriptions...").start();
+
+    try {
+      const groupBy = parseGroupBy(options.by);
+      const top = parsePositiveInt(options.top, "--top");
+      const threshold = parseThreshold(options.threshold);
+
+      // --threshold takes precedence when both are passed, per the spec. We
+      // explicitly note this to the user via stderr so they know which
+      // filter we honored.
+      const useThreshold = threshold !== undefined;
+      if (useThreshold && options.top !== undefined && options.top !== "10") {
+        process.stderr.write(
+          `  ℹ Both --threshold and --top specified; honoring --threshold ${threshold}%.\n`,
+        );
+      }
+
+      const [subsResult, companiesResult, productsResult] = await Promise.all([
+        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE }),
+        ctx.api.companies.list({ size: 200 }),
+        ctx.api.products.list({ size: 500 }).catch(() => null),
+      ]);
+
+      const companyNames = new Map<string, string>();
+      for (const c of companiesResult.content) companyNames.set(c.id, c.name);
+      enrichCompanyNames(companyNames, subsResult.content);
+      await enrichProductNames(ctx, subsResult.content as Record<string, unknown>[]);
+
+      const productVendor = new Map<string, string>();
+      if (productsResult) {
+        for (const p of productsResult.content as Product[]) {
+          if (p.vendorName) productVendor.set(p.id, p.vendorName);
+        }
+      }
+
+      spinner.stop();
+
+      const activeSubs = subsResult.content.filter(
+        (s: Subscription) => s.status === "Active",
+      );
+      const portfolioCurrency =
+        activeSubs.find((s: Subscription) => s.currencyCode)?.currencyCode ?? "USD";
+
+      // Per-entity rollup. Key is groupBy-dependent; we keep `id` separate
+      // from `name` so that company groupings render the UUID under
+      // `entityId` (canonical) while still showing the human name.
+      interface Bucket {
+        id: string;
+        name: string;
+        count: number;
+        cost: number;
+      }
+      const buckets = new Map<string, Bucket>();
+      let total = 0;
+
+      for (const sub of activeSubs as Subscription[]) {
+        const cost = subscriptionMrr(
+          sub.price ?? 0,
+          sub.quantity ?? 0,
+          String(sub.billingTerm ?? "Monthly"),
+        );
+        total += cost;
+
+        let id: string;
+        let name: string;
+        if (groupBy === "customer") {
+          id = sub.companyId;
+          name = sub.companyName ?? sub.companyId;
+        } else if (groupBy === "vendor") {
+          const vendor = productVendor.get(sub.productId) ?? "Unknown vendor";
+          id = vendor;
+          name = vendor;
+        } else {
+          id = sub.productId;
+          name = sub.productName ?? sub.productId;
+        }
+
+        const existing = buckets.get(id);
+        if (existing) {
+          existing.count += 1;
+          existing.cost += cost;
+        } else {
+          buckets.set(id, { id, name, count: 1, cost });
+        }
+      }
+
+      const sorted = [...buckets.values()].sort((a, b) => b.cost - a.cost);
+
+      // Build rows with share + cumulative share. We compute these BEFORE
+      // applying --top / --threshold so the cumulative number reflects the
+      // entity's share of the whole portfolio (not the displayed subset).
+      let cumulative = 0;
+      const ranked = sorted.map((b, i): ConcentrationRow => {
+        const share = total > 0 ? (b.cost / total) * 100 : 0;
+        cumulative += share;
+        return {
+          rank: i + 1,
+          entityId: b.id,
+          entityName: b.name,
+          activeSubscriptionCount: b.count,
+          monthlyCost: {
+            amount: Number(b.cost.toFixed(2)),
+            currency: portfolioCurrency,
+          },
+          sharePercent: Number(share.toFixed(2)),
+          cumulativeSharePercent: Number(cumulative.toFixed(2)),
+        };
+      });
+
+      let rows: ConcentrationRow[];
+      if (useThreshold) {
+        rows = ranked.filter((r) => r.sharePercent > (threshold as number));
+      } else {
+        rows = ranked.slice(0, top ?? 10);
+      }
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(
+          JSON.stringify(
+            {
+              groupBy,
+              totalMonthlyCost: {
+                amount: Number(total.toFixed(2)),
+                currency: portfolioCurrency,
+              },
+              concentration: rows,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      if (ctx.outputFormat === "csv") {
+        output(rows, {
+          format: "csv",
+          columns: tableColumns.map((c) =>
+            c.key === "monthlyCost"
+              ? { ...c, format: (v) => String((v as AmountCurrency).amount) }
+              : c,
+          ),
+        });
+        return;
+      }
+
+      if (rows.length === 0) {
+        output([], {
+          format: "table",
+          columns: tableColumns,
+          emptyState: {
+            headline: useThreshold
+              ? `No ${groupBy}s exceed ${threshold}% of total Pax8 cost.`
+              : `No ${groupBy} concentration data found.`,
+            suggestions: [
+              { command: "pax8 report subscriptions --by " + groupBy, description: "See the full breakdown" },
+              { command: "pax8 dashboard --json", description: "Portfolio overview" },
+            ],
+          },
+        });
+        return;
+      }
+
+      output(rows, { format: "table", columns: tableColumns });
+      process.stdout.write(
+        `\n  Total Pax8 monthly cost across ${ranked.length} ${groupBy}${ranked.length === 1 ? "" : "s"}: ${formatCurrency(total)}\n\n`,
+      );
+    } catch (error) {
+      await handleCommandError(error, spinner, "Failed to compute concentration");
+    }
+  });

--- a/packages/cli/src/commands/report/index.ts
+++ b/packages/cli/src/commands/report/index.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import { reportRenewalsCommand } from "./renewals.js";
+import { reportConcentrationCommand } from "./concentration.js";
+import { reportSubscriptionsCommand } from "./subscriptions.js";
+
+// `pax8 report *` is the honest Pax8-cost reporting surface. After #440
+// removed `report mrr` / `report growth` (those were partner-revenue framed
+// against Pax8-cost data), the three commands below fill the gap:
+//
+//   renewals       — what's ending soon, and how much Pax8 cost it represents
+//   concentration  — where my Pax8 spend is concentrated (customer/vendor/product)
+//   subscriptions  — what I'm currently paying Pax8 for, grouped
+//
+// Every subcommand emits AmountCurrency envelopes for currency-bearing fields
+// (post-#440 convention) and carries the standardized disclaimer footer on
+// --help. None of them claim to compute partner-side MRR / revenue.
+export function registerReportCommands(program: Command): void {
+  const report = new Command("report")
+    .description("Pax8-cost reporting — renewals, concentration, and subscription rollups")
+    .addHelpText(
+      "after",
+      `
+Subcommands:
+  renewals       Subscriptions with upcoming commitment-term-end dates
+  concentration  Where your Pax8 spend is concentrated (customer/vendor/product)
+  subscriptions  Active subscriptions grouped by customer, vendor, product, or billing term
+
+Examples:
+  pax8 report renewals --within 90
+  pax8 report concentration --by customer --top 5
+  pax8 report subscriptions --by billing-term --json
+
+Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.`,
+    );
+
+  report.addCommand(reportRenewalsCommand);
+  report.addCommand(reportConcentrationCommand);
+  report.addCommand(reportSubscriptionsCommand);
+
+  program.addCommand(report);
+}

--- a/packages/cli/src/commands/report/renewals.ts
+++ b/packages/cli/src/commands/report/renewals.ts
@@ -1,0 +1,306 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import {
+  ALL_SUBS_PAGE_SIZE,
+  ERROR_INVALID_INPUT,
+  getUpcomingRenewals,
+  type AmountCurrency,
+  type Product,
+  type Subscription,
+} from "@pax8/core";
+import { buildContext } from "../../lib/context.js";
+import { output, type Column } from "../../lib/output.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { CliError, handleCommandError } from "../../lib/errors.js";
+import {
+  formatCompanyName,
+  formatCurrency,
+  formatDaysUntil,
+} from "../../lib/formatters.js";
+import { enrichCompanyNames, enrichProductNames } from "../../lib/enrich-subscriptions.js";
+import { resolveCompanyId } from "../../lib/resolve-company.js";
+
+interface RenewalsOptions {
+  within?: string;
+  company?: string;
+  vendor?: string;
+  product?: string;
+  sort?: string;
+}
+
+interface RenewalRow {
+  subscriptionId: string;
+  companyId: string;
+  companyName: string;
+  productName: string;
+  vendorName: string;
+  quantity: number;
+  monthlyCost: AmountCurrency;
+  commitmentTermEndDate: string;
+  daysUntilEnd: number;
+}
+
+function parseWithin(raw: string | undefined): number {
+  // Accept either "90" or "90d" (the existing subscriptions renewals command
+  // uses "90d" notation). The spec for this command says "any positive int" —
+  // matches what partners type — but we tolerate the legacy suffix too so
+  // copy/paste from other commands doesn't blow up.
+  if (raw === undefined || raw === "") return 90;
+  const match = String(raw).match(/^(\d+)d?$/);
+  if (!match) {
+    throw new CliError(
+      `Invalid --within value: "${raw}". Use a positive integer (number of days).`,
+      undefined,
+      ["Try a value like --within 30, --within 90, or --within 180."],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  const n = parseInt(match[1], 10);
+  if (n <= 0) {
+    throw new CliError(
+      `--within must be a positive integer, got ${n}.`,
+      undefined,
+      ["Try --within 30, --within 90, or --within 180."],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return n;
+}
+
+const tableColumns: Column[] = [
+  {
+    key: "subscriptionId",
+    header: "Sub",
+    format: (v) => String(v).slice(0, 8),
+  },
+  {
+    key: "companyName",
+    header: "Customer",
+    format: (v) => formatCompanyName(String(v)),
+  },
+  { key: "productName", header: "Product" },
+  { key: "quantity", header: "Qty", format: (v) => String(v) },
+  {
+    key: "monthlyCost",
+    header: "Pax8 monthly cost",
+    format: (v) => {
+      const ac = v as AmountCurrency;
+      return formatCurrency(ac.amount);
+    },
+  },
+  {
+    key: "commitmentTermEndDate",
+    header: "Commitment ends",
+    format: (v, row) => {
+      const date = String(v);
+      const days = (row as { daysUntilEnd?: number })?.daysUntilEnd ?? 0;
+      return `${date} (${formatDaysUntil(date)}; ${days}d)`;
+    },
+  },
+];
+
+export const reportRenewalsCommand = new Command("renewals")
+  .description(
+    "Subscriptions with upcoming commitment-term-end dates and the Pax8 cost exposure they represent.",
+  )
+  .option("--within <days>", "Time window in days (e.g. 30, 60, 90, 180, 365)", "90")
+  .option("--company <id|name>", "Filter by company ID or name")
+  .option("--vendor <name>", "Filter by vendor (e.g. Microsoft, AvePoint)")
+  .option("--product <name>", "Filter by product name (substring match)")
+  .option("--sort <by-date|by-cost>", "Sort key — soonest renewal first, or largest Pax8 cost first", "by-date")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 report renewals
+  pax8 report renewals --within 30
+  pax8 report renewals --within 180 --sort by-cost
+  pax8 report renewals --vendor Microsoft --json
+  pax8 report renewals --company "Summit Healthcare Partners"
+
+JSON output (--json):
+  {
+    "windowDays": number,
+    "renewals": [{
+      "subscriptionId": string,
+      "companyId": string,
+      "companyName": string,
+      "productName": string,
+      "vendorName": string,
+      "quantity": number,
+      "monthlyCost": { "amount": number, "currency": string },
+      "commitmentTermEndDate": string,             // YYYY-MM-DD
+      "daysUntilEnd": number
+    }],
+    "totalCount": number,
+    "totalMonthlyCostExposure": { "amount": number, "currency": string }
+  }
+
+Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.`,
+  )
+  .action(async (options: RenewalsOptions, cmd: Command) => {
+    const allOpts = cmd.optsWithGlobals();
+    const ctx = await buildContext(allOpts);
+    const spinner = createSpinner("Fetching subscriptions...").start();
+
+    try {
+      const withinDays = parseWithin(options.within);
+
+      const sort = (options.sort ?? "by-date").toLowerCase();
+      if (sort !== "by-date" && sort !== "by-cost") {
+        throw new CliError(
+          `Invalid --sort value: "${options.sort}".`,
+          undefined,
+          ["Use --sort by-date (default) or --sort by-cost."],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      const companyId = options.company
+        ? await resolveCompanyId(ctx, options.company)
+        : undefined;
+
+      const [subsResult, companiesResult] = await Promise.all([
+        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, companyId }),
+        ctx.api.companies.list({ size: 200 }),
+      ]);
+
+      const companyNames = new Map<string, string>();
+      for (const c of companiesResult.content) companyNames.set(c.id, c.name);
+      enrichCompanyNames(companyNames, subsResult.content);
+      await enrichProductNames(ctx, subsResult.content as Record<string, unknown>[]);
+
+      // Build a productId -> vendorName map so we can attach vendor info to
+      // each renewal row. We fetch the full product catalog (size 500) once;
+      // demo mode tops out at ~10 products. The enrichment is best-effort —
+      // any product we can't resolve gets vendorName: "" so filters/sort
+      // still work.
+      const productsList = await ctx.api.products.list({ size: 500 }).catch(() => null);
+      const productVendor = new Map<string, string>();
+      const productNamesById = new Map<string, string>();
+      if (productsList) {
+        for (const p of productsList.content as Product[]) {
+          if (p.vendorName) productVendor.set(p.id, p.vendorName);
+          productNamesById.set(p.id, p.name);
+        }
+      }
+
+      spinner.stop();
+
+      const report = getUpcomingRenewals(subsResult.content, withinDays);
+
+      // Resolve currency from the first active sub that carries one — same
+      // convention dashboard uses post-#440. Mixed-currency portfolios are
+      // out of scope for v0.x.
+      const activeSubs = subsResult.content.filter(
+        (s: Subscription) => s.status === "Active",
+      );
+      const portfolioCurrency =
+        activeSubs.find((s: Subscription) => s.currencyCode)?.currencyCode ?? "USD";
+
+      const vendorFilter = options.vendor?.toLowerCase();
+      const productFilter = options.product?.toLowerCase();
+
+      const rows: RenewalRow[] = [];
+      for (const item of report.items) {
+        // Find the underlying sub to read productId (RenewalItem doesn't
+        // carry it). Fall back to "" if not found (shouldn't happen, but
+        // keeps the vendor enrichment best-effort).
+        const sub = subsResult.content.find(
+          (s: Subscription) => s.id === item.subscriptionId,
+        );
+        const productId = sub?.productId ?? "";
+        const vendorName = productVendor.get(productId) ?? "";
+
+        if (vendorFilter && !vendorName.toLowerCase().includes(vendorFilter)) continue;
+        if (productFilter && !item.productName.toLowerCase().includes(productFilter)) continue;
+
+        rows.push({
+          subscriptionId: item.subscriptionId,
+          companyId: item.companyId,
+          companyName: item.companyName,
+          productName: item.productName,
+          vendorName,
+          quantity: item.quantity,
+          monthlyCost: {
+            amount: Number(item.mrrRenewing.toFixed(2)),
+            currency: portfolioCurrency,
+          },
+          commitmentTermEndDate: item.renewalDate.toISOString().split("T")[0],
+          daysUntilEnd: item.daysUntilRenewal,
+        });
+      }
+
+      if (sort === "by-cost") {
+        rows.sort((a, b) => b.monthlyCost.amount - a.monthlyCost.amount);
+      } // by-date is already the default sort from getUpcomingRenewals.
+
+      const totalMonthly = rows.reduce((sum, r) => sum + r.monthlyCost.amount, 0);
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(
+          JSON.stringify(
+            {
+              windowDays: withinDays,
+              renewals: rows,
+              totalCount: rows.length,
+              totalMonthlyCostExposure: {
+                amount: Number(totalMonthly.toFixed(2)),
+                currency: portfolioCurrency,
+              },
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      if (ctx.outputFormat === "csv") {
+        output(rows, {
+          format: "csv",
+          columns: tableColumns.map((c) =>
+            c.key === "monthlyCost"
+              ? { ...c, format: (v) => String((v as AmountCurrency).amount) }
+              : c,
+          ),
+        });
+        return;
+      }
+
+      if (rows.length === 0) {
+        output([], {
+          format: "table",
+          columns: tableColumns,
+          emptyState: {
+            headline: `No commitments ending within ${withinDays} days.`,
+            filtersApplied: {
+              within: `${withinDays}d`,
+              ...(options.company ? { company: options.company } : {}),
+              ...(options.vendor ? { vendor: options.vendor } : {}),
+              ...(options.product ? { product: options.product } : {}),
+            },
+            suggestions: [
+              { command: "pax8 report renewals --within 365", description: "Widen the window" },
+              { command: "pax8 report subscriptions --by vendor", description: "See what you're paying Pax8 for today" },
+            ],
+          },
+        });
+        return;
+      }
+
+      output(rows, { format: "table", columns: tableColumns });
+      process.stdout.write(
+        `\n  ${rows.length} renewal${rows.length === 1 ? "" : "s"} within ${withinDays} days — ${formatCurrency(totalMonthly)}/mo Pax8 cost exposure\n\n`,
+      );
+    } catch (error) {
+      await handleCommandError(error, spinner, "Failed to fetch renewals");
+    }
+  });

--- a/packages/cli/src/commands/report/subscriptions.ts
+++ b/packages/cli/src/commands/report/subscriptions.ts
@@ -1,0 +1,296 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import {
+  ALL_SUBS_PAGE_SIZE,
+  ERROR_INVALID_INPUT,
+  subscriptionMrr,
+  type AmountCurrency,
+  type Product,
+  type Subscription,
+} from "@pax8/core";
+import { buildContext } from "../../lib/context.js";
+import { output, type Column } from "../../lib/output.js";
+import { createSpinner } from "../../lib/spinner.js";
+import { CliError, handleCommandError } from "../../lib/errors.js";
+import { formatCompanyName, formatCurrency } from "../../lib/formatters.js";
+import { enrichCompanyNames, enrichProductNames } from "../../lib/enrich-subscriptions.js";
+import { resolveCompanyId } from "../../lib/resolve-company.js";
+
+type GroupBy = "customer" | "vendor" | "product" | "billing-term";
+
+interface SubscriptionsOptions {
+  by?: string;
+  company?: string;
+  vendor?: string;
+}
+
+interface SubscriptionsGroupRow {
+  groupName: string;
+  subscriptionCount: number;
+  totalQuantity: number;
+  monthlyCost: AmountCurrency;
+  annualCost: AmountCurrency;
+}
+
+function parseGroupBy(raw: string | undefined): GroupBy {
+  const v = (raw ?? "vendor").toLowerCase();
+  if (
+    v === "customer" ||
+    v === "vendor" ||
+    v === "product" ||
+    v === "billing-term"
+  )
+    return v;
+  throw new CliError(
+    `Invalid --by value: "${raw}".`,
+    undefined,
+    ["Use --by customer, --by vendor, --by product, or --by billing-term."],
+    undefined,
+    ERROR_INVALID_INPUT,
+  );
+}
+
+const tableColumns: Column[] = [
+  {
+    key: "groupName",
+    header: "Group",
+    format: (v) => formatCompanyName(String(v), 32),
+  },
+  {
+    key: "subscriptionCount",
+    header: "Subs",
+    format: (v) => String(v),
+  },
+  {
+    key: "totalQuantity",
+    header: "Total qty",
+    format: (v) => String(v),
+  },
+  {
+    key: "monthlyCost",
+    header: "Pax8 monthly cost",
+    format: (v) => formatCurrency((v as AmountCurrency).amount),
+  },
+  {
+    key: "annualCost",
+    header: "Pax8 annual cost",
+    format: (v) => formatCurrency((v as AmountCurrency).amount),
+  },
+];
+
+export const reportSubscriptionsCommand = new Command("subscriptions")
+  .description(
+    "Audit and group your active Pax8 commitments. Useful for periodic state checks, capacity audits, and identifying orphaned subscriptions.",
+  )
+  .option("--by <customer|vendor|product|billing-term>", "Group axis", "vendor")
+  .option("--company <id|name>", "Filter by company ID or name")
+  .option("--vendor <name>", "Filter by vendor (e.g. Microsoft, AvePoint)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 report subscriptions
+  pax8 report subscriptions --by customer
+  pax8 report subscriptions --by billing-term --json
+  pax8 report subscriptions --company "Redwood Manufacturing"
+  pax8 report subscriptions --vendor Microsoft
+
+JSON output (--json):
+  {
+    "groupBy": "customer" | "vendor" | "product" | "billing-term",
+    "totalActiveSubscriptions": number,
+    "totalMonthlyCost": { "amount": number, "currency": string },
+    "groups": [{
+      "groupName": string,
+      "subscriptionCount": number,
+      "totalQuantity": number,
+      "monthlyCost": { "amount": number, "currency": string },
+      "annualCost": { "amount": number, "currency": string }
+    }]
+  }
+
+Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.`,
+  )
+  .action(async (options: SubscriptionsOptions, cmd: Command) => {
+    const allOpts = cmd.optsWithGlobals();
+    const ctx = await buildContext(allOpts);
+    const spinner = createSpinner("Fetching subscriptions...").start();
+
+    try {
+      const groupBy = parseGroupBy(options.by);
+
+      const companyId = options.company
+        ? await resolveCompanyId(ctx, options.company)
+        : undefined;
+
+      const [subsResult, companiesResult, productsResult] = await Promise.all([
+        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, companyId }),
+        ctx.api.companies.list({ size: 200 }),
+        ctx.api.products.list({ size: 500 }).catch(() => null),
+      ]);
+
+      const companyNames = new Map<string, string>();
+      for (const c of companiesResult.content) companyNames.set(c.id, c.name);
+      enrichCompanyNames(companyNames, subsResult.content);
+      await enrichProductNames(ctx, subsResult.content as Record<string, unknown>[]);
+
+      const productVendor = new Map<string, string>();
+      if (productsResult) {
+        for (const p of productsResult.content as Product[]) {
+          if (p.vendorName) productVendor.set(p.id, p.vendorName);
+        }
+      }
+
+      spinner.stop();
+
+      const vendorFilter = options.vendor?.toLowerCase();
+
+      const activeSubs = (subsResult.content as Subscription[]).filter(
+        (s) => s.status === "Active",
+      );
+
+      // Apply vendor filter (vendor isn't on Subscription directly — resolve
+      // through the productId -> vendor map). Done after activeSubs so the
+      // count + currency-resolution heuristic still reflects what survived
+      // both filters.
+      const filteredSubs = vendorFilter
+        ? activeSubs.filter((s) => {
+            const v = productVendor.get(s.productId)?.toLowerCase() ?? "";
+            return v.includes(vendorFilter);
+          })
+        : activeSubs;
+
+      const portfolioCurrency =
+        filteredSubs.find((s) => s.currencyCode)?.currencyCode ?? "USD";
+
+      interface Bucket {
+        name: string;
+        count: number;
+        quantity: number;
+        cost: number;
+      }
+      const buckets = new Map<string, Bucket>();
+      let totalMonthly = 0;
+      let totalSubs = 0;
+
+      for (const sub of filteredSubs) {
+        const cost = subscriptionMrr(
+          sub.price ?? 0,
+          sub.quantity ?? 0,
+          String(sub.billingTerm ?? "Monthly"),
+        );
+        totalMonthly += cost;
+        totalSubs += 1;
+
+        let key: string;
+        let name: string;
+        if (groupBy === "customer") {
+          key = sub.companyId;
+          name = sub.companyName ?? sub.companyId;
+        } else if (groupBy === "vendor") {
+          const v = productVendor.get(sub.productId) ?? "Unknown vendor";
+          key = v;
+          name = v;
+        } else if (groupBy === "product") {
+          key = sub.productId;
+          name = sub.productName ?? sub.productId;
+        } else {
+          // billing-term
+          key = String(sub.billingTerm ?? "Monthly");
+          name = key;
+        }
+
+        const existing = buckets.get(key);
+        if (existing) {
+          existing.count += 1;
+          existing.quantity += sub.quantity ?? 0;
+          existing.cost += cost;
+        } else {
+          buckets.set(key, {
+            name,
+            count: 1,
+            quantity: sub.quantity ?? 0,
+            cost,
+          });
+        }
+      }
+
+      const groups: SubscriptionsGroupRow[] = [...buckets.values()]
+        .sort((a, b) => b.cost - a.cost)
+        .map((b) => ({
+          groupName: b.name,
+          subscriptionCount: b.count,
+          totalQuantity: b.quantity,
+          monthlyCost: {
+            amount: Number(b.cost.toFixed(2)),
+            currency: portfolioCurrency,
+          },
+          annualCost: {
+            amount: Number((b.cost * 12).toFixed(2)),
+            currency: portfolioCurrency,
+          },
+        }));
+
+      if (ctx.outputFormat === "json") {
+        process.stdout.write(
+          JSON.stringify(
+            {
+              groupBy,
+              totalActiveSubscriptions: totalSubs,
+              totalMonthlyCost: {
+                amount: Number(totalMonthly.toFixed(2)),
+                currency: portfolioCurrency,
+              },
+              groups,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+        return;
+      }
+
+      if (ctx.outputFormat === "quiet") return;
+
+      if (ctx.outputFormat === "csv") {
+        output(groups, {
+          format: "csv",
+          columns: tableColumns.map((c) =>
+            c.key === "monthlyCost" || c.key === "annualCost"
+              ? { ...c, format: (v) => String((v as AmountCurrency).amount) }
+              : c,
+          ),
+        });
+        return;
+      }
+
+      if (groups.length === 0) {
+        output([], {
+          format: "table",
+          columns: tableColumns,
+          emptyState: {
+            headline: "No active subscriptions match these filters.",
+            filtersApplied: {
+              by: groupBy,
+              ...(options.company ? { company: options.company } : {}),
+              ...(options.vendor ? { vendor: options.vendor } : {}),
+            },
+            suggestions: [
+              { command: "pax8 subscriptions list --status Active --json", description: "Inspect every active sub" },
+              { command: "pax8 dashboard --json", description: "Portfolio overview" },
+            ],
+          },
+        });
+        return;
+      }
+
+      output(groups, { format: "table", columns: tableColumns });
+      process.stdout.write(
+        `\n  ${totalSubs} active subscription${totalSubs === 1 ? "" : "s"} across ${groups.length} ${groupBy === "billing-term" ? "billing term" : groupBy}${groups.length === 1 ? "" : "s"} — ${formatCurrency(totalMonthly)}/mo · ${formatCurrency(totalMonthly * 12)}/yr Pax8 cost\n\n`,
+      );
+    } catch (error) {
+      await handleCommandError(error, spinner, "Failed to compute subscriptions report");
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { registerWebhooksCommands } from "./commands/webhooks/index.js";
 import { registerContactsCommands } from "./commands/contacts/index.js";
 import { registerQuotesCommands } from "./commands/quotes/index.js";
 import { registerCostCommands } from "./commands/cost/index.js";
+import { registerReportCommands } from "./commands/report/index.js";
 import { dashboardCommand, statusCommand } from "./commands/dashboard.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { completionsCommand } from "./commands/completions.js";
@@ -107,6 +108,7 @@ export function createProgram(): Command {
   registerContactsCommands(program);
   registerQuotesCommands(program);
   registerCostCommands(program);
+  registerReportCommands(program);
   program.addCommand(dashboardCommand);
   // Deprecated alias for `dashboard`. Hidden from --help; emits a one-line
   // stderr deprecation notice when invoked. Will be removed in v1.0. Same

--- a/packages/core/src/mock/demo-data.test.ts
+++ b/packages/core/src/mock/demo-data.test.ts
@@ -173,11 +173,15 @@ describe("demo-data", () => {
       expect(summit).toHaveLength(3);
     });
 
-    it("Coastline Legal Group has 2 subscriptions", () => {
+    // Coastline now also carries a 2-Year M365 E3 commit renewing in 270d,
+    // added in the feat/reporting-reshape PR so the `pax8 report
+    // subscriptions --by billing-term` view exercises the post-#439
+    // 2-Year normalization fix visibly.
+    it("Coastline Legal Group has 3 subscriptions", () => {
       const coastline = subscriptions.filter(
         (s) => s.companyId === "b2c3d4e5-f6a7-8901-bcde-f12345678901"
       );
-      expect(coastline).toHaveLength(2);
+      expect(coastline).toHaveLength(3);
     });
 
     it("Redwood Manufacturing has 7 subscriptions", () => {
@@ -194,11 +198,57 @@ describe("demo-data", () => {
       expect(bright).toHaveLength(2);
     });
 
-    it("Pinnacle Financial Advisors has 3 subscriptions", () => {
+    // Pinnacle now also carries a 3-Year M365 E5 commit (added in the
+    // feat/reporting-reshape PR — see above).
+    it("Pinnacle Financial Advisors has 4 subscriptions", () => {
       const pinnacle = subscriptions.filter(
         (s) => s.companyId === "e5f6a7b8-c9d0-1234-efab-345678901234"
       );
-      expect(pinnacle).toHaveLength(3);
+      expect(pinnacle).toHaveLength(4);
+    });
+  });
+
+  // feat/reporting-reshape — invariants for the new `pax8 report *`
+  // commands. These guard against future demo-data edits that would
+  // silently regress the variety the commands depend on (multi-year
+  // billing terms, long-tail renewal windows, customer concentration).
+  describe("reporting-reshape demo variety", () => {
+    it("has at least one 2-Year billing term subscription (post-#439 normalization fixture)", () => {
+      expect(
+        subscriptions.some((s) => s.billingTerm === "2-Year" && s.status === "Active"),
+      ).toBe(true);
+    });
+
+    it("has at least one 3-Year billing term subscription (post-#439 normalization fixture)", () => {
+      expect(
+        subscriptions.some((s) => s.billingTerm === "3-Year" && s.status === "Active"),
+      ).toBe(true);
+    });
+
+    it("has at least one renewal in each of the 0-30d / 31-60d / 61-90d / 91-365d windows", () => {
+      const now = Date.now();
+      const day = 86_400_000;
+      const buckets = {
+        "0-30": 0,
+        "31-60": 0,
+        "61-90": 0,
+        "91-365": 0,
+      };
+      for (const s of subscriptions) {
+        if (!s.commitmentTermEndDate) continue;
+        const diffDays = Math.floor(
+          (new Date(s.commitmentTermEndDate).getTime() - now) / day,
+        );
+        if (diffDays < 0 || diffDays > 365) continue;
+        if (diffDays <= 30) buckets["0-30"]++;
+        else if (diffDays <= 60) buckets["31-60"]++;
+        else if (diffDays <= 90) buckets["61-90"]++;
+        else buckets["91-365"]++;
+      }
+      expect(buckets["0-30"]).toBeGreaterThanOrEqual(1);
+      expect(buckets["31-60"]).toBeGreaterThanOrEqual(1);
+      expect(buckets["61-90"]).toBeGreaterThanOrEqual(1);
+      expect(buckets["91-365"]).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -92,7 +92,19 @@ export interface Subscription {
    * least one non-USD record so the table-display branch is exercised.
    */
   currencyCode?: string;
-  billingTerm: "Monthly" | "Annual";
+  // Mirrors the public `BillingTermSchema` enum. The 2-Year / 3-Year values
+  // are seeded into the demo fixture so the `pax8 report subscriptions
+  // --by billing-term` view visibly exercises the post-#439 normalization
+  // fix (divide by 24 / 36) — previously these fell through to the unknown-
+  // term default and were over-counted.
+  billingTerm:
+    | "Monthly"
+    | "Annual"
+    | "2-Year"
+    | "3-Year"
+    | "One-Time"
+    | "Trial"
+    | "Activation";
   commitment?: { id: string; term: string; endDate: string };
   commitmentTermEndDate: string | null;
   provisioningStatus: "Provisioned" | "Pending" | "Error";
@@ -1198,6 +1210,92 @@ export const subscriptions: Subscription[] = [
     provisioningStatus: "Provisioned",
     companyName: "Acme Corp",
   },
+
+  // ── Reporting-reshape demo variety (feat/reporting-reshape) ─────────────
+  // Adds the renewal-window distribution + multi-year billing-term variety
+  // the three new `pax8 report *` commands rely on for meaningful demo
+  // output. Specifically:
+  //   * one 2-Year and one 3-Year commitment so `report subscriptions
+  //     --by billing-term` exercises the post-#439 normalization fix
+  //     (divide by 24 / 36) and the user can SEE that the monthly cost
+  //     for those tiers is not 24x / 36x overstated.
+  //   * extra 61-90d and 91-365d renewals so `report renewals --within
+  //     180 / --within 365` returns 2-3 rows in each window (per the
+  //     PR spec's variety asks). The existing fixture only had 1 sub
+  //     past 90 days.
+
+  // Coastline Legal — adds a 2-Year M365 E3 commitment renewing in 270d.
+  // Pushes Coastline into the 91-365d renewal window.
+  // 2-Year cost: 40 seats * 36/seat / 24 = $60/mo (post-#439 fix divides by 24).
+  {
+    id: "sub-coastline-e3-2yr-003",
+    companyId: COASTLINE_ID,
+    productId: "prod-m365-e3-0003",
+    productName: "Microsoft 365 E3 [New Commerce Experience]",
+    quantity: 40,
+    startDate: "2025-08-15",
+    createdDate: "2025-08-10",
+    createdAt: "2025-08-10",
+    billingStart: "2025-08-15",
+    status: "Active",
+    price: 36.0,
+    currencyCode: "EUR",
+    billingTerm: "2-Year",
+    commitment: { id: "cterm-0002-0001-0001-000000000003", term: "2-Year", endDate: daysFromNow(270) },
+    commitmentTermEndDate: daysFromNow(270),
+    provisioningStatus: "Provisioned",
+    companyName: "Coastline Legal Group",
+  },
+
+  // Pinnacle Financial — adds a 3-Year M365 E5 commitment renewing in 200d.
+  // Locks in the 3-Year term for the billing-term breakdown.
+  // 3-Year cost: 15 seats * 57/seat / 36 = $23.75/mo (post-#439 fix divides by 36).
+  {
+    id: "sub-pinnacle-e5-3yr-004",
+    companyId: PINNACLE_ID,
+    productId: "prod-m365-e5-0004",
+    productName: "Microsoft 365 E5 [New Commerce Experience]",
+    quantity: 15,
+    startDate: "2025-06-01",
+    createdDate: "2025-05-28",
+    createdAt: "2025-05-28",
+    billingStart: "2025-06-01",
+    status: "Active",
+    price: 57.0,
+    billingTerm: "3-Year",
+    commitment: { id: "cterm-0005-0001-0001-000000000004", term: "3-Year", endDate: daysFromNow(200) },
+    commitmentTermEndDate: daysFromNow(200),
+    provisioningStatus: "Provisioned",
+    companyName: "Pinnacle Financial Advisors",
+  },
+
+  // Acme Corp — adds a third 61-90d-window sub (Exchange Online Plan 1) so
+  // the `--within 90` / `--within 180` ranges return multiple rows for
+  // Acme as well, not just Redwood.
+  {
+    id: "sub-acme-exo1-004",
+    companyId: ACME_ID,
+    productId: "prod-exo-plan1-0005",
+    productName: "Exchange Online (Plan 1) [New Commerce Experience]",
+    quantity: 25,
+    startDate: "2025-05-20",
+    createdDate: "2025-05-18",
+    createdAt: "2025-05-18",
+    billingStart: "2025-05-20",
+    status: "Active",
+    price: 4.0,
+    billingTerm: "Annual",
+    commitment: { id: "cterm-0006-0001-0001-000000000004", term: "1-Year", endDate: daysFromNow(75) },
+    commitmentTermEndDate: daysFromNow(75),
+    provisioningStatus: "Provisioned",
+    companyName: "Acme Corp",
+  },
+
+  // (We deliberately do NOT add a Bright Minds Entra ID P1 active sub here —
+  // the "invoiced Entra ID P1 but no active subscription" invariant is the
+  // anchor for the auditor's "unexpected line" demo case. The long-tail
+  // 91-365d variety is covered by Coastline's 2-Year and Pinnacle's 3-Year
+  // commits above.)
 ];
 
 // ─── Invoices ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Motivation

[#440](https://github.com/pax8labs/pax8-cli/pull/440) removed `pax8 report mrr` and `pax8 report growth` because their partner-revenue framing was misleading — the figures underneath are the partner's COST paid to Pax8, not partner-side resale revenue or MRR. This PR fills the reporting-surface gap with three honestly-framed commands.

Bret Pittenger's domain review flagged three concerns: **label** (calling Pax8 cost "MRR" overloads the term partners use for their own revenue), **perspective** (the figure represents the partner's cost, not their customers' bookings), and **methodology** (canonical Pax8 MRR amortizes by billing period through warehouse-only data the public API can't replicate). Subsequent Rovo canon-alignment work surfaced:

- Pax8 has no canonical "run-rate" term.
- Canonical MRR uses warehouse-only data (`fact_invoice_detail_by_month` with billing-period amortization and a type-driven inclusion filter the CLI can't replicate against the public API).
- The recurring-vs-non-recurring signal in Pax8's canon is type-driven, not term-driven.

The CLI shouldn't claim to compute "MRR" against canonical Pax8 definitions. It should report on what it can honestly access: subscription cost and renewal exposure. The three commands below are framed that way.

## Removal + fix context

- [#440](https://github.com/pax8labs/pax8-cli/pull/440) — already merged. Removed `report mrr` / `report growth` and aligned vocabulary across `dashboard`, `recommendations`, `subscriptions renewals`, `clients more`, `companies more`. Introduced the standardized "Pax8 cost vs partner revenue" disclaimer footer and the `AmountCurrency` envelope convention for currency-bearing JSON fields.
- [#439](https://github.com/pax8labs/pax8-cli/pull/439) — already merged. Normalized 2-Year and 3-Year billing terms in `subscriptionMrr` to monthly equivalent (divide by 24 / 36). Without it, the `report subscriptions --by billing-term` view would over-count those tiers by 24× / 36×.

## Three new commands

| Command | Partner question | Key flags |
|---|---|---|
| `pax8 report renewals` | What subscriptions are ending soon and the Pax8 cost exposure they represent? | `--within`, `--company`, `--vendor`, `--product`, `--sort by-date\|by-cost` |
| `pax8 report concentration` | Where is my Pax8 spend concentrated? | `--by customer\|vendor\|product` (required), `--top N`, `--threshold <pct>` |
| `pax8 report subscriptions` | What am I currently paying Pax8 for, and how does it break down? | `--by customer\|vendor\|product\|billing-term`, `--company`, `--vendor` |

All three:

- Carry the verbatim standardized disclaimer footer on `--help`.
- Emit `AmountCurrency` envelopes (`{ amount, currency }`) for every currency-bearing JSON field — same convention `dashboard` adopted in #440.
- Reuse `subscriptionMrr` (correct for every `BillingTerm` after #439) and `getUpcomingRenewals` from `@pax8/core`. No reinvented math.
- Resolve currency from `Subscription.currencyCode ?? "USD"` (first active sub) — mixed-currency portfolios are out of scope for v0.x, matching `dashboard`'s convention.

## Inventory doc

`docs/triage/reporting-reshape-inventory.md` captures the full reporting / metrics primitive surface before this PR — `renewal-tracker`, `analytics` (`subscriptionMrr` / `computeMrr` / `computeGrowth`), `cost-simulator`, `invoice-auditor`, `recommendations`, the `dashboard` rollup pattern. Reuse decisions are explicit. Section 8 documents the exact disclaimer footer copy. Section 9 enumerates what's deferred.

## Deferred to v0.2

Invoice-line-item-based reporting (Candidate F: `report invoiced` / `report recurring`) is explicitly out of scope. Two unresolved canonical questions block it:

- **Bucket-key choice** — `invoiceDate` (when Pax8 invoiced the partner) versus `startPeriod` (the period the line was attributable to). Pax8's canonical warehouse rolls by `startPeriod` with billing-period amortization, which the CLI can't replicate from the public API alone.
- **Recurring filter** — Pax8's canon defines recurring by the underlying product *type*, not by billing-term flags reachable from the public API. The CLI can approximate (filter out `One-Time` / `Activation` terms) but can't reach the canonical answer.

Once those calls are made (likely in a v0.2 design doc with Bret), `report invoiced` and `report recurring` land. Until then, `@pax8/core`'s `computeMrr` / `computeGrowth` and the `invoice-auditor` service are the durable building blocks — the analytics engine stays; the CLI surface evolves.

## Test plan

- [x] `pnpm install && pnpm build && pnpm test && pnpm lint` — all green (1915 tests pass, 0 failures, 6 skipped).
- [x] Subprocess test `packages/cli/src/__tests__/report.test.ts` (36 tests) covers happy-path JSON shapes for all three commands, every filter flag, sort flag, `--top` / `--threshold`, the 2-Year / 3-Year normalization invariant, and the cumulative-share monotonic invariant.
- [x] Regression: `pax8 report --help` lists exactly `renewals`, `concentration`, `subscriptions` — no `mrr`, no `growth`. `pax8 report mrr` and `pax8 report growth` return unknown-command errors.
- [x] Disclaimer footer enforced on all three new commands via a verbatim regex (same form `help-json-output.test.ts` uses for the seven already-shipped commands).
- [x] Demo-fixture invariants added: at least one 2-Year, at least one 3-Year, and at least one renewal in each of the 0-30 / 31-60 / 61-90 / 91-365d windows — so future demo edits can't silently regress the variety these commands depend on.
- [x] Demo-mode smoke test on all three commands with `--json | jq`. Sample outputs verified: Redwood at 59% of total Pax8 spend (single dominant customer), 2-Year M365 E3 at $60/mo (40 × $36 / 24), 3-Year M365 E5 at $23.75/mo (15 × $57 / 36).

Related: #439 (2-Year / 3-Year normalization), #440 (mrr/growth removal + vocabulary alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)