### PR TITLE
fix(security): anonymize telemetry — bucket revenue, salt distinct_id, capture SIGINT

### DIFF
--- a/packages/cli/src/lib/signals.test.ts
+++ b/packages/cli/src/lib/signals.test.ts
@@ -91,6 +91,11 @@ describe("installSigintHandler — capture and invoke", () => {
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
 
+    // Reset the singleton on each test so we can wire a fresh stub via the
+    // public Telemetry instance returned by getTelemetry().
+    const core = await import("@pax8/core");
+    core.resetTelemetry();
+
     const fresh = await import("./signals.js");
     fresh._resetWriteInFlight();
     fresh.installSigintHandler();
@@ -183,6 +188,88 @@ describe("installSigintHandler — capture and invoke", () => {
     const written = stderrWrite.mock.calls.map((c) => String(c[0])).join("");
     expect(written).not.toContain("(cancelled)");
     expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+
+  it(
+    "on SIGINT pushes a synthetic command_executed { cancelled: true, error_code: 'ERROR_CANCELLED' } event " +
+      "to telemetry BEFORE flushAndShutdown (M-2)",
+    async () => {
+      expect(sigintHandler).not.toBeNull();
+
+      // Stub the singleton's track() / flushAndShutdown() to record the
+      // order of calls. The handler must call track() FIRST so the event
+      // lands in the buffer that flushAndShutdown() then drains.
+      const core = await import("@pax8/core");
+      const tel = core.getTelemetry();
+      // Force the instance enabled for this test (default is off).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (tel as any).enabled = true;
+
+      const callOrder: string[] = [];
+      const trackSpy = vi
+        .spyOn(tel, "track")
+        .mockImplementation((_event) => {
+          callOrder.push("track");
+        });
+      const flushSpy = vi
+        .spyOn(tel, "flushAndShutdown")
+        .mockImplementation(async () => {
+          callOrder.push("flushAndShutdown");
+        });
+
+      try {
+        sigintHandler!();
+        await settle();
+
+        expect(trackSpy).toHaveBeenCalledTimes(1);
+        const trackedEvent = trackSpy.mock.calls[0][0];
+        expect(trackedEvent.event).toBe("command_executed");
+        expect(trackedEvent.success).toBe(false);
+        expect(trackedEvent.cancelled).toBe(true);
+        expect(trackedEvent.error_code).toBe("ERROR_CANCELLED");
+
+        expect(flushSpy).toHaveBeenCalled();
+
+        // Ordering: track must be called before flushAndShutdown, or the
+        // event won't make it into PostHog before exit.
+        expect(callOrder.indexOf("track")).toBeLessThan(
+          callOrder.indexOf("flushAndShutdown"),
+        );
+        expect(exitSpy).toHaveBeenCalledWith(130);
+      } finally {
+        trackSpy.mockRestore();
+        flushSpy.mockRestore();
+      }
+    },
+  );
+
+  it("does NOT push the cancelled event when telemetry is disabled", async () => {
+    expect(sigintHandler).not.toBeNull();
+
+    const core = await import("@pax8/core");
+    const tel = core.getTelemetry();
+    // Default is disabled but be explicit so the test reads clearly.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tel as any).enabled = false;
+
+    const trackSpy = vi.spyOn(tel, "track").mockImplementation(() => {});
+    const flushSpy = vi
+      .spyOn(tel, "flushAndShutdown")
+      .mockImplementation(async () => {});
+
+    try {
+      sigintHandler!();
+      await settle();
+
+      // Opt-out users do not have a synthetic event pushed.
+      expect(trackSpy).not.toHaveBeenCalled();
+      // flushAndShutdown is still called — it's a fast no-op when disabled.
+      expect(flushSpy).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(130);
+    } finally {
+      trackSpy.mockRestore();
+      flushSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/cli/src/lib/signals.ts
+++ b/packages/cli/src/lib/signals.ts
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import chalk from "chalk";
-import { getTelemetry } from "@pax8/core";
+import { getTelemetry, ERROR_CANCELLED } from "@pax8/core";
 import { stopAllActiveSpinners } from "./spinner.js";
 import { recordWriteAudit } from "./write-audit.js";
+
+// Injected at build time by the rollup config (see packages/cli/rollup.config.js).
+declare const __CLI_VERSION__: string;
 
 /**
  * In-flight write tracking for SIGINT cleanup.
@@ -147,6 +150,32 @@ export function installSigintHandler(): void {
       } catch {
         // If we can't even write to stderr there's nothing more we can do.
       }
+    }
+
+    // M-2: emit the cancellation audit event BEFORE the bounded flush so
+    // PostHog actually receives it. Without this, a Ctrl+C during a write
+    // never surfaces in the telemetry stream — the postAction hook never
+    // runs, and the flush below would ship an empty buffer. Guard the
+    // track() in try/catch because telemetry must never break exit.
+    try {
+      const telemetry = getTelemetry();
+      if (telemetry.isEnabled()) {
+        telemetry.track({
+          event: "command_executed",
+          command: "sigint",
+          flags: [],
+          duration_ms: 0,
+          success: false,
+          cancelled: true,
+          error_code: ERROR_CANCELLED,
+          cli_version: typeof __CLI_VERSION__ !== "undefined" ? __CLI_VERSION__ : "0.0.0",
+          node_version: process.version,
+          os: process.platform,
+          demo_mode: process.env.PAX8_DEMO === "1",
+        });
+      }
+    } catch {
+      // Telemetry must never crash the SIGINT path.
     }
 
     // Best-effort telemetry flush before exit (#145). flushAndShutdown is a

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -26,6 +26,13 @@ export const ERROR_NOT_AUTHORIZED = "ERROR_NOT_AUTHORIZED";
 export const ERROR_NOT_FOUND = "ERROR_NOT_FOUND";
 export const ERROR_INTERNAL = "ERROR_INTERNAL";
 export const ERROR_QUOTE_LINE_ITEM_NOT_FOUND = "ERROR_QUOTE_LINE_ITEM_NOT_FOUND";
+/**
+ * The user interrupted the command (Ctrl+C / SIGINT) before it completed.
+ * Carried on the synthetic `command_executed` event emitted by the SIGINT
+ * handler so the telemetry stream distinguishes user-cancellations from
+ * real failures.
+ */
+export const ERROR_CANCELLED = "ERROR_CANCELLED";
 
 /**
  * Union of all known Pax8 CLI error codes. Use this for exhaustive switch
@@ -44,4 +51,5 @@ export type Pax8ErrorCode =
   | typeof ERROR_NOT_AUTHORIZED
   | typeof ERROR_NOT_FOUND
   | typeof ERROR_INTERNAL
-  | typeof ERROR_QUOTE_LINE_ITEM_NOT_FOUND;
+  | typeof ERROR_QUOTE_LINE_ITEM_NOT_FOUND
+  | typeof ERROR_CANCELLED;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export {
   ERROR_NOT_FOUND,
   ERROR_INTERNAL,
   ERROR_QUOTE_LINE_ITEM_NOT_FOUND,
+  ERROR_CANCELLED,
 } from "./errors/codes.js";
 export type { Pax8ErrorCode } from "./errors/codes.js";
 

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -4,9 +4,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- accessing private members for testing */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
+import * as fsSync from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { Telemetry, resetTelemetry, type TelemetryEvent } from "./telemetry.js";
+import {
+  Telemetry,
+  resetTelemetry,
+  bucketDollars,
+  bucketSeats,
+  bucketLineCount,
+  type TelemetryEvent,
+} from "./telemetry.js";
 import { ERROR_COMPANY_NOT_FOUND } from "../errors/codes.js";
 
 function makeTmpDir(): string {
@@ -241,6 +249,232 @@ describe("Telemetry", () => {
     ];
     for (const key of keys) {
       expect(allowedKeys).toContain(key);
+    }
+  });
+});
+
+describe("Telemetry — revenue bucketing (M-2)", () => {
+  // The security review flagged raw revenue values as a partner fingerprint
+  // when combined with the distinct_id. These tests pin the cuts so anyone
+  // editing the buckets has to acknowledge they're changing a security
+  // boundary, not just an arithmetic detail.
+
+  describe("bucketDollars", () => {
+    it("maps 0 to '<10'", () => expect(bucketDollars(0)).toBe("<10"));
+    it("maps negative to '<10'", () => expect(bucketDollars(-50)).toBe("<10"));
+    it("maps boundary 9.99 to '<10'", () => expect(bucketDollars(9.99)).toBe("<10"));
+    it("maps boundary 10 to '10-50'", () => expect(bucketDollars(10)).toBe("10-50"));
+    it("maps mid-range 40 to '10-50'", () => expect(bucketDollars(40)).toBe("10-50"));
+    it("maps boundary 50 to '50-200'", () => expect(bucketDollars(50)).toBe("50-200"));
+    it("maps 199.99 to '50-200'", () => expect(bucketDollars(199.99)).toBe("50-200"));
+    it("maps boundary 200 to '200-1000'", () => expect(bucketDollars(200)).toBe("200-1000"));
+    it("maps 999.99 to '200-1000'", () => expect(bucketDollars(999.99)).toBe("200-1000"));
+    it("maps boundary 1000 to '>1000'", () => expect(bucketDollars(1000)).toBe(">1000"));
+    it("maps very large to '>1000'", () => expect(bucketDollars(1_000_000)).toBe(">1000"));
+    it("maps NaN to '<10' (defensive: never let NaN ship as a bucket)", () =>
+      expect(bucketDollars(NaN)).toBe("<10"));
+    it("maps Infinity to '<10' (defensive: non-finite is never a real revenue value)", () =>
+      expect(bucketDollars(Infinity)).toBe("<10"));
+  });
+
+  describe("bucketSeats", () => {
+    it("maps 0 to '<10'", () => expect(bucketSeats(0)).toBe("<10"));
+    it("maps 9 to '<10'", () => expect(bucketSeats(9)).toBe("<10"));
+    it("maps boundary 10 to '10-50'", () => expect(bucketSeats(10)).toBe("10-50"));
+    it("maps boundary 50 to '10-50'", () => expect(bucketSeats(50)).toBe("10-50"));
+    it("maps 51 to '>50'", () => expect(bucketSeats(51)).toBe(">50"));
+    it("maps very large to '>50'", () => expect(bucketSeats(10_000)).toBe(">50"));
+  });
+
+  describe("bucketLineCount", () => {
+    it("maps 0 to '1'", () => expect(bucketLineCount(0)).toBe("1"));
+    it("maps 1 to '1'", () => expect(bucketLineCount(1)).toBe("1"));
+    it("maps 2 to '2-5'", () => expect(bucketLineCount(2)).toBe("2-5"));
+    it("maps 5 to '2-5'", () => expect(bucketLineCount(5)).toBe("2-5"));
+    it("maps 6 to '>5'", () => expect(bucketLineCount(6)).toBe(">5"));
+    it("maps 100 to '>5'", () => expect(bucketLineCount(100)).toBe(">5"));
+  });
+
+  it("flush ships *_bucket properties to PostHog, not raw revenue numbers", async () => {
+    const t = new Telemetry();
+    (t as any).enabled = true;
+    (t as any).storageDir = path.join(
+      os.tmpdir(),
+      `pax8-tel-buck-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+
+    const captures: Array<{ properties: Record<string, unknown> }> = [];
+    (t as any).posthog = {
+      capture: (payload: { properties: Record<string, unknown> }) => {
+        captures.push(payload);
+      },
+      flush: async () => {},
+      shutdown: async () => {},
+    };
+
+    t.track({
+      event: "command_executed",
+      command: "orders.create",
+      flags: [],
+      duration_ms: 100,
+      success: true,
+      cli_version: "0.1.0",
+      node_version: process.version,
+      os: process.platform,
+      demo_mode: false,
+      order_total_dollars: 4242,
+      order_mrr_impact: 175,
+      order_seats: 8,
+      order_line_count: 3,
+      recs_mrr_captured: 999.99,
+    });
+
+    await t.flush();
+
+    expect(captures).toHaveLength(1);
+    const props = captures[0].properties;
+
+    // Raw fields MUST be gone from the PostHog payload.
+    expect(props).not.toHaveProperty("order_total_dollars");
+    expect(props).not.toHaveProperty("order_mrr_impact");
+    expect(props).not.toHaveProperty("order_seats");
+    expect(props).not.toHaveProperty("order_line_count");
+    expect(props).not.toHaveProperty("recs_mrr_captured");
+
+    // Buckets present with the expected string values.
+    expect(props.order_total_bucket).toBe(">1000");
+    expect(props.order_mrr_bucket).toBe("50-200");
+    expect(props.order_seats_bucket).toBe("<10");
+    expect(props.order_line_count_bucket).toBe("2-5");
+    expect(props.recs_mrr_captured_bucket).toBe("200-1000");
+
+    await fs.rm((t as any).storageDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("flush ships the cancelled flag through to PostHog", async () => {
+    const t = new Telemetry();
+    (t as any).enabled = true;
+    (t as any).storageDir = path.join(
+      os.tmpdir(),
+      `pax8-tel-canc-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+
+    const captures: Array<{ properties: Record<string, unknown> }> = [];
+    (t as any).posthog = {
+      capture: (payload: { properties: Record<string, unknown> }) => captures.push(payload),
+      flush: async () => {},
+      shutdown: async () => {},
+    };
+
+    t.track({
+      event: "command_executed",
+      command: "sigint",
+      flags: [],
+      duration_ms: 0,
+      success: false,
+      cancelled: true,
+      error_code: "ERROR_CANCELLED",
+      cli_version: "0.1.0",
+      node_version: process.version,
+      os: process.platform,
+      demo_mode: false,
+    });
+
+    await t.flush();
+
+    expect(captures[0].properties.cancelled).toBe(true);
+    expect(captures[0].properties.success).toBe(false);
+    expect(captures[0].properties.error_code).toBe("ERROR_CANCELLED");
+
+    await fs.rm((t as any).storageDir, { recursive: true, force: true }).catch(() => {});
+  });
+});
+
+describe("Telemetry — salted distinct_id (M-2)", () => {
+  let isolatedDir: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    resetTelemetry();
+    isolatedDir = path.join(
+      os.tmpdir(),
+      `pax8-tel-id-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    process.env.PAX8_CONFIG_DIR = isolatedDir;
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    await fs.rm(isolatedDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("on first init creates ~/.pax8/telemetry-id with mode 0o600", () => {
+    const t = new Telemetry();
+    const id = (t as any).anonymousId as string;
+    const filePath = path.join(isolatedDir, "telemetry-id");
+
+    expect(id).toBeTruthy();
+    expect(fsSync.existsSync(filePath)).toBe(true);
+    const onDisk = fsSync.readFileSync(filePath, "utf-8").trim();
+    expect(onDisk).toBe(id);
+
+    if (process.platform !== "win32") {
+      const stat = fsSync.statSync(filePath);
+      // mode 0o600 means u=rw, g=, o= — mask off the file-type bits.
+      expect(stat.mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("on subsequent init reads the existing id and does NOT rewrite", () => {
+    const t1 = new Telemetry();
+    const id1 = (t1 as any).anonymousId as string;
+    const filePath = path.join(isolatedDir, "telemetry-id");
+    const mtime1 = fsSync.statSync(filePath).mtimeMs;
+
+    // Force a different mtime granularity tick on fast filesystems.
+    const wait = 25;
+    const start = Date.now();
+    while (Date.now() - start < wait) {
+      // busy-wait — short, deterministic across runners
+    }
+
+    resetTelemetry();
+    const t2 = new Telemetry();
+    const id2 = (t2 as any).anonymousId as string;
+    const mtime2 = fsSync.statSync(filePath).mtimeMs;
+
+    expect(id2).toBe(id1);
+    // The file shouldn't have been rewritten; mtime should match exactly.
+    expect(mtime2).toBe(mtime1);
+  });
+
+  it("is not derivable from hostname + username (no sha256-of-hostname pattern)", () => {
+    const t = new Telemetry();
+    const id = (t as any).anonymousId as string;
+    // UUIDs look like 8-4-4-4-12 hex with hyphens. The legacy ID was a
+    // 16-char hex slice with no hyphens — assert we've moved off that.
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("falls back to ephemeral UUID when the file write fails", () => {
+    // Point the config dir at a file (not a directory) so mkdirSync will
+    // throw ENOTDIR — the constructor must degrade gracefully rather than
+    // bubbling the error. NOTE: do NOT use a /proc path here; mkdirSync on
+    // Linux can deadlock on procfs targets (see #509 / earlier fix).
+    const blocker = path.join(
+      os.tmpdir(),
+      `pax8-tel-id-blocker-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    fsSync.writeFileSync(blocker, "not-a-directory", { mode: 0o600 });
+    process.env.PAX8_CONFIG_DIR = path.join(blocker, "child");
+
+    try {
+      // Must not throw.
+      const t = new Telemetry();
+      const id = (t as any).anonymousId as string;
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    } finally {
+      fsSync.unlinkSync(blocker);
     }
   });
 });

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -3,11 +3,12 @@
 
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
-import * as os from "node:os";
+import * as fsSync from "node:fs";
 import * as path from "node:path";
 import { PostHog } from "posthog-node";
 import { loadConfig, saveConfig, getConfigDir } from "../config/loader.js";
 import type { Pax8ErrorCode } from "../errors/codes.js";
+import { safeWriteFileSync } from "../security/safe-write.js";
 
 // PostHog project API key (public, write-only — safe to embed)
 const POSTHOG_API_KEY = "phc_XKIa0EPGDACY1p4Cczk6IWXFa3n9";
@@ -19,6 +20,11 @@ export interface TelemetryEvent {
   flags: string[];
   duration_ms: number;
   success: boolean;
+  /**
+   * Set when the command was interrupted (SIGINT) before completing.
+   * Always paired with `success: false` and `error_code: "ERROR_CANCELLED"`.
+   */
+  cancelled?: boolean;
   /**
    * Canonical machine-readable error code from `@pax8/core`'s `ERROR_*`
    * registry. Set on failed events (`success: false`); omitted on successful
@@ -33,15 +39,19 @@ export interface TelemetryEvent {
   subcommand?: string;
   /** For order create, did the order actually succeed */
   order_success?: boolean;
-  /** Revenue: order total in dollars (unit_price × quantity) */
+  /**
+   * Revenue: order total in dollars (unit_price × quantity) — RAW value
+   * staged by command handlers. Bucketed (M-2 security review) before
+   * leaving the machine; `order_total_bucket` is what actually ships.
+   */
   order_total_dollars?: number;
-  /** Revenue: monthly MRR impact of the order */
+  /** Revenue: monthly MRR impact of the order — RAW, see above. */
   order_mrr_impact?: number;
-  /** Revenue: number of seats ordered */
+  /** Revenue: number of seats ordered — RAW, see above. */
   order_seats?: number;
   /** For order create: whether the run was a dry-run validation (no real write) */
   order_dry_run?: boolean;
-  /** For order create: number of line items in the order */
+  /** For order create: number of line items in the order — RAW, see above. */
   order_line_count?: number;
   /** For recommendations act: total recs presented */
   recs_presented?: number;
@@ -49,8 +59,39 @@ export interface TelemetryEvent {
   recs_ordered?: number;
   /** For recommendations act: how many were skipped */
   recs_skipped?: number;
-  /** For recommendations act: total MRR uplift of orders placed */
+  /** For recommendations act: total MRR uplift of orders placed — RAW, see above. */
   recs_mrr_captured?: number;
+}
+
+/**
+ * Bucket a dollar/MRR value into a coarse string range so an internal
+ * employee with PostHog query access can't reverse a unique order size
+ * back to the partner who placed it. The cuts are deliberately wide and
+ * coarse — a small-MSP $40 order and a large-MSP $48 order both land in
+ * "10-50".
+ *
+ * Strings (not numbers) so PostHog queries can't sum them back to a total.
+ */
+export function bucketDollars(value: number): string {
+  if (!Number.isFinite(value) || value < 10) return "<10";
+  if (value < 50) return "10-50";
+  if (value < 200) return "50-200";
+  if (value < 1000) return "200-1000";
+  return ">1000";
+}
+
+/** Bucket a seat count. See {@link bucketDollars}. */
+export function bucketSeats(value: number): string {
+  if (!Number.isFinite(value) || value < 10) return "<10";
+  if (value <= 50) return "10-50";
+  return ">50";
+}
+
+/** Bucket a line-item count. See {@link bucketDollars}. */
+export function bucketLineCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 1) return "1";
+  if (value <= 5) return "2-5";
+  return ">5";
 }
 
 export const TELEMETRY_NOTICE = `
@@ -75,12 +116,46 @@ export const TELEMETRY_NOTICE = `
 `;
 
 /**
- * Generate a stable, anonymous machine ID by hashing hostname + username.
- * No PII leaves the machine — only the SHA-256 hash is used as distinct_id.
+ * Per-install salted distinct ID, stored at `<config-dir>/telemetry-id`.
+ *
+ * Prior versions derived this from `sha256(hostname + username).slice(0, 16)`,
+ * which the M-2 security review flagged as easily de-anonymizable: anyone with
+ * directory access could regenerate any user's distinct_id from the AD/LDAP
+ * record. Migration is forward-only — events already attributed to the legacy
+ * hostname-derived ID stay where they are; new events get the salted ID.
+ *
+ * On first call:
+ *   - If `<config-dir>/telemetry-id` exists and contains a non-empty UUID,
+ *     return that.
+ *   - Else: generate `crypto.randomUUID()`, write it via `safeWriteFileSync`
+ *     (atomic O_CREAT + 0o600 + O_NOFOLLOW), and return it.
+ *
+ * Failures (I/O error reading or writing) degrade to an ephemeral
+ * per-process UUID. We never throw out of telemetry init — opting in must
+ * never become a CLI-breaking decision.
  */
 function getAnonymousId(): string {
-  const raw = `${os.hostname()}:${os.userInfo().username}`;
-  return crypto.createHash("sha256").update(raw).digest("hex").slice(0, 16);
+  const dir = getConfigDir();
+  const filePath = path.join(dir, "telemetry-id");
+
+  try {
+    if (fsSync.existsSync(filePath)) {
+      const existing = fsSync.readFileSync(filePath, "utf-8").trim();
+      if (existing.length > 0) return existing;
+    }
+  } catch {
+    // Fall through to (re)generate.
+  }
+
+  const fresh = crypto.randomUUID();
+  try {
+    fsSync.mkdirSync(dir, { recursive: true });
+    safeWriteFileSync(filePath, fresh);
+  } catch {
+    // Disk full, permission denied, etc. — fall back to an ephemeral id
+    // for this process. Better than crashing on telemetry init.
+  }
+  return fresh;
 }
 
 export class Telemetry {
@@ -175,6 +250,15 @@ export class Telemetry {
     }
 
     // Send to PostHog
+    //
+    // M-2 (security review): raw revenue fields (`order_total_dollars`,
+    // `order_mrr_impact`, `recs_mrr_captured`, `order_seats`,
+    // `order_line_count`) fingerprint partners when combined with the
+    // distinct_id. Before transmission we bucket them into coarse string
+    // ranges and rename the keys to `*_bucket` so downstream PostHog
+    // queries can't accidentally sum them back to raw totals. The raw
+    // numbers stay in the local JSONL backup (already 0o600) so the
+    // operator can still audit their own machine's usage.
     try {
       const ph = this.getPostHog();
       for (const event of events) {
@@ -192,16 +276,27 @@ export class Telemetry {
             os: event.os,
             demo_mode: event.demo_mode,
             ...(event.subcommand !== undefined && { subcommand: event.subcommand }),
+            ...(event.cancelled !== undefined && { cancelled: event.cancelled }),
             ...(event.order_success !== undefined && { order_success: event.order_success }),
-            ...(event.order_total_dollars !== undefined && { order_total_dollars: event.order_total_dollars }),
-            ...(event.order_mrr_impact !== undefined && { order_mrr_impact: event.order_mrr_impact }),
-            ...(event.order_seats !== undefined && { order_seats: event.order_seats }),
+            ...(event.order_total_dollars !== undefined && {
+              order_total_bucket: bucketDollars(event.order_total_dollars),
+            }),
+            ...(event.order_mrr_impact !== undefined && {
+              order_mrr_bucket: bucketDollars(event.order_mrr_impact),
+            }),
+            ...(event.order_seats !== undefined && {
+              order_seats_bucket: bucketSeats(event.order_seats),
+            }),
             ...(event.order_dry_run !== undefined && { order_dry_run: event.order_dry_run }),
-            ...(event.order_line_count !== undefined && { order_line_count: event.order_line_count }),
+            ...(event.order_line_count !== undefined && {
+              order_line_count_bucket: bucketLineCount(event.order_line_count),
+            }),
             ...(event.recs_presented !== undefined && { recs_presented: event.recs_presented }),
             ...(event.recs_ordered !== undefined && { recs_ordered: event.recs_ordered }),
             ...(event.recs_skipped !== undefined && { recs_skipped: event.recs_skipped }),
-            ...(event.recs_mrr_captured !== undefined && { recs_mrr_captured: event.recs_mrr_captured }),
+            ...(event.recs_mrr_captured !== undefined && {
+              recs_mrr_captured_bucket: bucketDollars(event.recs_mrr_captured),
+            }),
           },
         });
       }


### PR DESCRIPTION
Addresses the three sub-fixes from the security review M-2 finding on the telemetry surface.

## Summary

- **Bucket revenue fields before transmission.** `order_total_dollars`, `order_mrr_impact`, `recs_mrr_captured`, `order_seats`, and `order_line_count` previously shipped as raw numbers — combined with the deterministic distinct_id, a uniquely-sized order fingerprints the partner who placed it. The PostHog payload now ships coarse string buckets (`order_total_bucket`, `order_seats_bucket`, etc.). The local `~/.pax8/telemetry/*.jsonl` backup keeps the raw values for the operator's own auditing.
- **Emit a `command_executed { cancelled: true, error_code: "ERROR_CANCELLED" }` event on SIGINT.** The postAction hook that normally pushes the canonical event never runs on Ctrl+C, so without this the cancellation was lost from the telemetry stream. The track() call lands BEFORE `flushAndShutdown(1000)` so the event makes it out before exit. New `ERROR_CANCELLED` constant added to the append-only error-code registry.
- **Replace the hostname/username-derived distinct_id with a per-install salted UUID.** `sha256(hostname + username).slice(0, 16)` was trivially de-anonymizable by anyone with directory access. New scheme: `crypto.randomUUID()` stored at `<config-dir>/telemetry-id` via `safeWriteFileSync` (0o600, O_NOFOLLOW). Forward-only migration. Falls back to an ephemeral per-process UUID on write failure so telemetry init never crashes the CLI.

Closes the M-2 finding from the standing security review (no GitHub issue number).

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 2065 passed, 0 failed
- [x] `packages/core/src/telemetry/telemetry.test.ts` adds 24 new tests covering bucket cut-points (0, 9.99, 10, 50, 199.99, 200, 999.99, 1000, NaN, Infinity for dollars; 0/9/10/50/51 for seats; 0/1/2/5/6 for line counts), the post-bucketing PostHog payload shape, the salted-id file mode + persistence, and the ephemeral fallback when the file write fails (using a file-as-parent ENOTDIR path, not procfs)
- [x] `packages/cli/src/lib/signals.test.ts` adds two tests: SIGINT must call `track()` BEFORE `flushAndShutdown()` with the cancellation event; opt-out users (telemetry disabled) do NOT have a synthetic event pushed

## Out of scope

- `confirm.ts`, `write-audit.ts`, `redactor.ts`, `recommendations.ts`, `auth/login.ts`, `credential-store.ts` — owned by #506/#508/#512/#513
- The telemetry opt-out mechanism — unchanged