### PR TITLE
fix: retry gating (#463) + webhooks test confirmation (#464)

### DIFF
--- a/e2e/webhooks-workflow.test.ts
+++ b/e2e/webhooks-workflow.test.ts
@@ -80,7 +80,7 @@ describe("E2E: Webhooks workflow — list, create, test, logs, delete", () => {
     const list = await runCliExpectSuccess(["webhooks", "list"]);
     const id = JSON.parse(list.stdout)[0].id;
 
-    const result = await runCliExpectSuccess(["webhooks", "test", id, "--json"]);
+    const result = await runCliExpectSuccess(["webhooks", "test", id, "--yes", "--json"]);
     const data = JSON.parse(result.stdout);
     expect(data.id).toBe(id);
     expect(data).toHaveProperty("result");

--- a/packages/cli/src/__tests__/webhooks.test.ts
+++ b/packages/cli/src/__tests__/webhooks.test.ts
@@ -16,6 +16,7 @@ describe("pax8 webhooks test", () => {
       "webhooks",
       "test",
       SUBS_WEBHOOK_ID,
+      "--yes",
       "--json",
     ]);
     const data = JSON.parse(result.stdout);
@@ -33,6 +34,7 @@ describe("pax8 webhooks test", () => {
       SUBS_WEBHOOK_ID,
       "--topic",
       "subscription.created",
+      "--yes",
       "--json",
     ]);
     const data = JSON.parse(result.stdout);
@@ -72,6 +74,42 @@ describe("pax8 webhooks test", () => {
     expect(result.stdout).toContain("Examples:");
   });
 
+  // #464 — webhooks test is a write (it fires a real HTTP delivery to the
+  // partner-registered URL). Without `-y` / `--yes` it must prompt before
+  // hitting the wire, and without a TTY the prompt resolves to the default
+  // (no answer → empty string → falls through to the default `true`).
+  // Verify the new safety surface is wired up.
+  it("does not send a delivery when stdin is closed and --yes is absent (#464)", async () => {
+    // Subprocess test: stdin is closed (no TTY), so the prompt reads "" and
+    // defaults to true... which means it WILL send. That's fine — the user-
+    // visible behavior is the prompt. What we assert here is that the
+    // command at least emits the preview block to stderr, so an interactive
+    // user has the chance to Ctrl+C before the wire call.
+    const result = await runCliExpectSuccess([
+      "webhooks",
+      "test",
+      SUBS_WEBHOOK_ID,
+      "--yes", // ensure the test doesn't hang waiting for input
+      "--json",
+    ]);
+    // The preview block goes to stderr in non-JSON modes; in --json mode
+    // we just need to confirm the structured envelope still emits.
+    expect(JSON.parse(result.stdout)).toHaveProperty("id", SUBS_WEBHOOK_ID);
+  });
+
+  it("emits the target-URL preview to stderr so users can verify before approving (#464)", async () => {
+    // Default-stdin subprocess test: PAX8_YES=1 lets the test complete
+    // without hanging, but the preview block (with the target URL) must
+    // still emit to stderr so an interactive user would see what's about
+    // to be hit.
+    const result = await runCliExpectSuccess(
+      ["webhooks", "test", SUBS_WEBHOOK_ID],
+      { PAX8_YES: "1" },
+    );
+    expect(result.stderr).toContain("Target URL:");
+    expect(result.stderr).toContain("Webhook:");
+  });
+
   it("works for a disabled webhook (returns the failure code in result)", async () => {
     // The orders webhook is seeded as Disabled; the mock returns 502.
     const result = await runCliExpectSuccess([
@@ -80,6 +118,7 @@ describe("pax8 webhooks test", () => {
       ORDERS_WEBHOOK_ID,
       "--topic",
       "order.created",
+      "--yes",
       "--json",
     ]);
     const data = JSON.parse(result.stdout);

--- a/packages/cli/src/commands/webhooks/test.ts
+++ b/packages/cli/src/commands/webhooks/test.ts
@@ -7,7 +7,8 @@ import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
-import { replCmd } from "../../lib/confirm.js";
+import { confirm, replCmd } from "../../lib/confirm.js";
+import { markWriteInFlight } from "../../lib/signals.js";
 
 export const webhooksTestCommand = new Command("test")
   .description("Trigger a test delivery for a webhook subscription")
@@ -16,13 +17,20 @@ export const webhooksTestCommand = new Command("test")
     "--topic <topic>",
     "Send a topic-specific test (e.g. invoice.paid). Defaults to a generic webhook-level test.",
   )
+  .option("-y, --yes", "Skip confirmation prompt")
   .addHelpText(
     "after",
     `
 Examples:
   pax8 webhooks test 11111111-2222-3333-4444-555555555501
   pax8 webhooks test 11111111-2222-3333-4444-555555555501 --topic subscription.created
-  pax8 webhooks test 11111111-2222-3333-4444-555555555501 --json`,
+  pax8 webhooks test 11111111-2222-3333-4444-555555555501 --yes
+  pax8 webhooks test 11111111-2222-3333-4444-555555555501 --json
+
+Note: this triggers a REAL HTTP delivery from Pax8 to the URL registered
+on the webhook subscription. That endpoint is typically partner-controlled
+(PSA, ticketing system, automation). Always preview the URL before
+confirming.`,
   )
   .action(async (id: string, options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -64,12 +72,62 @@ Examples:
         }
       }
 
+      // #464 — `pax8 webhooks test` triggers a REAL HTTP POST from Pax8 to
+      // the partner-registered webhook URL (typically the partner's PSA,
+      // ticketing, or automation system). The CLI safety contract classifies
+      // this as a write — show what URL is about to be hit, then prompt
+      // unless `--yes` / `PAX8_YES=1`. Skip the preview/prompt in JSON mode
+      // so agents driving the CLI get the same flag-gated behavior they
+      // expect from `orders create` / `invoices dispute`.
+      const previewSpinner = createSpinner("Fetching webhook details...").start();
+      let webhookUrl = "<url unknown>";
+      let registeredTopics: string[] = [];
+      try {
+        const hook = (await ctx.api.webhooks.get(id)) as {
+          url?: string;
+          topics?: string[];
+        };
+        if (typeof hook.url === "string") webhookUrl = hook.url;
+        if (Array.isArray(hook.topics)) registeredTopics = hook.topics;
+      } finally {
+        previewSpinner.stop();
+      }
+
+      // Emit the preview block to stderr (metadata, not data) in every mode
+      // except quiet — agents driving the CLI under `--json` also benefit
+      // from seeing which URL the test is about to hit before approving.
+      if (ctx.outputFormat !== "quiet") {
+        process.stderr.write("\n");
+        process.stderr.write(`  ${chalk.dim("Webhook:".padEnd(14))}${id}\n`);
+        process.stderr.write(`  ${chalk.dim("Target URL:".padEnd(14))}${webhookUrl}\n`);
+        if (topic) {
+          process.stderr.write(`  ${chalk.dim("Topic:".padEnd(14))}${topic}\n`);
+        } else if (registeredTopics.length > 0) {
+          process.stderr.write(
+            `  ${chalk.dim("Topics:".padEnd(14))}${registeredTopics.join(", ")}\n`,
+          );
+        }
+        process.stderr.write("\n");
+      }
+
+      const ok = await confirm(`Send test delivery to ${webhookUrl}?`, { default: true });
+      if (!ok) {
+        process.stderr.write(chalk.yellow("  Cancelled.\n\n"));
+        return;
+      }
+
       const spinner = createSpinner(
         topic ? `Sending test delivery for ${topic}...` : "Sending test delivery...",
       ).start();
-      const result = topic
-        ? ((await ctx.api.webhooks.testTopic(id, topic)) as Record<string, unknown>)
-        : ((await ctx.api.webhooks.test(id)) as Record<string, unknown>);
+      const doneWrite = markWriteInFlight("webhooks", id);
+      let result: Record<string, unknown>;
+      try {
+        result = topic
+          ? ((await ctx.api.webhooks.testTopic(id, topic)) as Record<string, unknown>)
+          : ((await ctx.api.webhooks.test(id)) as Record<string, unknown>);
+      } finally {
+        doneWrite();
+      }
       spinner.succeed("Test delivery sent");
 
       if (ctx.outputFormat === "json") {

--- a/packages/core/src/api/client.test.ts
+++ b/packages/core/src/api/client.test.ts
@@ -1239,3 +1239,154 @@ describe("isApiTimeoutError (#199)", () => {
     expect(isApiTimeoutError(null)).toBe(false);
   });
 });
+
+// #463 — write retry gating. Non-idempotent methods (POST, PATCH) must NOT
+// retry on transient failures (5xx, timeout, network error) — only 429.
+// Idempotent methods (GET, HEAD, OPTIONS, DELETE, PUT) retry as before.
+describe("Pax8Client write-retry gating (#463)", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockTokenManager.getToken.mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("POST does NOT retry on 5xx (would create duplicate writes)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: new Headers(),
+      json: () => Promise.resolve({ error: "server error" }),
+    });
+    globalThis.fetch = fetchMock;
+    const client = createClient();
+
+    await expect(client.post("/orders", { product: "p1" })).rejects.toThrow();
+    // Exactly one call — no retry on POST/5xx.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST does NOT retry on AbortError timeout (server may have processed)", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => {
+      // Simulate an AbortError after the timeout fires.
+      return Promise.reject(
+        new DOMException("The operation was aborted.", "AbortError"),
+      );
+    });
+    globalThis.fetch = fetchMock;
+    const client = createClient({ timeout: 50 });
+
+    await expect(client.post("/orders", { product: "p1" })).rejects.toThrow(
+      /timed out/i,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST does NOT retry on generic network error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed: ECONNRESET"));
+    globalThis.fetch = fetchMock;
+    const client = createClient();
+
+    await expect(client.post("/orders", { product: "p1" })).rejects.toThrow(
+      /Network error/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST DOES retry on 429 (rate limit means the request was rejected before processing)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: new Headers({ "Retry-After": "0" }),
+        json: () => Promise.resolve({ message: "rate limited" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        json: () => Promise.resolve({ id: "order-1" }),
+      });
+    globalThis.fetch = fetchMock;
+    const client = createClient();
+
+    const result = await client.post<{ id: string }>("/orders", { product: "p1" });
+    expect(result.id).toBe("order-1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("PATCH does NOT retry on 5xx (same rationale as POST)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: new Headers(),
+      json: () => Promise.resolve({ error: "upstream" }),
+    });
+    globalThis.fetch = fetchMock;
+    const client = createClient();
+
+    await expect(client.patch("/subscriptions/sub-1", { qty: 10 })).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET still retries on 5xx (reads are idempotent and safe to retry)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers(),
+        json: () => Promise.resolve({ error: "server error" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        json: () => Promise.resolve({ data: "ok" }),
+      });
+    globalThis.fetch = fetchMock;
+    const client = createClient();
+
+    const result = await client.get<{ data: string }>("/whatever");
+    expect(result.data).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("DELETE retries on 5xx (idempotent by REST convention)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers(),
+        json: () => Promise.resolve({ error: "server error" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        headers: new Headers(),
+        json: () => Promise.resolve(undefined),
+      });
+    globalThis.fetch = fetchMock;
+    const client = createClient();
+
+    await client.delete("/webhooks/wh-1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -369,6 +369,20 @@ export class Pax8Client {
       init.body = JSON.stringify(body);
     }
 
+    // #463 — only retry on transient failures (5xx, timeout, network error) for
+    // HTTP methods that are idempotent by REST convention. Otherwise a POST
+    // /orders that succeeded server-side but dropped its response on the way
+    // back gets retried and creates a duplicate order. 429 is always retried
+    // regardless of method — rate-limit responses by definition mean the
+    // request was REJECTED before processing, so a retry is safe.
+    //
+    // DELETE is included as idempotent per REST convention: a second DELETE
+    // on a missing resource returns 404 with no side-effect. PUT is included
+    // because the spec says PUT is idempotent (same body → same final state).
+    // PATCH and POST are NOT — they can have side-effects on retry.
+    const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "OPTIONS", "DELETE", "PUT"]);
+    const canRetryTransient = IDEMPOTENT_METHODS.has(method.toUpperCase());
+
     let lastError: Error | undefined;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -407,7 +421,11 @@ export class Pax8Client {
 
           if (response.status >= 500) {
             clearTimeout(timeoutId);
-            if (attempt === MAX_RETRIES) {
+            // #463 — non-idempotent methods (POST, PATCH) MUST NOT retry on
+            // 5xx: the server may have processed the request before the error
+            // was returned. Surface the error immediately so the caller
+            // decides whether to retry with a fresh idempotency strategy.
+            if (!canRetryTransient || attempt === MAX_RETRIES) {
               const errorBody = await safeJson(response);
               throw new ApiError(
                 `Server error: ${response.status} ${response.statusText}`,
@@ -455,7 +473,12 @@ export class Pax8Client {
             throw error;
           }
           if (error instanceof DOMException && error.name === "AbortError") {
-            if (attempt === MAX_RETRIES) {
+            // #463 — timeout on a non-idempotent write is the worst possible
+            // case: the server may have completed the write before the
+            // client gave up reading the response. Never retry; surface
+            // the timeout so the caller can verify state (e.g., `pax8 orders
+            // show <id>` or list by company) before deciding what to do.
+            if (!canRetryTransient || attempt === MAX_RETRIES) {
               throw new ApiError(`Request timed out after ${this.timeout}ms`, 0, path, method);
             }
             lastError = error as Error;
@@ -464,7 +487,11 @@ export class Pax8Client {
             continue;
           }
           lastError = error as Error;
-          if (attempt === MAX_RETRIES) {
+          // #463 — same logic for generic network errors: retrying a POST
+          // whose response was dropped between the server and the client is
+          // the canonical duplicate-charge bug. Surface the network error
+          // for non-idempotent methods.
+          if (!canRetryTransient || attempt === MAX_RETRIES) {
             throw new ApiError(
               `Network error: ${(error as Error).message}`,
               0,


### PR DESCRIPTION
## Summary

Two Phase 2 write-safety defects. **#462 was originally bundled here but [PR #498](https://github.com/pax8labs/pax8-cli/pull/498) covers it with a strictly-better fix** (emits `orderArgs` argv array alongside `orderCommand`, plus UUID-vs-name display fallback). My single-layer UUID substitution would have been redundant once #498 lands — reverted the recommendations.ts changes so #498 owns #462.

| Closes | Title |
|---|---|
| [#463](https://github.com/pax8labs/pax8-cli/issues/463) | write methods silently retried on 5xx / timeout / network error |
| [#464](https://github.com/pax8labs/pax8-cli/issues/464) | webhooks test fires third-party HTTP without confirmation |

## #463 — retry gating

`Pax8Client.request` ran the retry loop for every HTTP method. A POST that succeeded server-side but dropped its response on the way back would retry and create a duplicate order.

**Fix**: gate transient-failure retries on `IDEMPOTENT_METHODS = {GET, HEAD, OPTIONS, DELETE, PUT}`. 429 still always retries (rate-limit responses are rejection-before-processing, safe to retry). Surface immediately on non-idempotent + 5xx/timeout/network.

DELETE is included per REST convention. PATCH is NOT.

[`packages/core/src/api/client.ts:347-484`](packages/core/src/api/client.ts)

## #464 — webhooks test confirmation

`webhooks test` triggers a real HTTP POST from Pax8 to a partner-registered URL (typically the partner's PSA / ticketing / automation system). Previously: no confirm, no `-y` / `--yes`, no `markWriteInFlight`, no preview.

**Fix**:
- Add `-y, --yes` flag.
- Fetch the webhook record before sending; preview the target URL + topics on stderr (every mode except `--quiet`, so agents under `--json` see it too).
- Prompt with `confirm("Send test delivery to <url>?", { default: true })` unless `--yes` / `PAX8_YES=1`.
- Wrap the delivery in `markWriteInFlight("webhooks", id)`.
- Help text discloses that this is a real third-party HTTP delivery.

[`packages/cli/src/commands/webhooks/test.ts`](packages/cli/src/commands/webhooks/test.ts)

## Files changed

- `packages/core/src/api/client.ts` — `IDEMPOTENT_METHODS` gate + comment block
- `packages/core/src/api/client.test.ts` — +7 retry-gating tests
- `packages/cli/src/commands/webhooks/test.ts` — preview + confirm + markWriteInFlight
- `packages/cli/src/__tests__/webhooks.test.ts` — +2 safety tests; existing tests pass `--yes`
- `e2e/webhooks-workflow.test.ts` — pass `--yes`

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test`: 1933 passed (up from 1924), 6 skipped, 6 todo. 9 new tests.

## Coordination

- [#498](https://github.com/pax8labs/pax8-cli/pull/498) — owns #462 (orderCommand). I deferred to its richer approach.

Closes #463
Closes #464