### PR TITLE
ci: add Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Claude Code review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |
             actions: read
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,48 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            Review this pull request. Ground findings in the repo's
+            conventions — CLAUDE.md, docs/UX_GUIDE.md (§13 checklist),
+            and packages/claude-skill/skill.md for the agent-facing
+            read/write contract.
+
+            Focus on: correctness, security, agent-facing safety
+            (write commands must prompt, idempotency keys honored,
+            error codes from packages/core/src/errors/codes.ts),
+            stdout/stderr discipline (no console.log in command
+            code; output() only), and demo-mode behavior.
+
+            Skip generic praise. Cite file:line for every concrete
+            issue. If the change is small or routine, say so briefly
+            and move on.
+          claude_args: "--model opus"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-code-review.yml` — runs [`anthropics/claude-code-action@v1`](https://github.com/anthropics/claude-code-action) on every non-draft PR (`opened`, `synchronize`, `reopened`, `ready_for_review`) and posts a review comment.
- Uses the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret (same one operon uses). No other config or cross-org dependency — if we ever transfer orgs, one `git rm` removes it cleanly.
- The review prompt is grounded in this repo's conventions: CLAUDE.md, the §13 checklist in `docs/UX_GUIDE.md`, the agent-facing read/write contract in `packages/claude-skill/skill.md`, and the stdout/stderr + error-code rules.

We chose this over the operon ensemble bot because it's self-contained (no `pax8labs/service-workflows` reusable workflow, no operon checkout, no PAT). If we want a multi-model second opinion later, the ensemble bot can be added on top — they coexist fine.

## Test plan

- [ ] After merge, open a throwaway PR and confirm Claude posts a review within ~2 min
- [ ] Confirm draft PRs do **not** trigger the workflow
- [ ] Confirm the workflow appears under Actions → Claude Code Review with green status

🤖 Generated with [Claude Code](https://claude.com/claude-code)