### PR TITLE
fix(clients): resolve prefixed demo IDs (co-<uuid>) via get

### DIFF
--- a/packages/cli/src/lib/resolve-company.test.ts
+++ b/packages/cli/src/lib/resolve-company.test.ts
@@ -49,6 +49,25 @@ describe("resolveCompany", () => {
     expect(ctx.api.companies.list).not.toHaveBeenCalled();
   });
 
+  // #519: the large demo fixture issues IDs of the form
+  // `co-<uuid>` (e.g. `co-9e3779b1-9e37-79b1-00009e3779b10000`). The
+  // pre-fix `^`-anchored hex check missed the leading `co-` and
+  // dropped these lookups through to name-search, which truncated the
+  // 1000-company portfolio at the first 200 entries and produced
+  // "Could not load company summary" for any company past the cutoff.
+  it("prefixed demo ID (co-<uuid>) is treated as ID, not name (#519)", async () => {
+    const demoId = "co-9e3779b1-9e37-79b1-00009e3779b10000";
+    const company = makeCompany({ id: demoId, name: "Stonebridge Limited" });
+    const ctx = makeMockCtx([company]);
+
+    const result = await resolveCompany(ctx, demoId);
+    expect(result).toEqual(company);
+    expect(ctx.api.companies.get).toHaveBeenCalledWith(demoId);
+    // The whole point of the fix: no fall-through to the name-search
+    // path that truncates the company list.
+    expect(ctx.api.companies.list).not.toHaveBeenCalled();
+  });
+
   it("name input resolves via list + exact match (case-insensitive)", async () => {
     const company = makeCompany();
     const ctx = makeMockCtx([company]);

--- a/packages/cli/src/lib/resolve-company.ts
+++ b/packages/cli/src/lib/resolve-company.ts
@@ -23,9 +23,22 @@ export async function resolveCompany(ctx: CommandContext, input: string): Promis
     return ctx.api.companies.get(lastListMatch.id);
   }
 
-  // 2. UUID — fetch directly
-  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(input);
-  if (isUuid) {
+  // 2. ID-shaped input — fetch directly.
+  //
+  // Match either a bare RFC-4122 UUID (production Pax8: `a1b2c3d4-e5f6-…`)
+  // or the demo fixture's prefixed form (`co-9e3779b1-9e37-79b1-…`).
+  // The optional `[a-z]{2,5}-` head admits the demo's `co-` (and the
+  // analogous `prod-`, `sub-` etc. if ever fed here) without matching
+  // longer English-word prefixes, and the start-of-input anchor stops a
+  // UUID-shape embedded mid-name from being treated as an ID.
+  //
+  // #519: the previous regex was `^[0-9a-f]{8}-[0-9a-f]{4}-` — the
+  // `^`-anchor immediately rejected anything starting with `co-`, lookups
+  // fell through to name-search, and the `size: 200` truncation of the
+  // companies list left any company past the first page of the large
+  // fixture unresolvable by its canonical ID.
+  const isLikelyId = /^(?:[a-z]{2,5}-)?[0-9a-f]{8}-[0-9a-f]{4}-/i.test(input);
+  if (isLikelyId) {
     return ctx.api.companies.get(input);
   }
 


### PR DESCRIPTION
Closes #519.

## Summary

`resolveCompany`'s ID-shape detector was anchored at start-of-input:

```ts
const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(input);
```

Production Pax8 IDs are bare RFC-4122 UUIDs (`a1b2c3d4-e5f6-…`) so they matched. The large demo fixture (`PAX8_DEMO_SCALE=large`) issues IDs prefixed with `co-`:

```
co-9e3779b1-9e37-79b1-00009e3779b10000
```

The leading `co-` made the regex miss → lookup fell through to name-search → name-search calls `companies.list({ size: 200 })` → 800+ of the fixture's 1000 companies past that page were silently unresolvable by their own canonical ID.

User-visible symptom (per #519):

```
$ PAX8_DEMO=1 PAX8_DEMO_SCALE=large \
    pax8 clients more co-9e3779b1-9e37-79b1-00009e3779b10000
  ✗ Could not load company summary
```

…even though `clients list --json` confirmed the ID is real.

## Fix

Broaden the detector to admit an optional `[a-z]{2,5}-` prefix in front of the 8-4 hex pattern:

```diff
-const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(input);
+const isLikelyId = /^(?:[a-z]{2,5}-)?[0-9a-f]{8}-[0-9a-f]{4}-/i.test(input);
```

Covers `co-`, `prod-`, `sub-` etc. without admitting longer English-word prefixes; anchor stays at start so a UUID-shape embedded mid-name isn't misclassified.

## Tests

New case in `packages/cli/src/lib/resolve-company.test.ts` pinning both shapes route through `companies.get` (not the truncated name-search):

- Bare RFC-4122 UUID (production) → `companies.get`, no `companies.list` call
- `co-<uuid>` (demo prefix) → `companies.get`, no `companies.list` call

## End-to-end verification

```
$ PAX8_DEMO=1 PAX8_DEMO_SCALE=large \
    pax8 clients more co-9e3779b1-9e37-79b1-00009e3779b10000 --json
  ✔ Loaded Stonebridge Limited
  { ... full summary ... }
```

## Note

Cassie's #519 reproducer mentioned `pax8 clients more "Anvil Insurance"` also failing. That was a red herring — `Anvil Insurance` doesn't exist in the large fixture. The actual bug is purely about ID-shape detection; name lookups for real names in the fixture work fine via the substring-match path.

## Test plan

- [x] `pnpm build && pnpm lint` clean
- [x] `resolve-company.test.ts` — 10 passing (was 9, +1 for the demo-ID case)
- [x] Manual: `pax8 clients more <co-prefixed-id>` resolves under large fixture
- [ ] Spot-check that real Pax8 partner names containing UUID-shaped substrings aren't misclassified (e.g. a company literally named `Customer-abc12345-1234-…`). Unlikely in practice; doc-side note for future maintainers.