### PR TITLE
fix(money): zero non-recurring MRR; render currency by code, not hardcoded $

### DIFF
--- a/.changeset/money-correctness-mrr-and-currency.md
+++ b/.changeset/money-correctness-mrr-and-currency.md
@@ -1,0 +1,18 @@
+---
+"@pax8/cli": patch
+"@pax8/core": patch
+---
+
+Two interlocking money-correctness fixes that both inflated and mislabeled partner-cost numbers across dashboard, recommendations, cost-sim, and reports.
+
+**Breaking-feeling change for some users:** monthly-cost aggregates will drop for any partner whose portfolio includes `One-Time`, `Trial`, or `Activation` line items. The pre-fix code returned `price × quantity` (gross) for these terms, which inflated every "monthly Pax8 cost" and "potential uplift" figure that aggregates `subscriptionMrr()`. These terms are not recurring revenue and now correctly contribute **0** to monthly aggregates. The drop is the *correct* number — but it is a visible delta day-over-day, so partners reviewing dashboards after upgrade should expect their headline number to reset.
+
+Specifics:
+
+1. **`subscriptionMrr()` per-term divisor table.** Replaced the previous switch with a `Record<BillingTerm | "1-Year", number>` divisor table. `Monthly`, `Annual` (and the defensive `"1-Year"` alias used by `commitment.term`), `2-Year`, `3-Year` divide normally; `One-Time`, `Trial`, `Activation` contribute 0. Unknown enum values now contribute 0 and emit a one-shot stderr warning per process per unknown value — a future Pax8 enum addition surfaces instead of silently miscounting.
+
+2. **`formatCurrency()` honors `currencyCode`.** The previous implementation hard-coded `"$"`, so every EUR / GBP / CAD partner saw their subscriptions, dashboard, top customers, recommendations, and cost-sim output mislabeled as USD. The `subscriptions list` table had a workaround that appended `" EUR"` per row; that suffix is dropped here and the formatter is the single source of truth via `Intl.NumberFormat`. Falls back to a numeric + code-suffix render when ICU rejects a code. `cost sim` now threads the matched current subscription's currency through to output.
+
+New demo fixtures (`demo-data.ts`) provide regression gates: Coastline's One-Time EUR onboarding fee (zero-MRR + non-USD), Bright Minds' Trial Defender seat (zero-MRR), Acme's GBP Entra ID P2 (non-USD rendering).
+
+Closes #465, #472.

--- a/packages/cli/src/commands/cost/sim.ts
+++ b/packages/cli/src/commands/cost/sim.ts
@@ -164,6 +164,11 @@ JSON output (--json):
       // "Try next" block below can offer a pickable drill-in to it.
       let currentInput: SimulationInput["current"] | undefined;
       let affectedSubscriptionId: string | undefined;
+      // Currency for output rendering — inherited from the matched current
+      // subscription when one exists (#472). Cost-sim is a single-record
+      // simulation so the currency is unambiguous; defaults to USD when no
+      // current sub is present (add-new path).
+      let displayCurrency: string = "USD";
       if (allOpts.from) {
         // Explicit --from: resolve it as a separate product.
         const fromProduct = await resolveProduct(ctx, allOpts.from);
@@ -204,6 +209,7 @@ JSON output (--json):
           billingTerm: billingTerm ?? "Monthly",
           price: price ?? 0,
         };
+        if (existing?.currencyCode) displayCurrency = existing.currencyCode;
       } else {
         // No --from: try to auto-detect a matching subscription on the proposed product.
         const existing = pickCurrentSubscription(companySubs, proposedProduct.id);
@@ -216,6 +222,7 @@ JSON output (--json):
             billingTerm: existing.billingTerm,
             price: existing.price,
           };
+          if (existing.currencyCode) displayCurrency = existing.currencyCode;
         }
         // If no existing match, currentInput stays undefined → add-new simulation.
       }
