### PR TITLE
fix(cache): remove cache warmer and partition cache by tenant + base URL

### DIFF
--- a/.changeset/cache-tenant-scoping-and-warmer-removal.md
+++ b/.changeset/cache-tenant-scoping-and-warmer-removal.md
@@ -1,0 +1,14 @@
+---
+"@pax8/cli": patch
+"@pax8/core": patch
+---
+
+Three interlocking fixes to the response-cache layer:
+
+1. **Tenant + base-URL scoping.** `Pax8Client.buildCacheKey` previously keyed only on path / params / api / version, so a credential rotation or `PAX8_API_BASE` flip silently served tenant-A's cached responses into a tenant-B session for up to 24h (default TTL). Cache keys now include a SHA-256-truncated hash of `(clientId, PAX8_API_BASE env, baseUrl, apiBaseOverrides)`. **Upgrading invalidates existing on-disk cache entries** because the key prefix changes — first run after upgrade will be slower as the cache refills.
+
+2. **Detached cache warmer removed.** `buildContext` was spawning three detached `pax8 list` child processes on every command run (companies / subscriptions / products) as a "warm the cache" optimization. Net effect was every invocation fanning into four processes, unnecessary API calls on commands that didn't need the data, and noise in `--quiet` mode process listings. Removed.
+
+3. **`cache.enabled` / `cache.ttl_hours` honored.** The schema accepted these fields but `buildContext` never read them, so `cache.enabled: false` in `~/.pax8/config.yaml` still got the constructor's hard-coded 1h default. Now plumbed through end-to-end.
+
+Closes #455, #466. Addresses #253.

