### PR TITLE
chore(claude-skill): rename and reframe pax8_report_mrr to pax8_report_subscriptions

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1207,7 +1207,7 @@ Create `packages/claude-skill/src/tools.ts` with tool definitions for:
 - `pax8_invoices_list` — wraps `pax8 invoices list --json [--month <month>]`
 - `pax8_invoices_audit` — wraps `pax8 invoices audit --json [--month <month>]`
 - `pax8_products_search` — wraps `pax8 products search <query> --json`
-- `pax8_report_mrr` — wraps `pax8 report mrr --json` (if implemented, else subscriptions list and compute)
+- `pax8_report_subscriptions` — fetches `pax8 subscriptions list --json` (+ `companies list`) and computes a Pax8-cost rollup by company; returns wrapped `AmountCurrency` envelopes and the standard partner-revenue disclaimer.
 
 Each tool: name, description, JSON Schema parameters, `execute` function that spawns the CLI as a child process and returns parsed JSON.
 

--- a/packages/claude-skill/src/tools/index.ts
+++ b/packages/claude-skill/src/tools/index.ts
@@ -8,5 +8,5 @@ export {
 } from "./subscriptions.js";
 export { pax8_invoices_list, pax8_invoices_audit } from "./invoices.js";
 export { pax8_products_search } from "./products.js";
-export { pax8_report_mrr } from "./reports.js";
+export { pax8_report_subscriptions } from "./reports.js";
 export { pax8_recommendations } from "./recommendations.js";

