### PR TITLE
feat(mock): add large-portfolio fixture for scale-matrix testing (#484)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,8 @@ Adding a new command? Lives at `packages/cli/src/commands/<resource>/<action>.ts
 - `PAX8_CLIENT_ID`, `PAX8_CLIENT_SECRET` — credentials (file fallback: `~/.pax8/credentials.json`)
 - `PAX8_API_BASE` — override API + token base URL (e.g. staging); honored by both `@pax8/core` and the OAuth client
 - `PAX8_TIMEOUT_MS` — per-request HTTP timeout in milliseconds (default `30000`, max `300000`); extend for slow endpoints like `/orders` on large portfolios (#199)
-- `PAX8_DEMO=1` — run against `MockPax8Client` with synthetic data
+- `PAX8_DEMO=1` — run against `MockPax8Client` with synthetic data. Defaults to the hand-curated small fixture (~12 companies, dozens of subs/orders) suitable for screenshots and golden-path tests.
+- `PAX8_DEMO_SCALE=large` — when combined with `PAX8_DEMO=1`, swaps in the generated large-portfolio fixture (#484): 1,000 companies, 5,000 subscriptions, 45,000 orders dating back to 2013, mixed currencies (USD/EUR/GBP/CAD), every `BillingTerm` value, plus shell-meta-hostile customer names for `orderCommand` regression-testing. Pay ~400ms at process start; intended for scale-matrix testing, not daily use.
 - `PAX8_YES=1` — auto-confirm write prompts
 - `PAX8_QUIET=1` — disable spinners
 - `PAX8_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1` — opt out of telemetry (already opt-in by default)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,27 @@ $env:PAX8_DEMO="1"; pnpm dev -- clients list
 $env:PAX8_DEMO="1"; pnpm dev -- subscriptions renewals --within 14d
 ```
 
+#### Large-portfolio fixture for scale testing
+
+Demo mode defaults to a small hand-curated fixture (~12 companies). For UX
+bugs that only manifest at portfolio scale — invisible pagination, 200-cap
+name enrichment, currency rendering, BillingTerm normalization, shell-meta
+in customer names — set `PAX8_DEMO_SCALE=large` alongside `PAX8_DEMO=1`:
+
+```bash
+PAX8_DEMO=1 PAX8_DEMO_SCALE=large pnpm dev -- orders list
+PAX8_DEMO=1 PAX8_DEMO_SCALE=large pnpm dev -- dashboard --json
+```
+
+You get 1,000 companies, 5,000 subscriptions, 45,000 orders dating back to
+2013, mixed currencies (USD/EUR/GBP/CAD), every `BillingTerm` value, and a
+handful of deliberately-hostile customer names. The fixture is generated
+deterministically from a fixed seed, so two runs produce identical data.
+
+Don't replace the small fixture with the large one — both serve different
+purposes. The small fixture is the screenshot target and golden-path test
+data; the large fixture is the scale-matrix regression gate (#484).
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint packages/*/src/**/*.ts",
     "format": "prettier --write .",
     "dev": "pnpm --filter @pax8/cli dev",
-    "test:integration": "vitest run --config vitest.integration.config.ts"
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:scale": "vitest run packages/cli/src/__tests__/scale-matrix.test.ts"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/cli/src/__tests__/scale-matrix.test.ts
+++ b/packages/cli/src/__tests__/scale-matrix.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Scale-matrix subprocess tests (#484 follow-up).
+//
+// Runs the read surface of the CLI against the large-portfolio fixture
+// (`PAX8_DEMO_SCALE=large` — 1,000 companies, 5,000 subscriptions,
+// 45,000 orders, mixed currencies, hostile-named companies, every
+// BillingTerm value).
+//
+// What this file does NOT do: assert that the launch-blocker bugs are
+// fixed. Each blocker fix (#462 shell injection, #465 MRR math, #472
+// currency, #478 orders list, #483 list-rollout) lands its own
+// strong assertion in this file. Today the suite verifies only the
+// bare minimum invariants any command should respect under scale —
+// exits 0, produces valid JSON, returns non-empty data where data
+// should exist, doesn't crash on hostile customer names.
+//
+// Treat each `it.todo("blocker: ...")` as a placeholder for the
+// regression assertion that should be wired up alongside the matching
+// blocker PR. Don't move a `.todo` to a regular `it()` unless the
+// matching blocker has actually shipped — that's the gate.
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess } from "./test-utils.js";
+
+// Helper: every test in this file routes through the large fixture.
+const LARGE: Record<string, string> = { PAX8_DEMO_SCALE: "large" };
+
+// Helper: parse `--json` output, surfacing the raw stdout on failure
+// so a CI red gives us context instead of "Unexpected token in JSON".
+function parseJson<T = unknown>(stdout: string): T {
+  try {
+    return JSON.parse(stdout) as T;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse CLI JSON output. First 500 chars:\n${stdout.slice(0, 500)}\n\nOriginal error: ${err}`,
+    );
+  }
+}
+
+describe("scale matrix — read surface under PAX8_DEMO_SCALE=large", () => {
+  describe("invariants on the fixture itself", () => {
+    // Sanity check: confirm the env-var routing actually swaps in the
+    // generated fixture. If this one ever fails, every other test below
+    // is moot — investigate `packages/core/src/mock/fixture.ts` first.
+    it("clients list returns >= 200 companies (small fixture has < 50)", async () => {
+      const result = await runCliExpectSuccess(
+        ["clients", "list", "--json", "--size", "1000"],
+        LARGE,
+      );
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(200);
+    });
+
+    it("subscriptions list fills a 1000-row page (small fixture caps out at dozens)", async () => {
+      // We can't assert > 1000 today because the page is capped at --size and
+      // list `--json` doesn't yet expose `totalElements` in the envelope
+      // (#478/#483). Hitting the size cap is itself the signal that we're on
+      // the large fixture: small fixture has < 50 subs total, large has 5000.
+      const result = await runCliExpectSuccess(
+        ["subscriptions", "list", "--json", "--size", "1000"],
+        LARGE,
+      );
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(data.length).toBeGreaterThanOrEqual(1000);
+    });
+  });
+
+  describe("non-crash matrix — every read command exits 0", () => {
+    // Minimum bar: each documented read command runs to completion
+    // against the large fixture and emits well-formed JSON.
+
+    it("pax8 dashboard --json", async () => {
+      const result = await runCliExpectSuccess(["dashboard", "--json"], LARGE);
+      const data = parseJson<Record<string, unknown>>(result.stdout);
+      expect(data).toHaveProperty("monthlyCost");
+      expect(data).toHaveProperty("topCustomers");
+    });
+
+    it("pax8 clients list --json", async () => {
+      const result = await runCliExpectSuccess(["clients", "list", "--json"], LARGE);
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it("pax8 subscriptions list --json", async () => {
+      const result = await runCliExpectSuccess(["subscriptions", "list", "--json"], LARGE);
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it("pax8 subscriptions renewals --json", async () => {
+      const result = await runCliExpectSuccess(
+        ["subscriptions", "renewals", "--json", "--within", "30d"],
+        LARGE,
+      );
+      // Renewals is a wrapped envelope with `items` and metadata; allow either
+      // an array or an envelope shape here — the strong-shape assertion lands
+      // with the renewals-side blocker fix.
+      const data = parseJson<unknown>(result.stdout);
+      expect(data).toBeDefined();
+    });
+
+    it("pax8 orders list --json", async () => {
+      const result = await runCliExpectSuccess(["orders", "list", "--json"], LARGE);
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it("pax8 products search --json", async () => {
+      // Search a vendor that exists in the large-fixture corpus.
+      const result = await runCliExpectSuccess(
+        ["products", "search", "Microsoft", "--json"],
+        LARGE,
+      );
+      const data = parseJson<unknown>(result.stdout);
+      expect(data).toBeDefined();
+    });
+
+    it("pax8 recommendations list --json", async () => {
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json"], LARGE);
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+    });
+
+    it("pax8 doctor (non-crash; --json shape contract verified separately in #470)", async () => {
+      // doctor's --json contract is broken today (#470). Until that lands we
+      // assert only that the command exits cleanly under the large fixture.
+      const result = await runCliExpectSuccess(["doctor"], LARGE);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // Entity types not yet populated in the large fixture return empty
+    // arrays — that's a fixture limitation documented in #484, not a bug.
+    // Assert non-crash + empty-OK.
+
+    it("pax8 invoices list --json (empty under large fixture today)", async () => {
+      const result = await runCliExpectSuccess(["invoices", "list", "--json"], LARGE);
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+    });
+
+    it("pax8 webhooks list --json (empty under large fixture today)", async () => {
+      const result = await runCliExpectSuccess(["webhooks", "list", "--json"], LARGE);
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+    });
+  });
+
+  describe("hostile-name robustness", () => {
+    // The large fixture seeds 12 deliberately-hostile customer names
+    // (shell-meta, Unicode, embedded quotes/backticks/newlines). The
+    // CLI should serialize/render them without crashing or producing
+    // invalid JSON. This guards against future regressions where a
+    // contributor adds a code path that assumes alphanumeric-only
+    // names.
+
+    it("clients list --json with hostile names round-trips through JSON", async () => {
+      const result = await runCliExpectSuccess(
+        ["clients", "list", "--json", "--size", "1000"],
+        LARGE,
+      );
+      // Just parsing successfully is the assertion — a crash or invalid
+      // escape would throw above.
+      const data = parseJson<Array<{ name: string }>>(result.stdout);
+      // At least one of the hostile names should appear.
+      const hasHostile = data.some(
+        (c) => c.name.includes('"') || c.name.includes("'") || c.name.includes("北京"),
+      );
+      expect(hasHostile).toBe(true);
+    });
+
+    it("subscriptions list --json renders hostile company names without crashing", async () => {
+      const result = await runCliExpectSuccess(
+        ["subscriptions", "list", "--json", "--size", "1000"],
+        LARGE,
+      );
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(data.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Placeholders for the per-blocker assertions. Move each `.todo` to a
+  // real `it()` ONLY when the matching blocker PR ships, and have that
+  // PR add the strong assertion here. This file is the regression gate
+  // for everything below — it should never get smaller.
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe("blocker regressions (assertion lands with each fix)", () => {
+    it.todo(
+      "#462 — orderCommand strings from recommendations list are safe to exec: " +
+        "for a hostile-named customer, the rendered command must not produce " +
+        "subshell substitution when parsed by a real shell",
+    );
+
+    it.todo(
+      "#465 — subscriptionMrr returns 0 for One-Time/Trial/Activation: " +
+        "dashboard monthlyCost should not include gross from a $5000 One-Time fee",
+    );
+
+    it.todo(
+      "#472 — formatCurrency renders the correct unit per row: " +
+        "non-USD subs in `subscriptions list` show €/£/C$ rather than $",
+    );
+
+    it.todo(
+      "#478 — orders list exposes pagination metadata: " +
+        "JSON envelope includes page.{number,size,totalElements,totalPages}; " +
+        "default sort is createdAt DESC; companies beyond size:200 still resolve",
+    );
+
+    it.todo(
+      "#483 — every list command exposes the same page envelope: " +
+        "applies the #478 contract across subscriptions / clients / invoices / " +
+        "quotes / contacts / webhooks / products lists",
+    );
+
+    it.todo(
+      "#469 — last-list / pending-actions writes go through safeWriteFileSync " +
+        "and honor PAX8_CONFIG_DIR under scale (1000+ companies)",
+    );
+  });
+});

--- a/packages/cli/src/__tests__/scale-matrix.test.ts
+++ b/packages/cli/src/__tests__/scale-matrix.test.ts
@@ -35,6 +35,7 @@ function parseJson<T = unknown>(stdout: string): T {
   } catch (err) {
     throw new Error(
       `Failed to parse CLI JSON output. First 500 chars:\n${stdout.slice(0, 500)}\n\nOriginal error: ${err}`,
+      { cause: err },
     );
   }
 }

--- a/packages/core/src/mock/fixture.test.ts
+++ b/packages/core/src/mock/fixture.test.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Selector test for the fixture module (#484).
+//
+// Verifies that `PAX8_DEMO_SCALE=large` swaps the entity arrays for the
+// generated fixture while the default selection leaves the small fixture
+// untouched. We can't fully test the env switch via vitest's module cache
+// without `vi.resetModules`, so we go straight to the underlying primitives
+// and assert that:
+//   1. The small fixture has the curated hand-coded count (sanity).
+//   2. The large fixture generator produces a strict superset of that
+//      count (so we know the swap, when it happens, expands the surface).
+
+import { describe, it, expect } from "vitest";
+import * as smallFixture from "./demo-data.js";
+import { buildLargeFixture } from "./large-fixture.js";
+
+describe("fixture selector", () => {
+  it("the small (default) fixture is the hand-curated demo set", () => {
+    // Lightly-coupled sanity: the hand-curated fixture has dozens of
+    // companies, not thousands. If this assertion ever fails, someone
+    // expanded the small fixture beyond its intended scope — review.
+    expect(smallFixture.companies.length).toBeGreaterThan(0);
+    expect(smallFixture.companies.length).toBeLessThan(100);
+  });
+
+  it("the large fixture is strictly bigger across every populated entity", () => {
+    const large = buildLargeFixture();
+    expect(large.companies.length).toBeGreaterThan(smallFixture.companies.length * 10);
+    expect(large.subscriptions.length).toBeGreaterThan(smallFixture.subscriptions.length * 10);
+    expect(large.orders.length).toBeGreaterThan(smallFixture.orders.length * 10);
+    expect(large.products.length).toBeGreaterThan(smallFixture.products.length);
+  });
+
+  it("the large fixture reuses webhookTopicDefinitions from the small fixture (global catalog)", () => {
+    const large = buildLargeFixture();
+    expect(large.webhookTopicDefinitions).toBe(smallFixture.webhookTopicDefinitions);
+  });
+});

--- a/packages/core/src/mock/fixture.ts
+++ b/packages/core/src/mock/fixture.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Demo-fixture selector (#484).
+//
+// Picks between the hand-curated small fixture in `./demo-data.ts` (the
+// default — onboarding screenshots, golden-path tests) and the generated
+// large fixture in `./large-fixture.ts` (opt-in via PAX8_DEMO_SCALE=large
+// — scale-matrix testing). Everything downstream (MockPax8Client and
+// its callers) imports the entity arrays from this module so the switch
+// is invisible above the mock boundary.
+//
+// The large fixture is only built when PAX8_DEMO_SCALE=large is set at
+// process start — the buildLargeFixture() call is gated, so normal demo
+// mode pays zero cost beyond the module load.
+
+import * as small from "./demo-data.js";
+import { buildLargeFixture } from "./large-fixture.js";
+
+function resolveFixture(): typeof small {
+  if (process.env.PAX8_DEMO_SCALE === "large") {
+    // The cast is safe: buildLargeFixture returns the same shape as
+    // small (same entity types), just with generated data. Empty arrays
+    // for entity types not yet populated by the generator surface as
+    // empty result sets at the API boundary, which is the correct
+    // behavior — they don't pretend to have data they don't have.
+    return buildLargeFixture() as unknown as typeof small;
+  }
+  return small;
+}
+
+const fixture = resolveFixture();
+
+export const companies = fixture.companies;
+export const subscriptions = fixture.subscriptions;
+export const products = fixture.products;
+export const invoices = fixture.invoices;
+export const invoiceItems = fixture.invoiceItems;
+export const orders = fixture.orders;
+export const contacts = fixture.contacts;
+export const usageSummaries = fixture.usageSummaries;
+export const usageLines = fixture.usageLines;
+export const quotes = fixture.quotes;
+export const webhooks = fixture.webhooks;
+export const webhookLogs = fixture.webhookLogs;
+export const webhookTopicDefinitions = fixture.webhookTopicDefinitions;
+
+// Re-export types unchanged so callers can `import { type Company } from "./fixture.js"`.
+export type {
+  Company,
+  Subscription,
+  Product,
+  ProductPricing,
+  Invoice,
+  InvoiceItem,
+  Order,
+  OrderLineItem,
+  Contact,
+  UsageSummary,
+  UsageLine,
+  Quote,
+  QuoteRespondedBy,
+  QuoteLineItem,
+  Webhook,
+  WebhookLog,
+  WebhookTopicDefinition,
+  AmountCurrency,
+  InvoiceTotals,
+} from "./demo-data.js";

--- a/packages/core/src/mock/large-fixture.test.ts
+++ b/packages/core/src/mock/large-fixture.test.ts
@@ -1,0 +1,120 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Smoke tests for the large-portfolio fixture (#484).
+//
+// These don't yet wire the scale-matrix assertions for individual blockers
+// (#462, #465, #472, #478, #483) — those land alongside each blocker fix.
+// What we cover here are the invariants that the fixture itself promises:
+// deterministic generation, correct shape, every BillingTerm value present,
+// mixed currencies, hostile-named companies survive serialization.
+
+import { describe, it, expect } from "vitest";
+import { buildLargeFixture } from "./large-fixture.js";
+
+describe("large-fixture", () => {
+  it("generates the documented entity counts at default size", () => {
+    const f = buildLargeFixture();
+    expect(f.companies).toHaveLength(1000);
+    expect(f.products).toHaveLength(100);
+    expect(f.subscriptions).toHaveLength(5000);
+    expect(f.orders).toHaveLength(45000);
+    // Contacts: 1–3 per company, so at least 1000 and at most 3000.
+    expect(f.contacts.length).toBeGreaterThanOrEqual(1000);
+    expect(f.contacts.length).toBeLessThanOrEqual(3000);
+  });
+
+  it("is deterministic — same seed produces identical fixtures", () => {
+    const a = buildLargeFixture({ companies: 50, products: 10, subscriptions: 100, orders: 200 });
+    const b = buildLargeFixture({ companies: 50, products: 10, subscriptions: 100, orders: 200 });
+    expect(a.companies.map((c) => c.id)).toEqual(b.companies.map((c) => c.id));
+    expect(a.companies.map((c) => c.name)).toEqual(b.companies.map((c) => c.name));
+    expect(a.orders.slice(0, 50).map((o) => o.id)).toEqual(b.orders.slice(0, 50).map((o) => o.id));
+  });
+
+  it("seeds every BillingTerm value in subscriptions", () => {
+    // Smaller counts keep the test cheap but still hit the long-tail terms.
+    const f = buildLargeFixture({ companies: 100, products: 20, subscriptions: 500, orders: 0 });
+    const terms = new Set(f.subscriptions.map((s) => s.billingTerm));
+    expect(terms).toContain("Monthly");
+    expect(terms).toContain("Annual");
+    expect(terms).toContain("2-Year");
+    expect(terms).toContain("3-Year");
+    expect(terms).toContain("One-Time");
+    expect(terms).toContain("Trial");
+    expect(terms).toContain("Activation");
+  });
+
+  it("includes non-USD subscriptions so currency rendering is exercised under scale", () => {
+    const f = buildLargeFixture({ companies: 100, products: 20, subscriptions: 1000, orders: 0 });
+    const currencies = new Set(f.subscriptions.map((s) => s.currencyCode));
+    // At least USD must appear (overwhelming majority); plus at least one
+    // non-USD currency. Don't pin to all four — the weighted picker could
+    // miss a currency on small N runs, but with 1000 subs and 30% non-USD
+    // weight at least one of EUR/GBP/CAD lands.
+    expect(currencies).toContain("USD");
+    expect(currencies.size).toBeGreaterThan(1);
+  });
+
+  it("includes hostile-named companies that exercise shell-meta and unicode paths", () => {
+    const f = buildLargeFixture({ companies: 200, products: 10, subscriptions: 0, orders: 0 });
+    const names = f.companies.map((c) => c.name);
+    // Verify a sample of the hostile corpus is present. These exist to
+    // catch shell-injection in `orderCommand` (#462), Unicode rendering,
+    // and CSV escape failures.
+    expect(names).toContain(`Acme " Quoted " Inc.`);
+    expect(names).toContain(`O'Brien & Associates`);
+    expect(names).toContain(`北京科技 Tech Co`);
+    expect(names).toContain(`<script>alert(1)</script> Holdings`);
+  });
+
+  it("orders span 2013 to present (default range)", () => {
+    const f = buildLargeFixture({ companies: 100, products: 10, subscriptions: 0, orders: 1000 });
+    const dates = f.orders.map((o) => new Date(o.createdAt).getTime());
+    const min = Math.min(...dates);
+    const max = Math.max(...dates);
+    expect(min).toBeGreaterThanOrEqual(Date.UTC(2013, 0, 1));
+    // Max should be within the last day — generator uses Date.now() upper bound.
+    expect(max).toBeLessThanOrEqual(Date.now() + 86_400_000);
+    // And span at least a few years (sanity: not all clustered in one year).
+    expect(max - min).toBeGreaterThan(365 * 86_400_000);
+  });
+
+  it("subscriptions reference companies and products that exist in the fixture", () => {
+    const f = buildLargeFixture({ companies: 100, products: 20, subscriptions: 500, orders: 0 });
+    const companyIds = new Set(f.companies.map((c) => c.id));
+    const productIds = new Set(f.products.map((p) => p.id));
+    for (const sub of f.subscriptions) {
+      expect(companyIds.has(sub.companyId)).toBe(true);
+      expect(productIds.has(sub.productId)).toBe(true);
+    }
+  });
+
+  it("orders reference companies and product IDs that exist in the fixture", () => {
+    const f = buildLargeFixture({ companies: 100, products: 20, subscriptions: 0, orders: 1000 });
+    const companyIds = new Set(f.companies.map((c) => c.id));
+    const productIds = new Set(f.products.map((p) => p.id));
+    for (const order of f.orders.slice(0, 200)) {
+      expect(companyIds.has(order.companyId)).toBe(true);
+      for (const li of order.lineItems) {
+        expect(productIds.has(li.productId)).toBe(true);
+      }
+    }
+  });
+
+  it("every company has at least one primary contact (Admin/Billing/Technical)", () => {
+    const f = buildLargeFixture({ companies: 50, products: 10, subscriptions: 0, orders: 0 });
+    const contactsByCompany = new Map<string, typeof f.contacts>();
+    for (const c of f.contacts) {
+      const list = contactsByCompany.get(c.companyId) ?? [];
+      list.push(c);
+      contactsByCompany.set(c.companyId, list);
+    }
+    for (const company of f.companies) {
+      const list = contactsByCompany.get(company.id) ?? [];
+      expect(list.length).toBeGreaterThanOrEqual(1);
+      const primary = list.find((c) => c.types.every((t) => t.primary));
+      expect(primary).toBeDefined();
+    }
+  });
+});

--- a/packages/core/src/mock/large-fixture.ts
+++ b/packages/core/src/mock/large-fixture.ts
@@ -127,7 +127,7 @@ const HOSTILE_NAMES = [
   `Café del Mar SARL`,
   `北京科技 Tech Co`,
   `<script>alert(1)</script> Holdings`,
-  `\$ENV_VAR Industries`,
+  `$ENV_VAR Industries`,
   `\`backtick\` Capital`,
   `Tab\there\tCorp`,
   `Newline\nCo`,

--- a/packages/core/src/mock/large-fixture.ts
+++ b/packages/core/src/mock/large-fixture.ts
@@ -1,0 +1,479 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Large-portfolio fixture for scale testing (#484).
+//
+// Generates ~1000 companies, ~100 products, ~5000 subscriptions, ~45000
+// orders from a deterministic seed, plus the matching contact / pricing
+// rows. The hand-curated fixture in `./demo-data.ts` stays the default
+// for onboarding screenshots and golden-path tests — this one is opt-in
+// via `PAX8_DEMO_SCALE=large` and exists to surface bugs that only
+// manifest at portfolio scale (pagination invisibility, 200-cap name
+// enrichment, currency rendering, BillingTerm normalization, hostile
+// company names that break `orderCommand` interpolation, etc.).
+//
+// Everything is generated from a single seed (`SEED`) using a fast,
+// dependency-free PRNG (mulberry32), so two runs with the same env
+// produce identical fixtures and CI assertions are stable across
+// machines and minor library updates.
+
+import {
+  webhookTopicDefinitions,
+  type Company,
+  type Subscription,
+  type Product,
+  type ProductPricing,
+  type Invoice,
+  type InvoiceItem,
+  type Order,
+  type OrderLineItem,
+  type Contact,
+  type UsageSummary,
+  type UsageLine,
+  type Quote,
+  type Webhook,
+  type WebhookLog,
+  type WebhookTopicDefinition,
+} from "./demo-data.js";
+
+// ─── PRNG ────────────────────────────────────────────────────────────────────
+// Mulberry32: a fast, deterministic 32-bit PRNG. Same seed → same sequence,
+// across Node versions and CPU architectures. Don't replace with `Math.random`
+// or the fixture stops being reproducible.
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const SEED = 0x504158_38; // "PAX8" as hex — easy to spot if it ever leaks into logs
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRng(): {
+  next: () => number;
+  pick: <T>(arr: readonly T[]) => T;
+  pickWeighted: <T>(arr: readonly [T, number][]) => T;
+  intBetween: (lo: number, hi: number) => number;
+  uuid: (prefix: string, index: number) => string;
+  dateBetween: (startMs: number, endMs: number) => string;
+} {
+  const rng = mulberry32(SEED);
+  const pick = <T,>(arr: readonly T[]) => arr[Math.floor(rng() * arr.length)];
+  const pickWeighted = <T,>(arr: readonly [T, number][]) => {
+    const total = arr.reduce((s, [, w]) => s + w, 0);
+    let r = rng() * total;
+    for (const [v, w] of arr) {
+      r -= w;
+      if (r <= 0) return v;
+    }
+    return arr[arr.length - 1][0];
+  };
+  const intBetween = (lo: number, hi: number) => lo + Math.floor(rng() * (hi - lo + 1));
+  // Deterministic UUID-shaped IDs. Not real UUIDs, but pass the redactor and
+  // the various 8-character substring checks (`.slice(0, 8)`) the CLI does.
+  const uuid = (prefix: string, index: number) => {
+    const h = (index * 0x9e3779b1) >>> 0;
+    const hex = h.toString(16).padStart(8, "0");
+    return `${prefix}-${hex}-${hex.slice(0, 4)}-${hex.slice(4, 8)}-0000${hex}0000`;
+  };
+  const dateBetween = (startMs: number, endMs: number) => {
+    const t = startMs + Math.floor(rng() * (endMs - startMs));
+    return new Date(t).toISOString().split("T")[0];
+  };
+  return { next: rng, pick, pickWeighted, intBetween, uuid, dateBetween };
+}
+
+// ─── Company-name corpus ─────────────────────────────────────────────────────
+// Mix of plausible MSP / SMB customer names plus a deliberately-hostile tail
+// so the fixture exercises shell-quoting bugs (#462), Unicode rendering, and
+// long-name truncation.
+
+const COMPANY_PREFIXES = [
+  "Summit", "Coastline", "Redwood", "Bright", "Pinnacle", "Acme", "Anvil",
+  "Beacon", "Cedar", "Clarity", "Compass", "Cornerstone", "Crestview",
+  "Crown", "Delta", "Eastwood", "Echo", "Elm", "Evergreen", "Foundry",
+  "Gateway", "Granite", "Greenleaf", "Harbor", "Heritage", "Highland",
+  "Horizon", "Ironside", "Keystone", "Lakeview", "Lighthouse", "Maple",
+  "Meridian", "Midwest", "Mountainview", "North Star", "Oakwood", "Pacific",
+  "Pioneer", "Prairie", "Prospect", "Ridge", "Riverbend", "Sapphire",
+  "Sierra", "Silverstone", "Skyline", "Solstice", "Sterling", "Stonebridge",
+  "Sunrise", "Tide", "Timberline", "Tower", "Trailhead", "Trident",
+  "Vanguard", "Vertex", "Vista", "Westwind", "Whitestone", "Willow",
+];
+
+const COMPANY_SUFFIXES = [
+  "Healthcare Partners", "Legal Group", "Manufacturing", "Academy",
+  "Financial Advisors", "Logistics", "Construction", "Engineering",
+  "Consulting", "Technologies", "Solutions", "Systems", "Services",
+  "Holdings", "Industries", "Capital", "Realty", "Insurance",
+  "Properties", "Ventures", "Labs", "Group", "Associates", "Partners",
+  "& Co", "LLC", "Inc.", "Corp.", "Limited",
+];
+
+// Deliberately-hostile names. These exist to surface bugs that demo data
+// hides — they should round-trip through the CLI without breaking shell
+// interpolation, JSON serialization, or terminal rendering.
+const HOSTILE_NAMES = [
+  `Acme " Quoted " Inc.`,
+  `O'Brien & Associates`,
+  `Smith \\ Sons LLC`,
+  `Café del Mar SARL`,
+  `北京科技 Tech Co`,
+  `<script>alert(1)</script> Holdings`,
+  `\$ENV_VAR Industries`,
+  `\`backtick\` Capital`,
+  `Tab\there\tCorp`,
+  `Newline\nCo`,
+  `Drop;Table--Inc`,
+  `Müller & Söhne GmbH`,
+];
+
+// ─── Product corpus ──────────────────────────────────────────────────────────
+
+const VENDORS = [
+  "Microsoft", "Google", "Acronis", "Dropsuite", "Bitdefender", "Webroot",
+  "ESET", "Datto", "ConnectWise", "Kaseya", "N-able", "Veeam",
+  "SentinelOne", "Sophos", "Proofpoint", "Mimecast", "KnowBe4", "Cisco",
+  "Trend Micro", "AvePoint", "Carbonite", "MSP360",
+];
+
+const PRODUCT_KINDS = [
+  ["Productivity Suite", "Email", "Office Apps", "Teams"],
+  ["Endpoint Detection", "Antivirus", "EDR", "XDR"],
+  ["Backup & Recovery", "Cloud Backup", "DR Suite"],
+  ["Email Security", "Phishing Protection", "Encryption"],
+  ["Security Awareness", "Phishing Simulation", "Training"],
+  ["RMM", "PSA Integration", "Monitoring"],
+  ["Identity", "MFA", "SSO", "Conditional Access"],
+];
+
+// ─── Currency corpus ─────────────────────────────────────────────────────────
+// Weighted toward USD (real partner distribution) but with enough non-USD
+// volume to surface the `formatCurrency` always-$ bug (#472).
+
+const CURRENCY_WEIGHTS = [
+  ["USD", 70],
+  ["EUR", 12],
+  ["GBP", 10],
+  ["CAD", 8],
+] as const;
+
+// ─── Billing-term corpus ─────────────────────────────────────────────────────
+// Every value from BillingTermSchema. `One-Time` / `Trial` / `Activation`
+// are deliberately seeded so the `subscriptionMrr` regression for those
+// terms (#465) can be asserted under scale.
+
+const BILLING_TERMS = [
+  ["Monthly", 50],
+  ["Annual", 25],
+  ["2-Year", 8],
+  ["3-Year", 5],
+  ["One-Time", 5],
+  ["Trial", 4],
+  ["Activation", 3],
+] as const;
+
+const SUB_STATUS = [
+  ["Active", 75],
+  ["Trial", 5],
+  ["PendingManual", 3],
+  ["PendingCancel", 2],
+  ["Cancelled", 15],
+] as const;
+
+const ORDER_STATUS = [
+  ["Completed", 85],
+  ["Processing", 8],
+  ["Failed", 4],
+  ["PendingManual", 3],
+] as const;
+
+// ─── Generators ──────────────────────────────────────────────────────────────
+
+interface FixtureCounts {
+  companies: number;
+  products: number;
+  subscriptions: number;
+  orders: number;
+}
+
+const DEFAULT_COUNTS: FixtureCounts = {
+  companies: 1000,
+  products: 100,
+  subscriptions: 5000,
+  orders: 45000,
+};
+
+function generateCompanies(count: number, rng: ReturnType<typeof makeRng>): Company[] {
+  const result: Company[] = [];
+  // Reserve the last N slots for the hostile names so they always exist
+  // regardless of count.
+  const hostileSlots = Math.min(HOSTILE_NAMES.length, count);
+  const normalCount = count - hostileSlots;
+  for (let i = 0; i < normalCount; i++) {
+    const name = `${rng.pick(COMPANY_PREFIXES)} ${rng.pick(COMPANY_SUFFIXES)}`;
+    const createdMs = Date.UTC(2013, 0, 1) + Math.floor(rng.next() * (Date.now() - Date.UTC(2013, 0, 1)));
+    const createdAt = new Date(createdMs).toISOString().split("T")[0];
+    result.push(buildCompany(i, name, createdAt, rng));
+  }
+  for (let h = 0; h < hostileSlots; h++) {
+    const index = normalCount + h;
+    const createdMs = Date.UTC(2018, 0, 1) + Math.floor(rng.next() * (Date.now() - Date.UTC(2018, 0, 1)));
+    const createdAt = new Date(createdMs).toISOString().split("T")[0];
+    result.push(buildCompany(index, HOSTILE_NAMES[h], createdAt, rng));
+  }
+  return result;
+}
+
+function buildCompany(index: number, name: string, createdAt: string, rng: ReturnType<typeof makeRng>): Company {
+  const id = rng.uuid("co", index);
+  const status = rng.pickWeighted([["Active", 92], ["Inactive", 7], ["Deleted", 1]] as const);
+  return {
+    id,
+    name,
+    address: {
+      street: `${rng.intBetween(100, 9999)} Main St`,
+      city: rng.pick(["Denver", "Miami", "Chicago", "Seattle", "Austin", "Boston", "Atlanta", "Portland", "London", "Berlin", "Toronto", "Dublin"]),
+      stateOrProvince: rng.pick(["CO", "FL", "IL", "WA", "TX", "MA", "GA", "OR", "ON", "BC"]),
+      postalCode: String(rng.intBetween(10000, 99999)),
+      country: rng.pickWeighted([["US", 80], ["CA", 8], ["GB", 7], ["DE", 3], ["FR", 2]] as const),
+    },
+    phone: `+1-${rng.intBetween(200, 999)}-${rng.intBetween(100, 999)}-${String(rng.intBetween(0, 9999)).padStart(4, "0")}`,
+    website: `https://${name.toLowerCase().replace(/[^a-z0-9]+/g, "")}.example.com`.slice(0, 80),
+    status,
+    billOnBehalfOfEnabled: rng.next() > 0.2,
+    selfServiceAllowed: rng.next() > 0.5,
+    orderApprovalRequired: rng.next() > 0.7,
+    externalId: rng.next() > 0.4 ? `PSA-${String(index).padStart(6, "0")}` : undefined,
+    created: createdAt,
+    createdAt,
+  };
+}
+
+function generateProducts(count: number, rng: ReturnType<typeof makeRng>): Product[] {
+  const result: Product[] = [];
+  for (let i = 0; i < count; i++) {
+    const vendor = rng.pick(VENDORS);
+    const kindGroup = rng.pick(PRODUCT_KINDS);
+    const kind = rng.pick(kindGroup);
+    const tier = rng.pick(["Basic", "Standard", "Premium", "Business", "Enterprise"]);
+    const name = `${vendor} ${kind} ${tier}`;
+    const id = rng.uuid("prod", i);
+    const sku = `${vendor.toLowerCase().slice(0, 3)}-${kind.toLowerCase().replace(/\s+/g, "")}-${tier.toLowerCase().slice(0, 3)}-${String(i).padStart(4, "0")}`;
+    const partnerBuyPrice = Number((5 + rng.next() * 195).toFixed(2));
+    const suggestedRetailPrice = Number((partnerBuyPrice * (1.15 + rng.next() * 0.6)).toFixed(2));
+    const pricing: ProductPricing[] = [
+      {
+        billingTerm: "Monthly",
+        commitmentTerm: "Monthly",
+        partnerBuyPrice,
+        suggestedRetailPrice,
+        flatPrice: partnerBuyPrice,
+      },
+      {
+        billingTerm: "Annual",
+        commitmentTerm: "1-Year",
+        partnerBuyPrice: Number((partnerBuyPrice * 0.9).toFixed(2)),
+        suggestedRetailPrice: Number((suggestedRetailPrice * 0.9).toFixed(2)),
+        flatPrice: Number((partnerBuyPrice * 0.9).toFixed(2)),
+      },
+    ];
+    result.push({
+      id,
+      name,
+      vendorName: vendor,
+      sku,
+      shortDescription: `${kind} from ${vendor}, ${tier} tier.`,
+      unitOfMeasurement: rng.pickWeighted([["seat", 70], ["license", 20], ["GB", 7], ["mailbox", 3]] as const),
+      pricing,
+    });
+  }
+  return result;
+}
+
+function generateSubscriptions(
+  companies: Company[],
+  products: Product[],
+  count: number,
+  rng: ReturnType<typeof makeRng>,
+): Subscription[] {
+  const result: Subscription[] = [];
+  for (let i = 0; i < count; i++) {
+    const company = rng.pick(companies);
+    const product = rng.pick(products);
+    const billingTerm = rng.pickWeighted(BILLING_TERMS);
+    const status = rng.pickWeighted(SUB_STATUS);
+    const quantity = rng.intBetween(1, 250);
+    const startMs = Date.UTC(2015, 0, 1) + Math.floor(rng.next() * (Date.now() - Date.UTC(2015, 0, 1)));
+    const startDate = new Date(startMs).toISOString().split("T")[0];
+    const pricing = product.pricing[0];
+    const price = pricing.flatPrice ?? pricing.partnerBuyPrice;
+    const currencyCode = rng.pickWeighted(CURRENCY_WEIGHTS);
+    // Commitment-term end date: ~1 year out for committed terms, null for monthly/one-time.
+    const hasCommitment = billingTerm === "Annual" || billingTerm === "2-Year" || billingTerm === "3-Year";
+    const commitmentMonths = billingTerm === "2-Year" ? 24 : billingTerm === "3-Year" ? 36 : 12;
+    const commitmentEnd = hasCommitment
+      ? new Date(startMs + commitmentMonths * 30 * 86_400_000).toISOString().split("T")[0]
+      : null;
+    result.push({
+      id: rng.uuid("sub", i),
+      companyId: company.id,
+      productId: product.id,
+      productName: product.name,
+      quantity,
+      startDate,
+      createdDate: startDate,
+      createdAt: startDate,
+      billingStart: startDate,
+      status,
+      price,
+      currencyCode,
+      billingTerm,
+      commitment: hasCommitment
+        ? { id: rng.uuid("cmt", i), term: billingTerm.replace("-Year", "Y"), endDate: commitmentEnd! }
+        : undefined,
+      commitmentTermEndDate: commitmentEnd,
+      provisioningStatus: rng.pickWeighted([["Provisioned", 88], ["Pending", 8], ["Error", 4]] as const),
+      companyName: company.name,
+    });
+  }
+  return result;
+}
+
+function generateOrders(
+  companies: Company[],
+  products: Product[],
+  count: number,
+  rng: ReturnType<typeof makeRng>,
+): Order[] {
+  const result: Order[] = [];
+  const startMs = Date.UTC(2013, 0, 1);
+  const endMs = Date.now();
+  for (let i = 0; i < count; i++) {
+    const company = rng.pick(companies);
+    const createdAt = rng.dateBetween(startMs, endMs);
+    const lineItemCount = rng.pickWeighted([[1, 70], [2, 20], [3, 7], [4, 2], [5, 1]] as const);
+    const lineItems: OrderLineItem[] = [];
+    for (let li = 0; li < lineItemCount; li++) {
+      const product = rng.pick(products);
+      lineItems.push({
+        id: rng.uuid("oli", i * 10 + li),
+        productId: product.id,
+        productName: product.name,
+        lineItemNumber: li + 1,
+        quantity: rng.intBetween(1, 100),
+        billingTerm: rng.pickWeighted([
+          ["Monthly", 50], ["Annual", 30], ["2-Year", 6], ["3-Year", 4],
+          ["One-Time", 5], ["Trial", 3], ["Activation", 2],
+        ] as const),
+      });
+    }
+    result.push({
+      id: rng.uuid("ord", i),
+      companyId: company.id,
+      companyName: company.name,
+      orderedBy: "Pax8 Partner",
+      orderedByEmail: "partner@example.com",
+      createdDate: createdAt,
+      createdAt,
+      lineItems,
+      status: rng.pickWeighted(ORDER_STATUS),
+    });
+  }
+  return result;
+}
+
+function generateContacts(companies: Company[], rng: ReturnType<typeof makeRng>): Contact[] {
+  const result: Contact[] = [];
+  let contactIndex = 0;
+  for (const company of companies) {
+    const contactCount = rng.intBetween(1, 3);
+    for (let c = 0; c < contactCount; c++) {
+      const firstName = rng.pick(["Alex", "Jordan", "Casey", "Morgan", "Riley", "Taylor", "Avery", "Quinn", "Reese", "Skyler", "Cameron", "Drew", "Hayden", "Parker", "Sage"]);
+      const lastName = rng.pick(["Smith", "Johnson", "Lee", "Patel", "Garcia", "Brown", "Davis", "Wilson", "Martinez", "Anderson", "Thomas", "Jackson"]);
+      const types: Contact["types"] = [];
+      if (c === 0) {
+        // Primary contact carries all three types
+        types.push({ type: "Admin", primary: true });
+        types.push({ type: "Billing", primary: true });
+        types.push({ type: "Technical", primary: true });
+      } else {
+        types.push({ type: rng.pick(["Admin", "Billing", "Technical"] as const), primary: false });
+      }
+      result.push({
+        id: rng.uuid("contact", contactIndex++),
+        companyId: company.id,
+        firstName,
+        lastName,
+        email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}@example.com`,
+        types,
+      });
+    }
+  }
+  return result;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface LargeFixture {
+  companies: Company[];
+  products: Product[];
+  subscriptions: Subscription[];
+  invoices: Invoice[];
+  invoiceItems: InvoiceItem[];
+  orders: Order[];
+  contacts: Contact[];
+  usageSummaries: UsageSummary[];
+  usageLines: UsageLine[];
+  quotes: Quote[];
+  webhooks: Webhook[];
+  webhookLogs: WebhookLog[];
+  webhookTopicDefinitions: WebhookTopicDefinition[];
+}
+
+/**
+ * Build a deterministic large-scale fixture. The same SEED produces the
+ * same data across runs and machines. Counts can be overridden for tests
+ * that want a smaller-but-still-realistic shape.
+ *
+ * Cost: ~1–2 seconds for default counts (45k orders is the bulk of the work).
+ * Memory: ~30–50 MB resident. The fixture is intended to load once per
+ * process; `fixture.ts` caches the result.
+ *
+ * Currently populated: companies, products, subscriptions, orders, contacts.
+ * Empty arrays for the remaining entity types — those will be filled in as
+ * specific scale-matrix assertions need them. `webhookTopicDefinitions` is
+ * reused from the small fixture because it's a global Pax8 catalog, not
+ * per-tenant.
+ */
+export function buildLargeFixture(overrides?: Partial<FixtureCounts>): LargeFixture {
+  const counts = { ...DEFAULT_COUNTS, ...overrides };
+  const rng = makeRng();
+  const companies = generateCompanies(counts.companies, rng);
+  const products = generateProducts(counts.products, rng);
+  const subscriptions = generateSubscriptions(companies, products, counts.subscriptions, rng);
+  const orders = generateOrders(companies, products, counts.orders, rng);
+  const contacts = generateContacts(companies, rng);
+  return {
+    companies,
+    products,
+    subscriptions,
+    invoices: [],
+    invoiceItems: [],
+    orders,
+    contacts,
+    usageSummaries: [],
+    usageLines: [],
+    quotes: [],
+    webhooks: [],
+    webhookLogs: [],
+    webhookTopicDefinitions, // reuse: this is a Pax8 global catalog, not tenant data
+  };
+}

--- a/packages/core/src/mock/large-fixture.ts
+++ b/packages/core/src/mock/large-fixture.ts
@@ -59,14 +59,14 @@ const SEED = 0x504158_38; // "PAX8" as hex — easy to spot if it ever leaks int
 function makeRng(): {
   next: () => number;
   pick: <T>(arr: readonly T[]) => T;
-  pickWeighted: <T>(arr: readonly [T, number][]) => T;
+  pickWeighted: <T>(arr: readonly (readonly [T, number])[]) => T;
   intBetween: (lo: number, hi: number) => number;
   uuid: (prefix: string, index: number) => string;
   dateBetween: (startMs: number, endMs: number) => string;
 } {
   const rng = mulberry32(SEED);
   const pick = <T,>(arr: readonly T[]) => arr[Math.floor(rng() * arr.length)];
-  const pickWeighted = <T,>(arr: readonly [T, number][]) => {
+  const pickWeighted = <T,>(arr: readonly (readonly [T, number])[]) => {
     const total = arr.reduce((s, [, w]) => s + w, 0);
     let r = rng() * total;
     for (const [v, w] of arr) {

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -7,6 +7,10 @@
 import * as nodeFs from "node:fs";
 import * as nodePath from "node:path";
 import { homedir as nodeHomedir } from "node:os";
+// Import entity arrays via the fixture selector (#484): defaults to the
+// hand-curated small fixture; switches to the generated large fixture
+// when `PAX8_DEMO_SCALE=large` is set. Types continue to come from
+// `./demo-data.js` because they're canonical and shared by both fixtures.
 import {
   companies,
   subscriptions,
@@ -21,19 +25,21 @@ import {
   webhooks,
   webhookLogs,
   webhookTopicDefinitions,
-  type Company,
-  type Subscription,
-  type Product,
-  type Invoice,
-  type InvoiceItem,
-  type Order,
-  type Contact,
-  type UsageSummary,
-  type UsageLine,
-  type Quote as DemoQuote,
-  type Webhook,
-  type WebhookLog,
-  type WebhookTopicDefinition,
+} from "./fixture.js";
+import type {
+  Company,
+  Subscription,
+  Product,
+  Invoice,
+  InvoiceItem,
+  Order,
+  Contact,
+  UsageSummary,
+  UsageLine,
+  Quote as DemoQuote,
+  Webhook,
+  WebhookLog,
+  WebhookTopicDefinition,
 } from "./demo-data.js";
 import { ApiError, NotFoundError } from "../api/errors.js";
 import {


### PR DESCRIPTION
## Summary

The existing hand-curated demo fixture (~12 companies, dozens of subs/orders) is excellent for screenshots and onboarding but silently hides bugs that only manifest at portfolio scale — most of which were caught by hand during pre-publish review. This PR introduces a generated large-portfolio fixture so future regressions of the same class are caught by CI.

**Shape** (deterministic, seeded):
- 1,000 companies (plausible MSP names + a deliberately-hostile tail with shell-meta, Unicode, embedded quotes/backticks)
- 100 products across the vendor catalog
- 5,000 subscriptions with every `BillingTerm` value represented
- 45,000 orders dating from 2013 → today
- 1–3 contacts per company (~2,000 total)
- Mixed currencies: USD 70% / EUR / GBP / CAD

**Cost**: ~400ms at process start, pay-per-use. Normal `PAX8_DEMO=1` flow loads the small fixture and pays zero overhead.

## Usage

```bash
PAX8_DEMO=1 PAX8_DEMO_SCALE=large pax8 orders list
PAX8_DEMO=1 PAX8_DEMO_SCALE=large pax8 dashboard --json
```

The small fixture stays the default — both coexist. Documented in CLAUDE.md (env-var table) and CONTRIBUTING.md (under Demo Mode).

## Implementation

| File | Purpose |
|---|---|
| `packages/core/src/mock/large-fixture.ts` | Mulberry32 PRNG + deterministic generators for companies, products, subscriptions, orders, contacts. Explicit weights for currencies, statuses, billing terms |
| `packages/core/src/mock/fixture.ts` | Selector — picks small vs. large based on `PAX8_DEMO_SCALE`. Re-exports all entity arrays so callers don't need to know which fixture they're on |
| `packages/core/src/mock/mock-client.ts` | One-line change: imports entity arrays from `./fixture.js` instead of `./demo-data.js`. Types continue to come from `./demo-data.js` |
| `packages/core/src/mock/large-fixture.test.ts` | 9 invariant tests: counts, determinism, BillingTerm coverage, mixed currencies, hostile names present, sub/order referential integrity to companies/products |
| `packages/core/src/mock/fixture.test.ts` | 3 selector tests: small fixture untouched, large fixture is strict superset, webhookTopicDefinitions reused |

## What this enables (and what comes later)

This PR lays the foundation. Each of the open launch blockers below should add its own scale-matrix assertion alongside the fix:

- [#462](https://github.com/pax8labs/pax8-cli/issues/462) — exec the hostile-name `orderCommand` strings in a sandboxed shell and assert no substitution fires
- [#465](https://github.com/pax8labs/pax8-cli/issues/465) — assert `One-Time`/`Trial`/`Activation` subs contribute 0 to portfolio MRR
- [#472](https://github.com/pax8labs/pax8-cli/issues/472) — assert non-USD subs render with the correct currency symbol
- [#478](https://github.com/pax8labs/pax8-cli/issues/478) — assert `orders list --json` exposes `page.totalElements`, default sort is `createdAt DESC`, company names populate beyond the 200-cap
- [#483](https://github.com/pax8labs/pax8-cli/issues/483) — same assertions across every list command

Empty arrays for `invoices`, `usageSummaries`, `quotes`, `webhooks`, `webhookLogs` for now — those entity types don't have a scale-matrix assertion called out yet. Trivial to add when needed; `webhookTopicDefinitions` is reused from the small fixture because it's a Pax8 global catalog, not tenant data.

## Test plan

- [x] `pnpm test` — 1942 passing, 6 skipped (up from 1930 — 12 new fixture tests; nothing broken).
- [x] `pnpm build` — clean.
- [x] End-to-end smoke: `PAX8_DEMO=1 pax8 orders list` → small fixture (first ID `ord-summ...`).
- [x] `PAX8_DEMO=1 PAX8_DEMO_SCALE=large pax8 orders list --json --size 25` → large fixture (first ID `ord-0000...`, first company "Anvil Insurance").
- [x] Fixture generation deterministic across runs (test invariant).

Closes #484