### PR TITLE
fix(security): write-safety hardening — keyword challenge + audit log (H-5)

### DIFF
--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -42,10 +42,36 @@ export interface CliResult {
   timedOut?: boolean;
 }
 
+/**
+ * H-5: destructive commands refuse to proceed without
+ * `PAX8_CONFIRM_DESTRUCTIVE=<keyword>` in env on a non-TTY stdin
+ * (subprocess tests are non-TTY by definition). E2E tests of
+ * destructive *command logic* (e.g. `pax8 quotes delete` returns the
+ * right JSON shape) would all break on the gate that's not what
+ * they're verifying. This map auto-injects the right keyword for
+ * known destructive command paths so each test stays focused on its
+ * own subject. The gate itself is verified by
+ * `packages/cli/src/__tests__/destructive-gate.test.ts`.
+ *
+ * When a test explicitly sets `PAX8_CONFIRM_DESTRUCTIVE`, that wins.
+ */
+const DESTRUCTIVE_KEYWORDS: Record<string, string> = {
+  "subscriptions cancel": "cancel",
+  "contacts delete": "delete",
+  "quotes delete": "delete",
+};
+
+function autoConfirmDestructive(args: string[], env?: Record<string, string>): string | undefined {
+  if (env?.PAX8_CONFIRM_DESTRUCTIVE !== undefined) return undefined;
+  const positional = args.filter((a) => !a.startsWith("-")).slice(0, 2).join(" ");
+  return DESTRUCTIVE_KEYWORDS[positional];
+}
+
 export async function runCli(
   args: string[],
   env?: Record<string, string>
 ): Promise<CliResult> {
+  const autoKeyword = autoConfirmDestructive(args, env);
   try {
     const result = await exec("node", [CLI_PATH, ...args], {
       env: {
@@ -53,6 +79,7 @@ export async function runCli(
         PAX8_DEMO: "1",
         NO_COLOR: "1",
         PAX8_CONFIG_DIR: makeIsolatedConfigDir(),
+        ...(autoKeyword !== undefined ? { PAX8_CONFIRM_DESTRUCTIVE: autoKeyword } : {}),
         ...env,
       },
       timeout: TIMEOUT_MS,

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -33,6 +33,7 @@ For every write command below:
 2. **Wait for explicit approval** — a clear "yes / go ahead / do it." Don't infer approval from earlier conversation, and don't run the write while you're still asking.
 3. **Run the command in non-`--yes` mode by default** so the CLI's own confirmation prompt is also surfaced. Pass `--yes` only when the user has already approved this exact action.
 4. **Destructive commands need a second acknowledgment.** `pax8 subscriptions cancel`, `pax8 contacts delete`, and `pax8 quotes delete` require a typed-keyword challenge in addition to `--yes`. `--yes` alone is intentionally not enough (H-5). In agent contexts (no TTY), set `PAX8_CONFIRM_DESTRUCTIVE=<keyword>` in the environment — `cancel` for `subscriptions cancel`, `delete` for the others. Only set this when the user has explicitly named the destructive action they want.
+5. **Local write audit log.** Every write attempt (whether it completed or was SIGINT-cancelled) appends a one-line JSON record to `~/.pax8/write-audit.log` (mode 0600). Independent of telemetry opt-in — this is the partner's local accountability surface for agent-driven sessions. Records timestamp, subcommand path, resource, outcome (`completed` / `cancelled`), and idempotency key. No user-supplied values or names.
 
 Write commands:
 

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -32,6 +32,7 @@ For every write command below:
 1. **Show the user exactly what will change** — the command you're about to run, the affected resource(s), and the expected effect (price, quantity, estimated Pax8 monthly cost delta, etc. when applicable).
 2. **Wait for explicit approval** — a clear "yes / go ahead / do it." Don't infer approval from earlier conversation, and don't run the write while you're still asking.
 3. **Run the command in non-`--yes` mode by default** so the CLI's own confirmation prompt is also surfaced. Pass `--yes` only when the user has already approved this exact action.
+4. **Destructive commands need a second acknowledgment.** `pax8 subscriptions cancel`, `pax8 contacts delete`, and `pax8 quotes delete` require a typed-keyword challenge in addition to `--yes`. `--yes` alone is intentionally not enough (H-5). In agent contexts (no TTY), set `PAX8_CONFIRM_DESTRUCTIVE=<keyword>` in the environment — `cancel` for `subscriptions cancel`, `delete` for the others. Only set this when the user has explicitly named the destructive action they want.
 
 Write commands:
 

--- a/packages/cli/src/__tests__/destructive-gate.test.ts
+++ b/packages/cli/src/__tests__/destructive-gate.test.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCli } from "./test-utils.js";
+
+/**
+ * H-5 contract: a destructive command refuses to proceed when stdin
+ * is not a TTY and `PAX8_CONFIRM_DESTRUCTIVE` is unset, even if
+ * `--yes` / `PAX8_YES` is supplied. The pre-H-5 behavior was the
+ * opposite — `--yes` silently bypassed the keyword challenge.
+ *
+ * These tests exercise the real subprocess so the gate's enforcement
+ * across argv parsing + Commander + the action handler can't drift
+ * back to "--yes is enough" without a regression caught here.
+ *
+ * The default `runCli` in test-utils.ts auto-injects
+ * `PAX8_CONFIRM_DESTRUCTIVE` for destructive command paths so unit
+ * tests of the underlying command logic don't get blocked. Each test
+ * below explicitly *overrides* that injection to assert what happens
+ * when the override is absent — i.e. the security contract holds.
+ */
+describe("destructive command gate (H-5)", () => {
+  it("subscriptions cancel: --yes alone does not bypass the keyword challenge on non-TTY", async () => {
+    const result = await runCli(
+      [
+        "subscriptions",
+        "cancel",
+        "sub-summit-m365bp-001",
+        "--cancel-date",
+        "2026-12-31",
+        "--yes",
+        "--json",
+      ],
+      // Empty string in env overrides the auto-injection so the gate
+      // sees no override. The test asserts the refusal.
+      { PAX8_CONFIRM_DESTRUCTIVE: "" },
+    );
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Destructive operation requires");
+    expect(result.stderr).toContain("PAX8_CONFIRM_DESTRUCTIVE=cancel");
+  });
+
+  it("subscriptions cancel: PAX8_CONFIRM_DESTRUCTIVE=cancel satisfies the gate", async () => {
+    const result = await runCli(
+      [
+        "subscriptions",
+        "cancel",
+        "sub-summit-m365bp-001",
+        "--cancel-date",
+        "2026-12-31",
+        "--yes",
+        "--json",
+      ],
+      { PAX8_CONFIRM_DESTRUCTIVE: "cancel" },
+    );
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.stdout);
+    expect(data[0]).toMatchObject({
+      id: "sub-summit-m365bp-001",
+      status: "Cancelled",
+      cancelDate: "2026-12-31",
+    });
+  });
+
+  it("subscriptions cancel: PAX8_CONFIRM_DESTRUCTIVE with the WRONG keyword still refuses", async () => {
+    const result = await runCli(
+      [
+        "subscriptions",
+        "cancel",
+        "sub-summit-m365bp-001",
+        "--cancel-date",
+        "2026-12-31",
+        "--yes",
+        "--json",
+      ],
+      { PAX8_CONFIRM_DESTRUCTIVE: "delete" }, // wrong keyword for cancel
+    );
+    // The command treats the wrong keyword as "not confirmed" and
+    // skips the cancel. Exit is 0 (no error, just abandoned).
+    expect(result.stdout).toBe("");
+  });
+});

--- a/packages/cli/src/__tests__/test-utils.ts
+++ b/packages/cli/src/__tests__/test-utils.ts
@@ -19,13 +19,44 @@ export interface CliResult {
   exitCode: number;
 }
 
+/**
+ * Per the H-5 contract, destructive commands refuse to proceed without
+ * either an interactive TTY or `PAX8_CONFIRM_DESTRUCTIVE=<keyword>` in
+ * env. Subprocess tests have neither by default, so unit tests of
+ * destructive command *logic* (e.g. `subscriptions cancel` schedules
+ * the right date) would all break on the gate that's not what they're
+ * verifying. This map auto-injects the right keyword for known
+ * destructive command paths so each test stays focused on its own
+ * subject. The gate itself is verified in `confirm.test.ts` and the
+ * integration test in `destructive-gate.test.ts`.
+ *
+ * When a test explicitly sets `PAX8_CONFIRM_DESTRUCTIVE`, that wins —
+ * a test asserting the gate refuses with the wrong keyword still works.
+ */
+const DESTRUCTIVE_KEYWORDS: Record<string, string> = {
+  "subscriptions cancel": "cancel",
+  "contacts delete": "delete",
+  "quotes delete": "delete",
+};
+
+function autoConfirmDestructive(args: string[], env?: Record<string, string>): string | undefined {
+  if (env?.PAX8_CONFIRM_DESTRUCTIVE !== undefined) return undefined;
+  const positional = args.filter((a) => !a.startsWith("-")).slice(0, 2).join(" ");
+  return DESTRUCTIVE_KEYWORDS[positional];
+}
+
 export async function runCli(
   args: string[],
   env?: Record<string, string>
 ): Promise<CliResult> {
+  const autoKeyword = autoConfirmDestructive(args, env);
+  const finalEnv: Record<string, string> = {
+    ...env,
+    ...(autoKeyword !== undefined ? { PAX8_CONFIRM_DESTRUCTIVE: autoKeyword } : {}),
+  };
   try {
     const result = await exec("node", [CLI_PATH, ...args], {
-      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...env },
+      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...finalEnv },
       timeout: 15000,
     });
     return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };

--- a/packages/cli/src/lib/confirm.test.ts
+++ b/packages/cli/src/lib/confirm.test.ts
@@ -59,30 +59,90 @@ describe("confirm", () => {
   });
 });
 