--- a/packages/claude-skill/src/tools/reports.test.ts
+++ b/packages/claude-skill/src/tools/reports.test.ts
@@ -1,0 +1,190 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the parent module's execCli before importing the tool under test.
+// The tool reads execCli from "../index.js" (the skill entrypoint), so the
+// mock path is identical to the import specifier in reports.ts.
+const execCliMock = vi.fn<(args: string[]) => Promise<string>>();
+vi.mock("../index.js", () => ({
+  execCli: (args: string[]) => execCliMock(args),
+}));
+
+// Standardized disclaimer string — verbatim from the post-#440 / #443
+// CLI surfaces and the AmountCurrency reshape. The skill payload must
+// embed this string so an agent consuming this tool sees the framing.
+const DISCLAIMER =
+  "Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.";
+
+// Helper: wire the execCli mock to return a synthetic { subs, companies }
+// fixture in CLI envelope shape. Order matches the parallel call in the
+// tool: first the subscriptions list call, then the companies list call.
+function mockCliResponses(
+  subsContent: unknown[],
+  companiesContent: unknown[] = [],
+) {
+  execCliMock.mockReset();
+  execCliMock
+    .mockResolvedValueOnce(JSON.stringify({ content: subsContent }))
+    .mockResolvedValueOnce(JSON.stringify({ content: companiesContent }));
+}
+
+describe("pax8_report_subscriptions", () => {
+  beforeEach(() => {
+    execCliMock.mockReset();
+  });
+
+  it("exports the canonical name and a description that frames Pax8 cost honestly", async () => {
+    const { pax8_report_subscriptions } = await import("./reports.js");
+    expect(pax8_report_subscriptions.name).toBe("pax8_report_subscriptions");
+    // No "MRR" / "Monthly Recurring Revenue" / "ARR" in the description —
+    // the rename PR's whole point is to drop the misleading framing.
+    expect(pax8_report_subscriptions.description).not.toMatch(/\bMRR\b/);
+    expect(pax8_report_subscriptions.description).not.toMatch(
+      /Monthly Recurring Revenue/i,
+    );
+    expect(pax8_report_subscriptions.description).not.toMatch(/\bARR\b/);
+    // Should honestly describe what it returns.
+    expect(pax8_report_subscriptions.description).toMatch(/Pax8 cost/);
+    expect(pax8_report_subscriptions.description).toMatch(/AmountCurrency/);
+  });
+
+  it("returns wrapped AmountCurrency envelopes and the standardized disclaimer", async () => {
+    mockCliResponses(
+      [
+        {
+          companyId: "c1",
+          companyName: "Acme",
+          productId: "p1",
+          productName: "Widget",
+          quantity: 10,
+          price: 5,
+          status: "Active",
+          billingTerm: "Monthly",
+          currencyCode: "USD",
+        },
+      ],
+      [{ id: "c1", name: "Acme" }],
+    );
+
+    const { pax8_report_subscriptions } = await import("./reports.js");
+    const raw = await pax8_report_subscriptions.execute({});
+    const parsed = JSON.parse(raw);
+
+    // Top-level wrapped envelopes — same shape `dashboard --json` and
+    // `report subscriptions --json` emit on the CLI side.
+    expect(parsed.totalMonthlyCost).toEqual({ amount: 50, currency: "USD" });
+    expect(parsed.totalAnnualCost).toEqual({ amount: 600, currency: "USD" });
+    expect(parsed.totalActiveSubscriptions).toBe(1);
+    expect(parsed.totalSeats).toBe(10);
+
+    // Per-company array carries the same envelope, plus companyId so an
+    // agent can chain to other tools by ID.
+    expect(parsed.companiesByMonthlyCost).toEqual([
+      {
+        companyId: "c1",
+        companyName: "Acme",
+        monthlyCost: { amount: 50, currency: "USD" },
+        subscriptionCount: 1,
+        totalSeats: 10,
+      },
+    ]);
+
+    // Disclaimer is a first-class field, not just a docstring — JSON
+    // consumers can't see help text, so the framing must travel with
+    // the payload.
+    expect(parsed.disclaimer).toBe(DISCLAIMER);
+  });
+
+  it("normalizes 2-Year and 3-Year billing terms (not the pre-#439 monthly fall-through)", async () => {
+    // Two subs at identical gross (price × quantity = 1000) on different
+    // multi-year terms. Pre-fix bug: substring match on "annual"/"yearly"
+    // let "2-Year"/"3-Year" miss the divisor and double-count.
+    // Post-fix: 2-Year ÷ 24, 3-Year ÷ 36.
+    mockCliResponses(
+      [
+        {
+          companyId: "c1",
+          companyName: "TwoYr Co",
+          productId: "p1",
+          quantity: 10,
+          price: 100,
+          status: "Active",
+          billingTerm: "2-Year",
+          currencyCode: "USD",
+        },
+        {
+          companyId: "c2",
+          companyName: "ThreeYr Co",
+          productId: "p2",
+          quantity: 10,
+          price: 100,
+          status: "Active",
+          billingTerm: "3-Year",
+          currencyCode: "USD",
+        },
+      ],
+      [],
+    );
+
+    const { pax8_report_subscriptions } = await import("./reports.js");
+    const raw = await pax8_report_subscriptions.execute({});
+    const parsed = JSON.parse(raw);
+
+    // 2-Year: 1000 / 24 = 41.666… → rounded to 41.67
+    // 3-Year: 1000 / 36 = 27.777… → rounded to 27.78
+    const c1 = parsed.companiesByMonthlyCost.find(
+      (c: { companyId: string }) => c.companyId === "c1",
+    );
+    const c2 = parsed.companiesByMonthlyCost.find(
+      (c: { companyId: string }) => c.companyId === "c2",
+    );
+    expect(c1.monthlyCost.amount).toBeCloseTo(1000 / 24, 2);
+    expect(c2.monthlyCost.amount).toBeCloseTo(1000 / 36, 2);
+
+    // Sanity: total monthly cost ≈ 41.67 + 27.78 ≈ 69.44 — NOT 2000 (the
+    // pre-fix bug would have summed gross × 2 = 2000).
+    expect(parsed.totalMonthlyCost.amount).toBeCloseTo(1000 / 24 + 1000 / 36, 2);
+    expect(parsed.totalMonthlyCost.amount).toBeLessThan(100);
+  });
+
+  it("uses the first active subscription's currencyCode for the portfolio envelope", async () => {
+    mockCliResponses(
+      [
+        {
+          companyId: "c1",
+          quantity: 1,
+          price: 10,
+          status: "Active",
+          billingTerm: "Monthly",
+          currencyCode: "EUR",
+        },
+      ],
+      [],
+    );
+    const { pax8_report_subscriptions } = await import("./reports.js");
+    const raw = await pax8_report_subscriptions.execute({});
+    const parsed = JSON.parse(raw);
+    expect(parsed.totalMonthlyCost.currency).toBe("EUR");
+  });
+
+  it("defaults to USD when no active subscription carries a currencyCode", async () => {
+    mockCliResponses(
+      [
+        {
+          companyId: "c1",
+          quantity: 1,
+          price: 10,
+          status: "Active",
+          billingTerm: "Monthly",
+        },
+      ],
+      [],
+    );
+    const { pax8_report_subscriptions } = await import("./reports.js");
+    const raw = await pax8_report_subscriptions.execute({});
+    const parsed = JSON.parse(raw);
+    expect(parsed.totalMonthlyCost.currency).toBe("USD");
+  });
+});

