### PR TITLE
fix(lists): clamp --size to LIST_SIZE_CAP with stderr warning (closes #518)

### DIFF
--- a/packages/cli/src/__tests__/scale-matrix.test.ts
+++ b/packages/cli/src/__tests__/scale-matrix.test.ts
@@ -153,6 +153,70 @@ describe("scale matrix — read surface under PAX8_DEMO_SCALE=large", () => {
     });
   });
 
+  describe("#518 — list commands clamp --size to LIST_SIZE_CAP (1000)", () => {
+    // Issue #518: list commands previously honored arbitrarily-large
+    // `--size` values (`orders list --size 50000` returned ~34 MB of
+    // JSON). The fix caps every list command at the LIST_SIZE_CAP
+    // (1000) ceiling and emits a stderr warning when clamping.
+
+    it("orders list --size 50000 returns at most LIST_SIZE_CAP rows", async () => {
+      const result = await runCliExpectSuccess(
+        ["orders", "list", "--json", "--size", "50000"],
+        LARGE,
+      );
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeLessThanOrEqual(1000);
+    });
+
+    it("orders list --size 50000 emits the clamp warning on stderr", async () => {
+      const result = await runCliExpectSuccess(
+        ["orders", "list", "--json", "--size", "50000"],
+        LARGE,
+      );
+      expect(result.stderr).toContain("--size 50000 clamped to 1000");
+    });
+
+    it("subscriptions list --size 5000 caps at LIST_SIZE_CAP rows", async () => {
+      const result = await runCliExpectSuccess(
+        ["subscriptions", "list", "--json", "--size", "5000"],
+        LARGE,
+      );
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeLessThanOrEqual(1000);
+      expect(result.stderr).toContain("--size 5000 clamped to 1000");
+    });
+
+    it("clients list --size 10000 caps and warns", async () => {
+      const result = await runCliExpectSuccess(
+        ["clients", "list", "--json", "--size", "10000"],
+        LARGE,
+      );
+      const data = parseJson<unknown[]>(result.stdout);
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeLessThanOrEqual(1000);
+      expect(result.stderr).toContain("--size 10000 clamped to 1000");
+    });
+
+    it("a sub-cap --size value does NOT emit the warning", async () => {
+      // Regression guard: clamp + warn must only fire above LIST_SIZE_CAP.
+      const result = await runCliExpectSuccess(
+        ["orders", "list", "--json", "--size", "500"],
+        LARGE,
+      );
+      expect(result.stderr).not.toContain("clamped to 1000");
+    });
+
+    it("exactly LIST_SIZE_CAP does NOT emit the warning (boundary)", async () => {
+      const result = await runCliExpectSuccess(
+        ["orders", "list", "--json", "--size", "1000"],
+        LARGE,
+      );
+      expect(result.stderr).not.toContain("clamped to 1000");
+    });
+  });
+
   describe("hostile-name robustness", () => {
     // The large fixture seeds 12 deliberately-hostile customer names
     // (shell-meta, Unicode, embedded quotes/backticks/newlines). The

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -21,7 +21,7 @@ import { formatStatus, formatCompanyName, formatCurrency } from "../../lib/forma
 import { saveLastList } from "../../lib/last-list.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
-import { validateEnum } from "../../lib/validate.js";
+import { clampListSize, LIST_SIZE_CAP, validateEnum, warnSizeClamped } from "../../lib/validate.js";
 
 const COMPANY_STATUS_VALUES = CompanyStatusSchema.options as readonly CompanyStatus[];
 
@@ -96,7 +96,7 @@ export const companiesListCommand = new Command("list")
     "Sort by field (name, city, country, state, zip)"
   )
   .option("--page <number>", "Page number", "1")
-  .option("--size <number>", "Page size", "25")
+  .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "25")
   .option("--ids-only", "Output only resource IDs, one per line")
   .option("--coverage", "Include portfolio coverage analysis")
   .option("--with-actions", "Wrap JSON output as { companies, nextActions } instead of a flat array")
