### PR TITLE
fix(clients): canonical recovery-hint vocabulary + full fuzzy-match list with truncation hint

### DIFF
--- a/packages/cli/src/__tests__/clients-canonical-recovery-hints.test.ts
+++ b/packages/cli/src/__tests__/clients-canonical-recovery-hints.test.ts
@@ -1,0 +1,73 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectFailure } from "./test-utils.js";
+
+/**
+ * #522 regression guard: error-recovery hints across the resolve-company
+ * fan-in must point users (and agents) at `pax8 clients list` — the
+ * canonical surface — not the deprecated `pax8 companies list` alias.
+ *
+ * Before #522 only `clients more` used the new vocabulary; every other path
+ * that called through `resolveCompany` printed `pax8 companies list` on
+ * failure, bouncing the user back to a deprecated verb at exactly the
+ * moment they were already stuck.
+ *
+ * We exercise three of the surveyed paths end-to-end against the demo
+ * client so the assertion catches regressions in the shared hint source
+ * (`packages/cli/src/lib/resolve-company.ts`) as well as any future
+ * command that grows a local recovery hint and forgets to migrate.
+ */
+describe("recovery hints use canonical 'pax8 clients list' vocabulary (#522)", () => {
+  const NONEXISTENT = "DefinitelyNotARealCustomerXYZ";
+
+  it("clients show <unresolvable> recovers via `pax8 clients list`", async () => {
+    const result = await runCliExpectFailure([
+      "clients",
+      "show",
+      NONEXISTENT,
+    ]);
+    expect(result.stderr).toContain("pax8 clients list");
+    expect(result.stderr).not.toContain("pax8 companies list");
+  });
+
+  it("subscriptions list --company <unresolvable> recovers via `pax8 clients list`", async () => {
+    const result = await runCliExpectFailure([
+      "subscriptions",
+      "list",
+      "--company",
+      NONEXISTENT,
+    ]);
+    expect(result.stderr).toContain("pax8 clients list");
+    expect(result.stderr).not.toContain("pax8 companies list");
+  });
+
+  it("cost sim --company <unresolvable> recovers via `pax8 clients list`", async () => {
+    const result = await runCliExpectFailure([
+      "cost",
+      "sim",
+      "--company",
+      NONEXISTENT,
+      "--product",
+      "Microsoft 365 Business Standard",
+      "--quantity",
+      "1",
+    ]);
+    expect(result.stderr).toContain("pax8 clients list");
+    expect(result.stderr).not.toContain("pax8 companies list");
+  });
+
+  it("clients more --help references `from clients list` (not `companies list`)", async () => {
+    // --help exits 0, so use runCli directly via expectFailure's sibling.
+    // Easiest: invoke clients more with --help and inspect stdout. Reuse
+    // a small spawn via runCliExpectFailure on a malformed invocation
+    // would be wrong here — fall back to a direct spawn.
+    const { runCli } = await import("./test-utils.js");
+    const result = await runCli(["clients", "more", "--help"]);
+    expect(result.exitCode).toBe(0);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toContain("from clients list");
+    expect(combined).not.toContain("from companies list");
+  });
+});