--- a/packages/claude-skill/src/tools/reports.ts
+++ b/packages/claude-skill/src/tools/reports.ts
@@ -12,6 +12,7 @@ interface Subscription {
   price: number;
   status: string;
   billingTerm: string;
+  currencyCode?: string;
 }
 
 interface Company {
@@ -19,10 +20,58 @@ interface Company {
   name: string;
 }
 
-export const pax8_report_mrr = {
-  name: "pax8_report_mrr",
+/**
+ * Standardized partner-revenue disclaimer string. Quoted verbatim from
+ * `packages/cli/src/commands/report/*` (#440 / #443) and the dashboard
+ * AmountCurrency reshape. This is embedded in the JSON payload (not just a
+ * docstring) so an agent consuming this tool sees the framing — `--help`
+ * footers don't apply here since the consumer is JSON-only.
+ */
+const DISCLAIMER =
+  "Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.";
+
+/**
+ * Per-subscription monthly Pax8 cost. Mirrors the canonical
+ * `subscriptionMrr` from `@pax8/core` (`packages/core/src/services/analytics.ts`)
+ * — duplicated here only because the claude-skill package is intentionally
+ * dependency-free (it shells to the CLI rather than importing core directly).
+ * Case-insensitive switch on the canonical `BillingTerm` enum values:
+ * `Monthly` / `Annual` / `2-Year` / `3-Year`, with `One-Time` / `Trial` /
+ * `Activation` and unknown values falling through to `price × quantity`.
+ *
+ * Pre-#439 bug to NOT regress: substring matching on `"annual"` / `"yearly"`
+ * let multi-year terms fall through to the monthly default, double-counting
+ * 2-Year / 3-Year commitments.
+ */
+function monthlyCostOf(
+  price: number,
+  quantity: number,
+  billingTerm: string,
+): number {
+  const gross = price * quantity;
+  const normalizedTerm = (billingTerm ?? "").toLowerCase();
+  switch (normalizedTerm) {
+    case "monthly":
+      return gross;
+    case "annual":
+      return gross / 12;
+    case "2-year":
+      return gross / 24;
+    case "3-year":
+      return gross / 36;
+    case "one-time":
+    case "trial":
+    case "activation":
+      return gross;
+    default:
+      return gross;
+  }
+}
+
+export const pax8_report_subscriptions = {
+  name: "pax8_report_subscriptions",
   description:
-    "Calculate Monthly Recurring Revenue (MRR) with breakdown by company. Returns totalMRR, projectedARR, monthlyMRR, annualMRR_amortized, subscription counts, totalSeats, and a companiesByMRR array sorted descending with companyName, mrr, subscriptions, and seats. Pre-calculated — no follow-up calls needed. Optionally filter by companyId.",
+    "Compute the partner's Pax8 cost rollup across active subscriptions, grouped by company. Returns `totalMonthlyCost` and `totalAnnualCost` as wrapped `AmountCurrency` objects ({ amount, currency }), plus a `companiesByMonthlyCost` array sorted descending with companyId, companyName, monthlyCost, subscriptionCount, and totalSeats. This is the partner's cost paid to Pax8 — NOT partner-side resale revenue. Includes the standard partner-revenue disclaimer in the payload. Pre-calculated; no follow-up calls needed. Optionally filter by companyId. NOTE: divergence from the `pax8 report subscriptions` CLI command — that command supports `--by customer|vendor|product|billing-term`; this skill tool returns a fixed by-company rollup.",
   parameters: {
     type: "object" as const,
     properties: {
@@ -35,7 +84,15 @@ export const pax8_report_mrr = {
   },
   execute: async (params: { companyId?: string }) => {
     // Fetch subscriptions and companies in parallel — single CLI call each
-    const subsArgs = ["subscriptions", "list", "--status", "Active", "--json", "--size", "1000"];
+    const subsArgs = [
+      "subscriptions",
+      "list",
+      "--status",
+      "Active",
+      "--json",
+      "--size",
+      "1000",
+    ];
     if (params.companyId) subsArgs.push("--company", params.companyId);
 
     const [subsRaw, companiesRaw] = await Promise.all([
@@ -66,64 +123,69 @@ export const pax8_report_mrr = {
       companyNames.set(c.id, c.name);
     }
 
-    // Compute MRR
-    let totalMRR = 0;
-    let monthlyMRR = 0;
-    let annualMRR = 0;
-    let monthlyCount = 0;
-    let annualCount = 0;
+    // Compute Pax8 cost rollup
+    const activeSubs = subs.filter((sub) => sub.status === "Active");
+    const portfolioCurrency =
+      activeSubs.find((s) => s.currencyCode)?.currencyCode ?? "USD";
+
+    let totalMonthlyCost = 0;
     let totalSeats = 0;
-    const byCompany: Record<string, { name: string; mrr: number; subs: number; seats: number }> = {};
+    const byCompany: Record<
+      string,
+      { name: string; monthlyCost: number; subscriptionCount: number; totalSeats: number }
+    > = {};
 
-    for (const sub of subs) {
-      if (sub.status !== "Active") continue;
-      const lineTotal = sub.price * sub.quantity;
-      let mrr: number;
-
-      if (sub.billingTerm === "Annual") {
-        mrr = lineTotal / 12;
-        annualMRR += mrr;
-        annualCount++;
-      } else {
-        mrr = lineTotal;
-        monthlyMRR += mrr;
-        monthlyCount++;
-      }
-
-      totalMRR += mrr;
+    for (const sub of activeSubs) {
+      const monthlyCost = monthlyCostOf(sub.price, sub.quantity, sub.billingTerm);
+      totalMonthlyCost += monthlyCost;
       totalSeats += sub.quantity;
 
       const cid = sub.companyId;
       if (!byCompany[cid]) {
         const name = sub.companyName || companyNames.get(cid) || cid.slice(0, 8);
-        byCompany[cid] = { name, mrr: 0, subs: 0, seats: 0 };
+        byCompany[cid] = {
+          name,
+          monthlyCost: 0,
+          subscriptionCount: 0,
+          totalSeats: 0,
+        };
       }
-      byCompany[cid].mrr += mrr;
-      byCompany[cid].subs++;
-      byCompany[cid].seats += sub.quantity;
+      byCompany[cid].monthlyCost += monthlyCost;
+      byCompany[cid].subscriptionCount += 1;
+      byCompany[cid].totalSeats += sub.quantity;
     }
 
-    // Sort companies by MRR descending, include all
-    const companiesByMrr = Object.entries(byCompany)
-      .sort(([, a], [, b]) => b.mrr - a.mrr)
+    // Sort companies by monthly cost descending, include all
+    const companiesByMonthlyCost = Object.entries(byCompany)
+      .sort(([, a], [, b]) => b.monthlyCost - a.monthlyCost)
       .map(([id, data]) => ({
         companyId: id,
         companyName: data.name,
-        mrr: Number(data.mrr.toFixed(2)),
-        subscriptions: data.subs,
-        seats: data.seats,
+        monthlyCost: {
+          amount: Number(data.monthlyCost.toFixed(2)),
+          currency: portfolioCurrency,
+        },
+        subscriptionCount: data.subscriptionCount,
+        totalSeats: data.totalSeats,
       }));
 
-    return JSON.stringify({
-      totalMRR: Number(totalMRR.toFixed(2)),
-      projectedARR: Number((totalMRR * 12).toFixed(2)),
-      monthlyMRR: Number(monthlyMRR.toFixed(2)),
-      annualMRR_amortized: Number(annualMRR.toFixed(2)),
-      monthlySubscriptions: monthlyCount,
-      annualSubscriptions: annualCount,
-      totalSubscriptions: monthlyCount + annualCount,
-      totalSeats,
-      companiesByMRR: companiesByMrr,
-    }, null, 2);
+    return JSON.stringify(
+      {
+        totalActiveSubscriptions: activeSubs.length,
+        totalMonthlyCost: {
+          amount: Number(totalMonthlyCost.toFixed(2)),
+          currency: portfolioCurrency,
+        },
+        totalAnnualCost: {
+          amount: Number((totalMonthlyCost * 12).toFixed(2)),
+          currency: portfolioCurrency,
+        },
+        totalSeats,
+        companiesByMonthlyCost,
+        disclaimer: DISCLAIMER,
+      },
+      null,
+      2,
+    );
   },
 };


### PR DESCRIPTION
## Summary

Aligns the last MRR-framed surface in the repo — the JS skill-side rollup tool `pax8_report_mrr` at `packages/claude-skill/src/tools/reports.ts` — with the Pax8-cost framing established across the CLI in #440 (vocab + remove `report mrr`/`growth`) and #443 (three new `report` commands with wrapped `AmountCurrency` envelopes + the standardized partner-revenue disclaimer).

This surface was intentionally left out of #440's pass — it's a JS skill-side tool callable from a Claude Code agent that recomputes a portfolio rollup internally (reading `subscriptions list` data) rather than shelling to a removed CLI subcommand, so it was out of CLI-surface scope at the time. Cleaning it up now.

## What changed

- **Tool name:** `pax8_report_mrr` -> `pax8_report_subscriptions` (surface consistency with the CLI command `pax8 report subscriptions`). The skill tool is a fixed by-company rollup; the CLI command supports `--by customer|vendor|product|billing-term` — the divergence is called out in the tool description.
- **Output shape:** wrapped `AmountCurrency` envelopes (`{ amount, currency }`) for `totalMonthlyCost`, `totalAnnualCost`, and each `companiesByMonthlyCost[].monthlyCost`. Same shape `dashboard --json` and `report subscriptions --json` already emit. Dropped the `monthlyMRR` / `annualMRR_amortized` split (internal accounting noise). Added `companyId` to per-company rows so an agent can chain to other tools by ID. Embedded the standardized partner-revenue disclaimer as a first-class JSON field — agent consumers can't see `--help` footers.
- **Currency resolution:** first active sub's `currencyCode`, default `"USD"` — same convention as `report subscriptions --json`.
- **2-Year / 3-Year normalization:** the pre-#439 bug (substring matching on "annual" / "yearly" letting multi-year terms fall through to the monthly default) was present in this file too. Replaced with a case-insensitive switch on canonical `BillingTerm` enum values (`Monthly` / `Annual` / `2-Year` / `3-Year`, plus `One-Time` / `Trial` / `Activation` and unknown values falling through to `price × quantity`). Mirrors the canonical `subscriptionMrr` in `@pax8/core` — inlined here rather than imported because the claude-skill package is intentionally dependency-free and shells to the CLI for its existing tools.
- **Internal vars renamed** (`mrr` -> `monthlyCost`, `totalMRR` -> `totalMonthlyCost`, etc.) to match the output shape.
- **Tests:** new `packages/claude-skill/src/tools/reports.test.ts` (first vitest file in the claude-skill package) covering the rename, wrapped-envelope shape, embedded disclaimer string, 2-Year / 3-Year normalization (asserts both compute to ÷24 and ÷36, NOT the pre-fix monthly fall-through), and the currency-resolution heuristic.
- **`docs/BUILD.md` Step 37:** updated the historical reference from `pax8_report_mrr` to the new tool name and honest description.

`skill.md` (the agent-facing manifest) doesn't reference the tool by name — only CLI commands — so no manifest change is needed beyond what already landed in #440.

## Output snippet — before -> after

Before (MRR-framed, flat scalars, no disclaimer):

```json
{
  "totalMRR": 50,
  "projectedARR": 600,
  "monthlyMRR": 50,
  "annualMRR_amortized": 0,
  "companiesByMRR": [{ "companyId": "c1", "companyName": "Acme", "mrr": 50, ... }]
}
```

After (Pax8-cost framed, wrapped envelopes, embedded disclaimer):

```json
{
  "totalActiveSubscriptions": 1,
  "totalMonthlyCost": { "amount": 50, "currency": "USD" },
  "totalAnnualCost":  { "amount": 600, "currency": "USD" },
  "totalSeats": 10,
  "companiesByMonthlyCost": [{
    "companyId": "c1",
    "companyName": "Acme",
    "monthlyCost": { "amount": 50, "currency": "USD" },
    "subscriptionCount": 1,
    "totalSeats": 10
  }],
  "disclaimer": "Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA."
}
```

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 113 files / 1920 tests pass (5 new in `reports.test.ts`)
- [x] `pnpm lint` — clean
- [ ] Spot-check: a Claude Code agent invoking `pax8_report_subscriptions` sees the disclaimer in the JSON payload and treats numbers as partner-side cost (verified in test fixtures)

## Refs

- #440 — remove `report mrr` / `report growth` from the CLI, reframe to Pax8-cost
- #443 — three new `report` commands (renewals / concentration / subscriptions) with wrapped `AmountCurrency` envelopes and the standardized disclaimer
- #439 — 2-Year / 3-Year normalization fix in `subscriptionMrr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)