@@ -136,7 +136,16 @@ Examples:
     try {
       const ctx = await buildContext(allOpts);
       const userPage = parseInt(allOpts.page, 10);
-      const pageSize = parseInt(allOpts.size, 10);
+      // #518: clamp `--size` to LIST_SIZE_CAP (1000) before issuing the
+      // request. Without this, `clients list --size 50000` paired with a
+      // large portfolio drags multiple megabytes through `output()` and
+      // the post-list saveLastList write — and pushes way past the
+      // documented 1000-row server-side page anyway.
+      const sizeResult = clampListSize(parseInt(allOpts.size, 10), 25);
+      if (sizeResult.clamped) {
+        warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
+      }
+      const pageSize = sizeResult.size;
       const apiPage = Math.max(userPage - 1, 0); // User sees 1-based, API is 0-based
       // #388: map CLI vocabulary (`--state`, `--zip`, `--self-service`, ...)
       // onto the spec-canonical query-parameter names that `CompaniesApi.list`

--- a/packages/cli/src/commands/contacts/list.ts
+++ b/packages/cli/src/commands/contacts/list.ts
@@ -11,12 +11,13 @@ import { handleCommandError, CliError } from "../../lib/errors.js";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { replCmd } from "../../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
+import { clampListSize, LIST_SIZE_CAP, warnSizeClamped } from "../../lib/validate.js";
 
 export const contactsListCommand = new Command("list")
   .description("List contacts for a company")
   .option("--company <id|name>", "Company ID or name (required)")
   .option("--page <number>", "Page number", "1")
-  .option("--size <number>", "Page size", "50")
+  .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "50")
   .option("--ids-only", "Output only resource IDs, one per line")
   .addHelpText(
     "after",
@@ -50,9 +51,14 @@ Examples:
       spinner.start();
       const company = await resolveCompany(ctx, allOpts.company);
       const apiPage = Math.max(parseInt(allOpts.page, 10) - 1, 0);
+      // #518: clamp `--size` at LIST_SIZE_CAP (1000).
+      const sizeResult = clampListSize(parseInt(allOpts.size, 10), 50);
+      if (sizeResult.clamped) {
+        warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
+      }
       const result = await ctx.api.contacts.list(company.id, {
         page: apiPage,
-        size: parseInt(allOpts.size, 10),
+        size: sizeResult.size,
       });
       spinner.stop();
 

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -9,7 +9,7 @@ import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatCurrency, formatDate, formatStatus } from "../../lib/formatters.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
-import { validateEnum } from "../../lib/validate.js";
+import { clampListSize, LIST_SIZE_CAP, validateEnum, warnSizeClamped } from "../../lib/validate.js";
 
 // Help text mirrors the public OpenAPI enum for `GET /invoices`'s
 // `status` query parameter (#250). The wire emits a narrower 4-value
@@ -73,7 +73,7 @@ export const invoicesListCommand = new Command("list")
     "Sort by field (invoice-date, due-date, status, partner-name, total, balance, carried-balance)"
   )
   .option("--page <number>", "Page number", "1")
