### PR TITLE
fix(security): five low-severity hardening fixes — redactor, response cap, policy gate, lint plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,20 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
+import security from "eslint-plugin-security";
 
+// L-9 — `eslint-plugin-security` augments CodeQL's `security-extended` suite
+// (which runs at PR time in CI) with lint-time pattern checks that catch
+// classes of issue ESLint can flag without dataflow analysis: `eval`,
+// `child_process.exec` with non-literal args, regex DoS / unsafe regex,
+// non-literal `fs.*` filenames, etc. Many of its rules are necessarily
+// heuristic and produce false positives on legitimate code (e.g. dynamic
+// fs reads where the path comes from a validated CLI flag). Local
+// `// eslint-disable-next-line security/<rule>` comments with a one-line
+// justification are the documented escape hatch.
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  security.configs.recommended,
   {
     files: ["packages/*/src/**/*.ts"],
     rules: {
@@ -19,6 +30,29 @@ export default tseslint.config(
       ],
       "no-console": ["error", { allow: ["error", "warn"] }],
       "no-undef": "off",
+      // L-9 — disable noisy security rules that don't carry their weight
+      // for a CLI codebase. Each disable is annotated below; if a real
+      // issue is suspected in one of these categories, run the rule
+      // ad-hoc rather than re-enable it globally.
+      //
+      // `detect-object-injection`: triggers on any computed property
+      // access (`obj[key]`) regardless of whether `key` is attacker-
+      // controlled. Pure noise in a TypeScript codebase that types its
+      // object shapes. The CodeQL suite covers the real prototype-
+      // pollution / injection patterns.
+      "security/detect-object-injection": "off",
+      // `detect-non-literal-fs-filename`: every fs.* call in the CLI
+      // operates on paths derived from user CLI args or the validated
+      // config dir. The validated-input invariant is enforced by the
+      // separate `local-state-writers.test.ts` policy gate and the
+      // `validate-env.ts` home-rooted-path check. Re-flagging every
+      // fs.* call here would drown the signal.
+      "security/detect-non-literal-fs-filename": "off",
+      // `detect-non-literal-regexp`: the redactor and the cmdline
+      // tokenizer build regexes from validated, escaped input (see
+      // `escapeRegex` in `redactor.ts`). The rule has no way to see
+      // that, and would force a disable on every dynamic-regex site.
+      "security/detect-non-literal-regexp": "off",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@typescript-eslint/parser": "^8.59.2",
     "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^10.3.0",
+    "eslint-plugin-security": "^4.0.0",
     "prettier": "^3.8.1",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.59.2",

--- a/packages/cli/src/__tests__/local-state-writers.test.ts
+++ b/packages/cli/src/__tests__/local-state-writers.test.ts
@@ -45,6 +45,49 @@ const HOMEDIR_EXCEPTIONS = new Set<string>([
 ]);
 
 /**
+ * Files under `packages/core/src/` that are allowed to call `os.homedir()`
+ * directly. Core owns the canonical `~/.pax8` directory resolution (loader
+ * and credential store), so it legitimately reads the home dir; the CLI is
+ * the layer that must never bypass core. Keep this list short and comment
+ * each entry. L-8 / #504 — adding core coverage to catch homedir leaks in
+ * a future core service.
+ */
+const CORE_HOMEDIR_EXCEPTIONS = new Set<string>([
+  // loader.ts: resolves the default `~/.pax8` config dir. This is the
+  // canonical site — every other module routes through this loader.
+  "packages/core/src/config/loader.ts",
+  // credential-store.ts: writes ~/.pax8/credentials.json with O_NOFOLLOW
+  // and mode 0o600. The home-dir reference is intrinsic to its job.
+  "packages/core/src/auth/credential-store.ts",
+  // validate-env.ts: implements the home-anchored path validator that
+  // refuses to read credentials from outside $HOME. It MUST resolve the
+  // real home dir to perform the comparison.
+  "packages/core/src/security/validate-env.ts",
+  // Test fixtures legitimately reference homedir() for assertions.
+  "packages/core/src/auth/credential-store.test.ts",
+  "packages/core/src/config/loader-extended.test.ts",
+]);
+
+/**
+ * Files under `packages/core/src/` that are allowed to use raw
+ * `writeFileSync` / `fs.writeFile`. Core owns the lower-level write paths
+ * (config YAML, on-disk cache) and uses explicit `mode: 0o600`. The CLI is
+ * the layer that must funnel through `safeWriteFileSync`.
+ */
+const CORE_ALLOWED_RAW_WRITERS = new Set<string>([
+  // loader.ts: writes the user-edited config.yaml with mode 0o600. Async
+  // fs.writeFile is the canonical surface; not state-file-shaped.
+  "packages/core/src/config/loader.ts",
+  // cache.ts: writes a tmp file with mode 0o600 then renames atomically.
+  // The rename step doesn't need O_NOFOLLOW (rename doesn't follow links).
+  "packages/core/src/services/cache.ts",
+  // Tests legitimately write fixtures into tmpdirs.
+  "packages/core/src/config/loader-extended.test.ts",
+  "packages/core/src/config/loader.test.ts",
+  "packages/core/src/telemetry/telemetry.test.ts",
+]);
+
+/**
  * Files under `packages/cli/src/` that are allowed to use raw
  * `writeFileSync` / `fs.writeFile`. Document each entry.
  */
@@ -140,6 +183,41 @@ describe("local-state writer policy (#458 / #469)", () => {
     expect(
       violators,
       "CLI files writing local state without safeWriteFileSync (add to ALLOWED_RAW_WRITERS if intentional)",
+    ).toEqual([]);
+  });
+
+  // L-8 / #504 — extend the same shape to packages/core/src so a future
+  // core service introducing a homedir-resolving or raw-writeFile leak is
+  // caught at PR time. Core legitimately owns the canonical ~/.pax8 paths,
+  // so the exception lists are explicit (see CORE_HOMEDIR_EXCEPTIONS /
+  // CORE_ALLOWED_RAW_WRITERS at the top of this file).
+  it("core code does not call os.homedir() outside the documented exception list", () => {
+    const violators = listMatchingFiles(
+      "homedir\\(\\)|from .node:os.|from .os.|require\\(.os.\\)|require\\(.node:os.\\)",
+      ["packages/core/src"],
+    )
+      .filter((f) => {
+        const text = readFileSync(join(REPO_ROOT, f), "utf-8");
+        return /\bhomedir\s*\(/.test(text);
+      })
+      .filter((f) => !CORE_HOMEDIR_EXCEPTIONS.has(f));
+
+    expect(
+      violators,
+      "core files calling os.homedir() outside the exception list (add to CORE_HOMEDIR_EXCEPTIONS with a comment if intentional)",
+    ).toEqual([]);
+  });
+
+  it("core state-file writers route through documented sites", () => {
+    const violators = listMatchingFiles(
+      "writeFileSync\\(|fs\\.writeFile\\(",
+      ["packages/core/src"],
+    )
+      .filter((f) => !CORE_ALLOWED_RAW_WRITERS.has(f));
+
+    expect(
+      violators,
+      "core files writing without going through a documented write site (add to CORE_ALLOWED_RAW_WRITERS if intentional)",
     ).toEqual([]);
   });
 });

--- a/packages/cli/src/lib/redactor.test.ts
+++ b/packages/cli/src/lib/redactor.test.ts
@@ -128,6 +128,23 @@ describe("redactString", () => {
       expect(s.length).toBe(31);
       expect(redactString(`x=${s} y`)).toBe(`x=${s} y`);
     });
+
+    it("L-4: redacts a pure-lowercase ≥32-char opaque token", () => {
+      // Prior regex required uppercase + lowercase + digit, so a 40-char
+      // pure-lowercase nanoid-style / slugged API key slipped through.
+      // Defense-in-depth bug-report redactor should scrub these.
+      const tok = "abcdefghijklmnopqrstuvwxyzabcdefghijklmn"; // 40 chars, all lowercase
+      expect(tok.length).toBe(40);
+      const out = redactString(`secret=${tok} done`);
+      expect(out).toBe("secret=<REDACTED:TOKEN> done");
+    });
+
+    it("L-4: redacts a pure-lowercase 32-char token at the floor", () => {
+      // Exactly at the 32-char floor.
+      const tok = "abcdefghijklmnopqrstuvwxyzabcdef"; // 32 chars, all lowercase
+      expect(tok.length).toBe(32);
+      expect(redactString(`key=${tok}!`)).toBe("key=<REDACTED:TOKEN>!");
+    });
   });
 
   describe("idempotency", () => {
@@ -467,5 +484,69 @@ describe("redactEnvelope with upstream-resolved names (#473)", () => {
     const out = redactEnvelope(env, ["Acme Corp"]);
     expect(out.message).not.toContain("Acme Corp");
     expect(out.causes?.[0]).not.toContain("Acme Corp");
+  });
+});
+
+// L-5: defense-in-depth deep walk. The envelope's named-field pass only
+// scrubs declared keys. Any future code path that attaches a nested object
+// (e.g. `details = { partnerEmail: "..." }`) must still be redacted by the
+// generic deep walker.
+describe("redactEnvelope deep walk (L-5)", () => {
+  it("redacts strings inside an unknown nested object attached to the envelope", () => {
+    // Simulate a future code path putting structured detail under an
+    // unknown key. The redactor should NOT trust the closed BugReportEnvelope
+    // type — it should walk the actual object shape.
+    const env = {
+      message: "Something failed",
+      details: {
+        partnerEmail: "partner@example.com",
+        cachedPath: "/Users/jdoe/.pax8/cache/x.json",
+        clientId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      },
+    } as unknown as BugReportEnvelope;
+    const out = redactEnvelope(env) as unknown as {
+      details: { partnerEmail: string; cachedPath: string; clientId: string };
+    };
+    expect(out.details.partnerEmail).toBe("<REDACTED:EMAIL>");
+    expect(out.details.cachedPath).toContain("<REDACTED:PATH>");
+    expect(out.details.cachedPath).not.toContain("jdoe");
+    expect(out.details.clientId).toBe("<REDACTED:UUID>");
+  });
+
+  it("redacts strings inside a nested array attached to the envelope", () => {
+    const env = {
+      message: "Multi-failure",
+      failures: [
+        { who: "user@example.com" },
+        { who: "/Users/alice/.pax8/cred.json" },
+      ],
+    } as unknown as BugReportEnvelope;
+    const out = redactEnvelope(env) as unknown as {
+      failures: { who: string }[];
+    };
+    expect(out.failures[0].who).toBe("<REDACTED:EMAIL>");
+    expect(out.failures[1].who).toContain("<REDACTED:PATH>");
+    expect(out.failures[1].who).not.toContain("alice");
+  });
+
+  it("non-string primitives in nested objects pass through unchanged", () => {
+    const env = {
+      message: "ok",
+      meta: { count: 42, ok: true, missing: null },
+    } as unknown as BugReportEnvelope;
+    const out = redactEnvelope(env) as unknown as {
+      meta: { count: number; ok: boolean; missing: null };
+    };
+    expect(out.meta.count).toBe(42);
+    expect(out.meta.ok).toBe(true);
+    expect(out.meta.missing).toBeNull();
+  });
+
+  it("caps recursion at 8 levels (no stack blow-up on pathological input)", () => {
+    // Build a 12-deep nested object — the walker must not throw.
+    let inner: Record<string, unknown> = { tail: "user@example.com" };
+    for (let i = 0; i < 12; i++) inner = { nested: inner };
+    const env = { message: "deep", weird: inner } as unknown as BugReportEnvelope;
+    expect(() => redactEnvelope(env)).not.toThrow();
   });
 });

