### PR TITLE
ci(codeql): make analyze step non-blocking while repo is private

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,19 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # `continue-on-error: true` is intentional while the repo is private:
+      # CodeQL's upload step requires `code_security` enabled at the repo
+      # level, which on a private repo requires a paid GitHub Advanced
+      # Security license. The scan itself runs and produces SARIF; only the
+      # upload fails with "Code Security must be enabled for this repository
+      # to use code scanning." That failure shouldn't block every PR's CI.
+      #
+      # On a public repo, code scanning is free — the upload starts working
+      # automatically the moment the v0.1.0 public flip happens. Remove this
+      # `continue-on-error` once that's done so a future regression in the
+      # scan surfaces as a hard failure. Tracked in #138.
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
+        continue-on-error: true
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary

CodeQL's upload-results step requires `code_security` enabled at the repo level. On a private repo that's a paid GitHub Advanced Security license; on a public repo it's free. While the repo is still private (pre-v0.1.0 public flip), every PR's CodeQL check fails at the upload step with:

```
Code Security must be enabled for this repository to use code scanning.
```

The scan itself runs successfully and produces SARIF; only the upload fails. That shouldn't block CI on every PR while we wait for the public flip.

This was originally pushed as a second commit on [#492](https://github.com/pax8labs/pax8-cli/pull/492) but didn't get included in the merge (only the first commit landed). Filing it as its own small PR.

## Change

Add `continue-on-error: true` to the CodeQL analyze step. Inline comment explains the intent and points contributors at #138 to remove this once the repo flips public.

## After this lands

The six rebased PRs (incoming) plus any future PR will all pass CI fully — both `pnpm audit` (via [#492](https://github.com/pax8labs/pax8-cli/pull/492)) and CodeQL (via this PR). Remove the `continue-on-error` once the v0.1.0 public flip happens.

## Test plan

Workflow file change only; verified locally that the YAML is well-formed.