### PR TITLE
fix(ux): normalize Try next hints — replCmd wrap, prefer client names

### DIFF
--- a/.changeset/try-next-hint-normalization.md
+++ b/.changeset/try-next-hint-normalization.md
@@ -1,0 +1,12 @@
+---
+"@pax8/cli": patch
+---
+
+Normalize "Try next" pickable-step labels across the CLI:
+
+- `pax8 subscriptions renewals` previously rendered bare `subscriptions show <id>` and `clients more "<name>"` labels — no `pax8` prefix, no `replCmd()` wrap. Now matches every other command's pattern.
+- `pax8 quotes show` and `pax8 quotes send` drilled into the client by UUID; they now prefer the human-readable `quote.clientName` (flattened from the v2 quoting API's `client.name`) with the UUID as a fallback for shadow companies or older payloads. Matches the established `orders/show.ts` / `contacts/list.ts` pattern.
+
+Cosmetic / label-only. Action arrays are unchanged, so REPL behavior is identical.
+
+Closes #481, #482.

--- a/packages/cli/src/commands/quotes/send.ts
+++ b/packages/cli/src/commands/quotes/send.ts
@@ -136,6 +136,11 @@ Note:
       // rather than a pickable step the partner is unlikely to choose in
       // this moment.
       const companyId = (updated as Quote).companyId;
+      // #481: prefer the resolved client name when available (the v2
+      // quoting API populates `client.name`, flattened to `clientName`
+      // by QuoteSchema's preprocess step). Falls back to the UUID for
+      // shadow companies / partner-side records without a display name.
+      const clientName = (updated as Quote).clientName;
       const steps: NextStep[] = [
         {
           key: "1",
@@ -146,7 +151,7 @@ Note:
       if (companyId) {
         steps.push({
           key: "2",
-          label: `${chalk.cyan(replCmd(`pax8 clients more "${companyId}"`))}  ${chalk.dim("view client")}`,
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${clientName ?? companyId}"`))}  ${chalk.dim("view client")}`,
           command: ["clients", "more", companyId],
         });
       }

--- a/packages/cli/src/commands/quotes/show.ts
+++ b/packages/cli/src/commands/quotes/show.ts
@@ -260,7 +260,12 @@ JSON output (--json):
         }
         steps.push({
           key: String(n++),
-          label: `${chalk.cyan(replCmd(`pax8 clients more "${quote.companyId}"`))}  ${chalk.dim("view client")}`,
+          // #481: prefer the human-readable client name when the wire
+          // gave us one (QuoteSchema flattens `client.name` → `clientName`).
+          // Falls back to the UUID for shadow companies / older quote
+          // payloads where the name isn't populated. Matches the
+          // `orders/show.ts` pattern.
+          label: `${chalk.cyan(replCmd(`pax8 clients more "${quote.clientName ?? quote.companyId}"`))}  ${chalk.dim("view client")}`,
           command: ["clients", "more", quote.companyId],
         });
         // Delete stays accessible from non-Accepted states; once accepted it

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -16,6 +16,7 @@ import {
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
+import { replCmd } from "../../lib/confirm.js";
 
 function parseWithinDays(within: string): number {
   const match = within.match(/^(\d+)d$/);
@@ -243,12 +244,15 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
         const steps: NextStep[] = [
           {
             key: "1",
-            label: `${chalk.cyan(`subscriptions show ${top.subscriptionId}`)}  ${chalk.dim("view details")}`,
+            // #482: wrap in replCmd(`pax8 ...`) so the rendered label matches
+            // every other "Try next" surface — same visual shape (`pax8`
+            // prefix in non-REPL contexts, none inside the REPL).
+            label: `${chalk.cyan(replCmd(`pax8 subscriptions show ${top.subscriptionId}`))}  ${chalk.dim("view details")}`,
             command: ["subscriptions", "show", top.subscriptionId],
           },
           {
             key: "2",
-            label: `${chalk.cyan(`clients more "${top.companyName}"`)}  ${chalk.dim("view client")}`,
+            label: `${chalk.cyan(replCmd(`pax8 clients more "${top.companyName}"`))}  ${chalk.dim("view client")}`,
             command: ["clients", "more", top.companyName],
           },
         ];


### PR DESCRIPTION
## Summary

Two related "Try next" hint inconsistencies surfaced in the v0.1.0 review:

### 1. \`subscriptions renewals\` bypassed \`replCmd()\` (#482)

Both pickable steps emitted bare \`subscriptions show <id>\` and \`clients more \"<name>\"\` labels without the \`pax8 \` prefix and without going through \`replCmd()\`. Every other pickable hint in the CLI uses \`replCmd(\`pax8 ...\`)\`, so the renewals surface visually drifted from the rest of the product. Pure cosmetic — the \`command\` arrays remain correct — but consistent enough that reviewers flagged it.

### 2. \`quotes show\` / \`quotes send\` showed UUIDs instead of names (#481)

The \`clients more\` drill-in interpolated \`quote.companyId\` (a UUID) into the label, while the sibling \`orders/show.ts\` and \`contacts/list.ts\` patterns use a human-readable name. The v2 quoting API populates \`client.name\`, flattened to \`quote.clientName\` by \`QuoteSchema\`'s preprocess step, so the readable name is already in scope without a second read.

Switched to \`\${quote.clientName ?? quote.companyId}\` (matches the \`orders/show.ts\` pattern). The action array continues to dispatch by ID for robustness when names collide.

## Audit

Repo-wide grep:
\`\`\`
git grep -n -E \"chalk\.cyan\(\`(subscriptions|clients|orders|invoices|contacts|quotes|webhooks|recommendations|cost|products|dashboard|report|usage|doctor)\" -- 'packages/cli/src/commands/**/*.ts'
\`\`\`

Returns zero hits after this change — the two \`renewals.ts\` lines were the only stragglers. Any new pickable hint added later will need to go through \`replCmd()\` to keep this clean.

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 1924 passed / 6 skipped
- [x] Repo-wide audit grep returns zero un-wrapped pickable labels

## Scope notes

- Cosmetic / label-only. No \`command\` array changes; no action semantics change.
- The \`--company\` invocations in \`quotes/show.ts\` (\`orders list --company\`, \`subscriptions list --company\`) still take \`quote.companyId\` — out of #481's specific scope, which is the \`clients more\` drill-in.

Closes #481, closes #482.
