### PR TITLE
chore(deps): bump brace-expansion override to ^5.0.6 (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "overrides": {
       "vite": "^8.0.5",
       "picomatch": "^4.0.4",
-      "brace-expansion": "^5.0.5",
+      "brace-expansion": "^5.0.6",
       "yaml": "^2.8.3"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   vite: ^8.0.5
   picomatch: ^4.0.4
-  brace-expansion: ^5.0.5
+  brace-expansion: ^5.0.6
   yaml: ^2.8.3
 
 importers:
@@ -890,8 +890,8 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2640,7 +2640,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3102,7 +3102,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   mlly@1.8.2:
     dependencies:


### PR DESCRIPTION
## Summary

CI on every open PR (and any new branch off main) is failing at the `pnpm audit` step:

```
moderate: brace-expansion: Large numeric range defeats documented
\`max\` DoS protection — GHSA-jxxr-4gwj-5jf2
Vulnerable: >=5.0.0 <5.0.6  •  Patched: >=5.0.6
```

Brought in transitively through eslint + @typescript-eslint (44 paths).

## Why the existing override didn't catch it

`package.json` already pins `brace-expansion` in `pnpm.overrides` to control the transitive resolution — but the pin was `^5.0.5`, which permits both `5.0.5` (vulnerable) and `5.0.6` (patched). The lockfile resolved at `5.0.5`, so `pnpm audit` failed.

## Fix

Bump the override to `^5.0.6` and regenerate the lockfile. After this, `pnpm audit` reports `No known vulnerabilities found` locally.

## Test plan

- [x] `pnpm install` clean.
- [x] `pnpm audit` exit 0, "No known vulnerabilities found."
- [x] `pnpm build && pnpm test` — full suite passes (1924 tests).

## After merge

The six other open PRs ([#485](https://github.com/pax8labs/pax8-cli/pull/485), [#486](https://github.com/pax8labs/pax8-cli/pull/486), [#487](https://github.com/pax8labs/pax8-cli/pull/487), [#488](https://github.com/pax8labs/pax8-cli/pull/488), [#490](https://github.com/pax8labs/pax8-cli/pull/490), [#491](https://github.com/pax8labs/pax8-cli/pull/491)) need to merge main (or rebase) to pick up the fix. Each will then be green.

## Note on the separate CodeQL failure

The "Analyze (javascript-typescript)" CodeQL check is also failing on every PR with `Code Security must be enabled for this repository to use code scanning`. That's a **repo setting** — needs an admin to flip on **Settings → Code security → Code scanning** for `pax8labs/pax8-cli`. Not fixable from code; filing separately if it doesn't get flipped on before launch.