@@ -351,8 +358,8 @@ JSON output (--json):
         leg: { productName: string; quantity: number; monthly: number; annual: number; billingTerm: string },
       ): string => {
         const left = `${label.padEnd(labelWidth)}${leg.productName} × ${leg.quantity}`;
-        const monthlyStr = `${formatCurrency(leg.monthly)}/mo`;
-        const annualStr = `${formatCurrency(leg.annual)}/yr`;
+        const monthlyStr = `${formatCurrency(leg.monthly, displayCurrency)}/mo`;
+        const annualStr = `${formatCurrency(leg.annual, displayCurrency)}/yr`;
         return `  ${left.padEnd(56)}  ${chalk.cyan(monthlyStr.padEnd(14))} ${chalk.cyan(annualStr)}`;
       };
 
@@ -361,10 +368,11 @@ JSON output (--json):
       }
       process.stdout.write(renderLeg("Proposed:", result.proposed) + "\n");
 
-      // Delta line
-      const dMonthly = `${deltaSign(result.delta.monthly)}${formatCurrency(result.delta.monthly)}/mo`;
-      const dAnnual = `${deltaSign(result.delta.annual)}${formatCurrency(result.delta.annual)}/yr`;
-      const dPerSeat = `${deltaSign(result.delta.perSeat)}${formatCurrency(result.delta.perSeat)}/seat/mo`;
+      // Delta line — render with the existing subscription's currency so a
+      // EUR sub's "Delta:" line shows €, not $ (#472).
+      const dMonthly = `${deltaSign(result.delta.monthly)}${formatCurrency(result.delta.monthly, displayCurrency)}/mo`;
+      const dAnnual = `${deltaSign(result.delta.annual)}${formatCurrency(result.delta.annual, displayCurrency)}/yr`;
+      const dPerSeat = `${deltaSign(result.delta.perSeat)}${formatCurrency(result.delta.perSeat, displayCurrency)}/seat/mo`;
       const deltaColor = result.delta.monthly >= 0 ? chalk.green : chalk.yellow;
       process.stdout.write(
         `  ${"Delta:".padEnd(labelWidth)}` +

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -42,13 +42,14 @@ const columns: Column[] = [
   {
     key: "price",
     header: "Price",
-    // Append the ISO-4217 currency code only when it isn't USD. Common case
-    // stays unchanged; non-USD partners get e.g. `$1,234.56 EUR` so the unit
-    // isn't silently misread as dollars. Surfaced in #273 (fixes #6).
+    // Thread the row's `currencyCode` through `formatCurrency` so the
+    // rendered symbol matches the subscription's actual currency (#472).
+    // Previously this layered a `" EUR"` suffix on top of a hard-coded
+    // `"$"`; now `formatCurrency` handles the unit directly via
+    // `Intl.NumberFormat`.
     format: (v, row) => {
       const code = String((row as { currencyCode?: string } | undefined)?.currencyCode ?? "USD");
-      const price = formatCurrency(Number(v));
-      return code === "USD" ? price : `${price} ${code}`;
+      return formatCurrency(Number(v), code);
     },
   },
 ];

--- a/packages/cli/src/lib/formatters.test.ts
+++ b/packages/cli/src/lib/formatters.test.ts
@@ -75,6 +75,57 @@ describe("formatCurrency", () => {
   it("rounds to two decimals", () => {
     expect(formatCurrency(10.999)).toBe("$11.00");
   });
+
+  // Currency-code coverage (#472). Use string-contains assertions so a
+  // future ICU/CLDR symbol tweak (e.g. NBSP vs U+202F) doesn't flake the
+  // suite; the load-bearing contract is "render the right unit, not '$'".
+  it("renders EUR with the euro sign, not '$'", () => {
+    const result = formatCurrency(1234.56, "EUR");
+    expect(result).toContain("€");
+    expect(result).toContain("1,234.56");
+    expect(result).not.toContain("$");
+  });
+
+  it("renders GBP with the pound sign, not '$'", () => {
+    const result = formatCurrency(1234.56, "GBP");
+    expect(result).toContain("£");
+    expect(result).toContain("1,234.56");
+    expect(result).not.toContain("$");
+  });
+
+  it("disambiguates CAD with the 'CA$' prefix", () => {
+    const result = formatCurrency(1234.56, "CAD");
+    expect(result).toContain("CA$");
+    expect(result).toContain("1,234.56");
+  });
+
+  it("renders USD with the dollar sign", () => {
+    expect(formatCurrency(1234.56, "USD")).toBe("$1,234.56");
+  });
+
+  it("falls back to USD when currencyCode is empty", () => {
+    expect(formatCurrency(1234.56, "")).toBe("$1,234.56");
+  });
+
+  it("falls back to USD when currencyCode is omitted", () => {
+    expect(formatCurrency(1234.56)).toBe("$1,234.56");
+  });
+
+  it("handles unknown ISO codes by suffixing the code", () => {
+    // "XYZ" is not a real ISO-4217 code; Intl.NumberFormat throws on it.
+    // The fallback path keeps the amount visible with the code attached.
+    const result = formatCurrency(1234.56, "XYZ");
+    expect(result).toContain("1,234.56");
+    expect(result).toContain("XYZ");
+  });
+
+  it("renders negative EUR with a leading minus", () => {
+    const result = formatCurrency(-42.5, "EUR");
+    expect(result).toContain("€");
+    expect(result).toContain("42.50");
+    // Could be "-€42.50" or "(€42.50)" depending on ICU defaults; both
+    // contain '-' or '(' — just assert the magnitude renders correctly.
+  });
 });
 
 describe("formatQuantity", () => {

--- a/packages/cli/src/lib/formatters.ts
+++ b/packages/cli/src/lib/formatters.ts
@@ -23,13 +23,44 @@ export function formatTimeAgo(date: Date | string): string {
   return `${diffYears}y ago`;
 }
 
-export function formatCurrency(dollars: number): string {
-  const abs = Math.abs(dollars);
-  const formatted = abs.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-  return dollars < 0 ? `-$${formatted}` : `$${formatted}`;
+/**
+ * Render a money amount with the correct currency unit.
+ *
+ * Pre-#472 this hard-coded `"$"`, which mislabeled every EUR / GBP / CAD
+ * partner's subscriptions in the dashboard, top-customers table, cost
+ * simulator, and recommendations view. The `subscriptions list` table had a
+ * workaround that appended `" EUR"` per row; that suffix is dropped in favor
+ * of this single source of truth.
+ *
+ * Implementation: `Intl.NumberFormat` with `style: "currency"` so the
+ * runtime picks the correct symbol (or trailing ISO code) for the locale.
+ * Always two fraction digits to keep table alignment stable.
+ *
+ * @param amount Numeric amount in the major unit (e.g. dollars, not cents).
+ * @param currencyCode ISO-4217 code (default `"USD"`). Falls back to `"USD"`
+ *   when callers pass an empty string or `undefined` — preserves the legacy
+ *   "default to dollars" behavior at every call site that hasn't yet
+ *   threaded the real `currencyCode` from the upstream record.
+ */
+export function formatCurrency(amount: number, currencyCode: string = "USD"): string {
+  const code = (currencyCode && currencyCode.trim()) || "USD";
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: code,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    // Unknown / malformed ISO-4217 code: fall back to a plain numeric render
+    // with the code as a suffix so the unit isn't silently dropped.
+    const abs = Math.abs(amount);
+    const formatted = abs.toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    return amount < 0 ? `-${formatted} ${code}` : `${formatted} ${code}`;
+  }
 }
 
 export function formatQuantity(n: number): string {

--- a/packages/core/src/mock/demo-data.test.ts
+++ b/packages/core/src/mock/demo-data.test.ts
@@ -173,15 +173,15 @@ describe("demo-data", () => {
       expect(summit).toHaveLength(3);
     });
 
-    // Coastline now also carries a 2-Year M365 E3 commit renewing in 270d,
-    // added in the feat/reporting-reshape PR so the `pax8 report
-    // subscriptions --by billing-term` view exercises the post-#439
-    // 2-Year normalization fix visibly.
-    it("Coastline Legal Group has 3 subscriptions", () => {
+    // Coastline now also carries a 2-Year M365 E3 commit renewing in 270d
+    // (feat/reporting-reshape, exercises post-#439 2-Year normalization)
+    // and a One-Time EUR onboarding fee (money-correctness fixture for
+    // #465 zero-MRR + #472 non-USD rendering).
+    it("Coastline Legal Group has 4 subscriptions", () => {
       const coastline = subscriptions.filter(
         (s) => s.companyId === "b2c3d4e5-f6a7-8901-bcde-f12345678901"
       );
-      expect(coastline).toHaveLength(3);
+      expect(coastline).toHaveLength(4);
     });
 
     it("Redwood Manufacturing has 7 subscriptions", () => {
@@ -191,11 +191,13 @@ describe("demo-data", () => {
       expect(redwood).toHaveLength(7);
     });
 
-    it("Bright Minds Academy has 2 subscriptions", () => {
+    // Bright Minds also carries a Trial Defender seat (money-correctness
+    // fixture for #465 — Trial billingTerm must zero out in MRR aggregates).
+    it("Bright Minds Academy has 3 subscriptions", () => {
       const bright = subscriptions.filter(
         (s) => s.companyId === "d4e5f6a7-b8c9-0123-defa-234567890123"
       );
-      expect(bright).toHaveLength(2);
+      expect(bright).toHaveLength(3);
     });
 
     // Pinnacle now also carries a 3-Year M365 E5 commit (added in the

--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -1296,6 +1296,83 @@ export const subscriptions: Subscription[] = [
   // anchor for the auditor's "unexpected line" demo case. The long-tail
   // 91-365d variety is covered by Coastline's 2-Year and Pinnacle's 3-Year
   // commits above.)
+
+  // ── Money-correctness fixtures (#465 / #472) ───────────────────────────
+  // These exercise the long-tail billing-term + currency paths that the
+  // pre-#465 / pre-#472 code mishandled. Pre-fix behavior over-counted the
+  // One-Time and Trial subs at full gross and rendered every non-USD price
+  // with a "$" prefix in dashboard / recommendations / cost-sim output.
+  //
+  // After the fixes:
+  //   - One-Time onboarding fee contributes 0 to monthly cost (correct).
+  //   - Trial sub contributes 0 to monthly cost (correct).
+  //   - GBP sub renders with "£" via Intl.NumberFormat (correct).
+
+  // Coastline Legal — one-time onboarding fee. Contributes 0 to MRR.
+  {
+    id: "sub-coastline-onboarding-004",
+    companyId: COASTLINE_ID,
+    productId: "prod-m365-e3-0003",
+    productName: "M365 onboarding & migration (one-time)",
+    quantity: 1,
+    startDate: "2025-04-07",
+    createdDate: "2025-04-01",
+    createdAt: "2025-04-01",
+    billingStart: "2025-04-07",
+    status: "Active",
+    price: 5000,
+    currencyCode: "EUR",
+    billingTerm: "One-Time",
+    commitmentTermEndDate: null,
+    provisioningStatus: "Provisioned",
+    companyName: "Coastline Legal Group",
+  },
+
+  // Bright Minds — Trial Defender seat. Status remains Active in the demo
+  // fixture so the subscription is picked up by computeMrr's "active" filter
+  // (computeMrr only sums `status === "Active"` subs, but subscriptionMrr is
+  // the choke point — Trial billingTerm must zero out regardless of status).
+  {
+    id: "sub-bright-defender-trial-003",
+    companyId: BRIGHT_ID,
+    productId: "prod-defender-biz-0007",
+    productName: "Microsoft Defender for Office 365 (Plan 1) — trial",
+    quantity: 5,
+    startDate: "2025-05-10",
+    createdDate: "2025-05-08",
+    createdAt: "2025-05-08",
+    billingStart: "2025-05-10",
+    status: "Active",
+    price: 3.0,
+    currencyCode: "USD",
+    billingTerm: "Trial",
+    commitmentTermEndDate: daysFromNow(20),
+    provisioningStatus: "Provisioned",
+    companyName: "Bright Minds Academy",
+  },
+
+  // Acme Corp — GBP-priced Entra ID P2. Exercises Intl.NumberFormat's "£"
+  // rendering across dashboard / top-customers / subscriptions list / cost
+  // sim (#472). Annual term so it also contributes a sane MRR figure.
+  {
+    id: "sub-acme-aad-p2-gbp-004",
+    companyId: ACME_ID,
+    productId: "prod-aad-p1-0008",
+    productName: "Microsoft Entra ID P2 [New Commerce Experience]",
+    quantity: 25,
+    startDate: "2025-02-15",
+    createdDate: "2025-02-10",
+    createdAt: "2025-02-10",
+    billingStart: "2025-02-15",
+    status: "Active",
+    price: 9.0,
+    currencyCode: "GBP",
+    billingTerm: "Annual",
+    commitment: { id: "cterm-0006-0001-0001-000000000005", term: "1-Year", endDate: daysFromNow(120) },
+    commitmentTermEndDate: daysFromNow(120),
+    provisioningStatus: "Provisioned",
+    companyName: "Acme Corp",
+  },
 ];
 
 // ─── Invoices ────────────────────────────────────────────────────────────────

--- a/packages/core/src/services/analytics.test.ts
+++ b/packages/core/src/services/analytics.test.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { computeMrr, computeGrowth, subscriptionMrr } from "./analytics.js";
 
 describe("subscriptionMrr", () => {
@@ -31,16 +31,34 @@ describe("subscriptionMrr", () => {
       expect(subscriptionMrr(PRICE, QTY, "3-Year")).toBeCloseTo(GROSS / 36, 10);
     });
 
-    it("One-Time falls through to price × quantity (out of scope to re-define)", () => {
-      expect(subscriptionMrr(PRICE, QTY, "One-Time")).toBe(GROSS);
+    // #465 — One-Time, Trial, Activation are NOT recurring revenue. The
+    // pre-fix behavior returned gross, which inflated every dashboard and
+    // recommendation that aggregated MRR (a $5,000 one-time onboarding fee
+    // would appear as $5,000/mo recurring, i.e. $60k/yr).
+    it("One-Time contributes 0 to MRR (not recurring)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "One-Time")).toBe(0);
     });
 
-    it("Trial falls through to price × quantity (out of scope to re-define)", () => {
-      expect(subscriptionMrr(PRICE, QTY, "Trial")).toBe(GROSS);
+    it("Trial contributes 0 to MRR (not recurring)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "Trial")).toBe(0);
     });
 
-    it("Activation falls through to price × quantity (out of scope to re-define)", () => {
-      expect(subscriptionMrr(PRICE, QTY, "Activation")).toBe(GROSS);
+    it("Activation contributes 0 to MRR (not recurring)", () => {
+      expect(subscriptionMrr(PRICE, QTY, "Activation")).toBe(0);
+    });
+  });
+
+  describe("commitment-style aliases (defensive)", () => {
+    // `BillingTermSchema` proper doesn't include "1-Year" — Pax8 uses that on
+    // `commitment.term`, not `Subscription.billingTerm`. Treating it as an
+    // annual term anyway keeps us robust if the API ever surfaces it on
+    // `billingTerm` (#465).
+    it("1-Year treats as Annual", () => {
+      expect(subscriptionMrr(PRICE, QTY, "1-Year")).toBe(GROSS / 12); // 50
+    });
+
+    it("1-year (lowercased) treats as Annual", () => {
+      expect(subscriptionMrr(PRICE, QTY, "1-year")).toBe(GROSS / 12);
     });
   });
 
@@ -68,23 +86,60 @@ describe("subscriptionMrr", () => {
     });
   });
 
-  describe("default behavior for unknown / falsy terms", () => {
-    // `computeMrr` calls `subscriptionMrr(..., sub.billingTerm ?? "monthly")`
-    // — the `?? "monthly"` default plus the function's own tolerance must keep
-    // working so partners with stale or unrecognized term strings aren't
-    // silently zeroed out.
-    it("empty string treats as monthly (price × quantity)", () => {
-      expect(subscriptionMrr(PRICE, QTY, "")).toBe(GROSS);
+  describe("unknown / falsy terms (#465 — warn and zero, not silent gross)", () => {
+    // Pre-fix: unknown terms fell through to `price × quantity`, which was
+    // dangerous because a future Pax8 enum value (e.g. "Quarterly") would
+    // be silently counted at 4× its true monthly contribution. New behavior:
+    // contribute 0 + emit a one-shot `stderr` warning per unknown value.
+    //
+    // Note: `computeMrr` still uses `sub.billingTerm ?? "monthly"` so subs
+    // with a literally absent billingTerm continue to count as Monthly —
+    // the warn-and-zero path is for unrecognized strings that survive past
+    // the call site's default.
+    it("empty string contributes 0 (caller default kicks in upstream)", () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      try {
+        expect(subscriptionMrr(PRICE, QTY, "")).toBe(0);
+      } finally {
+        stderrSpy.mockRestore();
+      }
     });
 
-    it("undefined (cast through string) treats as monthly", () => {
-      // Mirrors how callers funnel `sub.billingTerm ?? "monthly"` — but also
-      // exercise the function's internal `?? ""` guard against undefined.
-      expect(subscriptionMrr(PRICE, QTY, undefined as unknown as string)).toBe(GROSS);
+    it("undefined (cast through string) contributes 0", () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      try {
+        expect(subscriptionMrr(PRICE, QTY, undefined as unknown as string)).toBe(0);
+      } finally {
+        stderrSpy.mockRestore();
+      }
     });
 
-    it("unknown future enum value treats as monthly (preserves historical default)", () => {
-      expect(subscriptionMrr(PRICE, QTY, "Quarterly")).toBe(GROSS);
+    it("unknown future enum value contributes 0", () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      try {
+        // Use a unique string per test so the one-shot-per-process dedup
+        // doesn't suppress the warning we want to observe.
+        expect(subscriptionMrr(PRICE, QTY, "Quarterly_test_unique_a")).toBe(0);
+        expect(stderrSpy).toHaveBeenCalled();
+      } finally {
+        stderrSpy.mockRestore();
+      }
+    });
+
+    it("warns at most once per unknown billingTerm value", () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      try {
+        subscriptionMrr(PRICE, QTY, "Septennial_test_unique_b");
+        subscriptionMrr(PRICE, QTY, "Septennial_test_unique_b");
+        subscriptionMrr(PRICE, QTY, "Septennial_test_unique_b");
+        // Should emit exactly one warning across the three calls.
+        const calls = stderrSpy.mock.calls.filter((c) =>
+          String(c[0]).includes("Septennial_test_unique_b"),
+        );
+        expect(calls).toHaveLength(1);
+      } finally {
+        stderrSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/core/src/services/analytics.ts
+++ b/packages/core/src/services/analytics.ts
@@ -1,7 +1,14 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Subscription, Invoice } from "../api/types.js";
+import type { Subscription, Invoice, BillingTerm } from "../api/types.js";
+
+/**
+ * Track which unknown `billingTerm` values we've already warned about so we
+ * only emit a single stderr line per process per unknown value, regardless of
+ * how many subscriptions carry it. Reset only by process restart.
+ */
+const unknownBillingTermsWarned = new Set<string>();
 
 /** The subset of Subscription fields used by analytics. */
 type AnalyticsSubscriptionInput = Partial<Subscription> & {
@@ -27,45 +34,86 @@ export interface GrowthReport {
 }
 
 /**
- * Calculate the Monthly Recurring Revenue for a single subscription.
+ * Per-term monthly divisor. Keys are the canonical `BillingTermSchema` enum
+ * values plus the defensive `"1-Year"` alias (Pax8 uses `"1-Year"` on
+ * `commitment.term` and on some product-pricing rows; if it ever leaks into a
+ * subscription's `billingTerm` we want to treat it as an annual commit, not
+ * as an unknown-term gross figure).
+ *
+ * A value of `0` means the term contributes **zero** to monthly cost — used
+ * for `One-Time`, `Trial`, and `Activation` line items, which are not
+ * recurring revenue and were previously over-counted at full gross.
+ *
+ * Append-only. Adding a new `BillingTermSchema` value? Add it here too — the
+ * TypeScript `Record<BillingTerm | "1-Year", ...>` constraint will block the
+ * compile until you do.
+ */
+const BILLING_TERM_MONTHLY_DIVISOR: Record<BillingTerm | "1-Year", number> = {
+  Monthly: 1,
+  Annual: 12,
+  "1-Year": 12,
+  "2-Year": 24,
+  "3-Year": 36,
+  "One-Time": 0,
+  Trial: 0,
+  Activation: 0,
+};
+
+/**
+ * Canonical lookup table keyed by lowercased term — call sites historically
+ * pass lowercased / loosely-typed strings (e.g. `"annual"`, `"2-year"`), so
+ * normalization happens here once.
+ */
+const BILLING_TERM_MONTHLY_DIVISOR_LOWER: Record<string, number> = Object.fromEntries(
+  Object.entries(BILLING_TERM_MONTHLY_DIVISOR).map(([k, v]) => [k.toLowerCase(), v]),
+);
+
+/**
+ * Calculate the Monthly Recurring Revenue contribution of a single
+ * subscription.
  *
  * Pax8's `Subscription.billingTerm` is a closed enum (`BillingTermSchema`):
  * `Monthly`, `Annual`, `2-Year`, `3-Year`, `One-Time`, `Trial`, `Activation`.
- * Each multi-period term is divided down to its monthly equivalent. The match
- * is case-insensitive against the canonical enum value so callers may pass
+ * Each multi-period term is divided down to its monthly equivalent. Match is
+ * case-insensitive against the canonical enum value so callers may pass
  * lowercased / loosely-typed strings (the call sites in `computeMrr`,
- * `cost-simulator`, etc. do this).
+ * `cost-simulator`, etc. do this). The `"1-Year"` alias is accepted for
+ * defensive parity with `commitment.term`.
  *
- * `One-Time`, `Trial`, `Activation`, and unknown / falsy values fall through
- * to `price × quantity` — preserving the pre-fix default. Reworking those
- * semantics is a separate question (they aren't really "recurring") and is
- * intentionally out of scope here.
+ * **One-Time, Trial, and Activation contribute 0** to monthly cost — they're
+ * not recurring. Previous behavior (#465) returned `price × quantity` for
+ * these, which inflated every dashboard, recommendation, and report that
+ * aggregated MRR. Reports that need the gross figure should sum `price ×
+ * quantity` directly rather than going through this function.
  *
- * This is the single source of truth for MRR calculation across the codebase.
+ * Unknown or falsy terms return 0 and emit a single-shot `stderr` warning
+ * per unknown value per process. Silently returning gross was the original
+ * bug — a future, unrecognized enum value would otherwise count at 12× /
+ * 24× / 36× its true monthly rate.
+ *
+ * This is the single source of truth for MRR calculation across the
+ * codebase.
  */
 export function subscriptionMrr(price: number, quantity: number, billingTerm: string): number {
   const gross = price * quantity;
   const normalizedTerm = (billingTerm ?? "").toLowerCase();
 
-  switch (normalizedTerm) {
-    case "monthly":
-      return gross;
-    case "annual":
-      return gross / 12;
-    case "2-year":
-      return gross / 24;
-    case "3-year":
-      return gross / 36;
-    case "one-time":
-    case "trial":
-    case "activation":
-      return gross;
-    default:
-      // Unknown / falsy billingTerm: preserve historical behavior (treat as
-      // monthly) so callers passing `undefined`, `""`, or future enum values
-      // we don't yet recognize don't suddenly start under-reporting MRR.
-      return gross;
+  const divisor = BILLING_TERM_MONTHLY_DIVISOR_LOWER[normalizedTerm];
+  if (divisor === undefined) {
+    // Unknown / falsy billingTerm: zero contribution + one-shot warning so
+    // partners aren't surprised by silent miscounting if Pax8 ever ships a
+    // new enum value before we update this table.
+    const key = normalizedTerm || "(empty)";
+    if (!unknownBillingTermsWarned.has(key)) {
+      unknownBillingTermsWarned.add(key);
+      process.stderr.write(
+        `[pax8] warn: unknown billingTerm "${billingTerm}"; contributing 0 to monthly cost.\n`,
+      );
+    }
+    return 0;
   }
+  if (divisor === 0) return 0;
+  return gross / divisor;
 }
 
 export function computeMrr(subscriptions: AnalyticsSubscriptionInput[]): MrrReport {

--- a/packages/core/src/services/cost-simulator.ts
+++ b/packages/core/src/services/cost-simulator.ts
@@ -77,15 +77,14 @@ function round2(n: number): number {
  */
 function normalizeTerm(term: string): string {
   const lower = term.toLowerCase();
+  if (lower.includes("month")) return "Monthly";
   if (lower.includes("annual") || lower.includes("yearly") || lower.includes("year")) {
-    if (lower === "monthly") return "Monthly";
     if (lower.includes("year") && !lower.includes("annual") && !lower.includes("yearly")) {
-      // Preserve commitment-style labels like "1-Year" verbatim.
+      // Preserve commitment-style labels like "1-Year" / "2-Year" verbatim.
       return term;
     }
     return "Annual";
   }
-  if (lower.includes("month")) return "Monthly";
   return term;
 }
 


### PR DESCRIPTION
> **Stacked on #499.** Once #499 merges, I'll switch the base to \`main\` (\`gh pr edit --base main\`) — the diff stays unchanged.

## Summary

Two interlocking money-correctness fixes that both inflated and mislabeled partner-cost numbers across dashboard, recommendations, cost-sim, and reports.

### 1. \`subscriptionMrr()\` per-term divisor table (#465)

The previous switch returned \`price × quantity\` (gross) for \`One-Time\`, \`Trial\`, and \`Activation\` billing terms — these are not recurring revenue. A \`\$5,000\` onboarding fee or a \`\$3.00 × 5\` trial on a fresh subscription would land in the monthly-cost aggregate as if it were a perpetual obligation, lifting every "monthly Pax8 cost" and "potential uplift" figure that aggregates this function.

Replaced with a \`Record<BillingTerm | \"1-Year\", number>\` divisor table whose values are 0 for non-recurring terms. **Unknown enum values now contribute 0 and emit a one-shot stderr warning per process** per unknown value, so a future Pax8 enum addition doesn't silently miscount — it pages us via the warning instead. The \`\"1-Year\"\` alias is accepted defensively (Pax8 uses it on \`commitment.term\` and on some product-pricing rows).

### 2. \`formatCurrency()\` honors \`currencyCode\` (#472)

The previous implementation hard-coded \`\"$\"\`, so every EUR / GBP / CAD partner saw their subscriptions, dashboard, top customers, recommendations, and cost-sim output mislabeled as USD. The \`subscriptions list\` table had a workaround that appended \`\" EUR\"\` per row; that suffix is dropped here and the formatter is the single source of truth, using \`Intl.NumberFormat\` to pick the correct symbol (or ISO code suffix for currencies without a Latin symbol). Falls back to a numeric + code-suffix render when ICU rejects a code (defensive against malformed upstream data). \`cost sim\` threads the matched current subscription's currency through to output.

### Mock fixtures (regression gates)

- **Coastline Legal Group**: One-Time EUR onboarding fee — must contribute 0 to monthly cost.
- **Bright Minds Academy**: Trial Defender seat — must contribute 0.
- **Acme Corp**: GBP Entra ID P2 — must render with \"£\", not \"$\".

\`demo-data.test.ts\` length assertions updated for the two companies that gained a fixture row.

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 1937 passed / 6 skipped
- [x] \`formatters.test.ts\` adds 8 new tests covering EUR / GBP / CAD / USD / empty / undefined / unknown-ISO / negative — uses \`.toContain(\"€\")\`-style assertions so a future ICU/CLDR symbol tweak (e.g. NBSP vs U+202F) doesn't flake CI
- [x] \`analytics.test.ts\` covers the zero-MRR contract for Trial / One-Time / Activation and the one-shot warning behavior for unknown enum values

## Scope notes

- Hand-curated fixture rows in \`demo-data.ts\`, not the generated large fixture from #484 — distinct work. The small fixture stays the screenshot/onboarding target; these rows are explicit regression gates for #465 and #472.
- This PR stacks on #499 (state-write hardening) only because both touch \`companies/list.ts\` and \`recommendations/list.ts\` in unrelated hunks. #499 already absorbed those; this PR has zero overlap with anything currently on \`main\`.

Closes #465, closes #472.
