### PR TITLE
docs: downgrade idempotency claims to accurate host-local scope (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Initial public release.
 - **Demo mode** (`PAX8_DEMO=1`) — every command runs against an in-memory fixture, so partners can evaluate the tool with no credentials and CI runs end-to-end against the same surface.
 - **OAuth 2.0 client-credentials flow** — secure local credential storage at `~/.pax8/credentials.json` with mode `0600`, tokens cached in memory only and never persisted, automatic refresh at 23h.
 - **Structured `--json` output with `nextActions`** — `status`, `report mrr/growth`, and `invoices audit` always include contextual next-step hints; list commands opt in via `--with-actions` to ride a `{ data, nextActions }` envelope alongside the flat JSON array (#97).
-- **Idempotency keys on write commands** — `--idempotency-key <uuid>` is accepted on every mutation command (#91).
+- **Host-local replay cache for write commands** — `--idempotency-key <uuid>` is accepted on every mutation command (#91). Same-host re-runs return the cached response. Note: the key is not currently sent on the wire (Pax8 API doesn't yet honor an Idempotency-Key header), so cross-host / cross-process retries are not deduped; the local cache is the v0.1 protection. Server-side dedup is planned in v0.2 (#474).
 - **Machine-readable error codes** — every `CliError` carries a stable `code` (one of the `ERROR_*` constants from `@pax8/core`) so agents and scripts can branch on outcome without parsing strings (#90).
 - **Output formats** — `--json`, `--csv`, `--quiet`, plus `--with-actions` (envelope mode) and `--ids-only` (one ID per line, for piping into the next command's `--company` filter).
 - **`PAX8_API_BASE` env var** — point the CLI at sandbox / staging environments without rebuilding (#135).

--- a/docs/UX_GUIDE.md
+++ b/docs/UX_GUIDE.md
@@ -322,16 +322,24 @@ When `--json` is set, the error serializes to stderr as a structured object inst
 
 Codes live in `packages/core/src/errors/codes.ts` and are append-only — never repurpose an existing code, even for a "near-match" failure mode. If you need a new code, add a new constant.
 
-### Idempotency keys for writes — (implemented)
+### Idempotency keys for writes — (implemented, local-only in v0.1)
 
-Write commands accept `--idempotency-key <uuid>` for replay-safe retries. The agent passes a key, retries on transient failure, and the CLI dedupes — you get either the original result or a cached "already processed" response, never a double-write. Today this is wired into `orders create` and `invoices dispute`; new write commands should follow the same pattern.
+Write commands accept `--idempotency-key <uuid>` to mark retry intent. Today the **Pax8 API does not honor an `Idempotency-Key` request header** on `POST /orders` or other write endpoints, so the key is **not sent over the wire**. The CLI maintains a host-local replay cache: when you re-run the same command on the same host with the same key, the CLI returns the cached response instead of issuing a second API call.
 
 ```bash
 pax8 orders create --company c1 --product p1 --quantity 5 \
   --idempotency-key 9f3b...e1
 ```
 
-Local cache: 24h TTL, keyed on `{command, key, args-hash}`. When a key matches a cached call, the command writes `(idempotent replay)` to stderr (dim) and returns the cached response. Exit code is unchanged. Prefer server-side idempotency tokens when the Pax8 API supports them; the local cache is a fallback for endpoints that don't.
+Local cache: 24h TTL, keyed on `{command, key, args-hash}`, stored under `~/.pax8/idempotency/`. When a key matches a cached call, the command writes `(idempotent replay)` to stderr (dim) and returns the cached response. Exit code is unchanged.
+
+**Limitations to be honest about**:
+
+- **Cross-process and cross-host retries are not deduped.** Two concurrent CLI invocations on different machines (or different `~/.pax8/` directories) with the same key both hit the API and both write. The local cache only protects same-host post-success replay.
+- **Connection drops mid-write are not protected** — if the response is lost after the server processed the request but before the client cached the result, a retry creates a duplicate. Pair `--idempotency-key` with `pax8 orders show` / `pax8 subscriptions list --company` to verify state before retrying after any timeout/network failure.
+- **v0.2 plan**: once Pax8 ships an `Idempotency-Key` header on write endpoints, the CLI will forward the key on the wire and the server will own deduplication. The local cache will downgrade to a fast-path response replay. Tracked in [#474](https://github.com/pax8labs/pax8-cli/issues/474).
+
+New write commands should accept `--idempotency-key` for forward-compatibility and follow the `orders create` / `invoices dispute` pattern.
 
 Reads never need a key.
 
@@ -346,7 +354,7 @@ The flow:
 3. The partner reviews the *exact* payload (company, product, quantity, price) and approves or denies it.
 4. On approval, the agent receives a token cryptographically scoped to that payload and submits the order with it. Mutating any field after sign-off invalidates the token — the agent cannot bait-and-switch.
 
-Composes with idempotency keys: the approval token is one-shot (single submission), but the submission itself is retried with the same `--idempotency-key` if the network drops. Together they give "approved exactly once, submitted at-least-once, deduped to exactly-once."
+Composes with idempotency keys: the approval token is one-shot (single submission). Same-host network-drop retries with the same `--idempotency-key` are deduped by the local replay cache (see above). Once the Pax8 API honors the `Idempotency-Key` header server-side ([#474](https://github.com/pax8labs/pax8-cli/issues/474)), the pair will give "approved exactly once, submitted at-least-once, deduped to exactly-once" across processes and hosts — until then, dedup is host-local.
 
 Expect an **approval threshold** pattern: orders under a configurable dollar amount auto-approve via the standard `-y` / `--yes` flag; orders above the threshold require CIBA sign-off regardless of `--yes`. The threshold is partner-configured, not agent-configured.
 

--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -233,7 +233,7 @@ export const invoicesDisputeCommand = new Command("dispute")
   .option("-y, --yes", "Skip the confirmation prompt")
   .option(
     "--idempotency-key <uuid>",
-    "Replay-safe key for retries (24h TTL). Accepts UUIDs or 8–128 char identifiers (letters, digits, '-', '_', '.')",
+    "Host-local replay cache key (24h TTL). Same-host re-runs return the cached draft. Cross-host / cross-process retries are NOT deduped — see #474. Accepts UUIDs or 8–128 char identifiers (letters, digits, '-', '_', '.')",
   )
   .addHelpText(
     "after",
@@ -251,7 +251,8 @@ Examples:
 
 Note: The Pax8 v1 API does not expose a public dispute endpoint, so this
 command files a local draft and produces a support ticket template you can
-paste into the Pax8 portal. The draft is replay-safe via --idempotency-key.`,
+paste into the Pax8 portal. Same-host re-runs with --idempotency-key
+return the cached draft (host-local; see #474 for v0.2 wire-level plan).`,
   )
   .action(async (_options, command: Command) => {
     const allOpts = command.optsWithGlobals();

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -359,7 +359,7 @@ export const ordersCreateCommand = new Command("create")
   .option("-y, --yes", "Skip confirmation prompt")
   .option(
     "--idempotency-key <uuid>",
-    "Replay-safe key for retries (24h TTL). Accepts UUIDs or 8–128 char identifiers (letters, digits, '-', '_', '.')",
+    "Host-local replay cache key (24h TTL). Same-host re-runs return the cached response. NOTE: not yet sent on the wire — cross-host / cross-process retries are NOT deduped (#474). Accepts UUIDs or 8–128 char identifiers (letters, digits, '-', '_', '.')",
   )
   .addHelpText(
     "after",
@@ -682,11 +682,14 @@ Examples:
         lineItems,
       };
 
-      // TODO: When the Pax8 API adds support for an `Idempotency-Key` request
-      // header on POST /orders (not currently documented in the existing
-      // `OrdersApi.create` shape — see packages/core/src/api/orders.ts), pass
-      // `idempotencyKey` through here so the server dedupes natively. Until
-      // then, deduplication is purely local via the file cache below.
+      // v0.2 plan (#474): once the Pax8 API honors an `Idempotency-Key`
+      // request header on POST /orders, forward `idempotencyKey` through
+      // OrdersApi.create so the server dedupes natively. Until then,
+      // deduplication is purely host-local via the file cache below —
+      // cross-host / cross-process retries with the same key are NOT
+      // deduped. The CLI help text and docs/UX_GUIDE.md are explicit about
+      // this limitation; don't reintroduce the "replay-safe" wording
+      // without first wiring the wire-level header.
       const doneWrite = markWriteInFlight("orders", undefined, idempotencyKey);
       let order;
       try {


### PR DESCRIPTION
## Summary

The CLI accepts `--idempotency-key <uuid>` on writes, but the Pax8 API does not currently honor an `Idempotency-Key` request header — the key is never sent on the wire. Today's behavior is a host-local replay cache: same-host re-runs return the cached response; cross-host or cross-process retries with the same key both hit the API.

Previous docs implied wire-level / cross-process replay safety. This PR corrects every user-facing claim to describe actual local-only behavior, names the limitations honestly (cross-host and connection-drop), and points at #474 for the v0.2 plan to wire the header server-side once the API supports it.

**No code behavior changes.**

## Files updated

| File | Change |
|---|---|
| `docs/UX_GUIDE.md` | "Idempotency keys for writes" section rewritten with explicit Limitations callout; CIBA-composition paragraph scoped to the v0.2 server-dedup future with the v0.1 host-local caveat |
| `packages/cli/src/commands/orders/create.ts` | `--idempotency-key` help text reworded; inline TODO at the API call site reframed as a v0.2 plan with a warning to future contributors not to reintroduce "replay-safe" wording without first wiring the wire-level header |
| `packages/cli/src/commands/invoices/dispute.ts` | Help text and the closing "draft is replay-safe" note both reworded |
| `CHANGELOG.md` | Unreleased v0.1.0 entry retitled "Host-local replay cache for write commands" with the wire-level caveat |

## Why this approach

Two paths in #474 were debated: (A) ship the `Idempotency-Key` header now (depends on Pax8 backend timeline; uncertain), or (B) correct the docs to match reality (small, immediate). This PR takes path B — it unblocks the v0.1.0 public flip without an embarrassing back-pedal on the contract later. The wire-level work is preserved as the v0.2 follow-up (still tracked in #474).

## Test plan

- [x] `pnpm build` clean.
- [x] `pnpm test` — 1924 passing, 6 skipped (same as baseline).
- [x] Spot-checked the rewritten section in UX_GUIDE.md reads coherently end-to-end.

Closes #474