### PR TITLE
fix(report): parse-time --by enforcement and client/customer alias taxonomy

### DIFF
--- a/packages/claude-skill/src/tools/reports.ts
+++ b/packages/claude-skill/src/tools/reports.ts
@@ -71,7 +71,7 @@ function monthlyCostOf(
 export const pax8_report_subscriptions = {
   name: "pax8_report_subscriptions",
   description:
-    "Compute the partner's Pax8 cost rollup across active subscriptions, grouped by company. Returns `totalMonthlyCost` and `totalAnnualCost` as wrapped `AmountCurrency` objects ({ amount, currency }), plus a `companiesByMonthlyCost` array sorted descending with companyId, companyName, monthlyCost, subscriptionCount, and totalSeats. This is the partner's cost paid to Pax8 — NOT partner-side resale revenue. Includes the standard partner-revenue disclaimer in the payload. Pre-calculated; no follow-up calls needed. Optionally filter by companyId. NOTE: divergence from the `pax8 report subscriptions` CLI command — that command supports `--by customer|vendor|product|billing-term`; this skill tool returns a fixed by-company rollup.",
+    "Compute the partner's Pax8 cost rollup across active subscriptions, grouped by company. Returns `totalMonthlyCost` and `totalAnnualCost` as wrapped `AmountCurrency` objects ({ amount, currency }), plus a `companiesByMonthlyCost` array sorted descending with companyId, companyName, monthlyCost, subscriptionCount, and totalSeats. This is the partner's cost paid to Pax8 — NOT partner-side resale revenue. Includes the standard partner-revenue disclaimer in the payload. Pre-calculated; no follow-up calls needed. Optionally filter by companyId. NOTE: divergence from the `pax8 report subscriptions` CLI command — that command supports `--by client|vendor|product|billing-term` (with `customer`/`company` accepted as deprecated aliases); this skill tool returns a fixed by-company rollup.",
   parameters: {
     type: "object" as const,
     properties: {

--- a/packages/cli/src/__tests__/report.test.ts
+++ b/packages/cli/src/__tests__/report.test.ts
@@ -314,6 +314,19 @@ describe("pax8 report concentration", () => {
     expect(result.stderr.toLowerCase()).toContain("--by");
   });
 
+  // #517: missing --by is enforced by Commander at parse time, BEFORE
+  // buildContext() / the subscriptions fetch runs. We verify the spinner
+  // never fired by asserting "Fetching subscriptions" appears nowhere in
+  // the combined output. If we ever regress to the throw-from-action
+  // form, this catches it.
+  it("rejects missing --by at parse time (no spinner / fetch)", async () => {
+    const result = await runCliExpectFailure(["report", "concentration"]);
+    const combined = result.stdout + result.stderr;
+    expect(combined).not.toContain("Fetching subscriptions");
+    // Commander's required-option error format.
+    expect(result.stderr.toLowerCase()).toMatch(/required option.*--by/);
+  });
+
   it("errors on invalid --by value", async () => {
     const result = await runCliExpectFailure([
       "report",

--- a/packages/cli/src/__tests__/report.test.ts
+++ b/packages/cli/src/__tests__/report.test.ts
@@ -209,7 +209,7 @@ describe("pax8 report renewals", () => {
 });
 
 describe("pax8 report concentration", () => {
-  for (const groupBy of ["customer", "vendor", "product"] as const) {
+  for (const groupBy of ["client", "vendor", "product"] as const) {
     it(`--by ${groupBy} returns the canonical JSON shape`, async () => {
       const { stdout } = await runCliExpectSuccess([
         "report",
@@ -246,7 +246,7 @@ describe("pax8 report concentration", () => {
       "report",
       "concentration",
       "--by",
-      "customer",
+      "client",
       "--top",
       "5",
       "--json",
@@ -260,7 +260,7 @@ describe("pax8 report concentration", () => {
       "report",
       "concentration",
       "--by",
-      "customer",
+      "client",
       "--threshold",
       "10",
       "--json",
@@ -294,7 +294,7 @@ describe("pax8 report concentration", () => {
       "report",
       "concentration",
       "--by",
-      "customer",
+      "client",
       "--json",
     ]);
     const data = JSON.parse(stdout);
@@ -336,11 +336,30 @@ describe("pax8 report concentration", () => {
     ]);
     expect(result.stderr.toLowerCase()).toContain("--by");
   });
+
+  // #516: `client` is the canonical noun (per #317). `customer` and
+  // `company` are accepted as deprecated aliases with a one-line stderr
+  // warning, and the response payload normalizes to `client`.
+  for (const alias of ["customer", "company"] as const) {
+    it(`accepts --by ${alias} as a deprecated alias for client (warns on stderr)`, async () => {
+      const { stdout, stderr } = await runCliExpectSuccess([
+        "report",
+        "concentration",
+        "--by",
+        alias,
+        "--json",
+      ]);
+      const data = JSON.parse(stdout);
+      expect(data.groupBy).toBe("client");
+      expect(stderr.toLowerCase()).toContain("deprecated");
+      expect(stderr).toContain(alias);
+    });
+  }
 });
 
 describe("pax8 report subscriptions", () => {
   for (const groupBy of [
-    "customer",
+    "client",
     "vendor",
     "product",
     "billing-term",
@@ -493,6 +512,25 @@ describe("pax8 report subscriptions", () => {
     ]);
     expect(result.stderr.toLowerCase()).toContain("--by");
   });
+
+  // #516: `client` is the canonical noun (per #317). `customer` and
+  // `company` are accepted as deprecated aliases with a one-line stderr
+  // warning, and the response payload normalizes to `client`.
+  for (const alias of ["customer", "company"] as const) {
+    it(`accepts --by ${alias} as a deprecated alias for client (warns on stderr)`, async () => {
+      const { stdout, stderr } = await runCliExpectSuccess([
+        "report",
+        "subscriptions",
+        "--by",
+        alias,
+        "--json",
+      ]);
+      const data = JSON.parse(stdout);
+      expect(data.groupBy).toBe("client");
+      expect(stderr.toLowerCase()).toContain("deprecated");
+      expect(stderr).toContain(alias);
+    });
+  }
 });
 
 describe("standardized Pax8-cost disclaimer footer", () => {

--- a/packages/cli/src/commands/report/concentration.ts
+++ b/packages/cli/src/commands/report/concentration.ts
@@ -36,6 +36,9 @@ interface ConcentrationRow {
 }
 
 function parseGroupBy(raw: string | undefined): GroupBy {
+  // Commander enforces --by required at parse time via .requiredOption(),
+  // so a missing value here would be a programming error rather than a
+  // user error. We still guard defensively.
   if (!raw) {
     throw new CliError(
       "--by is required for `pax8 report concentration`.",
@@ -119,7 +122,10 @@ export const reportConcentrationCommand = new Command("concentration")
   .description(
     "Pax8 spend concentration analysis. Shows where your Pax8 cost is concentrated across customers, vendors, or products — useful for risk modeling and capacity planning.",
   )
-  .option("--by <customer|vendor|product>", "Concentration axis (required)")
+  // .requiredOption() lets Commander reject `pax8 report concentration`
+  // with no `--by` at parse time — no spinner, no fetch, no fallback to
+  // the deferred CliError throw in parseGroupBy() (#517).
+  .requiredOption("--by <customer|vendor|product>", "Concentration axis (required)")
   .option("--top <n>", "Limit to the top N entities", "10")
   .option(
     "--threshold <pct>",

--- a/packages/cli/src/commands/report/concentration.ts
+++ b/packages/cli/src/commands/report/concentration.ts
@@ -17,13 +17,23 @@ import { CliError, handleCommandError } from "../../lib/errors.js";
 import { formatCompanyName, formatCurrency } from "../../lib/formatters.js";
 import { enrichCompanyNames, enrichProductNames } from "../../lib/enrich-subscriptions.js";
 
-type GroupBy = "customer" | "vendor" | "product";
+type GroupBy = "client" | "vendor" | "product";
 
 interface ConcentrationOptions {
   by?: string;
   top?: string;
   threshold?: string;
 }
+
+// `client` is the canonical noun (per #317 — `pax8 clients *` is the
+// canonical command surface). We accept `customer` and `company` as
+// deprecated aliases and emit a one-line stderr warning so existing
+// scripts keep working while the docs and tab-completion converge on
+// `client`.
+const BY_ALIASES: Record<string, "client"> = {
+  customer: "client",
+  company: "client",
+};
 
 interface ConcentrationRow {
   rank: number;
@@ -38,22 +48,28 @@ interface ConcentrationRow {
 function parseGroupBy(raw: string | undefined): GroupBy {
   // Commander enforces --by required at parse time via .requiredOption(),
   // so a missing value here would be a programming error rather than a
-  // user error. We still guard defensively.
+  // user error. We still guard defensively in case the field is reused.
   if (!raw) {
     throw new CliError(
       "--by is required for `pax8 report concentration`.",
       undefined,
-      ["Use --by customer, --by vendor, or --by product."],
+      ["Use --by client, --by vendor, or --by product."],
       undefined,
       ERROR_INVALID_INPUT,
     );
   }
   const v = raw.toLowerCase();
-  if (v === "customer" || v === "vendor" || v === "product") return v;
+  if (BY_ALIASES[v]) {
+    process.stderr.write(
+      `  ⚠ --by ${v} is deprecated; use --by client instead.\n`,
+    );
+    return BY_ALIASES[v];
+  }
+  if (v === "client" || v === "vendor" || v === "product") return v;
   throw new CliError(
     `Invalid --by value: "${raw}".`,
     undefined,
-    ["Use --by customer, --by vendor, or --by product."],
+    ["Use --by client, --by vendor, or --by product."],
     undefined,
     ERROR_INVALID_INPUT,
   );
@@ -125,7 +141,7 @@ export const reportConcentrationCommand = new Command("concentration")
   // .requiredOption() lets Commander reject `pax8 report concentration`
   // with no `--by` at parse time — no spinner, no fetch, no fallback to
   // the deferred CliError throw in parseGroupBy() (#517).
-  .requiredOption("--by <customer|vendor|product>", "Concentration axis (required)")
+  .requiredOption("--by <client|vendor|product>", "Concentration axis (required)")
   .option("--top <n>", "Limit to the top N entities", "10")
   .option(
     "--threshold <pct>",
@@ -135,14 +151,14 @@ export const reportConcentrationCommand = new Command("concentration")
     "after",
     `
 Examples:
-  pax8 report concentration --by customer
+  pax8 report concentration --by client
   pax8 report concentration --by vendor --top 5
   pax8 report concentration --by product --threshold 5
-  pax8 report concentration --by customer --json
+  pax8 report concentration --by client --json
 
 JSON output (--json):
   {
-    "groupBy": "customer" | "vendor" | "product",
+    "groupBy": "client" | "vendor" | "product",
     "totalMonthlyCost": { "amount": number, "currency": string },
     "concentration": [{
       "rank": number,
@@ -225,7 +241,7 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
         let id: string;
         let name: string;
-        if (groupBy === "customer") {
+        if (groupBy === "client") {
           id = sub.companyId;
           name = sub.companyName ?? sub.companyId;
         } else if (groupBy === "vendor") {

--- a/packages/cli/src/commands/report/index.ts
+++ b/packages/cli/src/commands/report/index.ts
@@ -25,12 +25,12 @@ export function registerReportCommands(program: Command): void {
       `
 Subcommands:
   renewals       Subscriptions with upcoming commitment-term-end dates
-  concentration  Where your Pax8 spend is concentrated (customer/vendor/product)
-  subscriptions  Active subscriptions grouped by customer, vendor, product, or billing term
+  concentration  Where your Pax8 spend is concentrated (client/vendor/product)
+  subscriptions  Active subscriptions grouped by client, vendor, product, or billing term
 
 Examples:
   pax8 report renewals --within 90
-  pax8 report concentration --by customer --top 5
+  pax8 report concentration --by client --top 5
   pax8 report subscriptions --by billing-term --json
 
 Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue (what you charge your customers), combine with sell-through pricing from your PSA.`,

--- a/packages/cli/src/commands/report/subscriptions.ts
+++ b/packages/cli/src/commands/report/subscriptions.ts
@@ -18,13 +18,23 @@ import { formatCompanyName, formatCurrency } from "../../lib/formatters.js";
 import { enrichCompanyNames, enrichProductNames } from "../../lib/enrich-subscriptions.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 
-type GroupBy = "customer" | "vendor" | "product" | "billing-term";
+type GroupBy = "client" | "vendor" | "product" | "billing-term";
 
 interface SubscriptionsOptions {
   by?: string;
   company?: string;
   vendor?: string;
 }
+
+// `client` is the canonical noun (per #317 — `pax8 clients *` is the
+// canonical command surface). We accept `customer` and `company` as
+// deprecated aliases and emit a one-line stderr warning so existing
+// scripts keep working while the docs and tab-completion converge on
+// `client`.
+const BY_ALIASES: Record<string, "client"> = {
+  customer: "client",
+  company: "client",
+};
 
 interface SubscriptionsGroupRow {
   groupName: string;
@@ -36,8 +46,14 @@ interface SubscriptionsGroupRow {
 
 function parseGroupBy(raw: string | undefined): GroupBy {
   const v = (raw ?? "vendor").toLowerCase();
+  if (BY_ALIASES[v]) {
+    process.stderr.write(
+      `  ⚠ --by ${v} is deprecated; use --by client instead.\n`,
+    );
+    return BY_ALIASES[v];
+  }
   if (
-    v === "customer" ||
+    v === "client" ||
     v === "vendor" ||
     v === "product" ||
     v === "billing-term"
@@ -46,7 +62,7 @@ function parseGroupBy(raw: string | undefined): GroupBy {
   throw new CliError(
     `Invalid --by value: "${raw}".`,
     undefined,
-    ["Use --by customer, --by vendor, --by product, or --by billing-term."],
+    ["Use --by client, --by vendor, --by product, or --by billing-term."],
     undefined,
     ERROR_INVALID_INPUT,
   );
@@ -84,7 +100,7 @@ export const reportSubscriptionsCommand = new Command("subscriptions")
   .description(
     "Audit and group your active Pax8 commitments. Useful for periodic state checks, capacity audits, and identifying orphaned subscriptions.",
   )
-  .option("--by <customer|vendor|product|billing-term>", "Group axis", "vendor")
+  .option("--by <client|vendor|product|billing-term>", "Group axis", "vendor")
   .option("--company <id|name>", "Filter by company ID or name")
   .option("--vendor <name>", "Filter by vendor (e.g. Microsoft, AvePoint)")
   .addHelpText(
@@ -92,14 +108,14 @@ export const reportSubscriptionsCommand = new Command("subscriptions")
     `
 Examples:
   pax8 report subscriptions
-  pax8 report subscriptions --by customer
+  pax8 report subscriptions --by client
   pax8 report subscriptions --by billing-term --json
   pax8 report subscriptions --company "Redwood Manufacturing"
   pax8 report subscriptions --vendor Microsoft
 
 JSON output (--json):
   {
-    "groupBy": "customer" | "vendor" | "product" | "billing-term",
+    "groupBy": "client" | "vendor" | "product" | "billing-term",
     "totalActiveSubscriptions": number,
     "totalMonthlyCost": { "amount": number, "currency": string },
     "groups": [{
@@ -186,7 +202,7 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
         let key: string;
         let name: string;
-        if (groupBy === "customer") {
+        if (groupBy === "client") {
           key = sub.companyId;
           name = sub.companyName ?? sub.companyId;
         } else if (groupBy === "vendor") {


### PR DESCRIPTION
## Summary

Two report-command fixes that bundle because both touch `packages/cli/src/commands/report/concentration.ts`.

### #517 — `report concentration --by` not enforced at parse time
`pax8 report concentration --json` (no flags) was firing the spinner, fetching subscriptions, then throwing `ERROR_INVALID_INPUT` after the round-trip cost. Switched to Commander's `.requiredOption()` so the missing `--by <axis>` is rejected at parse time with no spinner, no fetch, and no `buildContext()` call. The defensive `!raw` branch in `parseGroupBy()` stays as a guard for future refactors.

`report subscriptions --by` defaults to `vendor`, so it wasn't a required-but-not-enforced flag and didn't need the same change.

### #516 — flag taxonomy uses `customer` instead of `client`
`pax8 clients *` is the canonical command surface (per #317), but `report --by` rejected `--by client` and `--by company`. Renamed the accepted value to `client`. `customer` and `company` are accepted as deprecated aliases that warn once on stderr (`⚠ --by customer is deprecated; use --by client instead.`) and proceed as if `client` had been passed. Applies identically to `report concentration` and `report subscriptions`. Help text, recovery hints, and the JSON `groupBy` payload field all normalize to `client`. Updated the `pax8_report_subscriptions` claude-skill description to reflect the new canonical taxonomy.

## Test plan

- [x] `pnpm build` + `pnpm lint` clean
- [x] `pnpm test packages/cli/src/__tests__/report.test.ts` — 41 tests pass (including new parse-time / alias coverage)
- [x] Full CLI test suite — 560 tests pass, 6 todo
- [x] New tests added:
  - `rejects missing --by at parse time (no spinner / fetch)` — asserts no `Fetching subscriptions` string in failure output AND Commander's `required option ... --by` error format
  - `accepts --by customer as a deprecated alias for client (warns on stderr)` × 2 commands × 2 aliases (`customer`, `company`) = 4 alias-acceptance tests
- [x] Existing `concentration --by` parametric tests rotated from `customer` → `client`

Closes #516, closes #517