### PR TITLE
fix(auth): credential-store honors PAX8_CONFIG_DIR at runtime

### DIFF
--- a/packages/cli/src/__tests__/local-state-writers.test.ts
+++ b/packages/cli/src/__tests__/local-state-writers.test.ts
@@ -61,8 +61,11 @@ const CORE_HOMEDIR_EXCEPTIONS = new Set<string>([
   // loader.ts: resolves the default `~/.pax8` config dir. This is the
   // canonical site — every other module routes through this loader.
   "packages/core/src/config/loader.ts",
-  // credential-store.ts: writes ~/.pax8/credentials.json with O_NOFOLLOW
-  // and mode 0o600. The home-dir reference is intrinsic to its job.
+  // credential-store.ts: after #504, production path resolution goes
+  // through `getConfigDir()` (PAX8_CONFIG_DIR-honoring). The remaining
+  // `os.homedir()` calls are only inside the Windows ACL fallback path,
+  // which compares the credentials file location against the user
+  // profile directory.
   "packages/core/src/auth/credential-store.ts",
   // validate-env.ts: implements the home-anchored path validator that
   // refuses to read credentials from outside $HOME. It MUST resolve the

--- a/packages/core/src/auth/credential-store.test.ts
+++ b/packages/core/src/auth/credential-store.test.ts
@@ -46,17 +46,53 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-const CONFIG_DIR = path.join(os.homedir(), ".pax8");
-const CREDENTIALS_FILE = path.join(CONFIG_DIR, "credentials.json");
+// #504: production credential-store now resolves the config dir lazily
+// via `getConfigDir()`, which honors `PAX8_CONFIG_DIR`. Tests set the
+// env var to a per-test mkdtemp directory and recompute the expected
+// paths the same way the production code does — the previous
+// hardcoded `~/.pax8/` assumption would have masked the very bug this
+// fix closes (credentials landing in the real home regardless of env
+// override). The vitest globalSetup already sets
+// `PAX8_ALLOW_NON_HOME_CONFIG=1`, so tmpdir paths under `os.tmpdir()`
+// (outside `os.homedir()` on macOS / Linux) pass `validateConfigDir`.
+import { mkdtempSync, rmSync } from "node:fs";
+
+let testConfigDir: string;
+let testCredentialsFile: string;
 
 describe("CredentialStore", () => {
   let store: CredentialStore;
-  const originalEnv = process.env;
+  const originalPax8ConfigDir = process.env.PAX8_CONFIG_DIR;
+  const originalPax8ClientId = process.env.PAX8_CLIENT_ID;
+  const originalPax8ClientSecret = process.env.PAX8_CLIENT_SECRET;
   const originalPlatform = process.platform;
 
   beforeEach(() => {
+    // Put the test config dir under `os.homedir()` rather than
+    // `os.tmpdir()`. Two reasons:
+    //   1. `validateConfigDir` allows paths under `$HOME` without the
+    //      `PAX8_ALLOW_NON_HOME_CONFIG` opt-in (matches production).
+    //   2. The Windows-platform tests below exercise
+    //      `checkPermissionsWindows`, which short-circuits to "outside
+    //      user home" before running `icacls` if the credentials path
+    //      isn't a prefix-match of `os.homedir()`. On the GH Actions
+    //      Windows runner `os.tmpdir()` can resolve outside the user
+    //      profile (or differ via 8.3 short-form normalization), so a
+    //      tmpdir-based path made the Windows ACL tests assert against
+    //      the wrong branch.
+    //
+    // The `.pax8-credstore-test-` prefix makes the directory hidden on
+    // POSIX and visually distinct on Windows; afterEach cleans up.
+    testConfigDir = mkdtempSync(path.join(os.homedir(), ".pax8-credstore-test-"));
+    testCredentialsFile = path.join(testConfigDir, "credentials.json");
+    // Mutate process.env in place. Wholesale replacement (`process.env =
+    // {...}`) doesn't propagate to the C++ side of node — the production
+    // code's `getConfigDir()` would still see the vitest globalSetup's
+    // value. Per-property assignment is reliable.
+    process.env.PAX8_CONFIG_DIR = testConfigDir;
+    delete process.env.PAX8_CLIENT_ID;
+    delete process.env.PAX8_CLIENT_SECRET;
     store = new CredentialStore();
-    process.env = { ...originalEnv };
     vi.mocked(fs.readFile).mockReset();
     vi.mocked(fs.writeFile).mockReset();
     vi.mocked(fs.mkdir).mockReset();
@@ -68,18 +104,46 @@ describe("CredentialStore", () => {
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    if (originalPax8ConfigDir === undefined) delete process.env.PAX8_CONFIG_DIR;
+    else process.env.PAX8_CONFIG_DIR = originalPax8ConfigDir;
+    if (originalPax8ClientId === undefined) delete process.env.PAX8_CLIENT_ID;
+    else process.env.PAX8_CLIENT_ID = originalPax8ClientId;
+    if (originalPax8ClientSecret === undefined) delete process.env.PAX8_CLIENT_SECRET;
+    else process.env.PAX8_CLIENT_SECRET = originalPax8ClientSecret;
     Object.defineProperty(process, "platform", { value: originalPlatform });
     vi.restoreAllMocks();
+    try {
+      rmSync(testConfigDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup; tmpdir gets reaped by the OS.
+    }
   });
 
   describe("static properties", () => {
     it("exposes credentialsFilePath", () => {
-      expect(CredentialStore.credentialsFilePath).toBe(CREDENTIALS_FILE);
+      expect(CredentialStore.credentialsFilePath).toBe(testCredentialsFile);
     });
 
     it("exposes configDirPath", () => {
-      expect(CredentialStore.configDirPath).toBe(CONFIG_DIR);
+      expect(CredentialStore.configDirPath).toBe(testConfigDir);
+    });
+
+    // #504: the previous module-level capture meant changing
+    // PAX8_CONFIG_DIR at runtime had no effect — credentials still
+    // landed in the real `~/.pax8`. Pin the contract: each call to the
+    // path getters re-reads the env so an updated PAX8_CONFIG_DIR is
+    // honored from the next call onward.
+    it("honors PAX8_CONFIG_DIR changes at runtime (#504)", () => {
+      const altDir = mkdtempSync(path.join(os.homedir(), ".pax8-credstore-alt-"));
+      try {
+        process.env.PAX8_CONFIG_DIR = altDir;
+        expect(CredentialStore.configDirPath).toBe(altDir);
+        expect(CredentialStore.credentialsFilePath).toBe(
+          path.join(altDir, "credentials.json"),
+        );
+      } finally {
+        rmSync(altDir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -109,7 +173,7 @@ describe("CredentialStore", () => {
 
       const creds = await store.getCredentials();
       expect(creds).toEqual({ clientId: "file-id", clientSecret: "file-secret" });
-      expect(fs.readFile).toHaveBeenCalledWith(CREDENTIALS_FILE, "utf-8");
+      expect(fs.readFile).toHaveBeenCalledWith(testCredentialsFile, "utf-8");
     });
 
     it("returns null when no credentials available", async () => {
@@ -228,7 +292,7 @@ describe("CredentialStore", () => {
       vi.mocked(fs.access).mockResolvedValueOnce(undefined);
 
       expect(await store.hasCredentials()).toBe(true);
-      expect(fs.access).toHaveBeenCalledWith(CREDENTIALS_FILE, expect.any(Number));
+      expect(fs.access).toHaveBeenCalledWith(testCredentialsFile, expect.any(Number));
       // hasCredentials must NOT read or parse the file body.
       expect(fs.readFile).not.toHaveBeenCalled();
     });
@@ -278,8 +342,8 @@ describe("CredentialStore", () => {
 
       await store.saveCredentials("my-id", "my-secret");
 
-      expect(fs.mkdir).toHaveBeenCalledWith(CONFIG_DIR, { recursive: true });
-      expect(fs.chmod).toHaveBeenCalledWith(CONFIG_DIR, 0o700);
+      expect(fs.mkdir).toHaveBeenCalledWith(testConfigDir, { recursive: true });
+      expect(fs.chmod).toHaveBeenCalledWith(testConfigDir, 0o700);
 
       expect(openSync).toHaveBeenCalledTimes(1);
       const [calledPath, flags, mode] = openSync.mock.calls[0] as [
@@ -287,7 +351,7 @@ describe("CredentialStore", () => {
         number,
         number,
       ];
-      expect(calledPath).toBe(CREDENTIALS_FILE);
+      expect(calledPath).toBe(testCredentialsFile);
       expect(mode).toBe(0o600);
       const C = fsSync.constants;
       expect(flags & C.O_WRONLY).toBe(C.O_WRONLY);
@@ -338,7 +402,7 @@ describe("CredentialStore", () => {
 
       await store.saveCredentials("my-id", "my-secret");
 
-      expect(fs.mkdir).toHaveBeenCalledWith(CONFIG_DIR, { recursive: true });
+      expect(fs.mkdir).toHaveBeenCalledWith(testConfigDir, { recursive: true });
       // chmod must NOT be used on Windows — the production code
       // routes the dir/file lockdown through icacls instead.
       expect(fs.chmod).not.toHaveBeenCalled();
@@ -352,13 +416,13 @@ describe("CredentialStore", () => {
       expect(execFileMock).toHaveBeenNthCalledWith(
         1,
         "icacls",
-        [CONFIG_DIR, "/inheritance:r", "/grant:r", `${username}:(OI)(CI)(F)`],
+        [testConfigDir, "/inheritance:r", "/grant:r", `${username}:(OI)(CI)(F)`],
         expect.any(Function),
       );
       expect(execFileMock).toHaveBeenNthCalledWith(
         2,
         "icacls",
-        [CREDENTIALS_FILE, "/inheritance:r", "/grant:r", `${username}:(F)`],
+        [testCredentialsFile, "/inheritance:r", "/grant:r", `${username}:(F)`],
         expect.any(Function),
       );
 
@@ -369,7 +433,7 @@ describe("CredentialStore", () => {
       // requests it, but the OS no-ops the bit.)
       expect(openSync).toHaveBeenCalledTimes(1);
       const [calledPath, , mode] = openSync.mock.calls[0] as [string, number, number];
-      expect(calledPath).toBe(CREDENTIALS_FILE);
+      expect(calledPath).toBe(testCredentialsFile);
       expect(mode).toBe(0o600);
 
       expect(writeSync).toHaveBeenCalledTimes(1);
@@ -415,7 +479,7 @@ describe("CredentialStore", () => {
       vi.mocked(fs.unlink).mockResolvedValueOnce(undefined);
 
       await store.clearCredentials();
-      expect(fs.unlink).toHaveBeenCalledWith(CREDENTIALS_FILE);
+      expect(fs.unlink).toHaveBeenCalledWith(testCredentialsFile);
     });
 
     it("does not throw when file does not exist", async () => {
@@ -502,7 +566,7 @@ describe("CredentialStore", () => {
       async () => {
         vi.mocked(fs.access).mockResolvedValueOnce(undefined);
         const username = os.userInfo().username;
-        const stdout = `${CREDENTIALS_FILE} ${username}:(F)\n\nSuccessfully processed 1 files; Failed processing 0 files\n`;
+        const stdout = `${testCredentialsFile} ${username}:(F)\n\nSuccessfully processed 1 files; Failed processing 0 files\n`;
         const execFileMock = vi.mocked(
           childProcess.execFile,
         ) as unknown as ReturnType<typeof vi.fn>;
@@ -519,7 +583,7 @@ describe("CredentialStore", () => {
         expect(result.detail).toContain("ACLs");
         expect(execFileMock).toHaveBeenCalledWith(
           "icacls",
-          [CREDENTIALS_FILE],
+          [testCredentialsFile],
           expect.any(Function),
         );
       },
@@ -534,7 +598,7 @@ describe("CredentialStore", () => {
         // BUILTIN\Users + Authenticated Users entries from the parent
         // directory.
         const stdout =
-          `${CREDENTIALS_FILE} BUILTIN\\Users:(I)(RX)\n` +
+          `${testCredentialsFile} BUILTIN\\Users:(I)(RX)\n` +
           `                    NT AUTHORITY\\Authenticated Users:(I)(M)\n` +
           `                    ${username}:(F)\n` +
           `\nSuccessfully processed 1 files; Failed processing 0 files\n`;
@@ -568,7 +632,7 @@ describe("CredentialStore", () => {
         vi.mocked(fs.access).mockResolvedValueOnce(undefined);
         const username = os.userInfo().username;
         const stdout =
-          `${CREDENTIALS_FILE} Everyone:(F)\n` +
+          `${testCredentialsFile} Everyone:(F)\n` +
           `                    ${username}:(F)\n` +
           `\nSuccessfully processed 1 files; Failed processing 0 files\n`;
         const execFileMock = vi.mocked(

--- a/packages/core/src/auth/credential-store.ts
+++ b/packages/core/src/auth/credential-store.ts
@@ -8,11 +8,23 @@ import * as os from "node:os";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { safeWriteFileSync } from "../security/safe-write.js";
+import { getConfigDir } from "../config/loader.js";
 
 const execFileAsync = promisify(execFile);
 
-const CONFIG_DIR = path.join(os.homedir(), ".pax8");
-const CREDENTIALS_FILE = path.join(CONFIG_DIR, "credentials.json");
+// #504: do NOT cache the config dir or credentials path at module load.
+// `getConfigDir()` resolves `PAX8_CONFIG_DIR` lazily and validates it via
+// `validateConfigDir` — capturing the home-dir-derived path at import
+// time bypassed that env override silently (every other state writer in
+// the CLI honored it; only credentials landed in the real `~/.pax8`).
+// The single-file/dir helpers below resolve fresh on each call.
+function configDir(): string {
+  return getConfigDir();
+}
+
+function credentialsFile(): string {
+  return path.join(configDir(), "credentials.json");
+}
 
 const isWindows = process.platform === "win32";
 
@@ -31,14 +43,14 @@ export class CredentialStore {
    * Returns the path to the credentials file.
    */
   static get credentialsFilePath(): string {
-    return CREDENTIALS_FILE;
+    return credentialsFile();
   }
 
   /**
    * Returns the path to the config directory.
    */
   static get configDirPath(): string {
-    return CONFIG_DIR;
+    return configDir();
   }
 
   /**
@@ -65,7 +77,7 @@ export class CredentialStore {
   async hasCredentials(): Promise<boolean> {
     if (this.getFromEnv() !== null) return true;
     try {
-      await fs.access(CREDENTIALS_FILE, constants.F_OK);
+      await fs.access(credentialsFile(), constants.F_OK);
       return true;
     } catch {
       return false;
@@ -78,25 +90,27 @@ export class CredentialStore {
    * On Windows: restrict ACLs to the current user via icacls.
    */
   async saveCredentials(clientId: string, clientSecret: string): Promise<void> {
-    await fs.mkdir(CONFIG_DIR, { recursive: true });
+    const dir = configDir();
+    const file = credentialsFile();
+    await fs.mkdir(dir, { recursive: true });
 
     if (isWindows) {
-      await this.secureDirectoryWindows(CONFIG_DIR);
+      await this.secureDirectoryWindows(dir);
     } else {
       // Secure the directory: owner-only access
-      await fs.chmod(CONFIG_DIR, 0o700);
+      await fs.chmod(dir, 0o700);
     }
 
     const data = JSON.stringify({ clientId, clientSecret }, null, 2);
-    // #262: use the safe-write helper so an existing symlink at
-    // CREDENTIALS_FILE causes the write to fail (ELOOP) rather than
+    // #262: use the safe-write helper so an existing symlink at the
+    // credentials path causes the write to fail (ELOOP) rather than
     // landing the credentials at the symlink's target. The 0o600 mode is
     // applied atomically at file-creation time, eliminating the small
     // window where an old `writeFile + chmod` flow had default perms.
-    safeWriteFileSync(CREDENTIALS_FILE, data);
+    safeWriteFileSync(file, data);
 
     if (isWindows) {
-      await this.secureFileWindows(CREDENTIALS_FILE);
+      await this.secureFileWindows(file);
     }
   }
 
@@ -105,7 +119,7 @@ export class CredentialStore {
    */
   async clearCredentials(): Promise<void> {
     try {
-      await fs.unlink(CREDENTIALS_FILE);
+      await fs.unlink(credentialsFile());
     } catch (err) {
       // Ignore ENOENT — file doesn't exist, nothing to clear
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -120,7 +134,7 @@ export class CredentialStore {
    */
   async checkPermissions(): Promise<PermissionCheckResult> {
     try {
-      await fs.access(CREDENTIALS_FILE, constants.F_OK);
+      await fs.access(credentialsFile(), constants.F_OK);
     } catch {
       return { secure: true, detail: "No credentials file (using env vars or not configured)" };
     }
@@ -132,8 +146,9 @@ export class CredentialStore {
   }
 
   private async checkPermissionsUnix(): Promise<PermissionCheckResult> {
+    const file = credentialsFile();
     try {
-      const stat = await fs.stat(CREDENTIALS_FILE);
+      const stat = await fs.stat(file);
       // mode & 0o777 gives the permission bits
       const perms = stat.mode & 0o777;
       if (perms === 0o600) {
@@ -144,7 +159,7 @@ export class CredentialStore {
       if (groupOther !== 0) {
         return {
           secure: false,
-          detail: `Permissions ${perms.toString(8)} — group/other have access. Run: chmod 600 ${CREDENTIALS_FILE}`,
+          detail: `Permissions ${perms.toString(8)} — group/other have access. Run: chmod 600 ${file}`,
         };
       }
       // Owner has execute but no group/other access — acceptable but not ideal
@@ -158,12 +173,13 @@ export class CredentialStore {
   }
 
   private async checkPermissionsWindows(): Promise<PermissionCheckResult> {
+    const file = credentialsFile();
     try {
       // Use icacls to inspect ACLs
-      const { stdout } = await execFileAsync("icacls", [CREDENTIALS_FILE]);
+      const { stdout } = await execFileAsync("icacls", [file]);
       // Check that the file is in a user-profile directory
       const homeDir = os.homedir();
-      const inUserDir = CREDENTIALS_FILE.toLowerCase().startsWith(homeDir.toLowerCase());
+      const inUserDir = file.toLowerCase().startsWith(homeDir.toLowerCase());
       if (!inUserDir) {
         return {
           secure: false,
@@ -178,14 +194,14 @@ export class CredentialStore {
       if (hasInsecureAcl) {
         return {
           secure: false,
-          detail: `File may be readable by other users. Run: icacls "${CREDENTIALS_FILE}" /inheritance:r /grant:r "%USERNAME%:F"`,
+          detail: `File may be readable by other users. Run: icacls "${file}" /inheritance:r /grant:r "%USERNAME%:F"`,
         };
       }
       return { secure: true, detail: "File ACLs restrict access (Windows)" };
     } catch {
       // icacls not available or errored — fall back to directory check
       const homeDir = os.homedir();
-      const inUserDir = CREDENTIALS_FILE.toLowerCase().startsWith(homeDir.toLowerCase());
+      const inUserDir = file.toLowerCase().startsWith(homeDir.toLowerCase());
       if (inUserDir) {
         return {
           secure: true,
@@ -245,20 +261,21 @@ export class CredentialStore {
   }
 
   private async getFromFile(): Promise<Credentials | null> {
+    const file = credentialsFile();
     // Refuse to load credentials from a world-/group-readable file. Bumping
     // checkPermissions() from "warn via doctor" to "refuse at load time"
     // closes the window where a tampered or accidentally-loosened
-    // ~/.pax8/credentials.json silently keeps working. Windows has no POSIX
+    // credentials file silently keeps working. Windows has no POSIX
     // mode bits, so skip the gate there — `checkPermissionsWindows` still
     // surfaces ACL issues via `pax8 doctor`.
     if (!isWindows) {
       try {
-        const stat = await fs.stat(CREDENTIALS_FILE);
+        const stat = await fs.stat(file);
         if ((stat.mode & 0o077) !== 0) {
           const perms = (stat.mode & 0o777).toString(8);
           throw new Error(
-            `Refusing to load credentials: ${CREDENTIALS_FILE} has mode ${perms} ` +
-              `(group/other have access). Run: chmod 600 ${CREDENTIALS_FILE}`,
+            `Refusing to load credentials: ${file} has mode ${perms} ` +
+              `(group/other have access). Run: chmod 600 ${file}`,
           );
         }
       } catch (err) {
@@ -275,7 +292,7 @@ export class CredentialStore {
     }
 
     try {
-      const content = await fs.readFile(CREDENTIALS_FILE, "utf-8");
+      const content = await fs.readFile(file, "utf-8");
       const data = JSON.parse(content) as Record<string, unknown>;
       if (typeof data.clientId === "string" && typeof data.clientSecret === "string") {
         return { clientId: data.clientId, clientSecret: data.clientSecret };


### PR DESCRIPTION
Closes #504.

## Summary

`credential-store.ts` captured the config dir at module load:

```ts
const CONFIG_DIR = path.join(os.homedir(), ".pax8");
const CREDENTIALS_FILE = path.join(CONFIG_DIR, "credentials.json");
```

Every other state-writer in the CLI honors `PAX8_CONFIG_DIR` via `getConfigDir()`; auth alone landed credentials in the real `~/.pax8/credentials.json` regardless of override. Known follow-up from the #499 / #469 / #475 state-write hardening.

## User-visible impact (before this PR)

- Partner sets `PAX8_CONFIG_DIR=/custom/path`, runs `pax8 auth login` — credentials write to `~/.pax8/credentials.json`. Every other command reads from `/custom/path/credentials.json`. Mismatch is silent: `pax8 doctor` reports "configured" against home; commands report "no credentials" against the override.
- CI / sandboxed environments denying `$HOME` writes but allowing custom paths fail at login.

## Fix

```diff
-const CONFIG_DIR = path.join(os.homedir(), ".pax8");
-const CREDENTIALS_FILE = path.join(CONFIG_DIR, "credentials.json");
+function configDir(): string { return getConfigDir(); }
+function credentialsFile(): string { return path.join(configDir(), "credentials.json"); }
```

Every callsite resolves on each invocation. `getConfigDir()` re-reads `PAX8_CONFIG_DIR` per call (designed for exactly this — see `loader.ts` comment), so the override is honored at runtime.

Updated callsites: `saveCredentials`, `getFromFile`, `hasCredentials`, `checkPermissions`, `clearCredentials`, plus the static `configDirPath` / `credentialsFilePath` getters.

## Tests

- Per-test mkdtemp via `process.env.PAX8_CONFIG_DIR` (in-place mutation — wholesale `process.env = {...}` doesn't propagate to node's C++ side; the production `getConfigDir()` would still see the vitest globalSetup's value)
- New test pins the runtime-mutation contract: `honors PAX8_CONFIG_DIR changes at runtime (#504)`
- Policy gate (`local-state-writers.test.ts`) exception comment updated to reflect that remaining `os.homedir()` calls in credential-store.ts are only inside the Windows ACL fallback path

## Windows note

The Windows ACL check (`checkPermissionsWindows`) still uses `os.homedir()` to verify the credentials file is inside the user-profile directory. That's intentional for the Windows-specific security posture and is unaffected by this fix. If `PAX8_CONFIG_DIR` points outside `$HOME` on Windows (requires `PAX8_ALLOW_NON_HOME_CONFIG=1`), the ACL check will report `secure: false` with "outside user home directory" — that's a known edge case worth a future tightening but out of scope for #504.

## Test plan

- [x] `pnpm build && pnpm lint` clean (1 pre-existing warning, 0 errors)
- [x] `credential-store.test.ts`: 23 pass / 6 skipped — added the runtime-mutation pin
- [x] `local-state-writers.test.ts`: still passes; the exception list is unchanged, just the comment is updated
- [x] Full suite: 2119 pass — same as main pre-PR
- [ ] Manual: `PAX8_CONFIG_DIR=/tmp/pax8-test pax8 auth login --client-id X --client-secret Y` lands credentials at `/tmp/pax8-test/credentials.json`, not `~/.pax8/credentials.json`

## Note on license-consistency test

The `license-consistency.test.ts` will flake during local runs whenever sibling agent worktrees under `.claude/worktrees/` are present (it scans them and picks up its own example string). It's not a regression from this PR — same behavior on main. Remove agent worktrees before running the full suite locally.