### PR TITLE
ci: align Claude review workflow with operon pattern

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,7 +31,8 @@ jobs:
           additional_permissions: |
             actions: read
           prompt: |
-            Review this pull request. Ground findings in the repo's
+            Review pull request #${{ github.event.pull_request.number }}
+            in ${{ github.repository }}. Ground findings in the repo's
             conventions — CLAUDE.md, docs/UX_GUIDE.md (§13 checklist),
             and packages/claude-skill/skill.md for the agent-facing
             read/write contract.
@@ -45,4 +46,10 @@ jobs:
             Skip generic praise. Cite file:line for every concrete
             issue. If the change is small or routine, say so briefly
             and move on.
+
+            When done, post your review as a single PR comment by
+            running: `gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file <path>`
+            where <path> is a markdown file you've written with the
+            review. The review MUST be posted — analysis without a
+            posted comment is a failed run.
           claude_args: "--model opus"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,25 +31,34 @@ jobs:
           additional_permissions: |
             actions: read
           prompt: |
-            Review pull request #${{ github.event.pull_request.number }}
-            in ${{ github.repository }}. Ground findings in the repo's
-            conventions — CLAUDE.md, docs/UX_GUIDE.md (§13 checklist),
-            and packages/claude-skill/skill.md for the agent-facing
-            read/write contract.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Focus on: correctness, security, agent-facing safety
-            (write commands must prompt, idempotency keys honored,
-            error codes from packages/core/src/errors/codes.ts),
-            stdout/stderr discipline (no console.log in command
-            code; output() only), and demo-mode behavior.
+            **Tone**: Encouraging but concise. Limit emojis to section headers only (max 1 per section). Direct and actionable.
 
-            Skip generic praise. Cite file:line for every concrete
-            issue. If the change is small or routine, say so briefly
-            and move on.
+            FIRST: Before reviewing, run `gh pr view ${{ github.event.pull_request.number }} --comments` to read prior comments (including your previous reviews). Use it to stay consistent with points you've already raised, acknowledge issues that have been addressed, and avoid repeating yourself.
 
-            When done, post your review as a single PR comment by
-            running: `gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file <path>`
-            where <path> is a markdown file you've written with the
-            review. The review MUST be posted — analysis without a
-            posted comment is a failed run.
-          claude_args: "--model opus"
+            Also check CI status: `gh pr checks ${{ github.event.pull_request.number }}`.
+
+            Then review the PR. Ground findings in the repo's conventions — CLAUDE.md, docs/UX_GUIDE.md (§13 checklist), and packages/claude-skill/skill.md for the agent-facing read/write contract.
+
+            Focus on:
+            - Correctness and potential bugs
+            - Security concerns
+            - Agent-facing safety: write commands must prompt, idempotency keys honored, error codes from packages/core/src/errors/codes.ts
+            - Stdout/stderr discipline (no console.log in command code; output() only)
+            - Demo-mode behavior (PAX8_DEMO=1 must work end-to-end)
+            - Test coverage
+
+            IMPORTANT FORMATTING RULES:
+            - Keep visible review BRIEF — no more than 5–10 lines of immediately visible text.
+            - Use HTML `<details><summary>Section Title</summary><p>detailed content</p></details>` AGGRESSIVELY.
+            - Put all detailed explanations, code examples, and lengthy analysis inside collapsed details sections.
+            - The summary line is one short description; details go inside the collapsed section.
+            - Reference specific files and lines (e.g., `packages/cli/src/commands/foo.ts:42`) so feedback is actionable.
+            - Skip generic praise. If the change is small or routine, say so briefly and move on.
+
+            Before posting your new review, run `gh pr comment ${{ github.event.pull_request.number }} --edit-last --body "_This review is outdated. See latest review below._"` to mark any previous review outdated (ignore failure if there was no previous review).
+
+            Then post your new review with `gh pr comment ${{ github.event.pull_request.number }} --body-file <path>` where <path> is a markdown file you've written. The review MUST be posted — analysis without a posted comment is a failed run.
+          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*)"'


### PR DESCRIPTION
## Summary

Aligns this repo's Claude review workflow with the operon pattern (which is the working reference).

The root cause of silent reviews wasn't just the missing posting instruction (first commit) — it was almost certainly the missing **`--allowed-tools` allowlist**. In CI, `claude` won't execute a `Bash(gh pr comment ...)` call unless that exact tool pattern is explicitly allowed. Our previous prompt told Claude to run `gh pr comment` but the bash gate silently blocked it.

Changes vs. previous attempt:
- **Critical:** add `--allowed-tools` allowlist for the `gh` subcommands Claude needs (`gh pr comment`, `gh pr view`, `gh pr diff`, `gh pr list`, `gh pr checks`, plus `gh issue *` and `gh search`)
- Read prior PR comments first (`gh pr view --comments`) so re-reviews stay consistent and acknowledge resolved issues
- Read CI status (`gh pr checks`) so feedback can reference failing checks
- Mark previous review as outdated via `gh pr comment --edit-last` before posting the new one — keeps the comment history focused on the latest code
- `<details><summary>...</summary>` formatting rules to keep the visible review short
- Tone guidance (encouraging, concise, emoji-restricted)

Keeps the pax8-cli-specific focus areas (UX_GUIDE §13 checklist, skill.md write-safety contract, error code conventions, stdout/stderr discipline, demo mode).

## Test plan

- [ ] Merge, then push a small commit on any open PR (or open a throwaway PR) and confirm Claude posts a comment within ~8 min
- [ ] Confirm the posted comment uses `<details>` collapsing and cites file:line
- [ ] Push a second commit on the same PR and confirm the previous review is marked outdated and the new one is posted

> The workflow-validation gate from #495 still applies — this PR's own run will skip itself; the fix takes effect after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)