--- a/packages/cli/src/lib/context.test.ts
+++ b/packages/cli/src/lib/context.test.ts
@@ -3,8 +3,10 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Track spawn calls so we can assert on cache-warmer invocations without
-// actually spawning detached child processes during tests.
+// Track spawn calls so we can assert on subprocess invocations from
+// `buildContext()`. After #466 there should be zero — the detached
+// `spawnCacheWarmer` is gone and on-disk cache populates organically
+// from real user reads.
 const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
 
 vi.mock("node:child_process", async (importActual) => {
@@ -201,12 +203,10 @@ describe("buildContext", () => {
 
   // PAX8_DEMO=false / =0 must force demo OFF even when config has demo:true,
   // so users can keep `demo: true` in `~/.pax8/config.yaml` as a safety default
-  // and opt out per-invocation. Cache warming is disabled in these tests to
-  // avoid spawning detached child processes.
+  // and opt out per-invocation.
   for (const falsyValue of ["false", "0"]) {
     it(`PAX8_DEMO='${falsyValue}' overrides config 'demo: true'`, async () => {
       process.env.PAX8_DEMO = falsyValue;
-      process.env.PAX8_CACHE_WARMING = "1";
 
       const core = await import("@pax8/core");
       const cfg = {
@@ -233,7 +233,6 @@ describe("buildContext", () => {
       } finally {
         loadSpy.mockRestore();
         getCredSpy.mockRestore();
-        delete process.env.PAX8_CACHE_WARMING;
       }
     });
   }
@@ -248,8 +247,6 @@ describe("buildContext", () => {
 
   it("non-demo path constructs a real api client when credentials are present", async () => {
     delete process.env.PAX8_DEMO;
-    // Skip the cache warmer so the test doesn't spawn detached child procs.
-    process.env.PAX8_CACHE_WARMING = "1";
 
     const core = await import("@pax8/core");
     const getCredSpy = vi
@@ -274,13 +271,15 @@ describe("buildContext", () => {
       expect("webhooks" in ctx.api).toBe(true);
     } finally {
       getCredSpy.mockRestore();
-      delete process.env.PAX8_CACHE_WARMING;
     }
   });
 
-  it("non-demo path spawns three cache warmers when not already warming", async () => {
+  // Regression guard for #466: the detached `spawnCacheWarmer` has been removed.
+  // `buildContext()` must NOT spawn any subprocesses — neither in demo mode nor
+  // on the real-API path. The on-disk cache populates organically from user
+  // reads instead.
+  it("non-demo buildContext does not spawn any subprocesses (#466)", async () => {
     delete process.env.PAX8_DEMO;
-    delete process.env.PAX8_CACHE_WARMING;
     spawnCalls.length = 0;
 
     const core = await import("@pax8/core");
@@ -290,18 +289,77 @@ describe("buildContext", () => {
 
     try {
       await buildContext({ json: true });
-      expect(spawnCalls).toHaveLength(3);
-      // The warmers list companies, subscriptions, products in parallel.
-      const resources = spawnCalls.map((c) => c.args[0]).sort();
-      expect(resources).toEqual(["companies", "products", "subscriptions"]);
-      // Each should pass --quiet --json so they never write to a real terminal.
-      for (const c of spawnCalls) {
-        expect(c.args).toContain("--json");
-        expect(c.args).toContain("--quiet");
-      }
+      expect(spawnCalls).toEqual([]);
     } finally {
       getCredSpy.mockRestore();
     }
+  });
+
+  it("demo buildContext does not spawn any subprocesses (#466)", async () => {
+    process.env.PAX8_DEMO = "1";
+    spawnCalls.length = 0;
+    await buildContext({ json: true });
+    expect(spawnCalls).toEqual([]);
+  });
+
+  // #253: the schema documents `cache.enabled` and `cache.ttl_hours`. Before
+  // this change those values were silently ignored — `Pax8Client` got its
+  // 1h hardcoded default regardless of config. These tests pin that the
+  // values now flow through to the constructor.
+  describe("cache config plumbing (#253)", () => {
+    it("passes cacheTtlMs derived from config.cache.ttl_hours when enabled", async () => {
+      delete process.env.PAX8_DEMO;
+      const core = await import("@pax8/core");
+      const loadSpy = vi.spyOn(core, "loadConfig").mockResolvedValue({
+        version: "1.0",
+        defaults: { output_format: "table", page_size: 50, confirm_destructive: true },
+        cache: { enabled: true, ttl_hours: 6 },
+        telemetry: { enabled: false },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial config for tests
+      } as any);
+      const getCredSpy = vi
+        .spyOn(core.CredentialStore.prototype, "getCredentials")
+        .mockResolvedValue({ clientId: "id-x", clientSecret: "secret-y" });
+      const ctorSpy = vi.spyOn(core, "Pax8Client");
+
+      try {
+        await buildContext({ json: true });
+        expect(ctorSpy).toHaveBeenCalledTimes(1);
+        const opts = ctorSpy.mock.calls[0][0];
+        expect(opts.cacheTtlMs).toBe(6 * 3_600_000);
+      } finally {
+        loadSpy.mockRestore();
+        getCredSpy.mockRestore();
+        ctorSpy.mockRestore();
+      }
+    });
+
+    it("passes cacheTtlMs=0 when config.cache.enabled is false", async () => {
+      delete process.env.PAX8_DEMO;
+      const core = await import("@pax8/core");
+      const loadSpy = vi.spyOn(core, "loadConfig").mockResolvedValue({
+        version: "1.0",
+        defaults: { output_format: "table", page_size: 50, confirm_destructive: true },
+        cache: { enabled: false, ttl_hours: 24 },
+        telemetry: { enabled: false },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial config for tests
+      } as any);
+      const getCredSpy = vi
+        .spyOn(core.CredentialStore.prototype, "getCredentials")
+        .mockResolvedValue({ clientId: "id-x", clientSecret: "secret-y" });
+      const ctorSpy = vi.spyOn(core, "Pax8Client");
+
+      try {
+        await buildContext({ json: true });
+        expect(ctorSpy).toHaveBeenCalledTimes(1);
+        const opts = ctorSpy.mock.calls[0][0];
+        expect(opts.cacheTtlMs).toBe(0);
+      } finally {
+        loadSpy.mockRestore();
+        getCredSpy.mockRestore();
+        ctorSpy.mockRestore();
+      }
+    });
   });
 
   it("loadConfig failure is recovered with sane defaults", async () => {

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -19,7 +19,6 @@ import {
   ERROR_AUTH_MISSING,
 } from "@pax8/core";
 import type { Config } from "@pax8/core";
-import { spawn } from "node:child_process";
 import { CliError } from "./errors.js";
 import { replCmd } from "./confirm.js";
 
@@ -214,9 +213,20 @@ export async function buildContext(
       clientSecret: credentials.clientSecret,
     });
 
+    // Plumb the documented `cache.enabled` / `cache.ttl_hours` config fields
+    // through to `Pax8Client` so they actually take effect (#253). Previously
+    // these were defined in the schema but never read here, so a user setting
+    // `cache.enabled: false` in `~/.pax8/config.yaml` still got caching with
+    // the constructor's hard-coded 1h default. `cacheTtlMs: 0` disables the
+    // FileCache entirely inside `Pax8Client`.
+    const cacheEnabled = config.cache?.enabled ?? true;
+    const cacheTtlHours = config.cache?.ttl_hours ?? 24;
+    const cacheTtlMs = cacheEnabled ? cacheTtlHours * 3_600_000 : 0;
+
     const client = new Pax8Client({
       tokenManager,
       debug: verbose,
+      cacheTtlMs,
       // Per-API base URL overrides (#321). The Webhooks API lives at
       // `https://api.pax8.com/api/v2/webhooks/...` per the public webhooks
       // OpenAPI spec — a different *prefix* than the project-wide `/v1`
@@ -241,36 +251,5 @@ export async function buildContext(
     };
   }
 
-  // Spawn a detached background process to warm the cache.
-  // Skip if we're already a warmer child (prevents infinite recursion).
-  if (!isDemo && !process.env.PAX8_CACHE_WARMING) {
-    spawnCacheWarmer();
-  }
-
   return { api, outputFormat, config, isDemo, verbose };
-}
-
-/**
- * Spawn a detached child process that runs common pax8 queries to warm the file cache.
- * The child is fully detached (stdio ignored, unref'd) so the parent exits immediately.
- */
-function spawnCacheWarmer(): void {
-  const env = { ...process.env, PAX8_CACHE_WARMING: "1" };
-
-  spawnCacheWarm(["companies", "list", "--json", "--size", "200", "--quiet"], env, "companies");
-  spawnCacheWarm(["subscriptions", "list", "--json", "--size", "1000", "--quiet"], env, "subscriptions");
-  spawnCacheWarm(["products", "list", "--json", "--size", "500", "--quiet"], env, "products");
-}
-
-/**
- * Spawn a single detached `pax8 ...` cache-warm child. Errors are best-effort
- * and only surfaced under `PAX8_DEBUG`. Caller is responsible for passing the
- * env that already has `PAX8_CACHE_WARMING=1` set so the child doesn't recurse.
- */
-function spawnCacheWarm(args: string[], env: NodeJS.ProcessEnv, label: string): void {
-  const child = spawn("pax8", args, { detached: true, stdio: "ignore", env });
-  child.on("error", (err) => {
-    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] cache warmer (${label}) failed: ${err}\n`);
-  });
-  child.unref();
 }

--- a/packages/core/src/api/cache-key.test.ts
+++ b/packages/core/src/api/cache-key.test.ts
@@ -1,0 +1,129 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { buildCacheKey } from "./client.js";
+
+// Regression coverage for #455: the cache key MUST be partitioned by tenant
+// identity (`PAX8_CLIENT_ID`) and base URL (`PAX8_API_BASE`). Otherwise a
+// user who switches credentials — or flips between prod / staging / sandbox
+// — is silently served the previous identity's responses for up to 24h.
+
+describe("buildCacheKey (#455)", () => {
+  it("produces a stable key when nothing changes", () => {
+    const a = buildCacheKey({
+      path: "/companies",
+      params: { size: 50 },
+      clientId: "tenant-a",
+      apiBaseEnv: "https://api.pax8.com/v1",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    const b = buildCacheKey({
+      path: "/companies",
+      params: { size: 50 },
+      clientId: "tenant-a",
+      apiBaseEnv: "https://api.pax8.com/v1",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("differs when PAX8_CLIENT_ID changes (cross-tenant)", () => {
+    const tenantA = buildCacheKey({
+      path: "/companies",
+      params: { size: 50 },
+      clientId: "tenant-a",
+      apiBaseEnv: "https://api.pax8.com/v1",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    const tenantB = buildCacheKey({
+      path: "/companies",
+      params: { size: 50 },
+      clientId: "tenant-b",
+      apiBaseEnv: "https://api.pax8.com/v1",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    expect(tenantA).not.toBe(tenantB);
+  });
+
+  it("differs when PAX8_API_BASE changes (prod vs staging)", () => {
+    const prod = buildCacheKey({
+      path: "/companies",
+      params: { size: 50 },
+      clientId: "tenant-a",
+      apiBaseEnv: "https://api.pax8.com/v1",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    const staging = buildCacheKey({
+      path: "/companies",
+      params: { size: 50 },
+      clientId: "tenant-a",
+      apiBaseEnv: "https://api-staging.pax8.com/v1",
+      baseUrl: "https://api-staging.pax8.com/v1",
+    });
+    expect(prod).not.toBe(staging);
+  });
+
+  it("differs when both PAX8_CLIENT_ID and PAX8_API_BASE change", () => {
+    const a = buildCacheKey({
+      path: "/companies",
+      clientId: "tenant-a",
+      apiBaseEnv: "https://api.pax8.com/v1",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    const b = buildCacheKey({
+      path: "/companies",
+      clientId: "tenant-b",
+      apiBaseEnv: "https://api-staging.pax8.com/v1",
+      baseUrl: "https://api-staging.pax8.com/v1",
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("falls back to a tenant-less key when no identity inputs are supplied", () => {
+    // Backwards-compatible behavior for embedders that don't pass identity
+    // information. The key still includes path + params so it's still useful
+    // for in-process caching; just not safe across credential rotations.
+    const key = buildCacheKey({ path: "/companies", params: { size: 50 } });
+    expect(key).toBe("companies_size=50");
+  });
+
+  it("preserves api + apiVersion prefixes (#321/#307)", () => {
+    const v1 = buildCacheKey({
+      path: "/foo",
+      clientId: "tenant-a",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    const v2 = buildCacheKey({
+      path: "/foo",
+      apiVersion: "v2",
+      clientId: "tenant-a",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    const webhooks = buildCacheKey({
+      path: "/foo",
+      api: "webhooks",
+      clientId: "tenant-a",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    expect(v1).not.toBe(v2);
+    expect(v1).not.toBe(webhooks);
+    expect(v2).not.toBe(webhooks);
+  });
+
+  it("query-string params are key-order independent", () => {
+    const a = buildCacheKey({
+      path: "/companies",
+      params: { size: 50, page: 0 },
+      clientId: "tenant-a",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    const b = buildCacheKey({
+      path: "/companies",
+      params: { page: 0, size: 50 },
+      clientId: "tenant-a",
+      baseUrl: "https://api.pax8.com/v1",
+    });
+    expect(a).toBe(b);
+  });
+});

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -1,6 +1,7 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import { type ZodType } from "zod";
 import { ApiError, RateLimitError } from "./errors.js";
 import { PageSchema } from "./types.js";
@@ -211,6 +212,85 @@ export function isApiTimeoutError(error: unknown): boolean {
   return /timed out/i.test(error.message);
 }
 
+/**
+ * Inputs to {@link buildCacheKey}. All fields except `path` are optional; the
+ * helper degrades gracefully when a caller can't supply (for example) the
+ * tenant identity. The fields that ARE supplied are folded into the resulting
+ * key so changing any of them produces a distinct cache entry.
+ */
+export interface BuildCacheKeyInput {
+  path: string;
+  params?: Record<string, string | number | undefined>;
+  apiVersion?: string;
+  api?: string;
+  /** Resolved project-wide base URL the request will be issued against. */
+  baseUrl?: string;
+  /** Per-API base URL overrides registered on the client. */
+  apiBaseOverrides?: Record<string, string>;
+  /** Tenant identity, typically `process.env.PAX8_CLIENT_ID`. */
+  clientId?: string;
+  /** Raw `PAX8_API_BASE` env var, kept in the key so prod/staging/sandbox don't bleed. */
+  apiBaseEnv?: string;
+}
+
+/**
+ * Build a stable cache key for a request. Exported so the partitioning rule is
+ * unit-testable independent of the surrounding request plumbing.
+ *
+ * #455: cache entries must be partitioned by tenant identity (`PAX8_CLIENT_ID`)
+ * and base URL (`PAX8_API_BASE`) so a user who switches credentials or flips
+ * between prod/staging/sandbox is never served the previous identity or
+ * environment's cached responses. Default TTL is non-trivial (24h) and the
+ * cache lives on disk, so without these key components a credential rotation
+ * silently serves stale tenant-A data into a tenant-B session.
+ *
+ * Tenant/baseUrl bytes are SHA-256-hashed and truncated so the resulting
+ * filename stays short and never echoes raw credentials on disk. Filenames
+ * already go through `FileCache`'s safe-character filter, but hashing keeps
+ * the key length predictable regardless of how long a partner's clientId or
+ * custom base URL is.
+ */
+export function buildCacheKey(input: BuildCacheKeyInput): string {
+  const { path, params, apiVersion, api, baseUrl, apiBaseOverrides, clientId, apiBaseEnv } = input;
+
+  const normalized = path.replace(/^\/+/, "");
+  const paramStr = params
+    ? Object.entries(params)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join("&")
+    : "";
+
+  // Per-API base and per-call apiVersion both shift the resolved wire URL,
+  // so cache entries must be partitioned by both — otherwise a `/v1/foo`
+  // response could be served to a `/v2/foo` or `/api/v2/foo` caller (#321).
+  const apiPrefix = api ? `${api}:` : "";
+  const versionPrefix = apiVersion ? `${apiVersion}:` : "";
+
+  // Tenant/base-URL identity bytes. Hash so the on-disk filename stays short
+  // and doesn't carry raw credentials. The per-API override map is included
+  // because a downstream embedder that points the webhooks API at a different
+  // host should not share cache entries with one that doesn't.
+  const overrideStr = apiBaseOverrides
+    ? Object.entries(apiBaseOverrides)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join("&")
+    : "";
+  const identity = [
+    clientId ?? "",
+    apiBaseEnv ?? "",
+    baseUrl ?? "",
+    overrideStr,
+  ].join("|");
+  const tenantPrefix = identity === "|||"
+    ? ""
+    : `t${createHash("sha256").update(identity).digest("hex").slice(0, 16)}:`;
+
+  return `${tenantPrefix}${apiPrefix}${versionPrefix}${normalized}${paramStr ? "_" + paramStr : ""}`;
+}
+
 export class Pax8Client {
   private readonly tokenManager: { getToken(): Promise<string> };
   private readonly baseUrl: string;
@@ -278,20 +358,16 @@ export class Pax8Client {
     apiVersion?: string,
     api?: string,
   ): string {
-    const normalized = path.replace(/^\/+/, "");
-    const paramStr = params
-      ? Object.entries(params)
-          .filter(([, v]) => v !== undefined)
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([k, v]) => `${k}=${v}`)
-          .join("&")
-      : "";
-    // Per-API base and per-call apiVersion both shift the resolved wire URL,
-    // so cache entries must be partitioned by both — otherwise a `/v1/foo`
-    // response could be served to a `/v2/foo` or `/api/v2/foo` caller (#321).
-    const apiPrefix = api ? `${api}:` : "";
-    const versionPrefix = apiVersion ? `${apiVersion}:` : "";
-    return `${apiPrefix}${versionPrefix}${normalized}${paramStr ? "_" + paramStr : ""}`;
+    return buildCacheKey({
+      path,
+      params,
+      apiVersion,
+      api,
+      baseUrl: this.baseUrl,
+      apiBaseOverrides: this.apiBaseOverrides,
+      clientId: process.env.PAX8_CLIENT_ID,
+      apiBaseEnv: process.env.PAX8_API_BASE,
+    });
   }
 
   async post<T>(path: string, body: unknown, opts?: RequestOpts): Promise<T> {


### PR DESCRIPTION
## Summary

Three fixes to the `@pax8/core` cache layer that all shipped behind the same "caching just works" facade:

1. **Cache warmer removed.** `buildContext` was spawning three detached `pax8` child processes (`companies list --json --size 200`, `subscriptions list --json --size 1000`, `products list --json --size 500`) on every command run as a "warm the cache for the next call" optimization. In practice this fanned every invocation into four processes, fired unnecessary API calls on commands that didn't need the data, and made `--quiet` mode noisy in process listings.

2. **Tenant + base URL scoping (#455).** `Pax8Client.buildCacheKey` previously keyed only on `path` / `params` / `api` / `apiVersion`, so a credential rotation or `PAX8_API_BASE` flip silently served tenant-A's cached responses into a tenant-B session for up to 24h (default TTL). Keys now include a SHA-256-truncated hash of `(clientId, PAX8_API_BASE env, baseUrl, apiBaseOverrides)`. Hashing keeps the on-disk filename short and avoids echoing raw credentials. The hash is omitted when all identity bytes are empty (e.g. tests without `PAX8_CLIENT_ID`) so existing test keys don't shift.

3. **`cache.enabled` / `cache.ttl_hours` plumbed through (#253).** The schema accepted these fields but `buildContext` never read them, so a user setting `cache.enabled: false` in `~/.pax8/config.yaml` still got the constructor's hard-coded 1h default.

## Test plan

- [x] `pnpm test` — 1934 passed / 6 skipped
- [x] New `packages/core/src/api/cache-key.test.ts` exercises the partitioning rule independent of the surrounding request plumbing (different `clientId` → different key; same identity → same key; missing identity → no `t…:` prefix)

Closes #455, closes #466. Addresses #253 (config now plumbed through end-to-end; any follow-up docs work can ship separately).

