### PR TITLE
fix(recommendations): cap list at 10 by default, add --top + totalAvailable envelope

### DIFF
--- a/.changeset/recommendations-top-cap-and-envelope.md
+++ b/.changeset/recommendations-top-cap-and-envelope.md
@@ -1,0 +1,19 @@
+---
+"@pax8/cli": minor
+"@pax8/claude-skill": minor
+---
+
+Cap `pax8 recommendations list` at 10 by default and add `--top <n>` (with `--top 0` for unlimited). Closes #521.
+
+Against the large-portfolio fixture `pax8 recommendations list --json` returned 308 recommendations (101 marked `high`) — no cap, no sort by uplift. That's a context-window grenade for agents and signal-dilution for partners; both surfaces ended up triaging by hand.
+
+**Behavior changes (pre-publish, called out here so partner-readiness consumers see the diff):**
+
+- **New `--top <n>` flag.** Default is `10`. `--top 0` is the documented escape hatch — it opts out of the cap and emits every recommendation. Replaces the implicit "show everything" contract that #521 found was broken on real partner volumes.
+- **Sort is now `estimatedMrrUplift` DESC, with `priority` (high > medium > low) as tiebreaker. Recommendations with a null uplift sort last.** Priority tags ("missing security = high") are heuristic; uplift is concrete dollars. A $5k/mo medium opportunity outranks a $500/mo high one — which is what a partner trying to grow MRR actually wants at the top of the list.
+- **`pax8 recommendations list --json` is now ALWAYS a wrapped envelope `{ recommendations: Recommendation[], totalAvailable: number }` — even without `--with-actions`.** This is a JSON-shape breaking change for any agent/script that previously did `JSON.parse(stdout)` and treated the result as a flat array. `totalAvailable` is the engine count BEFORE the `--top` cap fires, so consumers can detect the cap and decide whether to re-query with `--top 0`. Capping by default while silently emitting a bare array would have been exactly the anti-pattern #483 is fixing on the report surface — partners and agents need to know what's behind the curtain. Pre-1.0, no deprecation period.
+- **`--with-actions` envelope extension.** Already wrapped, but now also carries `totalAvailable` alongside the existing `recommendations` / `nextActions` / `unmatchedProducts`. Shape: `{ recommendations, totalAvailable, nextActions, unmatchedProducts }`.
+- **Table-mode footer.** When the cap fires the human render appends `Showing top 10 of 308 recommendations. Use --top 50 or --top 0 to see more.` on stderr, so partners reading the table know there's more behind the cap without having to remember the new flag.
+- **Skill tool updated.** `pax8_recommendations` (the `@pax8/claude-skill` tool) now accepts a `top` parameter and the tool description documents the new envelope shape so MCP clients see the cap-and-totalAvailable contract.
+
+Out of scope (intentionally): `--priority` filtering already exists; `recommendations act` already consumes one rec at a time; the dashboard's `highRecs` already caps internally at 12. The engine in `@pax8/core` is unchanged — this is a CLI command-layer change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ When the user asks ANYTHING about Pax8 data (companies, subscriptions, Pax8 cost
 | renewals | `pax8 subscriptions renewals --json --within 30d 2>/dev/null` |
 | Pax8 cost / monthly spend / annualized spend | `pax8 dashboard --json 2>/dev/null` (top-line `monthlyCost.amount` / `annualCost.amount`) or `pax8 clients more "<name>" --json` for per-client breakdown. `pax8 report subscriptions --by vendor --json` for grouped Pax8 cost. |
 | growth / portfolio trend | `pax8 dashboard --json 2>/dev/null` (see `topCustomers`, `highPriorityRecs`, `potentialPax8MonthlyUplift`) or `pax8 subscriptions list --json --size 1000` for raw data |
