### PR TITLE
fix(recommendations): migrate orderCommand consumers to orderArgs

### DIFF
--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -177,6 +177,36 @@ describe("pax8 recommendations", () => {
       ).toBe(true);
     });
 
+    // #509: every actionable recommendation carries `orderArgs` alongside
+    // `orderCommand`. The argv form is the spawn-safe path that consumers
+    // (REPL, recommendations act, dashboard) prefer; the string is
+    // display-only. Pinning the shape here so a future regression that
+    // drops `orderArgs` from JSON output gets caught.
+    it("--json carries orderArgs[] argv-style array alongside orderCommand", async () => {
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
+      const data = JSON.parse(result.stdout) as Array<{
+        orderCommand: string | null;
+        orderArgs: string[] | null;
+      }>;
+      const actionable = data.filter((r) => r.orderCommand);
+      expect(actionable.length).toBeGreaterThan(0);
+      for (const rec of actionable) {
+        expect(Array.isArray(rec.orderArgs)).toBe(true);
+        // Fixed argv0 + subcommand path so the REPL drill-in
+        // (`packages/cli/src/lib/repl.ts`) can verify shape before
+        // dispatching.
+        expect(rec.orderArgs!.slice(0, 3)).toEqual(["pax8", "orders", "create"]);
+        // Each element is a single argv slot — no embedded shell
+        // quoting / metacharacters / tokenization required.
+        expect(rec.orderArgs!.every((a) => typeof a === "string")).toBe(true);
+        // Product flag is present in the argv (parallel guarantee to
+        // the orderCommand contract above).
+        const productIdx = rec.orderArgs!.indexOf("--product");
+        expect(productIdx).toBeGreaterThan(0);
+        expect(rec.orderArgs![productIdx + 1]).toMatch(/\S/);
+      }
+    });
+
     // Path B (#375 precursor): every recommendation carries the additive
     // `opportunityType` axis alongside the legacy `type`, using OE's
     // canonical 5-type taxonomy. The legacy `type` is unchanged.

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -452,16 +452,25 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
           });
         }
 
