### PR TITLE
fix(security): SHA-pin release.yml actions to immutable commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,20 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned per security review (H-4): this workflow has
+      # `contents: write` + `id-token: write` and runs `npm publish` via
+      # the changesets action, so it's the highest-leverage supply-chain
+      # surface in the repo. A mutable tag reference (`@v6`) here would
+      # let a compromise of any upstream action ship a poisoned package.
+      # Dependabot honors SHA pins with a trailing `# <tag>` comment and
+      # opens PRs to bump them — see .github/dependabot.yml.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "pnpm"
@@ -45,7 +52,7 @@ jobs:
       # push to main will publish whatever the open "chore: release" PR has
       # already version-bumped to.
       - name: Create release PR (publish gated — see #370)
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           # publish: pnpm changeset publish  # gated — enable when ready to ship
           version: pnpm changeset version


### PR DESCRIPTION
## Summary

Closes **H-4** from the recent security review. `release.yml` is the only workflow in the repo with `contents: write` + `id-token: write` and the capability to invoke `npm publish` (currently publish-gated per #370 but the trust boundary is there). With tag references like `@v6` / `@v5` / `@v1`, a compromise or rewrite of an upstream action's tag would ship a poisoned package the next time the workflow ran.

Replaced four tag refs with immutable commit SHAs, plus a trailing `# <tag>` comment so a maintainer reading the file knows what version is pinned and so Dependabot can still bump them.

| Action | Pinned SHA | Tag |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `pnpm/action-setup` | `fc06bc1257f339d1d5d8b3a19a8cae5388b55320` | v5.0.0 (held at v5 — repo currently targets v5) |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| `changesets/action` | `63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b` | v1.8.0 |

SHAs were resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` against the official upstream repos. Two of them are annotated tags (pnpm/action-setup, changesets/action), so the SHAs above are the dereferenced commit SHAs, not the tag-object SHAs.

### Why not all six workflows in one PR?

Scope discipline. The other five workflows (`ci`, `codeql`, `integration`, `demo-image`, `api-watch`) don't carry publish capability — at worst a compromise there pollutes a check run or wastes Actions minutes. They should be pinned eventually, but bundling them with `release.yml` would make a "did the most important one get pinned correctly" check harder.

## Test plan

- [x] `gh api` resolved each tag to the actual SHA on the upstream repo
- [x] Confirmed `.github/dependabot.yml` already enables `github-actions` ecosystem — SHA pins with trailing tag comments are bump-able
- [x] Diff is the four `@<tag>` → `@<sha> # <tag>` substitutions plus a comment block explaining why; no other workflow logic changed
- [ ] Manual: the next push to main will exercise this workflow — verify all four steps still resolve and run

## Follow-ups

- Pin the remaining five workflows in a separate PR
- Once Dependabot opens the first bump PR, double-check it round-trips the SHA+comment shape correctly