### PR TITLE
fix(security): SHA-pin remaining workflows and fail CI on high audit

### DIFF
--- a/.github/workflows/api-watch.yml
+++ b/.github/workflows/api-watch.yml
@@ -13,8 +13,10 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      # SHA-pinned per security review (H-4). Dependabot bumps SHA pins
+      # that carry a trailing `# <tag>` comment — see .github/dependabot.yml.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
       - name: Query PostHog for ERROR_API_VALIDATION spikes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned per security review (H-4). Dependabot bumps SHA pins
+      # that carry a trailing `# <tag>` comment — see .github/dependabot.yml.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -47,5 +49,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == 22
         run: pnpm test:coverage
 
+      # Fail the build on high/critical CVEs (M-4 from the security review).
+      # Moderate/low findings still print informationally — `pnpm audit` shows
+      # all severities regardless of `--audit-level`; the flag only controls
+      # the exit code threshold.
       - name: Audit
-        run: pnpm audit
+        run: pnpm audit --audit-level high

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,11 +29,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned per security review (H-4). Dependabot bumps SHA pins
+      # that carry a trailing `# <tag>` comment — see .github/dependabot.yml.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "pnpm"
@@ -47,7 +49,7 @@ jobs:
       # for OSS projects — broader coverage than `security-and-quality` minus
       # the noisier code-quality rules.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           languages: javascript-typescript
           queries: security-extended
@@ -67,7 +69,7 @@ jobs:
       # `continue-on-error` once that's done so a future regression in the
       # scan surfaces as a hard failure. Tracked in #138.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         continue-on-error: true
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -16,15 +16,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned per security review (H-4). Dependabot bumps SHA pins
+      # that carry a trailing `# <tag>` comment — see .github/dependabot.yml.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: .devcontainer/Dockerfile

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,11 +24,13 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned per security review (H-4). Dependabot bumps SHA pins
+      # that carry a trailing `# <tag>` comment — see .github/dependabot.yml.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: "pnpm"


### PR DESCRIPTION
## Summary

Completes the H-4 SHA-pin sweep started in #507 and fixes M-4 (`pnpm audit` exit code swallowed). Addresses **H-4** and **M-4** from the recent security review.

### H-4: SHA-pin remaining five workflows

PR #507 pinned `release.yml` (the highest-leverage workflow, with `contents: write` + npm OIDC). This PR completes the sweep across the other five — `ci.yml`, `codeql.yml`, `integration.yml`, `demo-image.yml`, `api-watch.yml`. With tag references like `@v6` / `@v5`, a compromise of an upstream action's tag would ship a poisoned action the next time the workflow ran. Replaced each tag ref with an immutable commit SHA, plus a trailing `# <tag>` comment so Dependabot can still bump them (github-actions ecosystem is already enabled in `.github/dependabot.yml`).

| Action | Pinned SHA | Tag |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `pnpm/action-setup` | `fc06bc1257f339d1d5d8b3a19a8cae5388b55320` | v5.0.0 (held at v5 — matches #507) |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| `github/codeql-action/{init,analyze}` | `458d36d7d4f47d0dd16ca424c1d3cda0060f1360` | v3.35.5 |
| `docker/login-action` | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v4.1.0 |
| `docker/build-push-action` | `bcafcacb16a39f128d818304e6c9c0c18556b85f` | v7.1.0 |

SHAs were resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`. Two of them are annotated tags (`pnpm/action-setup` v5.0.0, `github/codeql-action` v3.35.5) — those SHAs are dereferenced via `gh api .../git/tags/<sha>` so the commit SHA, not the tag-object SHA, is what's pinned. Each SHA was sanity-checked with `gh api repos/<owner>/<repo>/commits/<sha>`.

### M-4: Fail CI on high/critical CVEs

`pnpm audit` in `ci.yml` previously ran with no audit-level threshold, so its exit code on a high/critical CVE in the dependency graph never broke the build. Switched to `pnpm audit --audit-level high` — moderate/low findings still print informationally, only high/critical fail the job.

### Out of scope

- `release.yml` — already pinned in #507
- Other workflow logic — only `uses:` refs and the one `pnpm audit` line touched
- No `package.json` / `.changeset/` changes

## Test plan

- [x] `gh api` resolved each tag to a real commit SHA on the upstream repo (annotated tags dereferenced)
- [x] Each SHA is 40 hex chars and `gh api repos/<owner>/<repo>/commits/<sha>` returns a commit
- [x] All five workflow files lint-clean with `python3 -c 'import yaml; yaml.safe_load(...)'`
- [x] No `uses: ...@v<n>` tag refs remain in any of the five files
- [x] `.github/dependabot.yml` already has the `github-actions` ecosystem enabled — SHA pins with trailing `# <tag>` comments are bump-able
- [ ] Watch the next CI run on this PR to confirm all five workflows still resolve their pinned actions and run