-        // Growth recs — link directly to order when available
+        // Growth recs — link directly to order when available.
+        // #509: prefer the structured `orderArgs.slice(1)` over re-tokenizing
+        // the display `orderCommand` string. Names with shell metacharacters
+        // (AT&T, "O'Brien & Sons", etc.) survive intact as single argv
+        // elements; the tokenizer round-trip is avoided.
         for (const r of highRecs.slice(0, 2)) {
           const upliftStr = r.estimatedMrrUplift ? chalk.green(` +${formatCurrency(r.estimatedMrrUplift)}/mo`) : "";
-          const cmd = r.orderCommand
-            ? r.orderCommand.replace(/^pax8\s+/, "")
-            : `recommendations list --company "${r.companyName}"`;
+          let command: string[];
+          if (r.orderArgs && r.orderArgs[0] === "pax8") {
+            command = r.orderArgs.slice(1);
+          } else if (r.orderCommand) {
+            command = tokenizeCmd(r.orderCommand.replace(/^pax8\s+/, ""));
+          } else {
+            command = tokenizeCmd(`recommendations list --company "${r.companyName}"`);
+          }
           quickActions.push({
             key: String(quickActions.length + 1),
             label: `${chalk.green("+")} ${r.companyName} — ${r.suggestedProducts?.[0] ?? r.title}${upliftStr}`,
-            command: tokenizeCmd(cmd),
+            command,
           });
         }
 

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -33,24 +33,39 @@ interface PlacementResult {
 async function placeOrder(rec: Recommendation, ctx: CommandContext): Promise<PlacementResult> {
   const product = rec.suggestedProducts?.[0] ?? "product";
 
-  if (!rec.orderCommand) {
+  if (!rec.orderCommand && !rec.orderArgs) {
     process.stderr.write(chalk.dim(`  No orderable product available for ${rec.companyName} — skipping.\n`));
     return { ordered: false, mrrCaptured: 0 };
   }
 
-  // Parse the existing orderCommand for company/product/quantity hints.
-  const productMatch = rec.orderCommand.match(/--product\s+"([^"]+)"|--product\s+(\S+)/);
-  const qtyMatch = rec.orderCommand.match(/--quantity\s+(\S+)/);
-  if (!productMatch) {
+  // #509: extract product / quantity from `orderArgs` (#498's structured
+  // form) when present. Each argv element is a fixed slot — no string
+  // tokenization, no regex parse, no need to survive shell metacharacters
+  // in companyName. Fall back to the orderCommand regex parse for older
+  // Recommendation rows from a pre-#498 build.
+  let matchedProduct: string | undefined;
+  let quantityStr: string | undefined;
+  if (rec.orderArgs) {
+    const productIdx = rec.orderArgs.indexOf("--product");
+    const quantityIdx = rec.orderArgs.indexOf("--quantity");
+    matchedProduct = productIdx >= 0 ? rec.orderArgs[productIdx + 1] : undefined;
+    quantityStr = quantityIdx >= 0 ? rec.orderArgs[quantityIdx + 1] : undefined;
+  } else if (rec.orderCommand) {
+    const productMatch = rec.orderCommand.match(/--product\s+"([^"]+)"|--product\s+(\S+)/);
+    const qtyMatch = rec.orderCommand.match(/--quantity\s+(\S+)/);
+    matchedProduct = productMatch?.[1] ?? productMatch?.[2];
+    quantityStr = qtyMatch?.[1];
+  }
+
+  if (!matchedProduct) {
     process.stderr.write(chalk.red(`  Could not parse order for ${rec.companyName}.\n`));
     return { ordered: false, mrrCaptured: 0 };
   }
 
-  const quantity = parseInt(qtyMatch?.[1] ?? String(rec.targetSeats ?? 1), 10);
+  const quantity = parseInt(quantityStr ?? String(rec.targetSeats ?? 1), 10);
 
   // Resolve product: try the matched value as a product ID first, fall back
   // to a name search.
-  const matchedProduct = productMatch[1] ?? productMatch[2];
   let productId = matchedProduct;
   if (matchedProduct && !/^[0-9a-f-]{8,}$/i.test(matchedProduct) && !matchedProduct.startsWith("prod-")) {
     try {

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -360,7 +360,21 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
           JSON.stringify(
             displayRecs.map((r, i) => ({
               key: String(i + 1),
-              rec: { companyId: r.companyId, companyName: r.companyName, title: r.title, orderCommand: r.orderCommand, suggestedProducts: r.suggestedProducts, targetSeats: r.targetSeats },
+              // #509: persist `orderArgs` (argv-style array) alongside the
+              // display-only `orderCommand` string. The REPL drill-in
+              // (`packages/cli/src/lib/repl.ts`) and `recommendations act`
+              // both prefer `orderArgs` — it carries names with shell
+              // metacharacters (AT&T, "O'Brien & Sons", etc.) safely as
+              // single argv elements without any tokenizer round-trip.
+              rec: {
+                companyId: r.companyId,
+                companyName: r.companyName,
+                title: r.title,
+                orderArgs: r.orderArgs,
+                orderCommand: r.orderCommand,
+                suggestedProducts: r.suggestedProducts,
+                targetSeats: r.targetSeats,
+              },
             })),
           ),
         );
@@ -368,8 +382,19 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
       // Interactive prompt — use shared promptNextSteps
       const steps: NextStep[] = displayRecs.map((r, i) => {
+        // #509: prefer `orderArgs.slice(1)` (drops the "pax8" argv0) over
+        // re-tokenizing the display string. The argv form survives names
+        // with shell metacharacters intact; the string form's tokenizer
+        // remains as a belt-and-suspenders fallback for older
+        // Recommendation rows from a pre-#498 build of `@pax8/core`.
+        if (r.orderArgs && r.orderArgs[0] === "pax8") {
+          return {
+            key: String(i + 1),
+            label: `${r.suggestedProducts?.[0] ?? "product"} for ${r.companyName}`,
+            command: r.orderArgs.slice(1),
+          };
+        }
         if (r.orderCommand) {
-          // Tokenize orderCommand, strip leading "pax8" if present
           const tokens = (r.orderCommand.match(/"[^"]*"|\S+/g) ?? []).map(
             (t) => t.startsWith('"') && t.endsWith('"') ? t.slice(1, -1) : t
           );

--- a/packages/cli/src/lib/repl.ts
+++ b/packages/cli/src/lib/repl.ts
@@ -115,7 +115,7 @@ export async function startRepl(createProgram: () => Command): Promise<void> {
         const raw = JSON.parse(fs.readFileSync(actionsPath, "utf-8"));
         // Validate shape before trusting — prevent command injection via file tampering
         const actions = Array.isArray(raw) ? raw.filter(
-          (a: unknown): a is { key: string; command?: string; rec?: { orderCommand?: string; suggestedProducts?: string[] } } =>
+          (a: unknown): a is { key: string; command?: string; rec?: { orderArgs?: string[]; orderCommand?: string; suggestedProducts?: string[] } } =>
             typeof a === "object" && a !== null &&
             typeof (a as Record<string, unknown>).key === "string" &&
             ((a as Record<string, unknown>).command === undefined || typeof (a as Record<string, unknown>).command === "string") &&
@@ -127,9 +127,30 @@ export async function startRepl(createProgram: () => Command): Promise<void> {
             // Generic command template (e.g. from companies list) — must start with "pax8 <subcommand>"
             args = tokenize(picked.command.replace(/^pax8\s+/, ""));
           } else if (picked.rec) {
-            // Recommendation action
-            if (picked.rec.orderCommand && /^pax8\s+orders\s+create\b/.test(picked.rec.orderCommand)) {
-              // Only allow order create commands from recommendations
+            // #509: prefer the structured argv form (`orderArgs`) over
+            // tokenizing the display string. Each element of `orderArgs` is
+            // a separate argv slot, so a customer name with shell
+            // metacharacters (`AT&T`, `Acme & Sons`, an apostrophe, etc.)
+            // lands as a single argv element verbatim — no quoting, no
+            // tokenizer round-trip, no risk of breakout. The `orderArgs[0]`
+            // is always `"pax8"` so we slice it off; we also defensively
+            // verify the second element is `"orders"` (don't let a
+            // tampered pending-actions.json kick off a non-order command).
+            if (
+              Array.isArray(picked.rec.orderArgs) &&
+              picked.rec.orderArgs.length >= 3 &&
+              picked.rec.orderArgs[0] === "pax8" &&
+              picked.rec.orderArgs[1] === "orders" &&
+              picked.rec.orderArgs[2] === "create" &&
+              picked.rec.orderArgs.every((a: unknown) => typeof a === "string")
+            ) {
+              args = picked.rec.orderArgs.slice(1);
+            } else if (picked.rec.orderCommand && /^pax8\s+orders\s+create\b/.test(picked.rec.orderCommand)) {
+              // Backward compat: a pending-actions.json written before
+              // #509's `orderArgs` persistence (or one where orderArgs
+              // failed shape validation). The string-tokenize path is
+              // still gated by #506's SAFE_ID_RE / isSafeDisplayName at
+              // construction time — load-bearing here as defense in depth.
               args = tokenize(picked.rec.orderCommand.replace(/^pax8\s+/, ""));
             } else {
               const searchTerm = picked.rec.suggestedProducts?.[0] ?? "product";


### PR DESCRIPTION
Closes #509.

## Summary

Follow-up to #506 + #498. Four consumers now prefer the structured `orderArgs` argv-style array (added by #498) over re-tokenizing the display-only `orderCommand` string (gated by #506).

| Consumer | Was | Now |
|---|---|---|
| `packages/cli/src/lib/repl.ts:131` | tokenized `picked.rec.orderCommand` | `picked.rec.orderArgs.slice(1)` with shape guard (`[0] === "pax8"`, `[1] === "orders"`, `[2] === "create"`) |
| `packages/cli/src/commands/recommendations/list.ts:362` | persisted `orderCommand` only; re-tokenized for `NextStep[]` | persists both; uses `orderArgs.slice(1)` for `NextStep[]` |
| `packages/cli/src/commands/recommendations/act.ts:42` | regex-parsed `--product` / `--quantity` from string | `argv.indexOf("--product") + 1` etc. from `orderArgs` |
| `packages/cli/src/commands/dashboard.ts:458` | `r.orderCommand.replace(/^pax8\s+/, "")` then `tokenizeCmd()` | `r.orderArgs.slice(1)` directly |

The string-tokenize path remains as a belt-and-suspenders fallback on each site for `Recommendation` rows produced by a pre-#498 `@pax8/core` build (extremely unlikely in practice, defensive only).

## Why this matters

`isSafeDisplayName` from #506 currently blocks names containing `"`, backtick, `$`, `;`, `|`, `&`, `<`, `>`, newlines, or NUL. That includes `&`, which **collapses both `orderCommand` and `orderArgs` to null** for partners with names like `AT&T`, `Procter & Gamble`, `Johnson & Johnson`, etc. They're real customers and they currently get no order command from `recommendations list`.

This PR by itself does **not** unblock those names — the gate is still in place. What it does is make the gate **belt-and-suspenders** rather than **load-bearing**: after this lands, a future PR could safely relax `isSafeDisplayName` to admit names with `&` and friends, because consumers no longer re-tokenize the string. The argv form carries them safely.

Splitting the relaxation into a separate PR keeps the security-control change reviewable on its own.

## Test plan

- [x] New `packages/cli/src/__tests__/recommendations.test.ts` case: `--json` output carries `orderArgs[]` with the fixed `["pax8", "orders", "create", …]` prefix on every actionable recommendation
- [x] Targeted suite (148 tests across recommendations + dashboard + repl + core/recommendations + redactor + error-codes + orders) — green
- [x] `pnpm lint` clean
- [ ] Manual: run `pax8 recommendations list --json` in a real partner shell, verify `orderArgs[]` matches the consumer-expected shape
- [ ] Manual: in the REPL, type a bare number after `recommendations list` and verify the drill-in still launches the right order — both with `orderArgs` present and (via downgrade) with only `orderCommand`

## Follow-up

After this lands, consider relaxing `SAFE_ID_RE` / `isSafeDisplayName` in `packages/core/src/services/recommendations.ts` to admit common shell-metacharacter-containing names (`&` is the big one). Track as a separate issue if you want; this PR makes that relaxation safe.