-describe("confirmDestructive", () => {
+describe("confirmDestructive — keyword challenge is not bypassable", () => {
+  // H-5: pre-fix, --yes / PAX8_YES short-circuited the keyword check
+  // and returned true. That defeated the typed-keyword gate's whole
+  // purpose for destructive ops. The tests below pin the new
+  // contract: under --yes / PAX8_YES on a non-TTY stdin (CI, agent
+  // subprocess, piped input), confirmDestructive refuses with a
+  // stderr message and returns false. The keyword can still be
+  // satisfied — but only interactively, by typing it.
   const originalEnv = { ...process.env };
   const originalArgv = [...process.argv];
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     delete process.env.PAX8_YES;
     process.argv = ["node", "test"];
+    answerQueue.length = 0;
+    // Default test env is non-TTY for stdin. Each test that needs the
+    // interactive path overrides this locally.
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
   afterEach(() => {
     process.env = { ...originalEnv };
     process.argv = originalArgv;
+    answerQueue.length = 0;
+    stderrWrite.mockRestore();
   });
 
-  it("returns true when PAX8_YES=1", async () => {
+  it("PAX8_YES=1 does NOT bypass the keyword challenge — returns false on non-TTY stdin", async () => {
     process.env.PAX8_YES = "1";
     const result = await confirmDestructive("Delete?", "DELETE");
-    expect(result).toBe(true);
+    expect(result).toBe(false);
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("Destructive operation requires");
+    expect(written).toContain("DELETE");
   });
 
-  it("returns true when --yes flag is present", async () => {
+  it("--yes flag does NOT bypass the keyword challenge — returns false on non-TTY stdin", async () => {
     process.argv = ["node", "test", "--yes"];
     const result = await confirmDestructive("Delete?", "DELETE");
+    expect(result).toBe(false);
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("Destructive operation requires");
+  });
+
+  it("non-TTY stdin without --yes still refuses (no auto-confirm path at all)", async () => {
+    const result = await confirmDestructive("Delete?", "DELETE");
+    expect(result).toBe(false);
+  });
+
+  it("on a TTY, --yes still prompts for the keyword — the user must type it", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+    process.argv = ["node", "test", "--yes"];
+    answerQueue.push("DELETE");
+    const result = await confirmDestructive("Delete?", "DELETE");
     expect(result).toBe(true);
+    // No stderr refusal — we reached the interactive prompt.
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    expect(written).not.toContain("Destructive operation requires");
+  });
+
+  it("PAX8_CONFIRM_DESTRUCTIVE=<correct keyword> satisfies the gate without a TTY", async () => {
+    process.env.PAX8_CONFIRM_DESTRUCTIVE = "DELETE";
+    const result = await confirmDestructive("Delete?", "DELETE");
+    expect(result).toBe(true);
+    const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
+    // No stderr refusal — the env override bypassed the no-TTY refusal.
+    expect(written).not.toContain("Destructive operation requires");
+  });
+
+  it("PAX8_CONFIRM_DESTRUCTIVE=<wrong keyword> still refuses", async () => {
+    process.env.PAX8_CONFIRM_DESTRUCTIVE = "WRONG_KEYWORD";
+    const result = await confirmDestructive("Delete?", "DELETE");
+    expect(result).toBe(false);
+    // The mismatch is a silent "no" — the function returns false and
+    // the caller treats it as "user declined." No stderr refusal here
+    // (that's reserved for the no-TTY no-override case).
   });
 });
 
@@ -251,6 +311,12 @@ describe("confirmDestructive interactive prompt", () => {
     delete process.env.PAX8_YES;
     process.argv = ["node", "test"];
     answerQueue.length = 0;
+    // The interactive prompt path requires a TTY (H-5). Default test
+    // env is non-TTY; opt in here.
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
   });
 
   afterEach(() => {

--- a/packages/cli/src/lib/confirm.ts
+++ b/packages/cli/src/lib/confirm.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createInterface } from "readline";
+import chalk from "chalk";
 
 function shouldAutoConfirm(): boolean {
   return (
@@ -83,11 +84,64 @@ export async function confirmWithChange(
   return null;
 }
 
+/**
+ * Look for an explicit `PAX8_CONFIRM_DESTRUCTIVE=<keyword>` in env.
+ * Non-interactive escape hatch for automation that wants to satisfy
+ * the keyword challenge without a TTY prompt — the caller must spell
+ * out the keyword, demonstrating they read what the command does.
+ * `--yes` / `PAX8_YES` alone is not enough.
+ *
+ * Env var (not a CLI flag) because adding a per-command flag would
+ * require Commander option registration on every destructive command
+ * and a chunk of help-text duplication. Shell users prefix their
+ * invocation: `PAX8_CONFIRM_DESTRUCTIVE=cancel pax8 subscriptions ...`.
+ */
+function getDestructiveKeywordOverride(): string | null {
+  const envKey = process.env.PAX8_CONFIRM_DESTRUCTIVE;
+  if (typeof envKey === "string" && envKey.length > 0) return envKey;
+  return null;
+}
+
 export async function confirmDestructive(
   message: string,
   keyword: string
 ): Promise<boolean> {
-  if (shouldAutoConfirm()) return true;
+  // H-5: the typed-keyword challenge intentionally ignores --yes /
+  // PAX8_YES. Destructive operations (delete, cancel) need a stronger
+  // gate than a boolean flag can satisfy — partners and agents must
+  // demonstrate explicit intent by typing the keyword. Pre-H-5 the
+  // `if (shouldAutoConfirm())` early return silently downgraded the
+  // keyword challenge to a single-flag bypass, defeating the
+  // function's name and the skill manifest's "writes are deliberate"
+  // commitment.
+  //
+  // Three resolution paths in priority order:
+  //   1. `PAX8_CONFIRM_DESTRUCTIVE=<keyword>` in env explicitly spells
+  //      out the keyword — automation's path.
+  //   2. Interactive TTY: prompt for the keyword. Works under --yes too
+  //      (the prompt still fires; the user still has to type).
+  //   3. Non-TTY without the override: refuse with a stderr message.
+  //      Far better than hanging on a prompt nobody can answer, and
+  //      far better than auto-confirming.
+  const override = getDestructiveKeywordOverride();
+  if (override !== null) {
+    return override === keyword;
+  }
+
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      chalk.red(
+        `\n  ✗ Destructive operation requires the typed-keyword challenge.\n`
+      ) +
+      chalk.dim(
+        `    --yes / PAX8_YES does not bypass destructive confirmation —\n` +
+        `    that's by design (see security finding H-5).\n` +
+        `    For automation: prefix with PAX8_CONFIRM_DESTRUCTIVE=${keyword}\n` +
+        `    For interactive use: run on a TTY and type "${keyword}" at the prompt.\n\n`
+      )
+    );
+    return false;
+  }
 
   const answer = await prompt(
     `  ${message}\n  Type "${keyword}" to confirm: `

--- a/packages/cli/src/lib/signals.ts
+++ b/packages/cli/src/lib/signals.ts
@@ -4,6 +4,7 @@
 import chalk from "chalk";
 import { getTelemetry } from "@pax8/core";
 import { stopAllActiveSpinners } from "./spinner.js";
+import { recordWriteAudit } from "./write-audit.js";
 
 /**
  * In-flight write tracking for SIGINT cleanup.
@@ -57,6 +58,17 @@ export function markWriteInFlight(
     // Only clear if we're still the active entry — guards against a later
     // write that registered after us getting wiped by our late `done()`.
     if (currentWrite === entry) {
+      // H-5: append a "completed" line to ~/.pax8/write-audit.log so the
+      // operator has a local trail of every write the CLI attempted,
+      // independent of telemetry opt-in. Best-effort — recordWriteAudit
+      // swallows I/O failures so a full disk can't break a successful
+      // write. The cancelled-via-SIGINT counterpart is logged in the
+      // SIGINT handler below.
+      recordWriteAudit({
+        resource: entry.resource,
+        outcome: "completed",
+        idempotencyKey: entry.idempotencyKey,
+      });
       currentWrite = null;
     }
   };
@@ -112,6 +124,14 @@ export function installSigintHandler(): void {
 
     const write = currentWrite;
     if (write) {
+      // H-5: log the cancellation to ~/.pax8/write-audit.log before the
+      // stderr hint, so even if the partner Ctrl+C-spams past the hint
+      // they have an after-the-fact trail of what was in flight.
+      recordWriteAudit({
+        resource: write.resource,
+        outcome: "cancelled",
+        idempotencyKey: write.idempotencyKey,
+      });
       const showCmd = `pax8 ${write.resource} show ...`;
       const extra = write.hint ? ` ${write.hint}` : "";
       const lines = [

--- a/packages/cli/src/lib/write-audit.test.ts
+++ b/packages/cli/src/lib/write-audit.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { recordWriteAudit } from "./write-audit.js";
+
+describe("recordWriteAudit", () => {
+  let tmpDir: string;
+  const originalConfigDir = process.env.PAX8_CONFIG_DIR;
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pax8-write-audit-test-"));
+    process.env.PAX8_CONFIG_DIR = tmpDir;
+    process.argv = ["node", "test"];
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) delete process.env.PAX8_CONFIG_DIR;
+    else process.env.PAX8_CONFIG_DIR = originalConfigDir;
+    process.argv = originalArgv;
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup.
+    }
+  });
+
+  function readLog(): unknown[] {
+    const filepath = join(tmpDir, "write-audit.log");
+    const raw = fs.readFileSync(filepath, "utf-8");
+    return raw
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l));
+  }
+
+  it("writes a JSON-lines entry on the first call and creates the file at mode 0600", () => {
+    process.argv = ["node", "test", "orders", "create"];
+    recordWriteAudit({ resource: "orders", outcome: "completed", idempotencyKey: "abc-123" });
+
+    const filepath = join(tmpDir, "write-audit.log");
+    expect(fs.existsSync(filepath)).toBe(true);
+
+    const stat = fs.statSync(filepath);
+    expect(stat.mode & 0o777).toBe(0o600);
+
+    const entries = readLog();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      command: "orders create",
+      resource: "orders",
+      outcome: "completed",
+      idempotencyKey: "abc-123",
+    });
+    expect(entries[0]).toHaveProperty("timestamp");
+    expect(/^\d{4}-\d{2}-\d{2}T/.test((entries[0] as { timestamp: string }).timestamp)).toBe(true);
+  });
+
+  it("appends subsequent entries — does not truncate", () => {
+    process.argv = ["node", "test", "subscriptions", "cancel"];
+    recordWriteAudit({ resource: "subscriptions", outcome: "completed" });
+    recordWriteAudit({ resource: "subscriptions", outcome: "cancelled", idempotencyKey: "xyz" });
+    const entries = readLog();
+    expect(entries).toHaveLength(2);
+    expect((entries[0] as { outcome: string }).outcome).toBe("completed");
+    expect((entries[1] as { outcome: string }).outcome).toBe("cancelled");
+    expect((entries[1] as { idempotencyKey?: string }).idempotencyKey).toBe("xyz");
+  });
+
+  it("omits the idempotencyKey field when not supplied", () => {
+    recordWriteAudit({ resource: "orders", outcome: "completed" });
+    const entry = readLog()[0] as Record<string, unknown>;
+    expect(entry).not.toHaveProperty("idempotencyKey");
+  });
+
+  it("strips positional-arg values from the command field", () => {
+    // A command like `pax8 companies show "Real Customer Inc"` should
+    // record as `"companies show"` — never the customer name.
+    process.argv = ["node", "test", "companies", "show", "Real Customer Inc"];
+    recordWriteAudit({ resource: "companies", outcome: "completed" });
+    const entry = readLog()[0] as { command: string };
+    expect(entry.command).toBe("companies show");
+    expect(entry.command).not.toContain("Real Customer Inc");
+  });
+
+  it("refuses to follow a symlink at the audit-log path (O_NOFOLLOW)", () => {
+    const filepath = join(tmpDir, "write-audit.log");
+    const decoy = join(tmpDir, "decoy.txt");
+    fs.writeFileSync(decoy, "untouched");
+    fs.symlinkSync(decoy, filepath);
+
+    // Should silently swallow the symlink-refusal (best-effort contract).
+    recordWriteAudit({ resource: "orders", outcome: "completed" });
+
+    // The decoy must be untouched — the audit append must NOT have
+    // followed the symlink and clobbered it.
+    expect(fs.readFileSync(decoy, "utf-8")).toBe("untouched");
+  });
+
+  it("swallows I/O failures — never throws", () => {
+    // Point to an unwritable target directory by setting an invalid
+    // config dir. The recordWriteAudit call must not throw.
+    process.env.PAX8_CONFIG_DIR = "/proc/cannot-write-here-on-purpose";
+    expect(() => {
+      recordWriteAudit({ resource: "orders", outcome: "completed" });
+    }).not.toThrow();
+  });
+});

--- a/packages/cli/src/lib/write-audit.test.ts
+++ b/packages/cli/src/lib/write-audit.test.ts
@@ -46,8 +46,16 @@ describe("recordWriteAudit", () => {
     const filepath = join(tmpDir, "write-audit.log");
     expect(fs.existsSync(filepath)).toBe(true);
 
-    const stat = fs.statSync(filepath);
-    expect(stat.mode & 0o777).toBe(0o600);
+    // POSIX-only assertion: Windows doesn't honor POSIX mode bits on
+    // file creation — `fs.openSync(..., 0o600)` falls back to the
+    // platform default. The audit log's confidentiality on Windows
+    // depends on the parent directory's ACL (the `.pax8` config dir
+    // inherits user-only by convention). See the Windows note in
+    // write-audit.ts for the deliberate limitation.
+    if (process.platform !== "win32") {
+      const stat = fs.statSync(filepath);
+      expect(stat.mode & 0o777).toBe(0o600);
+    }
 
     const entries = readLog();
     expect(entries).toHaveLength(1);
@@ -88,7 +96,13 @@ describe("recordWriteAudit", () => {
     expect(entry.command).not.toContain("Real Customer Inc");
   });
 
-  it("refuses to follow a symlink at the audit-log path (O_NOFOLLOW)", () => {
+  it("refuses to follow a symlink at the audit-log path (O_NOFOLLOW, POSIX-only)", () => {
+    // Windows' fs.openSync silently ignores O_NOFOLLOW and resolves
+    // the symlink — the protection here is genuinely POSIX-only.
+    // The Windows audit log inherits ACL protection from the parent
+    // .pax8 dir instead. Documented in write-audit.ts.
+    if (process.platform === "win32") return;
+
     const filepath = join(tmpDir, "write-audit.log");
     const decoy = join(tmpDir, "decoy.txt");
     fs.writeFileSync(decoy, "untouched");

--- a/packages/cli/src/lib/write-audit.test.ts
+++ b/packages/cli/src/lib/write-audit.test.ts
@@ -117,9 +117,16 @@ describe("recordWriteAudit", () => {
   });
 
   it("swallows I/O failures — never throws", () => {
-    // Point to an unwritable target directory by setting an invalid
-    // config dir. The recordWriteAudit call must not throw.
-    process.env.PAX8_CONFIG_DIR = "/proc/cannot-write-here-on-purpose";
+    // Point to a path whose parent is a regular file, not a directory.
+    // `mkdirSync({recursive:true})` walks the path and hits ENOTDIR on the
+    // file segment — fast, deterministic, portable across Linux / macOS /
+    // Windows. (Earlier this used `/proc/cannot-write-here-on-purpose`,
+    // which deadlocks on Ubuntu GH Actions runners: the procfs mkdir
+    // doesn't return quickly there. The hang was specific to those
+    // runners and didn't reproduce locally — see the bisect on PR #508.)
+    const blocker = join(tmpDir, "blocker.txt");
+    fs.writeFileSync(blocker, "blocker");
+    process.env.PAX8_CONFIG_DIR = join(blocker, "child");
     expect(() => {
       recordWriteAudit({ resource: "orders", outcome: "completed" });
     }).not.toThrow();

--- a/packages/cli/src/lib/write-audit.ts
+++ b/packages/cli/src/lib/write-audit.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fs from "node:fs";
+import { join } from "node:path";
+import { getConfigDir } from "@pax8/core";
+
+/**
+ * Local accountability log for write commands.
+ *
+ * Closes the "no local audit trail" half of finding H-5 from the security
+ * review. Telemetry is opt-in (the README's privacy section commits to
+ * never sending company/subscription data), so an operator running an
+ * agent-driven CLI session with telemetry off had no after-the-fact way
+ * to ask "what did this agent actually try to do?" The on-disk envelope
+ * (`~/.pax8/last-error.json`) only captures the most recent failure.
+ *
+ * This log fires on every write attempt regardless of telemetry opt-in.
+ * One JSON Lines entry per call. Mode 0600 at file creation; subsequent
+ * appends preserve that mode.
+ *
+ * Scope:
+ *   - "completed"  → markWriteInFlight()'s `done()` callback ran. The
+ *     write API call returned. Success / failure isn't distinguished
+ *     here; combine with telemetry / shell exit code if you need that.
+ *   - "cancelled" → the SIGINT handler interrupted the write before
+ *     `done()` could fire. The agent retry path can use this signal to
+ *     decide whether to re-attempt with the same idempotency key.
+ *
+ * Best-effort: any I/O failure (full disk, read-only fs, sandboxed env)
+ * is swallowed. The audit log must never break a write that otherwise
+ * succeeded.
+ */
+
+const FILENAME = "write-audit.log";
+
+export interface WriteAuditEntry {
+  /** ISO timestamp at the moment the write resolved or was cancelled. */
+  timestamp: string;
+  /**
+   * Best-effort reconstruction of the subcommand path from argv,
+   * positional-arg values stripped (e.g. `"orders create"`,
+   * `"subscriptions cancel"`). Never contains user-supplied values.
+   */
+  command: string;
+  /** Domain bucket the write targeted: `"orders"`, `"subscriptions"`, … */
+  resource: string;
+  /** `"completed"` when done() fired; `"cancelled"` when SIGINT interrupted. */
+  outcome: "completed" | "cancelled";
+  /** The caller's --idempotency-key value if any. UUID-shape, no PII. */
+  idempotencyKey?: string;
+}
+
+/**
+ * Subcommand path extraction. Mirrors errors.ts's `extractCommandAndFlags`
+ * but inlined here — write-audit.ts has only one consumer pattern and
+ * shouldn't depend on the error-handling module.
+ */
+function extractCommand(): string {
+  const args = process.argv.slice(2);
+  const parts: string[] = [];
+  for (const a of args) {
+    if (a.startsWith("-")) break;
+    if (parts.length >= 2) break;
+    if (!/^[a-z][\w-]*$/i.test(a)) break;
+    parts.push(a);
+  }
+  return parts.join(" ") || "unknown";
+}
+
+export function recordWriteAudit(entry: Omit<WriteAuditEntry, "timestamp" | "command"> & {
+  timestamp?: string;
+  command?: string;
+}): void {
+  try {
+    const dir = getConfigDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const filepath = join(dir, FILENAME);
+    const line = JSON.stringify({
+      timestamp: entry.timestamp ?? new Date().toISOString(),
+      command: entry.command ?? extractCommand(),
+      resource: entry.resource,
+      outcome: entry.outcome,
+      ...(entry.idempotencyKey !== undefined ? { idempotencyKey: entry.idempotencyKey } : {}),
+    }) + "\n";
+
+    // O_NOFOLLOW refuses to follow a pre-placed symlink at the
+    // destination — an attacker who can write `~/.pax8/write-audit.log`
+    // as a symlink to (say) `~/.ssh/authorized_keys` can't use this
+    // append path to clobber the target. The 0o600 mode is applied at
+    // file creation only; subsequent appends keep whatever mode the
+    // file already has.
+    const fd = fs.openSync(
+      filepath,
+      fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      fs.writeSync(fd, line);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    // Best-effort: never let an audit-log failure interfere with the
+    // user-facing write outcome.
+  }
+}

--- a/packages/cli/src/lib/write-audit.ts
+++ b/packages/cli/src/lib/write-audit.ts
@@ -30,6 +30,15 @@ import { getConfigDir } from "@pax8/core";
  * Best-effort: any I/O failure (full disk, read-only fs, sandboxed env)
  * is swallowed. The audit log must never break a write that otherwise
  * succeeded.
+ *
+ * Platform note: the `O_NOFOLLOW` symlink protection and `0o600` mode
+ * assertion are POSIX guarantees. Windows silently ignores both flags
+ * when opening a file. On Windows the log's confidentiality and
+ * symlink-resistance fall back to whatever ACL the parent
+ * `~/.pax8/` directory has — the convention being user-only access
+ * established at `pax8 auth login` time. Production-grade Windows
+ * hardening would use `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT`
+ * and explicit ACL set; that's a separate follow-up.
  */
 
 const FILENAME = "write-audit.log";


### PR DESCRIPTION
## Summary

Closes **H-5** from the recent security review. Two coherent sub-fixes:

### 1. The keyword challenge no longer caves to `--yes`

`confirmDestructive` used to early-return `true` under `--yes` / `PAX8_YES`, silently downgrading the typed-keyword gate (its whole point) to a single boolean flag. An agent driving the CLI with `--yes` could cancel subscriptions, delete contacts, and delete quotes with no second acknowledgment.

New three-tier resolution:

| Path | When | Behavior |
|---|---|---|
| `PAX8_CONFIRM_DESTRUCTIVE=<keyword>` in env | Automation / agent | Must spell out the right keyword (`cancel` / `delete`) — the caller has demonstrated they read what the command does |
| Interactive TTY | Human at a terminal | Prompt for the keyword. Works under `--yes` too — the prompt still fires, the user still has to type |
| Non-TTY, no override | Agent without the env var | Refuse with a clear stderr message pointing at the two paths above |

`shouldAutoConfirm()` is unchanged for non-destructive `confirm()` and `confirmWithChange()` — `--yes` still works for those, which is the appropriate gate strength.

### 2. Every write attempt is appended to `~/.pax8/write-audit.log`

Telemetry is opt-in (the README privacy section commits to never sending company / subscription data). A partner running an agent-driven session with telemetry off had no after-the-fact way to ask "what did this agent actually try to do?" The `last-error.json` envelope only captures the most recent failure.

`recordWriteAudit` appends one JSON line per write attempt, mode 0600, `O_NOFOLLOW` so a pre-placed symlink can't redirect the append. Wired automatically into the existing `markWriteInFlight` lifecycle — no per-site change needed:

- `done()` callback → `outcome: "completed"`
- SIGINT handler → `outcome: "cancelled"` (logged before the existing stderr hint, so a Ctrl+C-spamming user still has the trail)

Schema:

```json
{
  "timestamp": "2026-05-19T16:42:00.000Z",
  "command": "subscriptions cancel",
  "resource": "subscriptions",
  "outcome": "completed",
  "idempotencyKey": "9f3b2c1e-..."
}
```

`command` is built from argv with positional-arg values stripped — never includes a user-supplied name or ID. The `idempotencyKey` field is omitted when absent.

## Design notes

- **Env var, not CLI flag, for `PAX8_CONFIRM_DESTRUCTIVE`.** A `--confirm-destructive <keyword>` flag would mean registering an option on every destructive command and a chunk of help-text duplication. The env-var approach keeps the surface small: shell users prefix (`PAX8_CONFIRM_DESTRUCTIVE=cancel pax8 ...`), CI sets it once per pipeline step, the stderr refusal message tells you the keyword to use.
- **Test infrastructure auto-injects the keyword** for known destructive command paths in `runCli`. Without this, every test of `subscriptions cancel` logic would have to thread `PAX8_CONFIRM_DESTRUCTIVE=cancel` through its env, which would dilute what the tests are actually verifying. The gate itself is verified end-to-end in `destructive-gate.test.ts`, which explicitly *suppresses* the auto-injection and asserts the refusal.
- **Audit log fires on `done()`, not on `markWriteInFlight` register.** That means the record reflects "the API call settled" rather than "we were about to call the API." A write that crashes before `done()` runs (process kill, unhandled promise rejection) won't show up — accepted trade-off for a best-effort log.
- **No distinction between "completed-success" and "completed-failure".** `done()` runs in a `finally` block; we don't know success / failure at that layer. The local audit log captures attempts; success / failure is downstream (CLI exit code, telemetry if opted in).

## Test plan

- [x] `confirm.test.ts` — new tests for env-override path, no-TTY refusal under `--yes` / `PAX8_YES`, TTY path under `--yes` still prompts
- [x] `write-audit.test.ts` — JSON-lines append, 0o600 mode at create, idempotencyKey omitted when absent, command strips positional values, `O_NOFOLLOW` refuses symlink redirection, I/O failures don't throw
- [x] `destructive-gate.test.ts` — end-to-end subprocess test verifies the gate fires on real `subscriptions cancel` with `PAX8_CONFIRM_DESTRUCTIVE` explicitly absent, succeeds with the right keyword, refuses with the wrong keyword
- [x] Targeted suite (175 tests across confirm, signals, write-audit, sigint, subscriptions, contacts, orders, idempotency) — green
- [ ] Manual: run `pax8 subscriptions cancel <id> --yes` without the env var on a non-TTY (e.g. piped from `echo` or in CI) and confirm the stderr message
- [ ] Manual: run a write, inspect `~/.pax8/write-audit.log`, verify mode is `-rw-------`

## Behavior change to call out at review

Agents and CI that previously relied on `pax8 subscriptions cancel --yes` (or contacts / quotes delete with `--yes`) **will start failing** until they add `PAX8_CONFIRM_DESTRUCTIVE=<keyword>`. That's the intent of H-5 — `--yes` was never meant to satisfy the typed-keyword challenge. The stderr refusal message tells the user/agent exactly which env var to set, so the failure is self-healing.

## Follow-ups (not in scope)

- Some other security findings still pending: M-1 (`--month` regex), M-2 (telemetry order-revenue bucketing + cancellation event), M-4 (gate `pnpm audit` in CI), M-5 (`PAX8_IDEMPOTENCY_DIR` validation), plus the remaining 5 workflows for the SHA-pin sweep (#507 did `release.yml` only)