### PR TITLE
test(repl): add REPL integration test and broaden resolveCliPath coverage

### DIFF
--- a/packages/cli/src/__tests__/repl.integration.test.ts
+++ b/packages/cli/src/__tests__/repl.integration.test.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// End-to-end coverage for the REPL bug class that closed #226 (PR #227):
+// typed-at-prompt commands spawned a child whose `node <path>` argv landed on
+// a file that did not exist (`packages/cli/index.js` instead of
+// `dist/index.js`), and every command crashed with MODULE_NOT_FOUND on global
+// installs. The previous test surface only checked the resolveCliPath helper
+// in isolation, never the actual spawn — so a regression would still ship
+// invisibly. This test drives the prompt through stdin and asserts the child
+// produces real command output without a module-resolution error.
+
+const CLI_PATH = resolve(
+  fileURLToPath(import.meta.url),
+  "../../../dist/index.js",
+);
+
+interface ReplResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function runRepl(stdin: string, timeoutMs = 15_000): Promise<ReplResult> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn("node", [CLI_PATH], {
+      env: {
+        ...process.env,
+        PAX8_REPL_FORCE: "1",
+        PAX8_DEMO: "1",
+        PAX8_QUIET: "1",
+        NO_COLOR: "1",
+        // The REPL exports FORCE_COLOR=1 to children; clear it so the
+        // child's --json output isn't littered with ANSI escapes.
+        FORCE_COLOR: "",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`REPL test timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolveResult({ stdout, stderr, exitCode: code ?? 1 });
+    });
+
+    child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}
+
+describe("REPL integration (prompt → child spawn)", () => {
+  it("dispatches a typed command without MODULE_NOT_FOUND", async () => {
+    const result = await runRepl("subscriptions list --json --size 1\nexit\n");
+
+    // The regression we are guarding against: a child crash from a bad
+    // process.argv[1]-derived spawn path. The crash surfaces as a
+    // Node-level error on the child's inherited stderr.
+    expect(result.stderr).not.toMatch(/MODULE_NOT_FOUND/i);
+    expect(result.stderr).not.toMatch(/Cannot find module/i);
+    expect(result.stderr).not.toMatch(/SyntaxError/i);
+
+    // The command actually ran: the child reached the subscriptions command
+    // and emitted at least one JSON object with a subscription shape.
+    expect(result.stdout).toContain('"id":');
+    expect(result.stdout).toContain('"companyId":');
+
+    // REPL closed cleanly on `exit`.
+    expect(result.exitCode).toBe(0);
+  }, 20_000);
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -225,7 +225,12 @@ async function main(): Promise<void> {
   }
 
   if (process.argv.length <= 2) {
-    if (process.stdin.isTTY) {
+    // PAX8_REPL_FORCE is an internal test seam: the REPL integration test
+    // (repl.integration.test.ts) needs to drive the prompt over a stdin pipe,
+    // which means stdin is not a TTY. Without this override there is no way
+    // to exercise REPL child-spawn from a subprocess test, and the
+    // MODULE_NOT_FOUND class of bug (#226 / #227) would ship invisibly again.
+    if (process.stdin.isTTY || process.env.PAX8_REPL_FORCE === "1") {
       await startRepl(createProgram);
     } else {
       await showWelcomeScreen();

--- a/packages/cli/src/lib/repl.test.ts
+++ b/packages/cli/src/lib/repl.test.ts
@@ -1,8 +1,14 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
-import { resolve as resolvePath, sep as pathSep } from "node:path";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  resolve as resolvePath,
+  sep as pathSep,
+  join as joinPath,
+} from "node:path";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolveCliPath, tokenize } from "./repl.js";
 
 describe("resolveCliPath", () => {
@@ -30,6 +36,70 @@ describe("resolveCliPath", () => {
   it("throws when process.argv[1] is empty (cannot determine entry)", () => {
     expect(() => resolveCliPath("")).toThrow(/cannot determine CLI entry/);
     expect(() => resolveCliPath(undefined)).toThrow(/cannot determine CLI entry/);
+  });
+
+  // Production install layouts — exercise the two paths the helper actually
+  // gets fed at runtime when a partner has run `npm install -g` or
+  // `pnpm install -g`. The dist-path case above only covers the dev/source
+  // tree.
+
+  describe("production install layouts", () => {
+    let tmpRoot: string;
+
+    beforeAll(() => {
+      tmpRoot = mkdtempSync(joinPath(tmpdir(), "pax8-resolve-cli-path-"));
+    });
+
+    afterAll(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it("npm install -g layout: returns the bin symlink path Node was invoked with", () => {
+      // npm install -g lays down /usr/local/bin/pax8 as a symlink to the
+      // real dist/index.js inside the global node_modules tree. Node sets
+      // process.argv[1] to the symlink path (NOT the dereferenced target),
+      // and child spawn with that path works because Node resolves the
+      // symlink before evaluating module paths. The helper must pass that
+      // path through unchanged.
+      const realDir = joinPath(tmpRoot, "npm-real", "node_modules", "@pax8", "cli", "dist");
+      const binDir = joinPath(tmpRoot, "npm-bin");
+      mkdirSync(realDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      const realFile = joinPath(realDir, "index.js");
+      const linkPath = joinPath(binDir, "pax8");
+      writeFileSync(realFile, "// real entry\n");
+      symlinkSync(realFile, linkPath);
+
+      // process.argv[1] under npm-global = the symlink path.
+      expect(resolveCliPath(linkPath)).toBe(linkPath);
+    });
+
+    it("pnpm install -g layout: returns the resolved dist path the sh shim execs", () => {
+      // pnpm install -g lays down an sh shim (NOT a JS shim or symlink) at
+      // ~/Library/pnpm/pax8 that ends with
+      //   exec node "$basedir/global/5/.pnpm/<pkg>/node_modules/@pax8/cli/dist/index.js" "$@"
+      // So when a partner types `pax8`, Node sees process.argv[1] = that
+      // resolved real path inside the .pnpm/ virtual store, NOT the shim
+      // path. The helper must preserve that path (with its .pnpm/ segment
+      // and trailing /dist/index.js) so REPL child-spawn can re-invoke it.
+      const pnpmDist = joinPath(
+        tmpRoot,
+        ".pnpm",
+        "@pax8+cli@0.1.0",
+        "node_modules",
+        "@pax8",
+        "cli",
+        "dist",
+      );
+      mkdirSync(pnpmDist, { recursive: true });
+      const distFile = joinPath(pnpmDist, "index.js");
+      writeFileSync(distFile, "// pnpm-installed entry\n");
+
+      const result = resolveCliPath(distFile);
+      expect(result).toBe(distFile);
+      expect(result).toContain(`${pathSep}.pnpm${pathSep}`);
+      expect(result).toContain(`${pathSep}dist${pathSep}`);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Closes the test-coverage gap that let the MODULE_NOT_FOUND class of bug (#226 / #227) ship invisibly: the fix in PR #227 used `process.argv[1]` for the REPL child-spawn `cliPath`, but the only test guarding it pinned the dist-path case in isolation. Neither production install layout (npm symlink, pnpm sh shim) was exercised, and no test spawned the binary in REPL mode and pushed a typed command through stdin.

- Adds `repl.integration.test.ts` — spawns the built CLI in REPL mode via a new `PAX8_REPL_FORCE=1` test seam, pipes `subscriptions list --json --size 1\nexit\n` through stdin, asserts the child produces real subscription JSON with no `MODULE_NOT_FOUND` / `Cannot find module` / `SyntaxError` on stderr. Confirmed to **fail** when `resolveCliPath` is reverted — the regression check is load-bearing.
- Adds `PAX8_REPL_FORCE=1` env var (1-line change in `index.ts`) that bypasses `process.stdin.isTTY` so the integration test can drive REPL over a pipe. Internal test seam, documented inline; not surfaced in `docs/UX_GUIDE.md`.
- Broadens `repl.test.ts` to cover both production install layouts: npm-style bin symlink → real dist/index.js, and pnpm-style real dist/index.js inside `.pnpm/` virtual store. Each test materializes a real fs layout under a tmp dir (with a real symlink for the npm case).

## pnpm install -g verification

The task brief flagged pnpm install -g as the highest-value gap: pnpm allegedly uses a JS shim that would break `process.argv[1]`-based resolution. **The premise was wrong on the current pnpm version** — the bug does not reproduce under pnpm.

Reproduction recipe used:

1. `pnpm pack` from `packages/cli` and `packages/core`.
2. Patch the cli tarball's `package.json` so `@pax8/core` resolves via `file:` to the local core tarball (`workspace:*` gets rewritten to `0.1.0` by `pnpm pack`, which would otherwise hit the registry).
3. `pnpm install -g <patched-cli-tarball>` into `~/Library/pnpm`.

The pnpm shim is an `sh` script (not a JS shim) whose final line is:

```sh
exec node "$basedir/global/5/.pnpm/<pkg>/.../dist/index.js" "$@"
```

So `process.argv[1]` inside the running CLI is the fully resolved real path to `dist/index.js` — identical in shape to the npm-symlink case after Node's symlink-resolves-before-module-path-computation step. The existing PR #227 fix (process.argv[1] pass-through) works under both managers without modification.

A real-PTY REPL test via `script -q` typed `subscriptions list --json --size 1` at the `pax8>` prompt and received the full demo-data subscription JSON object with zero `MODULE_NOT_FOUND` / `Cannot find module` / `SyntaxError` on stderr.

## Verified

- **Node**: 22.19.0
- **Package managers**: npm install -g (per PR #227 verification); pnpm install -g (this PR — sh shim layout, `.pnpm/` virtual store, pnpm 9.15.4 / 10.28.1).
- `pnpm build` clean
- `pnpm test` — 1932 passed / 6 skipped, 0 failed
- `pnpm lint` clean

## Not in scope

- yarn install -g (different shim format; not verified).
- Windows install layouts (pnpm uses a `.cmd` shim there; not verified).
- A comprehensive global-install matrix CI step (npm × pnpm × yarn × bun across Node 18 / 20 / 22). The local pnpm verification + the new in-process integration test cover the gap that mattered; a CI matrix would be additive.

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test packages/cli/src/__tests__/repl.integration.test.ts` — 1 passed
- [x] `pnpm test packages/cli/src/lib/repl.test.ts` — 8 passed (5 resolveCliPath + 3 tokenize)
- [x] Regression check: reverted `resolveCliPath` to broken behavior → integration test fails with `MODULE_NOT_FOUND` on stderr; restored fix → green
- [x] `pnpm test` (full suite) — 1932 passed, 0 failed
- [x] `pnpm lint` clean
- [x] Manual: `pnpm install -g` of cli + core tarballs; `script -q` PTY drive of `pax8` REPL typed `subscriptions list --json --size 1` → real JSON, no module errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)