### PR TITLE
docs(readme): hide npm install path until v0.1.0 publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,10 @@ PAX8_DEMO=1 pax8 dashboard
 
 For watch mode, tests, and the rest of the contributor workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+<!-- TODO: once v0.1.0 publishes to npm, restore the "From npm" section as the primary install path -->
 ### From npm (coming soon)
 
-Once v0.1.0 ships, the documented path will be:
-
-```bash
-# Install (not yet published — tracked in repo Status section above)
-npm install -g @pax8/cli
-
-# Authenticate
-pax8 auth login
-
-# See how your business is doing
-pax8 dashboard
-
-# Or try with demo data (no credentials needed)
-PAX8_DEMO=1 pax8 dashboard
-```
+*Not yet available.* `@pax8/cli` has not been published to npm — `npm install -g @pax8/cli` will 404 until v0.1.0 ships. Use [Running from source](#running-from-source) above in the meantime; once v0.1.0 lands on npm, this section will document the `npm install -g @pax8/cli` → `pax8 auth login` → `pax8 dashboard` flow as the primary install path.
 
 ## Demo Flow (90 seconds)
 


### PR DESCRIPTION
## Summary

- The "From npm (coming soon)" section presented a copy-pasteable `npm install -g @pax8/cli` block. A first-time visitor reading top-down saw the pre-release caveat (line ~9) but still reached for the formatted install command and 404'd from the npm registry.
- Approach A from #477: replace the code block with a single italicized paragraph that explicitly says npm will 404 and points readers at the "Running from source" path above. No copy-paste-able install command remains until v0.1.0 publishes.
- Embedded `<!-- TODO ... -->` HTML comment above the section as a reminder to restore the npm install block once v0.1.0 ships.

## Test plan

- [x] Section no longer contains a runnable `npm install -g @pax8/cli` code block.
- [x] First-time-visitor read-through: pre-release caveat → "Running from source" with copyable git clone → italicized "Not yet available" paragraph that explicitly names the 404.

Closes #477