### PR TITLE
fix(security): validate --month and PAX8_*_DIR env vars at parse time

### DIFF
--- a/packages/cli/src/__tests__/idempotency.test.ts
+++ b/packages/cli/src/__tests__/idempotency.test.ts
@@ -159,3 +159,125 @@ describe("--idempotency-key", () => {
     expect(result.stdout).not.toContain("--idempotency-key");
   });
 });
+
+// #M-5: PAX8_IDEMPOTENCY_DIR sidestepped the home-dir guard that already
+// applies to PAX8_CONFIG_DIR. A CI/sandboxed environment that controls this
+// env var could point it anywhere — `/etc/...`, a sibling user's home, etc.
+// Route both that var and PAX8_DISPUTES_DIR through `validateConfigDir()` so
+// the same allow-list semantics apply uniformly.
+describe("PAX8_IDEMPOTENCY_DIR home-dir guard (#M-5)", () => {
+  const NON_HOME_PATH = "/tmp/pax8-m5-guard-test";
+  const KEY = "9f3b2c1e-7d4f-4a8b-9c2d-1e2f3a4b5c6d";
+  // Use a fresh in-$HOME dir per test run so we don't pollute the
+  // contributor's home and so afterAll can clean up cleanly. This sidesteps
+  // the test-isolation setup's tmpdir (which is under /var/folders and
+  // would itself trip the home-dir guard when we unset the opt-out).
+  let inHomeConfigDir: string;
+  beforeEach(async () => {
+    inHomeConfigDir = await fs.mkdtemp(path.join(os.homedir(), ".pax8-m5-cfg-"));
+  });
+  afterEach(async () => {
+    await fs.rm(inHomeConfigDir, { recursive: true, force: true });
+  });
+
+  it("rejects non-home PAX8_IDEMPOTENCY_DIR without PAX8_ALLOW_NON_HOME_CONFIG", async () => {
+    // Default test env sets PAX8_ALLOW_NON_HOME_CONFIG=1 globally
+    // (vitest.config.ts). To exercise the guard we have to *unset* it for
+    // this single subprocess. runCli's env-merge means setting it to ""
+    // doesn't unset, so we pass an explicit override; the guard treats
+    // anything not literally "1" as opt-out.
+    //
+    // We also point PAX8_CONFIG_DIR at a sub-path of $HOME so the *outer*
+    // config-dir guard (which would otherwise see the vitest-injected
+    // tmpdir under /var/folders) passes, leaving only the
+    // PAX8_IDEMPOTENCY_DIR guard to trip. Without this, the parent
+    // PAX8_CONFIG_DIR=/var/folders/... fails first and we measure the
+    // wrong thing.
+    const result = await runCliExpectFailure(
+      [
+        "orders", "create",
+        "--company", COMPANY_ID,
+        "--product", PRODUCT_ID,
+        "--quantity", "5",
+        "--yes", "--json",
+        "--idempotency-key", KEY,
+      ],
+      {
+        PAX8_CONFIG_DIR: inHomeConfigDir,
+        PAX8_IDEMPOTENCY_DIR: NON_HOME_PATH,
+        PAX8_ALLOW_NON_HOME_CONFIG: "",
+      },
+    );
+    expect(result.stderr).toMatch(/Refusing to use config directory outside of \$HOME/i);
+    const envelope = JSON.parse(extractJsonEnvelope(result.stderr));
+    expect(envelope.code).toBe("ERROR_INVALID_INPUT");
+  });
+
+  it("accepts non-home PAX8_IDEMPOTENCY_DIR when PAX8_ALLOW_NON_HOME_CONFIG=1", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-m5-allow-"));
+    try {
+      // Inherit PAX8_ALLOW_NON_HOME_CONFIG=1 from the vitest env. The
+      // command should succeed exactly as in the existing idempotency tests.
+      const result = await runCliExpectSuccess(
+        [
+          "orders", "create",
+          "--company", COMPANY_ID,
+          "--product", PRODUCT_ID,
+          "--quantity", "5",
+          "--yes", "--json",
+          "--idempotency-key", KEY,
+        ],
+        { PAX8_IDEMPOTENCY_DIR: tmpDir },
+      );
+      const json = JSON.parse(result.stdout);
+      expect(json).toHaveProperty("id");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("PAX8_DISPUTES_DIR home-dir guard (#M-5)", () => {
+  const NON_HOME_PATH = "/tmp/pax8-m5-disputes-test";
+  let inHomeConfigDir: string;
+  beforeEach(async () => {
+    inHomeConfigDir = await fs.mkdtemp(path.join(os.homedir(), ".pax8-m5-disp-cfg-"));
+  });
+  afterEach(async () => {
+    await fs.rm(inHomeConfigDir, { recursive: true, force: true });
+  });
+
+  it("rejects non-home PAX8_DISPUTES_DIR without PAX8_ALLOW_NON_HOME_CONFIG", async () => {
+    // Same setup as the idempotency-dir test above: pin PAX8_CONFIG_DIR
+    // inside $HOME so the outer guard passes, then assert that
+    // PAX8_DISPUTES_DIR (pointing outside $HOME) trips the same guard.
+    const result = await runCliExpectFailure(
+      [
+        "invoices", "dispute",
+        "--company", "Summit Healthcare",
+        "--product", "Microsoft 365",
+        "--yes",
+        "--json",
+      ],
+      {
+        PAX8_CONFIG_DIR: inHomeConfigDir,
+        PAX8_DISPUTES_DIR: NON_HOME_PATH,
+        PAX8_ALLOW_NON_HOME_CONFIG: "",
+      },
+    );
+    expect(result.stderr).toMatch(/Refusing to use config directory outside of \$HOME/i);
+    const envelope = JSON.parse(extractJsonEnvelope(result.stderr));
+    expect(envelope.code).toBe("ERROR_INVALID_INPUT");
+  });
+});
+
+/**
+ * Pull the JSON error envelope out of stderr. Demo mode prints a banner and
+ * spinner-fail glyph before the envelope when `--json` is set, so we can't
+ * `JSON.parse(stderr)` directly.
+ */
+function extractJsonEnvelope(stderr: string): string {
+  const start = stderr.indexOf("{");
+  if (start < 0) throw new Error("no JSON envelope in stderr: " + stderr);
+  return stderr.slice(start);
+}

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { runCliExpectSuccess } from "./test-utils.js";
+import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 
 describe("pax8 invoices", () => {
   describe("invoices list", () => {
@@ -214,6 +214,70 @@ describe("pax8 invoices", () => {
       expect(disc).toHaveProperty("dollarImpact");
       expect(disc).toHaveProperty("type");
     });
+
+    // #M-1: `--month` is interpolated into `nextActions[].command` strings on
+    // stdout. Agents (the Claude skill, scripts) extract that field and exec
+    // it, so a value like "2026-01; rm -rf ~" would turn the read into shell
+    // injection. The validator rejects at the parse boundary with
+    // ERROR_INVALID_INPUT before any side effects.
+    it("rejects --month with shell metacharacters (#M-1)", async () => {
+      const result = await runCliExpectFailure([
+        "invoices",
+        "audit",
+        "--month",
+        "2026-01; rm -rf",
+        "--json",
+      ]);
+      expect(result.stderr).toMatch(/Invalid value for --month/i);
+      // JSON error envelope carries the structured code. stderr also has a
+      // demo banner and spinner-fail glyph before the envelope; grab the
+      // first `{`-bracketed payload to parse.
+      const envelope = JSON.parse(extractJsonEnvelope(result.stderr));
+      expect(envelope.code).toBe("ERROR_INVALID_INPUT");
+    });
+
+    it("rejects --month with garbage shape (#M-1)", async () => {
+      const result = await runCliExpectFailure([
+        "invoices",
+        "audit",
+        "--month",
+        "not-a-month",
+        "--json",
+      ]);
+      expect(result.stderr).toMatch(/Invalid value for --month/i);
+    });
+
+    it("rejects --month with out-of-range month (#M-1)", async () => {
+      const result = await runCliExpectFailure([
+        "invoices",
+        "audit",
+        "--month",
+        "2026-13",
+        "--json",
+      ]);
+      expect(result.stderr).toMatch(/Invalid value for --month/i);
+    });
+  });
+
+  // #M-1: same validator runs on `pax8 invoices dispute --month` — that
+  // command also emits a `nextActions[].command` string that interpolates
+  // the user-supplied value (line ~417 in dispute.ts).
+  describe("invoices dispute --month validation (#M-1)", () => {
+    it("rejects --month with shell metacharacters", async () => {
+      const result = await runCliExpectFailure([
+        "invoices",
+        "dispute",
+        "--discrepancy",
+        "disc-deadbeef0000",
+        "--month",
+        "2026-01; echo pwned",
+        "--json",
+        "-y",
+      ]);
+      expect(result.stderr).toMatch(/Invalid value for --month/i);
+      const envelope = JSON.parse(extractJsonEnvelope(result.stderr));
+      expect(envelope.code).toBe("ERROR_INVALID_INPUT");
+    });
   });
 
   describe("invoices --help", () => {
@@ -280,3 +344,15 @@ describe("pax8 invoices", () => {
     });
   });
 });
+
+/**
+ * Pull the JSON error envelope out of stderr. Demo mode prints a banner and
+ * spinner-fail glyph before the envelope when `--json` is set, so we can't
+ * `JSON.parse(stderr)` directly. The envelope is the JSON object that
+ * starts at the first `{` in stderr.
+ */
+function extractJsonEnvelope(stderr: string): string {
+  const start = stderr.indexOf("{");
+  if (start < 0) throw new Error("no JSON envelope in stderr: " + stderr);
+  return stderr.slice(start);
+}

--- a/packages/cli/src/__tests__/local-state-writers.test.ts
+++ b/packages/cli/src/__tests__/local-state-writers.test.ts
@@ -42,6 +42,11 @@ const HOMEDIR_EXCEPTIONS = new Set<string>([
   // This file — the regression test itself doesn't call homedir(), but
   // it references the string in comments, so the grep would false-flag.
   "packages/cli/src/__tests__/local-state-writers.test.ts",
+  // M-5 home-dir-guard tests: need to create a tmpdir *inside* $HOME so
+  // the subprocess validates PAX8_CONFIG_DIR=under-home and only the
+  // per-feature *_DIR env trips the guard. mkdtemp+rm cleanup means no
+  // leftover state.
+  "packages/cli/src/__tests__/idempotency.test.ts",
 ]);
 
 /**

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -13,6 +13,7 @@ import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { discrepancyId } from "./dispute.js";
 import { replCmd } from "../../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
+import { validateMonth } from "../../lib/validate.js";
 
 export const invoicesAuditCommand = new Command("audit")
   .description("Audit invoices against active subscriptions")
@@ -59,6 +60,12 @@ JSON output (--json):
     const spinner = createSpinner("Fetching invoices...");
 
     try {
+      // #M-1: `options.month` is interpolated into `nextActions[].command`
+      // strings on stdout that agents may extract and exec. Validate the
+      // shape at the parse boundary so shell metacharacters can't ride a
+      // `--month "2026-01; …"` value out through that channel.
+      validateMonth(options.month);
+
       spinner.start();
 
       const companyId = options.company

--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -13,6 +13,7 @@ import {
   ERROR_INTERNAL,
   getConfigDir,
   safeWriteFileSync,
+  validateConfigDir,
   type Pax8ErrorCode,
 } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
@@ -23,6 +24,7 @@ import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { confirm, replCmd } from "../../lib/confirm.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 import { hashArgs, isValidKey, withIdempotency } from "../../lib/idempotency.js";
+import { validateMonth } from "../../lib/validate.js";
 
 /**
  * NOTE: The Pax8 v1 API does not expose a public dispute / write-off / credit
@@ -45,7 +47,17 @@ function disputesDir(): string {
   // #458: route through getConfigDir() so PAX8_CONFIG_DIR is honored.
   // PAX8_DISPUTES_DIR retains precedence as the explicit per-feature
   // escape hatch used in tests.
-  return process.env[DISPUTES_DIR_ENV] ?? path.join(getConfigDir(), "disputes");
+  //
+  // #M-5: PAX8_DISPUTES_DIR also goes through validateConfigDir() so a
+  // sandboxed/CI environment that controls this var can't redirect dispute
+  // drafts to an arbitrary location. The same PAX8_ALLOW_NON_HOME_CONFIG=1
+  // escape hatch applies — vitest.config.ts already sets it for the test
+  // workers, so existing tests continue to use tmpdir-based isolation.
+  const override = process.env[DISPUTES_DIR_ENV];
+  if (override && override.length > 0) {
+    return validateConfigDir(override);
+  }
+  return path.join(getConfigDir(), "disputes");
 }
 
 /**
@@ -271,6 +283,24 @@ return the cached draft (host-local; see #474 for v0.2 wire-level plan).`,
   )
   .action(async (_options, command: Command) => {
     const allOpts = command.optsWithGlobals();
+
+    // #M-1: `allOpts.month` is interpolated into `nextActions[].command`
+    // strings on stdout that agents may extract and exec. Validate shape
+    // (YYYY-MM only) at the parse boundary before any side effects so a
+    // value like `2026-01; rm -rf ~` can't slip through that channel.
+    //
+    // #M-5: eagerly probe disputesDir() so PAX8_DISPUTES_DIR is run
+    // through validateConfigDir() at parse time. The actual write
+    // (writeDraft) is deep in the action flow behind a confirm prompt and
+    // an audit network call; surfacing the security error at the top
+    // means the user / agent sees it immediately rather than after a
+    // multi-second roundtrip.
+    try {
+      validateMonth(allOpts.month);
+      disputesDir();
+    } catch (error) {
+      await handleCommandError(error, createSpinner(""));
+    }
 
     // ── Idempotency handling ────────────────────────────────────────────────
     const idempotencyKey: string | undefined = allOpts.idempotencyKey;

--- a/packages/cli/src/lib/idempotency.ts
+++ b/packages/cli/src/lib/idempotency.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { createHash } from "node:crypto";
-import { getConfigDir, safeWriteFileSync } from "@pax8/core";
+import { getConfigDir, safeWriteFileSync, validateConfigDir } from "@pax8/core";
 import { CliError } from "./errors.js";
 import { debugLog } from "./debug.js";
 
@@ -39,8 +39,18 @@ function dirPath(): string {
   // #458: route through getConfigDir() so PAX8_CONFIG_DIR is honored.
   // PAX8_IDEMPOTENCY_DIR retains precedence as the explicit per-feature
   // escape hatch used in tests.
-  return process.env.PAX8_IDEMPOTENCY_DIR
-    ?? path.join(getConfigDir(), "idempotency");
+  //
+  // #M-5: PAX8_IDEMPOTENCY_DIR also goes through validateConfigDir() so a
+  // sandboxed/CI environment that controls this var can't redirect the
+  // cache to an arbitrary location (e.g. `/etc/...`). The same
+  // PAX8_ALLOW_NON_HOME_CONFIG=1 escape hatch applies — vitest.config.ts
+  // already sets it for the test workers, so existing tests continue to
+  // use tmpdir-based isolation unchanged.
+  const override = process.env.PAX8_IDEMPOTENCY_DIR;
+  if (override && override.length > 0) {
+    return validateConfigDir(override);
+  }
+  return path.join(getConfigDir(), "idempotency");
 }
 
 function entryFilePath(command: string, key: string): string {
@@ -210,6 +220,16 @@ export async function withIdempotency<T>(
   if (idempotencyKey === undefined) {
     return action();
   }
+
+  // #M-5: eagerly validate the cache dir env-var so a hostile
+  // PAX8_IDEMPOTENCY_DIR (e.g. /etc/...) is rejected by the home-dir
+  // guard with a propagating CliError. The downstream loadEntry/saveEntry
+  // calls are deliberately fail-open for transient cache problems
+  // (read-only fs, full disk) — which would otherwise swallow the
+  // security error and silently fall back to running the action. By
+  // probing dirPath() here, validateConfigDir() runs in a context that
+  // can throw cleanly through to handleCommandError.
+  dirPath();
 
   // Cache hit branch. `loadEntry` itself is wrapped so that a transient
   // read failure leaves us in fail-open mode (we run the action). The

--- a/packages/cli/src/lib/validate.ts
+++ b/packages/cli/src/lib/validate.ts
@@ -57,6 +57,58 @@ export function validateEnum<T extends string>(
 }
 
 /**
+ * Validate a `--month <YYYY-MM>` flag value.
+ *
+ * The string is interpolated verbatim into machine-readable
+ * `nextActions[].command` strings emitted on stdout — which agents
+ * (Claude Code's skill, scripts) are explicitly invited to extract and
+ * execute. An unvalidated `--month "2026-01; rm -rf ~"` would round-trip
+ * through that channel and turn a read command into a shell injection
+ * vector. Validating at the parse boundary keeps the danger contained:
+ * if the input isn't shaped like `YYYY-MM`, the command never runs.
+ *
+ * Contract:
+ *   - `undefined` passes through (the user didn't supply the flag).
+ *   - A string matching `/^\d{4}-\d{2}$/` with a month in 01–12 returns
+ *     the value unchanged.
+ *   - Anything else throws `CliError(ERROR_INVALID_INPUT)`.
+ *
+ * The year range is intentionally permissive (any 4-digit year) — we
+ * don't want to reject the partner's legitimate 2019 invoice query
+ * three years from now. The injection-risk-relevant check is the
+ * shape: only digits and a single hyphen, no shell metacharacters.
+ */
+export function validateMonth(
+  value: string | undefined,
+  flagName = "--month",
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (!/^\d{4}-\d{2}$/.test(value)) {
+    throw new CliError(
+      `Invalid value for ${flagName}: "${value}"`,
+      [`${flagName} must be in YYYY-MM format (e.g. 2026-03).`],
+      [
+        `Example: ${flagName} 2026-03`,
+        "Use four-digit year, hyphen, two-digit month — no other characters.",
+      ],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  const month = parseInt(value.slice(5, 7), 10);
+  if (month < 1 || month > 12) {
+    throw new CliError(
+      `Invalid value for ${flagName}: "${value}"`,
+      [`Month component must be 01–12; got "${value.slice(5, 7)}".`],
+      [`Example: ${flagName} 2026-03`],
+      undefined,
+      ERROR_INVALID_INPUT,
+    );
+  }
+  return value;
+}
+
+/**
  * Comma-separated list variant of `validateEnum`. Returns the parsed
  * canonical values (deduplicated, original order). Empty / all-whitespace
  * input throws `ERROR_INVALID_INPUT` so the caller doesn't have to


### PR DESCRIPTION
Two narrow input-validation gaps from a recent security review (M-1, M-5).

## M-1: `--month` shell-injection via `nextActions[].command`

`pax8 invoices audit` and `pax8 invoices dispute` both accept `--month <YYYY-MM>` and interpolate the raw value into a `pax8 invoices ...` string emitted in JSON output as `nextActions[0].command`. `CLAUDE.md` and `skill.md` document the "extract `nextActions[].command` and run it" pattern, so agents (the Claude skill, scripts) may shell out to that string. Today `--month "2026-01; rm -rf ~"` is accepted and emitted verbatim — a read command turns into a shell-injection vector at the agent → shell boundary.

**Fix:** new `validateMonth()` helper in `packages/cli/src/lib/validate.ts` (sibling to `validateEnum`) rejects anything not matching `/^\d{4}-\d{2}$/` at parse time with `CliError(ERROR_INVALID_INPUT)`. Wired into `audit.ts` and `dispute.ts` before any side effects. Year is permissive (any 4-digit year — partners legitimately query 2019 invoices) but the shape gate (digits + single hyphen, no shell metacharacters) is what closes the vector.

## M-5: env-var dir overrides bypassed the home-dir guard

`PAX8_CONFIG_DIR` goes through `validateConfigDir()` (#262 / #475) which refuses non-home paths unless `PAX8_ALLOW_NON_HOME_CONFIG=1`. Two per-feature escape hatches sidestepped this: `PAX8_IDEMPOTENCY_DIR` and `PAX8_DISPUTES_DIR`. A CI / sandboxed environment that controls these could redirect cache / draft writes anywhere — `/etc/...`, a sibling user's home, etc.

**Fix:** route both env vars through `validateConfigDir()` with identical allow-list semantics. Eager probes in `withIdempotency()` and the dispute action surface the error at the parse boundary rather than letting it get swallowed by the fail-open cache wrappers downstream. The existing `PAX8_ALLOW_NON_HOME_CONFIG=1` opt-out and `vitest.config.ts` test-env setup mean all current tests work unchanged.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] Targeted sweep: `invoices.test.ts` (19 tests, +5 new), `idempotency.test.ts` (10 tests, +3 new), `loader-extended.test.ts` (existing), `local-state-writers.test.ts` (regression — exception added for new `os.homedir()` use in idempotency test)
- [x] Manual repro confirmed:
  - `--month "2026-01; rm -rf"` now exits 1 with `ERROR_INVALID_INPUT`
  - `PAX8_IDEMPOTENCY_DIR=/tmp/x` (without opt-out) now exits 1 with the same code
  - `PAX8_DISPUTES_DIR=/tmp/x` (without opt-out) now exits 1 with the same code
- [x] No leftover state in contributor `$HOME` after test run (mkdtemp + rm cleanup)