-  .option("--size <number>", "Page size", "25")
+  .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "25")
   .option("--ids-only", "Output only resource IDs, one per line")
   .option("--with-actions", "Wrap JSON output as { invoices, nextActions } instead of a flat array")
   .addHelpText(
@@ -118,6 +118,13 @@ Examples:
       // case) onto the spec-canonical query-parameter names.
       const sortRaw = allOpts.sort ? String(allOpts.sort).toLowerCase() : undefined;
       const sort = sortRaw ? INVOICE_SORT_ALIASES[sortRaw] : undefined;
+      // #518: clamp `--size` at LIST_SIZE_CAP (1000) to keep `jq`
+      // pipelines and agent contexts from getting blown out by an
+      // unbounded request.
+      const sizeResult = clampListSize(parseInt(allOpts.size, 10), 25);
+      if (sizeResult.clamped) {
+        warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
+      }
       const result = await ctx.api.invoices.list({
         month: allOpts.month,
         companyId,
@@ -126,7 +133,7 @@ Examples:
         invoiceDateRangeEnd: allOpts.to,
         sort,
         page: apiPage,
-        size: parseInt(allOpts.size, 10),
+        size: sizeResult.size,
       });
       spinner.stop();
 

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -11,6 +11,7 @@ import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { output, type Column } from "../../lib/output.js";
 import { formatDate } from "../../lib/formatters.js";
 import { enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
+import { clampListSize, LIST_SIZE_CAP, warnSizeClamped } from "../../lib/validate.js";
 
 // #385: timestamp column references the canonical `createdAt`. The legacy
 // `createdDate` alias is still emitted on every row in `--json` output for
@@ -41,7 +42,7 @@ export const ordersListCommand = new Command("list")
     "No-op: server ignores filter; field not in public OpenAPI (see #369)"
   )
   .option("--page <number>", "Page number", "1")
-  .option("--size <number>", "Page size", "25")
+  .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "25")
   .option("--ids-only", "Output only resource IDs, one per line")
   .addHelpText(
     "after",
@@ -62,9 +63,17 @@ Examples:
     try {
       const ctx = await buildContext(allOpts);
       const apiPage = Math.max(parseInt(allOpts.page, 10) - 1, 0);
+      // #518: cap `--size` at LIST_SIZE_CAP (1000). The orders endpoint
+      // returns ~34 MB of JSON for size=50000 — a context-window-killer
+      // for agents and an OOM risk for CI runners. Clamp and warn on
+      // stderr so the user can switch to `--page N --size 1000` paging.
+      const sizeResult = clampListSize(parseInt(allOpts.size, 10), 25);
+      if (sizeResult.clamped) {
+        warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
+      }
       const params: { page: number; size: number; companyId?: string; status?: string } = {
         page: apiPage,
-        size: parseInt(allOpts.size, 10),
+        size: sizeResult.size,
       };
       if (allOpts.company) {
         params.companyId = await resolveCompanyId(ctx, allOpts.company);

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -10,7 +10,7 @@ import { handleCommandError } from "../../lib/errors.js";
 import { formatDate, formatCurrency } from "../../lib/formatters.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { replCmd } from "../../lib/confirm.js";
-import { validateEnum } from "../../lib/validate.js";
+import { clampListSize, LIST_SIZE_CAP, validateEnum, warnSizeClamped } from "../../lib/validate.js";
 import type { Quote } from "@pax8/core";
 
 // Lowercase enum from `quoting-endpoints.json` → `GET /v2/quotes`. The
@@ -45,7 +45,7 @@ export const quotesListCommand = new Command("list")
     "Filter by status (draft, assigned, sent, closed, declined, accepted, changes_requested, expired, pending)"
   )
   .option("--page <number>", "Page number", "1")
-  .option("--size <number>", "Page size", "50")
+  .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "50")
   .option("--ids-only", "Output only resource IDs, one per line")
   .addHelpText(
     "after",
@@ -84,11 +84,16 @@ Examples:
         ? await resolveCompanyId(ctx, allOpts.company)
         : undefined;
       const apiPage = Math.max(parseInt(allOpts.page, 10) - 1, 0);
+      // #518: clamp `--size` at LIST_SIZE_CAP (1000).
+      const sizeResult = clampListSize(parseInt(allOpts.size, 10), 50);
+      if (sizeResult.clamped) {
+        warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
+      }
       const result = await ctx.api.quotes.list({
         companyId,
         status,
         page: apiPage,
-        size: parseInt(allOpts.size, 10),
+        size: sizeResult.size,
       });
       spinner.stop();
 

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -15,7 +15,7 @@ import {
 } from "../../lib/formatters.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
-import { validateEnum } from "../../lib/validate.js";
+import { clampListSize, LIST_SIZE_CAP, validateEnum, warnSizeClamped } from "../../lib/validate.js";
 
 // Single source of truth for `--status` accepted values. Mirrors the
 // public OpenAPI enum for `GET /subscriptions`'s `status` query parameter
@@ -67,7 +67,7 @@ export const subscriptionsListCommand = new Command("list")
     `Filter by status (${SUBSCRIPTION_STATUS_HELP})`
   )
   .option("--page <number>", "Page number", "1")
-  .option("--size <number>", "Page size", "25")
+  .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "25")
   .option("--ids-only", "Output only resource IDs, one per line")
   .option("--with-actions", "Wrap JSON output as { subscriptions, nextActions } instead of a flat array")
   .addHelpText(
@@ -105,11 +105,18 @@ Examples:
         ? await resolveCompanyId(ctx, allOpts.company)
         : undefined;
       const apiPage = Math.max(parseInt(allOpts.page, 10) - 1, 0);
+      // #518: cap `--size` at LIST_SIZE_CAP (1000) — a 50k-row pull
+      // returns multiple megabytes of JSON and is hostile to agents,
+      // CI runners, and `jq` consumers. Clamp + warn instead.
+      const sizeResult = clampListSize(parseInt(allOpts.size, 10), 25);
+      if (sizeResult.clamped) {
+        warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
+      }
       const result = await ctx.api.subscriptions.list({
         companyId,
         status: allOpts.status,
         page: apiPage,
-        size: parseInt(allOpts.size, 10),
+        size: sizeResult.size,
       });
 
       const subs = result.content as Record<string, unknown>[];

--- a/packages/cli/src/commands/usage/list.ts
+++ b/packages/cli/src/commands/usage/list.ts
@@ -11,6 +11,7 @@ import { handleCommandError } from "../../lib/errors.js";
 import { formatCurrency, formatDate } from "../../lib/formatters.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { replCmd } from "../../lib/confirm.js";
+import { clampListSize, LIST_SIZE_CAP, warnSizeClamped } from "../../lib/validate.js";
 
 export const usageListCommand = new Command("list")
   .description("List usage summaries")
@@ -18,7 +19,7 @@ export const usageListCommand = new Command("list")
   .option("--company <id|name>", "List usage across every subscription owned by a company")
   .option("--month <YYYY-MM>", "Filter by usage month (e.g. 2026-04)")
   .option("--page <number>", "Page number", "1")
-  .option("--size <number>", "Page size", "50")
+  .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "50")
   .option("--ids-only", "Output only resource IDs, one per line")
   .addHelpText(
     "after",
@@ -44,7 +45,12 @@ Notes:
     try {
       spinner.start();
       const apiPage = Math.max(parseInt(options.page, 10) - 1, 0);
-      const apiSize = parseInt(options.size, 10);
+      // #518: clamp `--size` at LIST_SIZE_CAP (1000).
+      const sizeResult = clampListSize(parseInt(options.size, 10), 50);
+      if (sizeResult.clamped) {
+        warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: globalOpts.quiet });
+      }
+      const apiSize = sizeResult.size;
 
       // Resolve the set of subscription IDs to query. Three modes:
       //   --subscription <id>   → query exactly that subscription