-| recommendations / upsell | `pax8 recommendations list --json 2>/dev/null` |
+| recommendations / upsell | `pax8 recommendations list --json 2>/dev/null` — returns `{ recommendations, totalAvailable }` (wrapped envelope, #521). Default cap is `--top 10`, sorted by `estimatedMrrUplift` DESC with `priority` as tiebreaker (nulls last). Compare `recommendations.length` to `totalAvailable` to know whether the cap fired; pass `--top 0` for the unbounded set. |
 | invoices / billing | `pax8 invoices list --json 2>/dev/null` |
 | invoice audit | `pax8 invoices audit --json 2>/dev/null` |
 | invoice line items | `pax8 invoices items --invoice-id <invoice-id> --json 2>/dev/null` |

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -64,11 +64,11 @@ If you're unsure whether a command counts as a write, default to confirming. Bet
 
 | Flag | When to use |
 |---|---|
-| `--json` | Default. You parse it. List commands return flat arrays. |
+| `--json` | Default. You parse it. List commands return flat arrays, except `recommendations list` which returns a wrapped `{ recommendations, totalAvailable }` envelope (#521 — see Commands section). |
 | `--csv` | User asks for a spreadsheet, export, or PSA import. |
 | `--quiet` | Suppress output entirely (rare; mostly for write commands you're chaining). |
 | `--ids-only` | Pipe one command's output into another's `--company` filter. |
-| `--with-actions` | Wrap list-command JSON as `{ items, nextActions }` so suggested next commands ride along. Available on `recommendations list`, `subscriptions renewals`, `webhooks list`, `webhooks logs`. Single-object commands (`dashboard`, `invoices audit`) always include `nextActions` inline. |
+| `--with-actions` | Wrap list-command JSON as `{ items, nextActions }` so suggested next commands ride along. Available on `recommendations list`, `subscriptions renewals`, `webhooks list`, `webhooks logs`. Single-object commands (`dashboard`, `invoices audit`) always include `nextActions` inline. `recommendations list` always wraps (#521); `--with-actions` adds `nextActions` + `unmatchedProducts` on top. |
 
 Result size: list commands default to `--size 25`. For portfolio-wide analysis (Pax8 cost rollups, audits, recommendations) use `--size 1000`. Don't fetch 1000 if the user asked for "top 5."
 
@@ -87,7 +87,10 @@ pax8 subscriptions renewals --json --within 7d|30d|90d [--company <id|name>]
 pax8 invoices list --json [--company <id|name>] [--status Paid|Unpaid]
 pax8 invoices audit --json [--month YYYY-MM] [--company <id|name>]
 pax8 products search "<query>" --json
-pax8 recommendations list --json [--priority high|medium|low] [--company <id|name>] [--product <name>]
+pax8 recommendations list --json [--priority high|medium|low] [--company <id|name>] [--product <name>] [--top <n>|--top 0]
+  # Wrapped envelope (#521): { recommendations, totalAvailable }
+  # — sorted by estimatedMrrUplift DESC, priority tiebreaker, nulls last.
+  # Capped at 10 by default; pass --top 0 for the full set.
 pax8 recommendations act [--company <id|name>] [--product <name>] [--yes]    # multi-select picker; --yes places all without prompting
 pax8 orders list --json
 pax8 orders create --company <id|name> --product <id|name> --quantity <n> [--billing-term Monthly|Annual]
@@ -123,7 +126,7 @@ Run in parallel:
 pax8 recommendations list --json --priority high
 pax8 clients list --json
 ```
-For each rec, show: company, missing product, additional Pax8 monthly cost if acted on (wire-side field name: `estimatedMrrUplift`). The JSON output includes an `orderCommand` field — that's the exact `pax8 orders create …` to run. **Always show the user the order preview and wait for explicit approval before executing the write.**
+The recommendations call returns `{ recommendations, totalAvailable }` — capped at 10 by default and sorted by `estimatedMrrUplift` DESC (priority breaks ties; nulls sort last). If `totalAvailable` exceeds `recommendations.length`, more opportunities exist behind the cap; re-run with `--top 50` or `--top 0` (unlimited) to widen. For each rec, show: company, missing product, additional Pax8 monthly cost if acted on (wire-side field name: `estimatedMrrUplift`). The JSON output includes an `orderCommand` field — that's the exact `pax8 orders create …` to run. **Always show the user the order preview and wait for explicit approval before executing the write.**
 
 For an interactive batch flow, hand the human `pax8 recommendations act` (with `--company` / `--product` / `--priority` filters as needed) — it presents a multi-select picker and a single batch confirmation rather than a per-rec y/s/q walk. The agent should not pass `--yes` unless the user has approved the entire matching set.
 

--- a/packages/claude-skill/src/tools/recommendations.ts
+++ b/packages/claude-skill/src/tools/recommendations.ts
@@ -6,7 +6,7 @@ import { execCli } from "../index.js";
 export const pax8_recommendations = {
   name: "pax8_recommendations",
   description:
-    "Analyze customer portfolios and recommend products they should consider. Returns type (cross-sell or seat-gap), companyName, productName, priority (high/medium/low), reason, estimatedMRR, and orderCommand for each recommendation. Filter by companyId (name or UUID) and/or priority level. Use this for upsell opportunities, product gaps, or revenue growth questions.",
+    "Analyze customer portfolios and recommend products they should consider. Returns a wrapped envelope `{ recommendations: [...], totalAvailable: number }` — each recommendation carries type (cross-sell or seat-gap), companyName, productName, priority (high/medium/low), reason, estimatedMRR, and orderCommand. Sorted by estimatedMrrUplift DESC, priority as tiebreaker, nulls last. Capped at 10 by default; pass `top: 0` to retrieve all (compare against `totalAvailable` to know if the cap fired). Filter by companyId (name or UUID) and/or priority level. Use this for upsell opportunities, product gaps, or revenue growth questions.",
   parameters: {
     type: "object" as const,
     properties: {
@@ -20,12 +20,18 @@ export const pax8_recommendations = {
         description:
           "Filter by priority: high, medium, or low. Optional — omit for all priorities.",
       },
+      top: {
+        type: "number",
+        description:
+          "Cap the number of recommendations returned (default 10). Pass 0 for unlimited. Compare the returned array length against `totalAvailable` to know whether the cap hid additional opportunities.",
+      },
     },
   },
-  execute: async (params: { companyId?: string; priority?: string }) => {
+  execute: async (params: { companyId?: string; priority?: string; top?: number }) => {
     const args = ["recommendations", "list", "--json"];
     if (params.companyId) args.push("--company", params.companyId);
     if (params.priority) args.push("--priority", params.priority);
+    if (typeof params.top === "number") args.push("--top", String(params.top));
     return execCli(args);
   },
 };

--- a/packages/cli/src/__tests__/json-contract.test.ts
+++ b/packages/cli/src/__tests__/json-contract.test.ts
@@ -100,9 +100,16 @@ const COMMANDS: CommandCase[] = [
     },
   },
   {
+    // #521: `recommendations list --json` is now always a wrapped envelope
+    // { recommendations, totalAvailable }. The pre-#521 contract was a flat
+    // array; the change is pre-publish and called out as breaking in the
+    // changeset. We pin the new shape here so a future regression that
+    // drops the envelope (or silently re-flattens it) gets caught.
     args: ["recommendations", "list", "--json"],
     shape: (parsed) => {
-      expect(Array.isArray(parsed)).toBe(true);
+      const data = parsed as { recommendations?: unknown; totalAvailable?: unknown };
+      expect(Array.isArray(data.recommendations)).toBe(true);
+      expect(typeof data.totalAvailable).toBe("number");
     },
   },
 ];

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -10,25 +10,112 @@ import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.j
 
 describe("pax8 recommendations", () => {
   describe("recommendations list", () => {
-    it("returns a flat array of recommendations in JSON by default", async () => {
+    // #521: JSON output is now ALWAYS a wrapped envelope
+    // `{ recommendations: [...], totalAvailable: number }`, even without
+    // `--with-actions`. The previous flat-array shape was a footgun on
+    // large portfolios — capping by default but emitting a bare array
+    // silently hid 298 of 308 recs (same anti-pattern #483 fixed
+    // elsewhere). Pre-publish, so OK to break.
+    it("returns a wrapped envelope { recommendations, totalAvailable } in JSON by default", async () => {
       const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
       const data = JSON.parse(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
-      expect(data.length).toBeGreaterThan(0);
-      expect(data[0]).toHaveProperty("companyId");
-      expect(data[0]).toHaveProperty("companyName");
-      expect(data[0]).toHaveProperty("type");
-      expect(data[0]).toHaveProperty("priority");
+      expect(data).toHaveProperty("recommendations");
+      expect(data).toHaveProperty("totalAvailable");
+      expect(Array.isArray(data.recommendations)).toBe(true);
+      expect(typeof data.totalAvailable).toBe("number");
+      expect(data.recommendations.length).toBeGreaterThan(0);
+      // Default cap = 10
+      expect(data.recommendations.length).toBeLessThanOrEqual(10);
+      // totalAvailable is the pre-cap count and must be >= what was returned.
+      expect(data.totalAvailable).toBeGreaterThanOrEqual(data.recommendations.length);
+      expect(data.recommendations[0]).toHaveProperty("companyId");
+      expect(data.recommendations[0]).toHaveProperty("companyName");
+      expect(data.recommendations[0]).toHaveProperty("type");
+      expect(data.recommendations[0]).toHaveProperty("priority");
     });
 
-    it("--with-actions wraps in { recommendations, nextActions, unmatchedProducts }", async () => {
+    it("--top <n> caps recommendations to N", async () => {
+      const result = await runCliExpectSuccess([
+        "recommendations", "list", "--json", "--top", "5",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data.recommendations)).toBe(true);
+      expect(data.recommendations.length).toBeLessThanOrEqual(5);
+      expect(data.totalAvailable).toBeGreaterThanOrEqual(data.recommendations.length);
+    });
+
+    // `--top 0` is the agent escape hatch — opt out of the cap entirely
+    // and stream every rec the engine produced. Cassie's spec is clear
+    // that this is the documented way to recover the pre-#521 unbounded
+    // shape for downstream tooling that wants it.
+    it("--top 0 returns all recommendations (unlimited)", async () => {
+      const result = await runCliExpectSuccess([
+        "recommendations", "list", "--json", "--top", "0",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data.recommendations)).toBe(true);
+      // When uncapped, totalAvailable === recommendations.length (no rows hidden).
+      expect(data.totalAvailable).toBe(data.recommendations.length);
+    });
+
+    it("sorts by estimatedMrrUplift DESC with nulls last; priority breaks ties", async () => {
+      const result = await runCliExpectSuccess([
+        "recommendations", "list", "--json", "--top", "0",
+      ]);
+      const data = JSON.parse(result.stdout) as {
+        recommendations: Array<{
+          estimatedMrrUplift: number | null;
+          priority: "high" | "medium" | "low";
+        }>;
+      };
+      const recs = data.recommendations;
+      expect(recs.length).toBeGreaterThan(1);
+
+      // No non-null uplift appears AFTER a null uplift (nulls-last
+      // invariant). Once we cross into the null run, every subsequent
+      // entry must also be null.
+      let sawNull = false;
+      for (const rec of recs) {
+        if (rec.estimatedMrrUplift == null) {
+          sawNull = true;
+        } else {
+          expect(sawNull).toBe(false);
+        }
+      }
+
+      // First item is either the max non-null uplift OR (if every rec
+      // has null uplift) is null.
+      const nonNull = recs.filter((r) => r.estimatedMrrUplift != null);
+      if (nonNull.length > 0) {
+        const maxUplift = Math.max(...nonNull.map((r) => r.estimatedMrrUplift as number));
+        expect(recs[0].estimatedMrrUplift).toBe(maxUplift);
+      }
+
+      // Within a same-uplift run, priority order is high > medium > low.
+      // Walk adjacent pairs with identical non-null uplifts and assert the
+      // priority rank is non-decreasing (lower index → better priority).
+      const rank = { high: 0, medium: 1, low: 2 } as const;
+      for (let i = 1; i < recs.length; i++) {
+        const a = recs[i - 1];
+        const b = recs[i];
+        if (a.estimatedMrrUplift != null && a.estimatedMrrUplift === b.estimatedMrrUplift) {
+          expect(rank[a.priority]).toBeLessThanOrEqual(rank[b.priority]);
+        }
+      }
+    });
+
+    it("--with-actions extends the envelope with nextActions + unmatchedProducts (and totalAvailable)", async () => {
       const result = await runCliExpectSuccess(["recommendations", "list", "--json", "--with-actions"]);
       const data = JSON.parse(result.stdout);
       expect(data).toHaveProperty("recommendations");
+      expect(data).toHaveProperty("totalAvailable");
       expect(data).toHaveProperty("nextActions");
       expect(data).toHaveProperty("unmatchedProducts");
       expect(Array.isArray(data.recommendations)).toBe(true);
+      expect(typeof data.totalAvailable).toBe("number");
       expect(Array.isArray(data.nextActions)).toBe(true);
+      // Default cap still applies under --with-actions.
+      expect(data.recommendations.length).toBeLessThanOrEqual(10);
       expect(data.nextActions.length).toBeLessThanOrEqual(5);
       if (data.nextActions.length > 0) {
         expect(data.nextActions[0]).toHaveProperty("command");
@@ -38,22 +125,22 @@ describe("pax8 recommendations", () => {
 
     it("filters by exact company name", async () => {
       const result = await runCliExpectSuccess([
-        "recommendations", "list", "--company", "Bright Minds Academy", "--json",
+        "recommendations", "list", "--company", "Bright Minds Academy", "--json", "--top", "0",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data.length).toBeGreaterThan(0);
-      for (const rec of data) {
+      expect(data.recommendations.length).toBeGreaterThan(0);
+      for (const rec of data.recommendations) {
         expect(rec.companyName).toBe("Bright Minds Academy");
       }
     });
 
     it("filters by partial company name (contains match)", async () => {
       const result = await runCliExpectSuccess([
-        "recommendations", "list", "--company", "Bright", "--json",
+        "recommendations", "list", "--company", "Bright", "--json", "--top", "0",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data.length).toBeGreaterThan(0);
-      for (const rec of data) {
+      expect(data.recommendations.length).toBeGreaterThan(0);
+      for (const rec of data.recommendations) {
         expect(rec.companyName.toLowerCase()).toContain("bright");
       }
     });
@@ -62,22 +149,22 @@ describe("pax8 recommendations", () => {
       // Simulates: --company Bright Minds Academy (no quotes)
       // Commander captures "Bright", "Minds" and "Academy" become excess args
       const result = await runCliExpectSuccess([
-        "recommendations", "list", "--company", "Bright", "Minds", "Academy", "--json",
+        "recommendations", "list", "--company", "Bright", "Minds", "Academy", "--json", "--top", "0",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data.length).toBeGreaterThan(0);
-      for (const rec of data) {
+      expect(data.recommendations.length).toBeGreaterThan(0);
+      for (const rec of data.recommendations) {
         expect(rec.companyName).toBe("Bright Minds Academy");
       }
     });
 
     it("filters by priority", async () => {
       const result = await runCliExpectSuccess([
-        "recommendations", "list", "--priority", "high", "--json",
+        "recommendations", "list", "--priority", "high", "--json", "--top", "0",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data.length).toBeGreaterThan(0);
-      for (const rec of data) {
+      expect(data.recommendations.length).toBeGreaterThan(0);
+      for (const rec of data.recommendations) {
         expect(rec.priority).toBe("high");
       }
     });
@@ -87,12 +174,14 @@ describe("pax8 recommendations", () => {
         "recommendations", "list", "--company", "NonExistentCorp99999", "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data).toEqual([]);
+      expect(data.recommendations).toEqual([]);
+      expect(data.totalAvailable).toBe(0);
     });
 
     it("JSON output includes both available and unavailable recs for downstream filtering", async () => {
-      const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
-      const allRecs = JSON.parse(result.stdout);
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json", "--top", "0"]);
+      const parsed = JSON.parse(result.stdout);
+      const allRecs = parsed.recommendations;
 
       // Some recs should have productAvailable: true, some false
       const available = allRecs.filter((r: { productAvailable: boolean }) => r.productAvailable);
@@ -109,15 +198,29 @@ describe("pax8 recommendations", () => {
     });
 
     it("--include-all shows unavailable recs in JSON output", async () => {
-      const withAll = await runCliExpectSuccess(["recommendations", "list", "--include-all", "--json"]);
-      const withoutAll = await runCliExpectSuccess(["recommendations", "list", "--json"]);
+      const withAll = await runCliExpectSuccess(["recommendations", "list", "--include-all", "--json", "--top", "0"]);
+      const withoutAll = await runCliExpectSuccess(["recommendations", "list", "--json", "--top", "0"]);
 
-      const allRecs = JSON.parse(withAll.stdout);
-      const defaultRecs = JSON.parse(withoutAll.stdout);
+      const allRecs = JSON.parse(withAll.stdout).recommendations;
+      const defaultRecs = JSON.parse(withoutAll.stdout).recommendations;
 
       // Both should return the same set since JSON output is pre-filter
       // (JSON returns all recs; filtering only affects table mode)
       expect(allRecs.length).toBe(defaultRecs.length);
+    });
+
+    // #521 footer hint: when the cap fires, table mode must tell the
+    // partner that there's more behind the curtain and how to widen it.
+    // Forcing table mode via PAX8_OUTPUT_FORMAT because a non-TTY stdout
+    // (the test subprocess) otherwise auto-falls back to JSON.
+    it("table mode shows 'Showing top N of M' footer when --top caps the list", async () => {
+      const result = await runCliExpectSuccess(
+        ["recommendations", "list", "--top", "2"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      // The footer is on stderr (hints/banners are never on stdout).
+      expect(result.stderr).toMatch(/Showing top \d+ of \d+/);
+      expect(result.stderr).toMatch(/--top 0/);
     });
 
     // Issue #195: human render leaked product UUIDs in a "Quick actions"
@@ -163,8 +266,8 @@ describe("pax8 recommendations", () => {
     });
 
     it("--json output still carries the full orderCommand with product id (agent contract)", async () => {
-      const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
-      const data = JSON.parse(result.stdout) as Array<{ orderCommand: string | null }>;
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json", "--top", "0"]);
+      const data = (JSON.parse(result.stdout) as { recommendations: Array<{ orderCommand: string | null }> }).recommendations;
       const withCommand = data.filter((r) => r.orderCommand);
       expect(withCommand.length).toBeGreaterThan(0);
       // The JSON `orderCommand` MUST still include `--product <id>` so
@@ -183,11 +286,13 @@ describe("pax8 recommendations", () => {
     // display-only. Pinning the shape here so a future regression that
     // drops `orderArgs` from JSON output gets caught.
     it("--json carries orderArgs[] argv-style array alongside orderCommand", async () => {
-      const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
-      const data = JSON.parse(result.stdout) as Array<{
-        orderCommand: string | null;
-        orderArgs: string[] | null;
-      }>;
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json", "--top", "0"]);
+      const data = (JSON.parse(result.stdout) as {
+        recommendations: Array<{
+          orderCommand: string | null;
+          orderArgs: string[] | null;
+        }>;
+      }).recommendations;
       const actionable = data.filter((r) => r.orderCommand);
       expect(actionable.length).toBeGreaterThan(0);
       for (const rec of actionable) {
@@ -211,11 +316,13 @@ describe("pax8 recommendations", () => {
     // `opportunityType` axis alongside the legacy `type`, using OE's
     // canonical 5-type taxonomy. The legacy `type` is unchanged.
     it("--json carries both legacy type and additive opportunityType (OE 5-type taxonomy)", async () => {
-      const result = await runCliExpectSuccess(["recommendations", "list", "--json"]);
-      const data = JSON.parse(result.stdout) as Array<{
-        type: string;
-        opportunityType: string;
-      }>;
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json", "--top", "0"]);
+      const data = (JSON.parse(result.stdout) as {
+        recommendations: Array<{
+          type: string;
+          opportunityType: string;
+        }>;
+      }).recommendations;
       expect(data.length).toBeGreaterThan(0);
       const allowed = new Set(["Upsell", "Cross-sell", "Add-on", "Upgrade", "Net-new"]);
       for (const rec of data) {

--- a/packages/cli/src/__tests__/scale-matrix.test.ts
+++ b/packages/cli/src/__tests__/scale-matrix.test.ts
@@ -125,8 +125,14 @@ describe("scale matrix — read surface under PAX8_DEMO_SCALE=large", () => {
 
     it("pax8 recommendations list --json", async () => {
       const result = await runCliExpectSuccess(["recommendations", "list", "--json"], LARGE);
-      const data = parseJson<unknown[]>(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
+      // #521: list output is now an envelope { recommendations, totalAvailable }
+      // even without --with-actions. Default cap is 10; under the large
+      // fixture totalAvailable should be substantially larger.
+      const data = parseJson<{ recommendations: unknown[]; totalAvailable: number }>(result.stdout);
+      expect(Array.isArray(data.recommendations)).toBe(true);
+      expect(data.recommendations.length).toBeLessThanOrEqual(10);
+      expect(typeof data.totalAvailable).toBe("number");
+      expect(data.totalAvailable).toBeGreaterThanOrEqual(data.recommendations.length);
     });
 
     it("pax8 doctor (non-crash; --json shape contract verified separately in #470)", async () => {

--- a/packages/cli/src/__tests__/table-output.test.ts
+++ b/packages/cli/src/__tests__/table-output.test.ts
@@ -186,8 +186,12 @@ describe("table output — TTY-aware rendering", () => {
       const result = await runTable(["recommendations", "list", "--json"]);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain("\x1b[");
+      // #521: list output is now wrapped { recommendations, totalAvailable }.
+      // The cleanliness assertion still passes — we're checking that the
+      // wrapped JSON is parseable and ANSI-free.
       const data = JSON.parse(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
+      expect(Array.isArray(data.recommendations)).toBe(true);
+      expect(typeof data.totalAvailable).toBe("number");
     });
 
     it("CSV output has no ANSI codes", async () => {

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -59,6 +59,46 @@ const columns: Column[] = [
   },
 ];
 
+// `--top` is intentionally a string-typed option (Commander parses to string
+// by default) so we can preserve "0 = unlimited" semantics without a NaN /
+// undefined ambiguity. A non-positive non-zero value falls back to the
+// default 10 — partners typo'ing `--top -5` shouldn't get an empty list.
+function parseTopFlag(raw: unknown): number {
+  if (raw === undefined || raw === null) return 10;
+  const n = parseInt(String(raw), 10);
+  if (Number.isNaN(n)) return 10;
+  if (n < 0) return 10;
+  return n; // 0 = unlimited; positive = cap
+}
+
+const PRIORITY_RANK: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
+// Cassie's locked sort (#521): estimatedMrrUplift DESC first, priority as
+// tiebreaker (high > medium > low), nulls last. The reasoning is that
+// priority tags are heuristic ("missing security = high") while uplift is
+// concrete dollars — a $5k/mo medium opportunity outranks a $500/mo high
+// one for a partner trying to grow MRR. Pure function; no in-place mutation
+// of the input so callers can still hold the original reference if they
+// need to.
+function sortRecommendations<T extends { estimatedMrrUplift?: number | null; priority?: string }>(
+  recs: T[],
+): T[] {
+  return [...recs].sort((a, b) => {
+    const aUplift = a.estimatedMrrUplift;
+    const bUplift = b.estimatedMrrUplift;
+    const aNull = aUplift == null;
+    const bNull = bUplift == null;
+    // Nulls last
+    if (aNull && !bNull) return 1;
+    if (!aNull && bNull) return -1;
+    if (!aNull && !bNull && aUplift !== bUplift) return (bUplift as number) - (aUplift as number);
+    // Tiebreaker: priority rank ascending (high=0 sorts first)
+    const aRank = PRIORITY_RANK[a.priority ?? "low"] ?? 3;
+    const bRank = PRIORITY_RANK[b.priority ?? "low"] ?? 3;
+    return aRank - bRank;
+  });
+}
+
 async function promptLine(question: string): Promise<string> {
   const { createInterface } = await import("readline");
   const rl = createInterface({ input: process.stdin, output: process.stderr });
@@ -77,7 +117,8 @@ export const recommendationsListCommand = new Command("list")
   .option("--type <type>", "Filter by type (seat_gap or cross_sell)")
   .option("--product <name>", "Filter by product name (e.g. 'AvePoint', 'Entra')")
   .option("--include-all", "Show all recommendations including ones without orderable products")
-  .option("--with-actions", "Wrap JSON output as { recommendations, nextActions, unmatchedProducts } instead of a flat array")
+  .option("--with-actions", "Extend the JSON envelope with nextActions + unmatchedProducts (recommendations + totalAvailable are always present)")
+  .option("--top <number>", "Cap the number of recommendations returned/displayed (default 10; 0 = unlimited)", "10")
   .option("--limit <number>", "Max rows to show in table (default 10)")
   .addHelpText(
     "after",
@@ -123,8 +164,17 @@ Estimate semantics:
   the CLI's user-visible label uses Pax8-cost framing.
 
 JSON output (--json):
-  Default: a flat array of Recommendation objects. With --with-actions,
-  wrapped as { recommendations, nextActions, unmatchedProducts }.
+  Always wrapped as { recommendations: Recommendation[], totalAvailable: number }.
+  With --with-actions, the envelope is extended with nextActions and
+  unmatchedProducts: { recommendations, totalAvailable, nextActions,
+  unmatchedProducts }. totalAvailable is the count of recommendations the
+  engine produced before --top capping, so agents can decide whether to
+  re-query with --top 0 (unlimited) when triaging at portfolio scale.
+
+  Sort order: estimatedMrrUplift DESC (concrete dollars first), then
+  priority (high > medium > low) as tiebreaker. Recommendations with a
+  null estimatedMrrUplift sort last. Cap defaults to --top 10; pass
+  --top 0 to disable.
 
   Recommendation = {
     "companyId": string,
@@ -224,21 +274,59 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
       recs = filterRecommendations(recs, options);
 
+      // Sort by estimatedMrrUplift DESC (concrete dollars beat heuristic
+      // priority tags); tiebreak by priority (high > medium > low). Recs
+      // with a null uplift sort LAST so the top of the list is always the
+      // partner's highest-dollar opportunities (Cassie / #521).
+      recs = sortRecommendations(recs);
+
+      // Cap the count. `--top 0` opts out (unlimited); any positive int
+      // caps; default is 10. We capture `totalAvailable` BEFORE capping so
+      // the envelope can honestly report "you're seeing N of M" — capping
+      // by default but silently hiding 298 of 308 recs is exactly the
+      // anti-pattern #483 is fixing elsewhere (#521).
+      const totalAvailable = recs.length;
+      const topCap = parseTopFlag(options.top);
+      const capped = topCap === 0 ? recs : recs.slice(0, topCap);
+
       if (ctx.outputFormat === "json") {
         if (options.withActions) {
-          const nextActions = recs
+          const nextActions = capped
             .filter((r) => r.orderCommand)
             .slice(0, 5)
             .map((r) => ({
               command: r.orderCommand!,
               description: `${r.title} for ${r.companyName}`,
             }));
-          process.stdout.write(JSON.stringify({ recommendations: recs, nextActions, unmatchedProducts: report.unmatchedProducts }, null, 2) + "\n");
+          process.stdout.write(
+            JSON.stringify(
+              {
+                recommendations: capped,
+                totalAvailable,
+                nextActions,
+                unmatchedProducts: report.unmatchedProducts,
+              },
+              null,
+              2,
+            ) + "\n",
+          );
         } else {
-          process.stdout.write(JSON.stringify(recs, null, 2) + "\n");
+          // #521: JSON shape change (pre-publish, no deprecation needed).
+          // Previously a flat Recommendation[]; now always wrapped as
+          // { recommendations, totalAvailable } so the cap is visible to
+          // agents instead of silently hidden. --with-actions still adds
+          // nextActions / unmatchedProducts on top of the same envelope.
+          process.stdout.write(
+            JSON.stringify({ recommendations: capped, totalAvailable }, null, 2) + "\n",
+          );
         }
         return;
       }
+
+      // From this point we operate on the capped set for human render too,
+      // so the count of items the user sees in the table matches the
+      // count the agent saw in the JSON envelope.
+      recs = capped;
 
       // In table mode, hide unavailable recs unless --include-all
       // Count hidden items BEFORE filtering so we can show "N hidden" message
@@ -294,6 +382,19 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
       if (recs.length > limit) {
         process.stderr.write(chalk.dim(`\n  Showing top ${limit} of ${recs.length} recommendations`) + chalk.dim(` · use --limit ${recs.length} to see all\n`));
+      }
+
+      // #521: when the engine produced more recs than the --top cap let
+      // through, surface that count so the partner knows there's more to
+      // see. `totalAvailable` is pre-cap; `recs` is post-cap-and-visibility-
+      // filter. We only print this hint when the cap (not the catalog-
+      // availability filter) is what's hiding rows.
+      if (topCap > 0 && totalAvailable > capped.length) {
+        process.stderr.write(
+          chalk.dim(
+            `\n  Showing top ${capped.length} of ${totalAvailable} recommendations. Use --top 50 or --top 0 to see more.\n`,
+          ),
+        );
       }
 
       const visibleCompanyCount = new Set(recs.map((r) => r.companyId)).size;


### PR DESCRIPTION
Closes #521.

## Summary

- `pax8 recommendations list` now caps at 10 recs by default and accepts `--top <n>` (`--top 0` = unlimited).
- Sort is `estimatedMrrUplift` DESC with `priority` (high > medium > low) as tiebreaker; null uplift sorts last. Uplift is concrete dollars; priority tags are heuristic — a $5k/mo medium opportunity outranks a $500/mo high one for a partner trying to grow MRR.
- JSON output is **always** a wrapped envelope `{ recommendations, totalAvailable }` — even without `--with-actions`. `totalAvailable` is the engine count BEFORE the cap fires, so agents can detect that the cap hid rows and re-query with `--top 0` if they need the full set.
- `--with-actions` extends that envelope with `nextActions` and `unmatchedProducts` (and inherits `totalAvailable`).
- Table-mode footer prints `Showing top N of M recommendations. Use --top 50 or --top 0 to see more.` on stderr when the cap fires.
- The `@pax8/claude-skill` `pax8_recommendations` tool now accepts a `top` param and its description documents the new envelope shape so MCP clients see the cap-and-totalAvailable contract.

## Breaking change

**This PR breaks the `recommendations list --json` shape.** It was a flat `Recommendation[]`; it's now a wrapped `{ recommendations, totalAvailable }`. Pre-publish (pre-1.0 `@pax8/cli`), so no deprecation period — the changeset entry (`.changeset/recommendations-top-cap-and-envelope.md`) is explicit about this. Capping by default while emitting a bare array would have been exactly the anti-pattern #483 is fixing on the report surface — partners and agents need to know what's behind the curtain.

## Out of scope (per Cassie's spec)

- `--priority` already exists on `recommendations list`.
- `recommendations act` consumes one rec at a time and doesn't need a cap.
- The dashboard's `highRecs` already caps at 12 internally — different code path.
- The `@pax8/core` recommendations engine is unchanged; this is a CLI command-layer change.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm test packages/cli/src/__tests__/recommendations.test.ts` — 26/26 passing (includes new tests for default cap, custom cap, unlimited, sort order, nulls-last, `--with-actions` envelope shape, and the table-mode footer)
- [x] `pnpm test packages/cli/src/__tests__/{json-contract,table-output,scale-matrix}.test.ts` — JSON-shape assertions updated to the wrapped envelope
- [x] Full suite (`pnpm test`) — 2122 passed, 6 skipped, 6 todo

## Files touched

- `packages/cli/src/commands/recommendations/list.ts` — flag, sort, cap, envelope, footer
- `packages/cli/src/__tests__/recommendations.test.ts` — new + updated tests for the envelope and cap
- `packages/cli/src/__tests__/json-contract.test.ts`, `scale-matrix.test.ts`, `table-output.test.ts` — pin the new wrapped shape
- `packages/claude-skill/src/tools/recommendations.ts` — tool description + `top` param
- `packages/claude-skill/skill.md` — flag/recipe docs
- `CLAUDE.md` — data-queries table row
- `.changeset/recommendations-top-cap-and-envelope.md` — changeset entry calling out the breaking shape change