--- a/packages/cli/src/commands/companies/more.ts
+++ b/packages/cli/src/commands/companies/more.ts
@@ -61,13 +61,13 @@ function daysUntil(dateStr: string | undefined): number | null {
 
 export const companiesMoreCommand = new Command("more")
   .description("Full client summary — subscriptions, vendors, seats, Pax8 monthly cost, and issues")
-  .argument("<name-or-number>", "Client name, ID, or # from companies list")
+  .argument("<name-or-number>", "Client name, ID, or # from clients list")
   .allowExcessArguments(true)
   .addHelpText(
     "after",
     `
 Examples:
-  pax8 clients more 1                                  Use # from companies list
+  pax8 clients more 1                                  Use # from clients list
   pax8 clients more "Summit Healthcare Partners"
   pax8 clients more "Summit Healthcare Partners" --json
 

--- a/packages/cli/src/lib/resolve-company.test.ts
+++ b/packages/cli/src/lib/resolve-company.test.ts
@@ -76,6 +76,56 @@ describe("resolveCompany", () => {
     await expect(resolveCompany(ctx, "Summit")).rejects.toThrow(/Multiple companies match/);
   });
 
+  it("lists all matches inline when fuzzy match count is ≤10 (#520)", async () => {
+    // 8 matches — under the 10 cap, so every name should appear with no
+    // "and N more" tail.
+    const companies = Array.from({ length: 8 }, (_, i) =>
+      makeCompany({ id: `id-${i}`, name: `Acme ${i}` })
+    );
+    const ctx = makeMockCtx(companies);
+
+    let caught: unknown;
+    try {
+      await resolveCompany(ctx, "Acme");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    const e = caught as { causes?: string[] };
+    expect(e.causes).toBeDefined();
+    const matchesLine = e.causes![0];
+    // All 8 names must surface; no truncation tail.
+    for (let i = 0; i < 8; i++) {
+      expect(matchesLine).toContain(`Acme ${i}`);
+    }
+    expect(matchesLine).not.toMatch(/and \d+ more/);
+  });
+
+  it("truncates at 10 with 'and N more' hint when fuzzy match count >10 (#520)", async () => {
+    // 15 matches — over the cap. First 10 should surface, last 5 collapse
+    // into the "and 5 more" tail with a grep recovery hint.
+    const companies = Array.from({ length: 15 }, (_, i) =>
+      makeCompany({ id: `id-${i}`, name: `Acme ${String(i).padStart(2, "0")}` })
+    );
+    const ctx = makeMockCtx(companies);
+
+    let caught: unknown;
+    try {
+      await resolveCompany(ctx, "Acme");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    const e = caught as { causes?: string[] };
+    const matchesLine = e.causes![0];
+    expect(matchesLine).toMatch(/… and 5 more/);
+    expect(matchesLine).toContain('grep "Acme"');
+    // First and tenth should be present; eleventh must NOT appear inline.
+    expect(matchesLine).toContain("Acme 00");
+    expect(matchesLine).toContain("Acme 09");
+    expect(matchesLine).not.toMatch(/Acme 10[,\b]|Acme 10$/);
+  });
+
   it("throws descriptive error when name not found", async () => {
     const ctx = makeMockCtx([makeCompany()]);
 

--- a/packages/cli/src/lib/resolve-company.ts
+++ b/packages/cli/src/lib/resolve-company.ts
@@ -50,11 +50,11 @@ export async function resolveCompany(ctx: CommandContext, input: string): Promis
     const matchesLine =
       names.length <= MAX_INLINE
         ? `Matches: ${names.join(", ")}`
-        : `Matches: ${names.slice(0, MAX_INLINE).join(", ")} … and ${names.length - MAX_INLINE} more (run ${replCmd(`pax8 companies list | grep "${input}"`)} to see all)`;
+        : `Matches: ${names.slice(0, MAX_INLINE).join(", ")} … and ${names.length - MAX_INLINE} more (run ${replCmd(`pax8 clients list | grep "${input}"`)} to see all)`;
     throw new CliError(
       `Multiple companies match "${input}"`,
       [matchesLine],
-      [`Use an exact name or ID. Run ${replCmd("pax8 companies list")} to see all companies.`],
+      [`Use an exact name or ID. Run ${replCmd("pax8 clients list")} to see all companies.`],
       undefined,
       ERROR_COMPANY_NOT_FOUND,
     );
@@ -63,7 +63,7 @@ export async function resolveCompany(ctx: CommandContext, input: string): Promis
   throw new CliError(
     `Company not found: "${input}"`,
     ["No active company matched the supplied name or ID."],
-    [`Run ${replCmd("pax8 companies list")} to see available companies.`],
+    [`Run ${replCmd("pax8 clients list")} to see available companies.`],
     undefined,
     ERROR_COMPANY_NOT_FOUND,
   );

--- a/packages/cli/src/lib/resolve-company.ts
+++ b/packages/cli/src/lib/resolve-company.ts
@@ -41,9 +41,19 @@ export async function resolveCompany(ctx: CommandContext, input: string): Promis
   const fuzzy = result.content.filter((c) => c.name.toLowerCase().includes(lower));
   if (fuzzy.length === 1) return fuzzy[0];
   if (fuzzy.length > 1) {
+    // #520: when the user typed an ambiguous query, surfacing a truncated list
+    // gives the wrong impression that those are the only candidates. List all
+    // matches when ≤10; for larger result sets show the first 10 plus an
+    // explicit "and N more" tail so the user knows the list isn't exhaustive.
+    const MAX_INLINE = 10;
+    const names = fuzzy.map((c) => c.name);
+    const matchesLine =
+      names.length <= MAX_INLINE
+        ? `Matches: ${names.join(", ")}`
+        : `Matches: ${names.slice(0, MAX_INLINE).join(", ")} … and ${names.length - MAX_INLINE} more (run ${replCmd(`pax8 companies list | grep "${input}"`)} to see all)`;
     throw new CliError(
       `Multiple companies match "${input}"`,
-      [`Matches: ${fuzzy.map((c) => c.name).join(", ")}`],
+      [matchesLine],
       [`Use an exact name or ID. Run ${replCmd("pax8 companies list")} to see all companies.`],
       undefined,
       ERROR_COMPANY_NOT_FOUND,


### PR DESCRIPTION
## Summary

Two small UX fixes on the `resolveCompany` fan-in, bundled because both
edit the same file:

- **#520** — When `pax8 clients more <ambiguous>` matched many companies,
  the recovery hint surfaced an apparently-truncated subset with no
  "and N more" tail, so a partner with 12 same-stem subsidiaries thought
  they had 4. Now lists every match when ≤10; for larger sets shows the
  first 10 plus `… and N more (run pax8 clients list | grep "<query>" to
  see all)`.
- **#522** — Five of six error paths fanning through `resolveCompany`
  printed `pax8 companies list` (the deprecated alias) in their recovery
  hints, bouncing partners off the canonical surface they were just
  migrated to. The `clients more --help` example text had the same
  drift. Both are now `pax8 clients list` / `from clients list`. The
  `pax8 companies *` aliases themselves are untouched — they remain
  indefinitely supported per #317.

Two commits, one per issue.

## Test plan

- [x] `resolveCompany` unit tests cover both `≤10 matches inline, no
      tail` and `>10 matches → first 10 + 'and N more'` shapes.
- [x] New subprocess test (`clients-canonical-recovery-hints.test.ts`)
      exercises three of the surveyed paths end-to-end against the demo
      client — `clients show <unresolvable>`, `subscriptions list
      --company <unresolvable>`, `cost sim --company <unresolvable>` —
      plus `clients more --help` example text, all asserting `pax8
      clients list` is present and `pax8 companies list` is not.
- [x] `pnpm build` clean, `pnpm lint` clean.
- [x] Existing `companies.test.ts` and `clients-companies-parity.test.ts`
      still pass — alias parity is unaffected.

Closes #520, closes #522