--- a/packages/cli/src/lib/redactor.ts
+++ b/packages/cli/src/lib/redactor.ts
@@ -48,10 +48,18 @@ const TOKEN_CHARS = "A-Za-z0-9_\\-+/";
 
 // macOS / Linux home paths. The capture preserves the suffix so the tail
 // (e.g. `/.pax8/config.yaml`) remains useful for debugging.
+//
+// The eslint-plugin-security rule flags this as a potentially-unsafe regex
+// because of the nested optional group, but each character class excludes
+// the path separator (`/`) and whitespace, so backtracking is bounded by
+// the input length — no quadratic catastrophic-backtracking shape.
+// eslint-disable-next-line security/detect-unsafe-regex
 const POSIX_HOME_RE = /\/(?:Users|home)\/[^/\s"'`]+(\/[^\s"'`]*)?/g;
 
 // Windows home paths. Both backslash and forward-slash forms appear in
-// stringified paths; handle both.
+// stringified paths; handle both. Same bounded-backtracking shape as
+// POSIX_HOME_RE above; the inner character classes exclude the separators.
+// eslint-disable-next-line security/detect-unsafe-regex
 const WIN_HOME_RE = /[Cc]:[\\/]Users[\\/][^\\/\s"'`]+([\\/][^\s"'`]*)?/g;
 
 // Tilde-style home references — only when followed by a path separator so we
@@ -64,16 +72,24 @@ const TILDE_HOME_RE = /~(\/[^\s"'`]*)/g;
 const HEX_TOKEN_RE = /\b[0-9a-fA-F]{32,}\b/g;
 
 // Long base64-ish opaque strings that look like API tokens / client_secrets.
-// Pax8 client secrets are roughly 40–60 chars of base64; we use a 32+ floor
-// with required mixed character classes to avoid eating English words.
-// Excluded: pure-alpha words, pure-digit numbers, hex (covered above).
+// Pax8 client secrets are roughly 40–60 chars of base64; we use a 32+ floor.
+// L-4 fix: the prior version required mixed-case AND a digit, which let
+// pure-lowercase ≥32-char tokens (e.g. nanoid-style API keys, slugged
+// secrets) slip through entirely. The relaxation here drops the
+// character-class lookaheads: any ≥32-char run of token-character bytes
+// bounded by non-token-chars is redacted. The word-boundary anchors (the
+// `(?<![TOKEN_CHARS])` lookbehind and the embedded `(?![TOKEN_CHARS])`
+// lookahead) prevent matching inside a longer alphanumeric run, and the
+// 32-char floor keeps English prose safe — the longest commonly-written
+// English word is "antidisestablishmentarianism" at 28 chars, under the
+// floor. The handful of >32 char technical compound words that exist
+// (e.g. medical terminology) showing up in a bug report is acceptable
+// over-redaction for a privacy-first error pipeline; the `<REDACTED:TOKEN>`
+// marker tells a human reviewer something was scrubbed.
 const OPAQUE_TOKEN_RE = new RegExp(
   `(?<![${TOKEN_CHARS}])` +
-    `(?=[${TOKEN_CHARS}]{32,}(?![${TOKEN_CHARS}]))` +
-    `(?=[${TOKEN_CHARS}]*[A-Z])` +
-    `(?=[${TOKEN_CHARS}]*[a-z])` +
-    `(?=[${TOKEN_CHARS}]*[0-9])` +
-    `[${TOKEN_CHARS}]{32,}`,
+    `[${TOKEN_CHARS}]{32,}` +
+    `(?![${TOKEN_CHARS}])`,
   "g",
 );
 
@@ -222,6 +238,40 @@ function extractQuotedTokens(input: string | undefined): string[] {
  * `CliError.causes[]` entry via the canonical `… "${name}"` pattern) that
  * are not in argv. See #473.
  */
+/**
+ * L-5 helper: recursively walk a value (object / array / primitive) and apply
+ * `redactString(_, allTokens)` to every string encountered. Depth-capped so a
+ * pathological structure can't blow the stack or pin a CPU. Non-string
+ * primitives (numbers, booleans, null) pass through unchanged.
+ *
+ * The envelope-level redactor names a closed set of fields (`message`,
+ * `causes[]`, `recoverySteps[]`, `docsUrl`, `command`, `flags[]`) and scrubs
+ * each individually. If a future code path attaches a nested object to the
+ * envelope (e.g. `details = { partnerEmail: "..." }`), those nested strings
+ * would otherwise sail through the named-field pass untouched. This deep
+ * walker is the defense-in-depth backstop: after the named-field pass runs,
+ * we re-walk the full envelope and scrub any string we find. Idempotent —
+ * already-redacted markers like `<REDACTED:UUID>` re-run through the rules
+ * with no further change.
+ */
+const DEEP_WALK_MAX_DEPTH = 8;
+
+function redactDeep(value: unknown, allTokens: string[], depth = 0): unknown {
+  if (depth > DEEP_WALK_MAX_DEPTH) return value;
+  if (typeof value === "string") return redactString(value, allTokens);
+  if (Array.isArray(value)) {
+    return value.map((v) => redactDeep(v, allTokens, depth + 1));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = redactDeep(v, allTokens, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
 export function redactEnvelope(
   env: BugReportEnvelope,
   argTokens: string[] = [],
@@ -261,5 +311,14 @@ export function redactEnvelope(
   if (env.node_version !== undefined) out.node_version = env.node_version;
   if (env.os !== undefined) out.os = env.os;
   if (env.timestamp !== undefined) out.timestamp = env.timestamp;
-  return out;
+
+  // L-5: defense-in-depth deep walk. The named-field pass above only knows
+  // about the declared BugReportEnvelope keys. If a future code path
+  // attaches an ad-hoc nested object (e.g. `env.details = { partnerEmail:
+  // "..." }`), the new strings would otherwise reach the bug-report payload
+  // unredacted. The walker re-scans the full envelope and scrubs every
+  // string it encounters. Idempotent — re-running redactString on already-
+  // redacted text produces the same text. Depth-capped at 8.
+  const deepRedacted = redactDeep(out, allTokens) as BugReportEnvelope;
+  return deepRedacted;
 }

--- a/packages/core/src/api/client.test.ts
+++ b/packages/core/src/api/client.test.ts
@@ -1390,3 +1390,70 @@ describe("Pax8Client write-retry gating (#463)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
+
+// L-7 — cap upstream response body size before `response.json()` buffers
+// the entire payload. A 50 MB Content-Length advertisement must trip the
+// guard before parsing; a normal-sized response must pass through.
+describe("Pax8Client response size cap (L-7)", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockTokenManager.getToken.mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("throws ApiError before parsing when Content-Length exceeds the 10 MB cap", async () => {
+    // Track whether the body was ever read. The guard must fire BEFORE
+    // `.json()` is invoked — that's the whole point of the check.
+    const jsonSpy = vi.fn(() => Promise.resolve({ huge: "payload" }));
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "content-length": "50000000" }),
+      json: jsonSpy,
+      text: () => Promise.resolve(""),
+    });
+    const client = createClient();
+
+    await expect(client.get("/companies")).rejects.toThrow(ApiError);
+    await expect(client.get("/companies")).rejects.toThrow(/Response body too large/);
+    // The guard short-circuits before `.json()`.
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes through when Content-Length is under the cap", async () => {
+    const responseData = { ok: true };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "content-length": "42" }),
+      json: () => Promise.resolve(responseData),
+      text: () => Promise.resolve(""),
+    });
+    const client = createClient();
+    const result = await client.get("/companies");
+    expect(result).toEqual(responseData);
+  });
+
+  it("passes through when Content-Length is absent (chunked responses fall back to timeout bound)", async () => {
+    const responseData = { ok: true };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      json: () => Promise.resolve(responseData),
+      text: () => Promise.resolve(""),
+    });
+    const client = createClient();
+    const result = await client.get("/companies");
+    expect(result).toEqual(responseData);
+  });
+});

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -86,6 +86,18 @@ const MAX_TIMEOUT_MS = 300_000;
 const MAX_RETRIES = 3;
 
 /**
+ * L-7 defense-in-depth: cap upstream response body size before `response.json()`
+ * buffers the entire payload. 10 MB is well above any legitimate Pax8 response
+ * (the heaviest known endpoint, paginated orders at `size=200`, returns roughly
+ * 100 KB per page). A misbehaving or compromised upstream returning a multi-GB
+ * body would otherwise exhaust Node's heap. We check `Content-Length` before
+ * `.json()` — for chunked responses (no `Content-Length`) the existing
+ * AbortController timeout (`PAX8_TIMEOUT_MS`, default 30s) bounds the worst
+ * case: a slow-loris-style stream can't outlast the timeout.
+ */
+const MAX_RESPONSE_BYTES = 10_000_000;
+
+/**
  * Substitute the trailing version segment of a base URL.
  *
  * The Pax8 partner API splits its surface across version prefixes — most
@@ -107,6 +119,9 @@ const MAX_RETRIES = 3;
  */
 export function applyApiVersion(baseUrl: string, apiVersion?: string): string {
   if (!apiVersion) return baseUrl;
+  // Anchored to end-of-string and uses a simple `\d+` run optionally followed
+  // by `.\d+`; no nested quantifiers that could backtrack catastrophically.
+  // eslint-disable-next-line security/detect-unsafe-regex
   const versionTail = /\/v\d+(?:\.\d+)?$/;
   if (versionTail.test(baseUrl)) {
     return baseUrl.replace(versionTail, `/${apiVersion}`);
@@ -539,6 +554,30 @@ export class Pax8Client {
           // DELETE returns no body
           if (response.status === 204 || method === "DELETE") {
             return undefined as T;
+          }
+
+          // L-7: cap upstream response body size before parsing. A misbehaving
+          // or compromised upstream returning a multi-GB JSON body would
+          // otherwise buffer the entire payload through Node's fetch and
+          // exhaust memory. We check `Content-Length` (when present) against
+          // a 10 MB ceiling — well above any legitimate Pax8 response
+          // (the largest known endpoint, paginated orders, returns ~100 KB
+          // per page). For chunked responses (no `Content-Length` header)
+          // we rely on the existing AbortController timeout (`this.timeout`,
+          // default 30s) to bound the worst case: a slow-loris-style stream
+          // can't outlast the timeout.
+          const contentLength = response.headers.get("content-length");
+          if (contentLength !== null) {
+            const len = Number(contentLength);
+            if (Number.isFinite(len) && len > MAX_RESPONSE_BYTES) {
+              clearTimeout(timeoutId);
+              throw new ApiError(
+                `Response body too large: ${len} bytes (limit ${MAX_RESPONSE_BYTES})`,
+                response.status,
+                path,
+                method,
+              );
+            }
           }
 
           const data = await response.json();

--- a/packages/core/src/security/redact-debug.ts
+++ b/packages/core/src/security/redact-debug.ts
@@ -50,8 +50,11 @@ const SECRET_KEY_RE =
 
 // Long opaque hex / base64-url blobs (>=32 chars). 32 is a deliberate
 // floor — a 16-char hex blob can be a legit short ID; a 32+ char one is
-// almost always a token / secret / hash. Word-boundary anchors keep this
-// from chopping inside a longer string.
+// almost always a token / secret / hash. The character class deliberately
+// includes lowercase-only runs (L-4): nanoid-style and slugged API keys
+// are entirely lowercase, and a mixed-case requirement would let them slip
+// through. Word-boundary anchors (`\b`) keep this from chopping inside
+// longer alphanumeric strings.
 const OPAQUE_TOKEN_RE = /\b[A-Za-z0-9_\-+/=]{32,}\b/g;
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       eslint:
         specifier: ^10.3.0
         version: 10.3.0
+      eslint-plugin-security:
+        specifier: ^4.0.0
+        version: 4.0.0
       prettier:
         specifier: ^3.8.1
         version: 3.8.3
@@ -1010,6 +1013,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-plugin-security@4.0.0:
+    resolution: {integrity: sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1574,6 +1581,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -1601,6 +1612,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-regex@2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2753,6 +2767,10 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-plugin-security@4.0.0:
+    dependencies:
+      safe-regex: 2.1.1
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -3254,6 +3272,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  regexp-tree@0.1.27: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -3320,6 +3340,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-regex@2.1.1:
+    dependencies:
+      regexp-tree: 0.1.27
 
   safer-buffer@2.1.2: {}
 


### PR DESCRIPTION
Five disjoint low-severity security findings, one PR, one commit per area.

## Findings addressed

### L-4 — opaque-token redactor caught pure-lowercase tokens

`packages/cli/src/lib/redactor.ts` `OPAQUE_TOKEN_RE` required mixed-case + a digit, so a 32+ char pure-lowercase token (nanoid-style API keys, slugged secrets) slipped through entirely. Relaxed the constraint: any 32+ char run of token-character bytes bounded by non-token-chars is now redacted. Word-boundary anchors and the 32-char floor still protect ordinary English prose (longest common English word is 28 chars). New test asserts a 40-char pure-lowercase token redacts correctly.

The sibling regex in `packages/core/src/security/redact-debug.ts` already did not have the mixed-case constraint; updated its comment to document why and keep both redactors in sync.

### L-5 — `redactEnvelope` deep-walks nested string values

`redactEnvelope` only scrubbed named envelope fields (`message`, `causes[]`, `recoverySteps[]`, `docsUrl`, `command`, `flags[]`). Any future code path attaching a nested object (e.g. `env.details = { partnerEmail: "..." }`) would skip redaction entirely. Added a depth-capped (max 8) recursive deep walk that runs after the named-field pass and scrubs every string in any nested object/array. Idempotent — `<REDACTED:UUID>` markers re-run through the rules unchanged. New tests cover nested objects, nested arrays, primitive pass-through, and 12-deep pathological input.

### L-7 — cap `response.json()` parse size

`packages/core/src/api/client.ts` `request()` called `response.json()` with no size check. A misbehaving / compromised upstream returning a multi-GB body would buffer the whole payload through Node's fetch. Added a `Content-Length` check against a 10 MB ceiling (well above any legitimate Pax8 response — the heaviest endpoint paginated at `size=200` is roughly 100 KB per page). For chunked responses with no `Content-Length`, the existing 30s `AbortController` timeout bounds the worst case. New test asserts the guard short-circuits with `ApiError` before `.json()` is invoked when `Content-Length: 50000000` is advertised.

### L-8 — extend local-state policy gate to `packages/core/src`

The `#458`/`#469` policy gate in `packages/cli/src/__tests__/local-state-writers.test.ts` only scanned `packages/cli/src`. Added two parallel `it()` blocks that scan `packages/core/src` with their own explicit exception lists: `CORE_HOMEDIR_EXCEPTIONS` covers `config/loader.ts`, `auth/credential-store.ts`, and `security/validate-env.ts` (each with a one-line justification for why they legitimately resolve `homedir()`). `CORE_ALLOWED_RAW_WRITERS` covers `config/loader.ts` and `services/cache.ts`. The new `it()` blocks ARE the test for this finding.

### L-9 — add `eslint-plugin-security`

CodeQL `security-extended` queries already run in CI but ESLint-time pattern checks (`eval`, `child_process.exec` with non-literal args, regex DoS, unsafe regex) aren't covered. Wired `security.configs.recommended` into `eslint.config.js` as a flat-config dependency. Three rules disabled with inline justifications (too noisy for a TypeScript CLI): `detect-object-injection`, `detect-non-literal-fs-filename`, `detect-non-literal-regexp`. Three regex-DoS heuristic flags surfaced — all false positives, each gets a `// eslint-disable-next-line security/detect-unsafe-regex` with a one-line justification noting the bounded-backtracking shape.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean (no errors, no warnings)
- [x] `pnpm test packages/cli/src/lib/redactor.test.ts` — 51 tests pass (5 new for L-4/L-5)
- [x] `pnpm test packages/core/src/api/client.test.ts` — 90 tests pass (3 new for L-7)
- [x] `pnpm test packages/cli/src/__tests__/local-state-writers.test.ts` — 4 tests pass (2 new for L-8)
- [x] Full suite: `pnpm test` — 2030 passed, 6 skipped, 6 todo

## Out of scope

Per the brief: `signals.ts`, `confirm.ts`, `write-audit.ts`, `recommendations.ts`, `credential-store.ts`, `auth/login.ts`, and workflow files were not touched.