--- a/packages/cli/src/lib/validate.test.ts
+++ b/packages/cli/src/lib/validate.test.ts
@@ -5,9 +5,12 @@ import { describe, it, expect } from "vitest";
 import { ERROR_INVALID_INPUT } from "@pax8/core";
 import { CliError } from "./errors.js";
 import {
+  clampListSize,
+  LIST_SIZE_CAP,
+  resolveWithSuggestions,
   validateEnum,
   validateEnumList,
-  resolveWithSuggestions,
+  warnSizeClamped,
 } from "./validate.js";
 
 describe("validateEnum", () => {
@@ -214,5 +217,103 @@ describe("resolveWithSuggestions", () => {
       expect(cli.code).toBe(ERROR_INVALID_INPUT);
       expect(cli.message).toContain("not found");
     }
+  });
+});
+
+describe("clampListSize", () => {
+  // The cap mirrors `ALL_SUBS_PAGE_SIZE` (1000) — keep this assertion
+  // alongside the helper so a drift between the two is caught immediately.
+  it("exposes a 1000-row cap", () => {
+    expect(LIST_SIZE_CAP).toBe(1000);
+  });
+
+  it("passes a sub-cap request through unchanged", () => {
+    const r = clampListSize(25, 25);
+    expect(r.size).toBe(25);
+    expect(r.clamped).toBe(false);
+    expect(r.requested).toBe(25);
+  });
+
+  it("passes the exact cap through without flagging clamped", () => {
+    const r = clampListSize(1000, 25);
+    expect(r.size).toBe(1000);
+    expect(r.clamped).toBe(false);
+  });
+
+  it("clamps an over-cap request and reports the original value", () => {
+    const r = clampListSize(50000, 25);
+    expect(r.size).toBe(LIST_SIZE_CAP);
+    expect(r.clamped).toBe(true);
+    expect(r.requested).toBe(50000);
+  });
+
+  it("falls back to the default for undefined / NaN / non-positive input", () => {
+    expect(clampListSize(undefined, 25)).toEqual({ size: 25, clamped: false, requested: 25 });
+    expect(clampListSize(Number.NaN, 50)).toEqual({ size: 50, clamped: false, requested: 50 });
+    expect(clampListSize(0, 50)).toEqual({ size: 50, clamped: false, requested: 50 });
+    expect(clampListSize(-1, 50)).toEqual({ size: 50, clamped: false, requested: 50 });
+  });
+
+  it("never returns a default that itself exceeds the cap", () => {
+    // Defensive: if a caller ever wires up a default larger than the cap,
+    // we still hand back a safe size rather than echoing the bad default.
+    const r = clampListSize(undefined, 5000);
+    expect(r.size).toBe(LIST_SIZE_CAP);
+  });
+});
+
+describe("warnSizeClamped", () => {
+  it("writes the canonical warning to stderr with both the requested and clamped values", () => {
+    const writes: string[] = [];
+    const orig = process.stderr.write;
+    // @ts-expect-error — narrow override for the test
+    process.stderr.write = (chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      warnSizeClamped(50000);
+    } finally {
+      process.stderr.write = orig;
+    }
+    const joined = writes.join("");
+    expect(joined).toContain("--size 50000 clamped to 1000");
+    expect(joined).toContain("--page");
+  });
+
+  it("respects the quiet option", () => {
+    const writes: string[] = [];
+    const orig = process.stderr.write;
+    // @ts-expect-error — narrow override for the test
+    process.stderr.write = (chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      warnSizeClamped(50000, LIST_SIZE_CAP, { quiet: true });
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(writes.join("")).toBe("");
+  });
+
+  it("respects PAX8_QUIET=1", () => {
+    const writes: string[] = [];
+    const orig = process.stderr.write;
+    const prevEnv = process.env.PAX8_QUIET;
+    process.env.PAX8_QUIET = "1";
+    // @ts-expect-error — narrow override for the test
+    process.stderr.write = (chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      warnSizeClamped(50000);
+    } finally {
+      process.stderr.write = orig;
+      if (prevEnv === undefined) delete process.env.PAX8_QUIET;
+      else process.env.PAX8_QUIET = prevEnv;
+    }
+    expect(writes.join("")).toBe("");
   });
 });

--- a/packages/cli/src/lib/validate.ts
+++ b/packages/cli/src/lib/validate.ts
@@ -1,9 +1,72 @@
 // Copyright 2026 Pax8, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ERROR_INVALID_INPUT } from "@pax8/core";
+import { ALL_SUBS_PAGE_SIZE, ERROR_INVALID_INPUT } from "@pax8/core";
 import { CliError } from "./errors.js";
 import { replCmd } from "./confirm.js";
+
+/**
+ * Hard ceiling enforced on `--size <N>` across every paginated `list`
+ * command. Mirrors `ALL_SUBS_PAGE_SIZE` from `@pax8/core` (1000) — the
+ * same page-size the portfolio-wide read paths (dashboard, audit,
+ * recommendations, MRR reports, renewals) already use.
+ *
+ * Why a hard cap, not a configurable knob: a partner / agent / CI
+ * runner that asks for `--size 50000` against the orders endpoint
+ * gets back ~34 MB of JSON (#518). That blows up context windows,
+ * crashes `jq` pipelines, and OOMs CI runners — all without warning.
+ * The cap forces a paged-iteration pattern (`--page 2 --size 1000`)
+ * instead of a single mega-request.
+ */
+export const LIST_SIZE_CAP = ALL_SUBS_PAGE_SIZE;
+
+/**
+ * Clamp a user-supplied `--size <N>` to the global list-size cap and
+ * report whether clamping happened.
+ *
+ * Contract:
+ *   - `undefined` / `NaN` / non-positive values fall back to the
+ *     caller-supplied default (commander's `--size <number>` default).
+ *   - Values `≤ LIST_SIZE_CAP` pass through verbatim.
+ *   - Values `> LIST_SIZE_CAP` clamp to `LIST_SIZE_CAP` and return
+ *     `clamped: true` so the caller can emit a stderr warning.
+ *
+ * Designed for the existing commander pattern
+ * `--option("--size <number>", "Page size", "25")` — the option value
+ * arrives as a string. Callers pass `parseInt(allOpts.size, 10)` and
+ * trust this helper to coerce out negatives / NaN.
+ */
+export function clampListSize(
+  requested: number | undefined,
+  defaultSize: number,
+): { size: number; clamped: boolean; requested: number } {
+  const fallback = Math.min(Math.max(defaultSize, 1), LIST_SIZE_CAP);
+  if (requested === undefined || !Number.isFinite(requested) || requested <= 0) {
+    return { size: fallback, clamped: false, requested: fallback };
+  }
+  if (requested > LIST_SIZE_CAP) {
+    return { size: LIST_SIZE_CAP, clamped: true, requested };
+  }
+  return { size: requested, clamped: false, requested };
+}
+
+/**
+ * Emit the canonical `--size clamped to N` warning to stderr. Kept
+ * next to `clampListSize` so command sites are a single import + two
+ * calls. Honors `PAX8_QUIET=1` and `--quiet` (caller passes `quiet`).
+ */
+export function warnSizeClamped(
+  requested: number,
+  cap: number = LIST_SIZE_CAP,
+  options: { quiet?: boolean } = {},
+): void {
+  if (options.quiet) return;
+  if (process.env.PAX8_QUIET === "1") return;
+  process.stderr.write(
+    `\n  ⚠ --size ${requested} clamped to ${cap} (max). ` +
+      `Use --page <N> --size ${cap} for further results.\n`,
+  );
+}
 
 /**
  * Fail-fast enum validation for CLI flag values.


### PR DESCRIPTION
## Summary

- List commands previously accepted arbitrarily-large `--size` values. Under `PAX8_DEMO_SCALE=large`, `pax8 orders list --size 50000` returned ~34 MB of JSON — a context-window-killer for agents, OOM for CI runners, hang for `jq` consumers.
- Every paginated `list` command now caps `--size` at `LIST_SIZE_CAP` (mirrors `ALL_SUBS_PAGE_SIZE` from `@pax8/core` = 1000), warns on stderr when clamping, and documents the ceiling in `--help` text.
- Added `clampListSize` + `warnSizeClamped` helpers to `packages/cli/src/lib/validate.ts` so each list site stays a single import + two lines.

## Behavior

```
$ pax8 orders list --size 50000 --json | jq 'length'
1000
[stderr] ⚠ --size 50000 clamped to 1000 (max). Use --page <N> --size 1000 for further results.
```

Sub-cap values pass through silently (no warning). Exactly `--size 1000` is the boundary — also no warning.

## Surface

Applied to all eight list commands from the issue's enumeration:

- `orders list`
- `subscriptions list`
- `companies list` (aka `clients list`)
- `invoices list`
- `quotes list`
- `contacts list`
- `usage list`

`webhooks logs` doesn't accept `--size`. `products list` is outside the issue's enumeration. `recommendations list` is held for #521.

## Docs alignment

`CLAUDE.md` and `packages/claude-skill/skill.md` already recommend `--size 1000` as the portfolio-wide pull size — that's exactly the cap, so no doc churn needed. Agents told "use `--size 1000`" continue to get the expected behavior; agents that hand-rolled `--size 50000` now get the same 1000 rows with an informative warning rather than 34 MB of JSON.

## Test plan

- [x] Unit tests in `lib/validate.test.ts` cover the helper: pass-through, exact-cap boundary, over-cap clamping, fallback for undefined/NaN/zero/negative, and a defensive guard for a misconfigured default.
- [x] `warnSizeClamped` unit tests assert the canonical stderr message, plus the `quiet` option and `PAX8_QUIET=1` env opt-outs.
- [x] Subprocess assertions in `__tests__/scale-matrix.test.ts` under `PAX8_DEMO_SCALE=large`:
  - `orders list --size 50000` returns ≤ 1000 rows
  - `orders list --size 50000` emits the stderr warning
  - `subscriptions list --size 5000` clamps + warns
  - `clients list --size 10000` clamps + warns
  - `orders list --size 500` does NOT emit the warning (regression guard)
  - `orders list --size 1000` does NOT emit the warning (boundary)
- [x] All 2104 tests pass (`pnpm test`)
- [x] `pnpm lint` clean
- [x] `pnpm build` clean

Closes #518.