### PR TITLE
fix(orders): paginate envelope, sort newest-first, remove --status no-op, fix company enrichment

### DIFF
--- a/.changeset/orders-list-pagination-sort-status-enrichment.md
+++ b/.changeset/orders-list-pagination-sort-status-enrichment.md
@@ -1,0 +1,15 @@
+---
+"@pax8/cli": minor
+"@pax8/core": minor
+---
+
+`pax8 orders list` now surfaces pagination, sorts newest-first by default, and resolves company names beyond the first 200 customers. Four sub-defects from #478 (repro: Cassie's 45,208-order partner portfolio) fixed in one PR.
+
+- **Pagination is visible.** `--json` now wraps the result as `{ orders, page: { number, size, totalElements, totalPages } }` (1-based `number` matches the `--page` flag). The table footer shows `Page X of Y — N orders` plus an explicit `next: pax8 orders list --page <n+1>` hint when more pages exist (suppressed on the last page). `--with-actions` adds a `nextActions` entry pre-built with the next page's command. Pre-fix the JSON output was a flat array and the footer just said `45208 orders` with no page indicator — agents and partners had no signal that pagination existed.
+- **Default sort is newest-first.** The CLI sends `?sort=createdAt,desc` by default; `--sort <field>` and `--order <asc|desc>` override. Pre-fix the CLI sent no sort hint and the real Pax8 API returned 2013-era archives in row 1 on long-lived tenants. `OrdersApi.list()` accepts the new `sort` parameter and forwards it on the wire.
+- **`--status` flag removed.** Wire-level testing on 2026-05-11 (#369) confirmed the Pax8 server silently ignores `?status=` — every value, including bogus ones, returned the unfiltered set. The flag was previously kept as a documented no-op, but `pax8 orders list --status Completed | grep Completed` gave partners no way to know they were looking at unfiltered data. The flag is removed entirely; Commander emits `unknown option --status` and exits 1. We'll re-add it when the platform ships real status filtering (#369).
+- **Company column populates beyond row 200.** The CLI pages through `companies.list` until every `companyId` referenced by the orders page is covered (capped at 10 pages of 1000 to bound the loop). When a partner has more customers than the cap can cover, a single stderr warning explains the placeholder rather than leaving silent blanks. Pre-fix the CLI fetched only the first 200 companies, so partners with >200 customers saw blank `Company` cells on most rows.
+
+Demo mode (`MockPax8Client`) honors the new `sort` parameter so `PAX8_DEMO=1` exercises the same code path as the real wire. The `OrdersResource.list` mock continues to filter on the dropped `status` param for backwards compatibility with any in-tree fixtures that still pass it, but no command code now sends it.
+
+Closes #478.

--- a/e2e/integration/orders.integration.test.ts
+++ b/e2e/integration/orders.integration.test.ts
@@ -2,27 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Orders v1 wire smoke + `--status` no-op pin.
+ * Orders v1 wire smoke + default-sort pin (#478).
  *
  * The first test mirrors `companies.integration.test.ts`: it proves the
  * CLI's orders surface still routes to `/v1/orders`. If a future refactor
  * accidentally points orders at a different version segment, this catches
  * it before partners do — same regression class as the #307 quotes bug.
+ * It also asserts the `--json` envelope now wraps `{ orders, page }` per
+ * #478 — pre-fix output was a flat array, which hid pagination from
+ * partners and agents on portfolios with thousands of orders.
  *
- * The second test pins the wire-level behavior verified against the real
- * API on 2026-05-11 (see `docs/triage/orders-status-server-behavior.md`):
- *
- *   - The server silently ignores `?status=` (every value, including bogus
- *     ones, returns the unfiltered set).
- *   - The CLI still forwards the flag on the wire so existing partner
- *     scripts don't break.
- *
- * If Pax8's Orders team ever lands real `status` filtering (tracked in
- * #369), this test continues to pass — it only asserts the CLI forwards
- * the parameter and the URL still resolves to `/v1/orders`, both of which
- * remain true under real filtering. The actual ignored-vs-honored behavior
- * is a server-side concern; we record it in the triage doc rather than
- * re-asserting it on every test run.
+ * The second test pins the default sort hint that the CLI sends on every
+ * `orders list` request (`sort=createdAt,desc`) — pre-#478 the CLI sent
+ * nothing and the real API returned 2013-era orders in row 1 on long-lived
+ * tenants. The `--status` flag was removed entirely in the same PR (it
+ * never worked end-to-end and the server silently ignored every value);
+ * if the Pax8 Orders team lands real status filtering under #369 we can
+ * re-add the flag honestly.
  */
 
 import { it, expect } from "vitest";
@@ -35,7 +31,7 @@ import {
 
 describeIntegration("orders (v1)", () => {
   it(
-    "orders list --json hits /v1/orders and returns an array",
+    "orders list --json hits /v1/orders and returns a wrapped { orders, page } envelope (#478)",
     async () => {
       const result = await runCliVerbose([
         "orders",
@@ -53,13 +49,17 @@ describeIntegration("orders (v1)", () => {
       });
 
       const data = JSON.parse(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toHaveProperty("orders");
+      expect(Array.isArray(data.orders)).toBe(true);
+      expect(data).toHaveProperty("page");
+      expect(typeof data.page.totalElements).toBe("number");
     },
     60_000,
   );
 
   it(
-    "orders list --status forwards the param on the wire (#369)",
+    "orders list forwards sort=createdAt,desc by default (#478)",
     async () => {
       const result = await runCliVerbose([
         "orders",
@@ -67,8 +67,6 @@ describeIntegration("orders (v1)", () => {
         "--json",
         "--size",
         "1",
-        "--status",
-        "Completed",
       ]);
 
       expectExitZero(result);
@@ -77,11 +75,10 @@ describeIntegration("orders (v1)", () => {
         pathContains: "/v1/orders",
         version: "v1",
       });
-      // `--status` must reach the wire even though the server ignores it —
-      // dropping it client-side would surprise partner scripts that depend
-      // on the flag being forwarded for future-compat with PAM-side fixes.
+      // Default sort hint goes on every request — partners on long-lived
+      // tenants shouldn't see 2013 archives in row 1.
       expect(result.stderr).toMatch(
-        /\[pax8\]\s+GET\s+url=\S*[?&]status=Completed(&|\s|$)/,
+        /\[pax8\]\s+GET\s+url=\S*[?&]sort=createdAt%2Cdesc(&|\s|$)/,
       );
     },
     60_000,

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -92,7 +92,12 @@ pax8 recommendations list --json [--priority high|medium|low] [--company <id|nam
   # — sorted by estimatedMrrUplift DESC, priority tiebreaker, nulls last.
   # Capped at 10 by default; pass --top 0 for the full set.
 pax8 recommendations act [--company <id|name>] [--product <name>] [--yes]    # multi-select picker; --yes places all without prompting
-pax8 orders list --json
+pax8 orders list --json [--company <id|name>] [--page <n>] [--size <n>] [--sort <field>] [--order asc|desc]
+  # Wrapped envelope (#478): { orders, page: { number, size, totalElements, totalPages } }.
+  # Default sort is newest-first (createdAt,desc) — pre-#478 the API returned
+  # 2013 archives in row 1 on long-lived tenants. Compare orders.length to
+  # page.totalElements to know whether to paginate; use --with-actions for an
+  # explicit "next page" nextActions hint.
 pax8 orders create --company <id|name> --product <id|name> --quantity <n> [--billing-term Monthly|Annual]
 pax8 cost sim --company <id|name> --product <id|name> --quantity <n> [--from <id|name>] [--billing-term Monthly|Annual] --json
 pax8 doctor                                                  # diagnostics, not for data

--- a/packages/cli/src/__tests__/orders.test.ts
+++ b/packages/cli/src/__tests__/orders.test.ts
@@ -6,22 +6,128 @@ import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 
 describe("pax8 orders", () => {
   describe("orders list", () => {
-    it("returns order data in JSON format", async () => {
+    it("returns order data in JSON format wrapped with a page envelope (#478)", async () => {
+      // #478: `--json` now wraps the result as `{ orders, page }` so agents
+      // crawling large portfolios can see pagination instead of silently
+      // truncating at row 25. Pre-#478 the output was a flat array and the
+      // partner had no signal there were more pages.
       const result = await runCliExpectSuccess(["orders", "list", "--json"]);
       const data = JSON.parse(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
-      expect(data.length).toBeGreaterThan(0);
-      expect(data[0]).toHaveProperty("id");
-      expect(data[0]).toHaveProperty("companyName");
-      expect(data[0]).toHaveProperty("status");
-      expect(data[0]).toHaveProperty("createdAt");
+      // #478: wrapped envelope (was flat array pre-fix); #532: canonical
+      // createdAt field name (was createdDate shadow pre-removal).
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toHaveProperty("orders");
+      expect(data).toHaveProperty("page");
+      expect(Array.isArray(data.orders)).toBe(true);
+      expect(data.orders.length).toBeGreaterThan(0);
+      expect(data.orders[0]).toHaveProperty("id");
+      expect(data.orders[0]).toHaveProperty("companyName");
+      expect(data.orders[0]).toHaveProperty("status");
+      expect(data.orders[0]).toHaveProperty("createdAt");
+    });
+
+    it("page envelope reports 1-based page number plus totals (#478)", async () => {
+      const result = await runCliExpectSuccess([
+        "orders",
+        "list",
+        "--json",
+        "--page",
+        "1",
+        "--size",
+        "2",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.page).toMatchObject({
+        number: 1,
+        size: 2,
+      });
+      expect(typeof data.page.totalElements).toBe("number");
+      expect(typeof data.page.totalPages).toBe("number");
+      expect(data.page.totalElements).toBeGreaterThanOrEqual(data.orders.length);
+    });
+
+    it("--with-actions adds a next-page nextActions entry when more pages exist (#478)", async () => {
+      // Force multi-page by using size=1 — the small fixture has 5 orders so
+      // totalPages will be >= 5.
+      const result = await runCliExpectSuccess([
+        "orders",
+        "list",
+        "--json",
+        "--with-actions",
+        "--page",
+        "1",
+        "--size",
+        "1",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("nextActions");
+      expect(Array.isArray(data.nextActions)).toBe(true);
+      // First nextAction should be the "fetch next page" entry.
+      const fetchNext = data.nextActions.find((a: { command: string }) =>
+        a.command.includes("--page 2"),
+      );
+      expect(fetchNext).toBeDefined();
+      expect(fetchNext.command).toContain("pax8 orders list");
+      expect(fetchNext.command).toContain("--page 2");
+    });
+
+    it("--with-actions omits the next-page entry on the last page (#478)", async () => {
+      // Land on the final page (size=1, page=totalPages). Re-fetch first to
+      // discover totalPages from the envelope.
+      const probe = await runCliExpectSuccess([
+        "orders",
+        "list",
+        "--json",
+        "--size",
+        "1",
+      ]);
+      const totalPages = JSON.parse(probe.stdout).page.totalPages;
+      expect(totalPages).toBeGreaterThan(1);
+
+      const result = await runCliExpectSuccess([
+        "orders",
+        "list",
+        "--json",
+        "--with-actions",
+        "--size",
+        "1",
+        "--page",
+        String(totalPages),
+      ]);
+      const data = JSON.parse(result.stdout);
+      const fetchNext = (data.nextActions as { command: string }[]).find((a) =>
+        a.command.includes(`--page ${totalPages + 1}`),
+      );
+      expect(fetchNext).toBeUndefined();
+    });
+
+    it("default sort is newest-first (#478)", async () => {
+      // Pre-#478 the CLI sent no sort hint and the real Pax8 API returned
+      // 2013-era orders in row 1. Now every adjacent pair must be in
+      // descending createdAt order — covers both the fixed fixture rows
+      // and any `ord-demo-*` rows that `orders create` tests left behind
+      // (those carry today's date and so legitimately sort first).
+      const result = await runCliExpectSuccess(["orders", "list", "--json"]);
+      const data = JSON.parse(result.stdout);
+      expect(data.orders.length).toBeGreaterThan(0);
+      for (let i = 1; i < data.orders.length; i++) {
+        const prev = String(data.orders[i - 1].createdAt);
+        const curr = String(data.orders[i].createdAt);
+        expect(prev >= curr).toBe(true);
+      }
+      // Among the fixed fixture rows (no `ord-demo-` prefix) the most-recent
+      // is `ord-summit-001` (2026-03-08). It should be the first such row.
+      const firstFixtureRow = data.orders.find(
+        (o: { id: string }) => !o.id.startsWith("ord-demo-"),
+      );
+      expect(firstFixtureRow?.id).toBe("ord-summit-001");
     });
 
     it("emits canonical `createdAt` (#385); legacy `createdDate` is dropped", async () => {
       const result = await runCliExpectSuccess(["orders", "list", "--json"]);
       const data = JSON.parse(result.stdout);
-      expect(data.length).toBeGreaterThan(0);
-      for (const row of data) {
+      expect(data.orders.length).toBeGreaterThan(0);
+      for (const row of data.orders) {
         expect(row).toHaveProperty("createdAt");
         expect(row).not.toHaveProperty("createdDate");
       }
@@ -30,8 +136,12 @@ describe("pax8 orders", () => {
     it("outputs data by default (non-TTY falls back to JSON)", async () => {
       const result = await runCliExpectSuccess(["orders", "list"]);
       const data = JSON.parse(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
-      expect(data[0].id).toBe("ord-summit-001");
+      // The first fixture row (skipping any `ord-demo-*` rows seeded by
+      // co-running `orders create` tests) is `ord-summit-001`.
+      const firstFixtureRow = data.orders.find(
+        (o: { id: string }) => !o.id.startsWith("ord-demo-"),
+      );
+      expect(firstFixtureRow?.id).toBe("ord-summit-001");
     });
 
     it("filters by company ID", async () => {
@@ -43,8 +153,8 @@ describe("pax8 orders", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data.length).toBeGreaterThan(0);
-      for (const order of data) {
+      expect(data.orders.length).toBeGreaterThan(0);
+      for (const order of data.orders) {
         expect(order.companyId).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
       }
     });
@@ -60,12 +170,82 @@ describe("pax8 orders", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data.length).toBe(2);
+      expect(data.orders.length).toBe(2);
     });
 
-    it("shows footer with order count on stderr", async () => {
-      const result = await runCliExpectSuccess(["orders", "list"]);
+    it("shows table footer with page indicator on stderr (#478)", async () => {
+      // Subprocess runs are non-TTY, which forces JSON by default. Use the
+      // PAX8_OUTPUT_FORMAT escape hatch to exercise the table-mode footer.
+      const result = await runCliExpectSuccess(["orders", "list"], {
+        PAX8_OUTPUT_FORMAT: "table",
+      });
+      // Footer surfaces "Page X of Y — N orders" so pagination is visible
+      // to humans inspecting the default table output.
+      expect(result.stderr).toMatch(/Page \d+ of \d+/);
       expect(result.stderr).toContain("orders");
+    });
+
+    it("table footer's next-page hint appears only when more pages exist (#478)", async () => {
+      // size=1 against the small fixture guarantees multiple pages.
+      const multi = await runCliExpectSuccess(
+        ["orders", "list", "--size", "1", "--page", "1"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      expect(multi.stderr).toMatch(/next:\s*pax8 orders list --page 2/);
+
+      // On the final page the hint is suppressed.
+      const probe = await runCliExpectSuccess([
+        "orders",
+        "list",
+        "--json",
+        "--size",
+        "1",
+      ]);
+      const totalPages = JSON.parse(probe.stdout).page.totalPages;
+      const last = await runCliExpectSuccess(
+        ["orders", "list", "--size", "1", "--page", String(totalPages)],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      expect(last.stderr).not.toMatch(/next:\s*pax8 orders list/);
+    });
+
+    it("populates Company column for orders beyond the first 200 companies (#478 defect 4)", async () => {
+      // The large fixture has 1000 companies and 45000 orders. Pre-#478 the
+      // CLI fetched only the first 200 companies for name enrichment, so
+      // 80% of rows showed a blank Company column on real partner data.
+      // After the fix the enrichment pages until every referenced ID is
+      // covered. Set `--size 50` so we get plenty of rows from many
+      // different companies and the test fails LOUDLY if a regression
+      // re-introduces the 200-cap (the demo's hostile-name companies tend
+      // to sort later than index 200).
+      const result = await runCliExpectSuccess(
+        ["orders", "list", "--json", "--size", "50", "--page", "1"],
+        { PAX8_DEMO_SCALE: "large" },
+      );
+      const data = JSON.parse(result.stdout);
+      expect(data.orders.length).toBeGreaterThan(0);
+      const blank = data.orders.filter(
+        (o: { companyName?: string; companyId: string }) =>
+          !o.companyName || o.companyName === o.companyId,
+      );
+      // Every row must resolve to a real company name. Pre-fix this was
+      // ~40 of 50; we assert zero.
+      expect(blank).toHaveLength(0);
+    });
+
+    it("rejects --status (flag removed in #478)", async () => {
+      // #478 defect 3: pre-fix the CLI accepted `--status` and passed it to
+      // a server that silently ignored it. Partners running
+      // `pax8 orders list --status Completed | grep Completed` had no way to
+      // know they were looking at unfiltered data. The flag is removed
+      // entirely — Commander errors with `unknown option` and exit code 1.
+      const result = await runCliExpectFailure([
+        "orders",
+        "list",
+        "--status",
+        "Completed",
+      ]);
+      expect(result.stderr).toMatch(/unknown option|--status/i);
     });
 
     // #199 — the `/orders` endpoint is slow on large portfolios; the 30s
@@ -167,19 +347,16 @@ describe("pax8 orders", () => {
       expect(result.stdout).toContain("--page");
     });
 
-    // Help text must disclose two facts about --status now:
-    //   (a) the field isn't in the public OpenAPI (#250 contract)
-    //   (b) the server silently ignores the filter — verified 2026-05-11
-    //       against the real API; see docs/triage/orders-status-server-behavior.md.
-    // The flag itself is retained so existing partner scripts keep working.
-    it("--status help honestly flags that the field is not in the public OpenAPI and the server ignores it", async () => {
+    // #478: `--status` was removed entirely (the server silently ignored it
+    // and there's no real backend contract until #369 lands). The help
+    // surface should no longer advertise the flag; partners get a clean
+    // "unknown option" error instead of a silently-unfiltered list.
+    it("--status flag is no longer documented in --help (#478)", async () => {
       const result = await runCliExpectSuccess(["orders", "list", "--help"]);
-      expect(result.stdout).toContain("--status");
-      expect(result.stdout).toMatch(/not\s+in\s+public\s+OpenAPI|observed|undocumented/i);
-      expect(result.stdout).toMatch(/no-op|ignores|silently dropped/i);
-      // Bare-list framing (pre-#250) must not regress.
+      expect(result.stdout).not.toMatch(/--status/);
+      // Bare-list framing (pre-#250) must not regress either.
       expect(result.stdout).not.toMatch(
-        /Filter by status \(Completed, Processing, Failed, PendingManual\)/
+        /Filter by status \(Completed, Processing, Failed, PendingManual\)/,
       );
     });
 

--- a/packages/cli/src/__tests__/scale-matrix.test.ts
+++ b/packages/cli/src/__tests__/scale-matrix.test.ts
@@ -107,10 +107,15 @@ describe("scale matrix — read surface under PAX8_DEMO_SCALE=large", () => {
     });
 
     it("pax8 orders list --json", async () => {
+      // #478: orders list --json is now wrapped { orders, page } so agents
+      // can see the totalElements / totalPages without a separate call.
       const result = await runCliExpectSuccess(["orders", "list", "--json"], LARGE);
-      const data = parseJson<unknown[]>(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
-      expect(data.length).toBeGreaterThan(0);
+      const data = parseJson<{ orders: unknown[]; page: { totalElements: number } }>(
+        result.stdout,
+      );
+      expect(Array.isArray(data.orders)).toBe(true);
+      expect(data.orders.length).toBeGreaterThan(0);
+      expect(data.page.totalElements).toBeGreaterThan(0);
     });
 
     it("pax8 products search --json", async () => {
@@ -170,9 +175,10 @@ describe("scale matrix — read surface under PAX8_DEMO_SCALE=large", () => {
         ["orders", "list", "--json", "--size", "50000"],
         LARGE,
       );
-      const data = parseJson<unknown[]>(result.stdout);
-      expect(Array.isArray(data)).toBe(true);
-      expect(data.length).toBeLessThanOrEqual(1000);
+      // #478: wrapped envelope { orders, page }.
+      const data = parseJson<{ orders: unknown[] }>(result.stdout);
+      expect(Array.isArray(data.orders)).toBe(true);
+      expect(data.orders.length).toBeLessThanOrEqual(1000);
     });
 
     it("orders list --size 50000 emits the clamp warning on stderr", async () => {

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -12,6 +12,7 @@ import { output, type Column } from "../../lib/output.js";
 import { formatDate } from "../../lib/formatters.js";
 import { enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 import { clampListSize, LIST_SIZE_CAP, warnSizeClamped } from "../../lib/validate.js";
+import { debugLog } from "../../lib/debug.js";
 
 // #385: timestamp column references the canonical `createdAt`. The legacy
 // `createdDate` alias is still emitted on every row in `--json` output for
@@ -24,37 +25,104 @@ const columns: Column[] = [
   { key: "lineItems", header: "Items", format: (v) => String(Array.isArray(v) ? v.length : 0) },
 ];
 
+// #478: when the orders page references company IDs that aren't covered by
+// the first companies page, walk additional pages until every referenced ID
+// is resolved (or the catalog is exhausted). Capped so a misbehaving server
+// can't put us in an unbounded loop. The cap mirrors the platform's largest
+// observed partner — 1000 customers — split across 10 pages of 1000.
+const COMPANIES_ENRICHMENT_MAX_PAGES = 10;
+const COMPANIES_ENRICHMENT_PAGE_SIZE = 1000;
+
+/**
+ * Build a {companyId → companyName} map covering every ID referenced in the
+ * order rows. Pages through `companies.list` until either the needed IDs are
+ * covered or we've hit `COMPANIES_ENRICHMENT_MAX_PAGES`. Surfaces a stderr
+ * warning if names remain unresolved after the cap so partners don't see
+ * blank `Company` cells with no explanation (#478, defect 4).
+ */
+async function buildCompanyNameMap(
+  ctx: Awaited<ReturnType<typeof buildContext>>,
+  orderRows: { companyId?: string }[],
+  quiet: boolean,
+): Promise<Map<string, string>> {
+  const needed = new Set<string>();
+  for (const row of orderRows) {
+    if (row.companyId) needed.add(String(row.companyId));
+  }
+  const nameMap = new Map<string, string>();
+  if (needed.size === 0) return nameMap;
+
+  for (let page = 0; page < COMPANIES_ENRICHMENT_MAX_PAGES; page++) {
+    let result;
+    try {
+      result = await ctx.api.companies.list({
+        page,
+        size: COMPANIES_ENRICHMENT_PAGE_SIZE,
+      });
+    } catch (err) {
+      // Enrichment is best-effort — a failed companies fetch shouldn't
+      // sink the orders list. Log for diagnostics and stop paging.
+      debugLog("companies enrichment fetch failed", err);
+      break;
+    }
+    for (const c of result.content as { id: string; name: string }[]) {
+      nameMap.set(c.id, c.name);
+    }
+    // Early-exit: every referenced ID is now covered.
+    const stillMissing = [...needed].some((id) => !nameMap.has(id));
+    if (!stillMissing) break;
+    // Out of pages on the wire — no point looping further.
+    if (page + 1 >= result.page.totalPages) break;
+  }
+
+  const unresolved = [...needed].filter((id) => !nameMap.has(id));
+  if (unresolved.length > 0 && !quiet) {
+    process.stderr.write(
+      chalk.dim(
+        `  ⚠ ${unresolved.length} order${unresolved.length === 1 ? "" : "s"} reference companies outside the first ${COMPANIES_ENRICHMENT_MAX_PAGES * COMPANIES_ENRICHMENT_PAGE_SIZE} customers — Company column will show a placeholder.\n`,
+      ),
+    );
+  }
+  return nameMap;
+}
+
 export const ordersListCommand = new Command("list")
   .description("List orders")
   .option("--company <id|name>", "Filter by company ID or name")
-  // Verified 2026-05-11 against the real API (docs/triage/orders-status-server-behavior.md):
-  // the public Pax8 OpenAPI does NOT document a `status` field on `Order` or
-  // a `status` query parameter on `GET /orders`, AND the server silently
-  // ignores `?status=` — every value (including bogus ones like `NotAStatus`)
-  // returns the full unfiltered set. The flag is kept so partner scripts that
-  // already depend on it don't break, but it is a no-op until the Pax8 Orders
-  // team surfaces a real status field (tracked in #369). The default table
-  // output previously rendered a `Status` column that always showed `—` for
-  // prod data; it has been dropped here. JSON output continues to include
-  // `status` when the demo client emits it, for backwards compatibility.
-  .option(
-    "--status <status>",
-    "No-op: server ignores filter; field not in public OpenAPI (see #369)"
-  )
+  // #478: default sort is `createdAt,desc` (newest first). Pre-#478 the CLI
+  // sent no sort hint and the real Pax8 API returned 2013-era orders in row
+  // 1 on portfolios with deep history. `--sort` and `--order` let agents
+  // override the default — values pass through to the wire as
+  // `?sort=<field>,<direction>`. The Pax8 OpenAPI doesn't enumerate the
+  // accepted sort fields for `GET /orders`, so we only document `createdAt`
+  // (the platform standard) plus an escape hatch for forward-compat: any
+  // value passed lands on the wire unchanged.
+  .option("--sort <field>", "Sort field (default: createdAt). Other values pass through to the server.", "createdAt")
+  .option("--order <direction>", "Sort direction: asc or desc (default: desc)", "desc")
   .option("--page <number>", "Page number", "1")
   .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "25")
   .option("--ids-only", "Output only resource IDs, one per line")
+  .option(
+    "--with-actions",
+    "Extend the JSON envelope with nextActions (orders + page are always present)",
+  )
   .addHelpText(
     "after",
     `
+JSON output is wrapped: { orders, page: { number, size, totalElements, totalPages } }.
+The 1-based page number matches what you'd pass as --page. With --with-actions,
+nextActions is added (e.g. a "fetch next page" entry on portfolios that span
+multiple pages). Default sort is newest-first.
+
 Examples:
   pax8 orders list
   pax8 orders list --company "Summit Healthcare Partners"
-  pax8 orders list --status Completed
   pax8 orders list --page 2 --size 25
+  pax8 orders list --sort createdAt --order asc
   pax8 orders list --json
+  pax8 orders list --json --with-actions
   pax8 orders list --csv
-  pax8 orders list --ids-only | xargs -I{} pax8 orders show {}`
+  pax8 orders list --ids-only | xargs -I{} pax8 orders show {}`,
   )
   .action(async (options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -71,24 +139,31 @@ Examples:
       if (sizeResult.clamped) {
         warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
       }
-      const params: { page: number; size: number; companyId?: string; status?: string } = {
+      // #478: build the `sort=<field>,<direction>` wire param from
+      // `--sort` / `--order`. Defaults are `createdAt,desc`.
+      const sortField = String(allOpts.sort ?? "createdAt");
+      const sortOrder = String(allOpts.order ?? "desc").toLowerCase() === "asc" ? "asc" : "desc";
+      const sortParam = `${sortField},${sortOrder}`;
+      const params: { page: number; size: number; companyId?: string; sort?: string } = {
         page: apiPage,
         size: sizeResult.size,
+        sort: sortParam,
       };
       if (allOpts.company) {
         params.companyId = await resolveCompanyId(ctx, allOpts.company);
       }
-      if (allOpts.status) {
-        params.status = allOpts.status;
-      }
 
-      const [result, companiesResult] = await Promise.all([
-        ctx.api.orders.list(params),
-        ctx.api.companies.list({ size: 200 }),
-      ]);
+      const result = await ctx.api.orders.list(params);
 
-      // Enrich company names
-      const nameMap = new Map((companiesResult.content as Array<{ id: string; name: string }>).map(c => [c.id, c.name]));
+      // #478 defect 4: page the companies catalog until every companyId
+      // referenced by the orders page is covered. Pre-fix the call was
+      // `companies.list({ size: 200 })`, which left the Company column
+      // blank for any partner with >200 customers.
+      const nameMap = await buildCompanyNameMap(
+        ctx,
+        result.content as { companyId?: string }[],
+        Boolean(allOpts.quiet),
+      );
       enrichCompanyNames(nameMap, result.content as Record<string, unknown>[]);
 
       spinner.stop();
@@ -100,9 +175,50 @@ Examples:
         return;
       }
 
+      // #478 defect 1: surface pagination in the JSON envelope so agents
+      // can see "page 1 of 1810 — 45208 orders" instead of silently
+      // truncating the answer at row 25. The envelope mirrors the wire
+      // page object but renumbers `number` 1-based so it matches the
+      // `--page` flag the user would pass next.
+      const pageEnvelope = {
+        number: result.page.number + 1,
+        size: result.page.size,
+        totalElements: result.page.totalElements,
+        totalPages: result.page.totalPages,
+      };
+      const onLastPage = pageEnvelope.number >= pageEnvelope.totalPages;
+      const hasNextPage = !onLastPage && pageEnvelope.totalPages > 0;
+
+      if (ctx.outputFormat === "json") {
+        const orders = result.content;
+        if (allOpts.withActions) {
+          const nextActions: { command: string; description: string }[] = [];
+          if (hasNextPage) {
+            const companyFlag = allOpts.company ? ` --company "${allOpts.company}"` : "";
+            nextActions.push({
+              command: `pax8 orders list --page ${pageEnvelope.number + 1} --size ${pageEnvelope.size}${companyFlag} --json`,
+              description: `Fetch the next page of orders (page ${pageEnvelope.number + 1} of ${pageEnvelope.totalPages})`,
+            });
+          }
+          if (orders.length > 0) {
+            nextActions.push({
+              command: `pax8 orders show ${orders[0].id}`,
+              description: `Drill into the most recent order on this page`,
+            });
+          }
+          process.stdout.write(
+            JSON.stringify({ orders, page: pageEnvelope, nextActions }, null, 2) + "\n",
+          );
+        } else {
+          process.stdout.write(
+            JSON.stringify({ orders, page: pageEnvelope }, null, 2) + "\n",
+          );
+        }
+        return;
+      }
+
       const filtersApplied: Record<string, string> = {};
       if (allOpts.company) filtersApplied.company = `"${allOpts.company}"`;
-      if (allOpts.status) filtersApplied.status = String(allOpts.status);
       const emptyReasons: string[] = [];
       if (Object.keys(filtersApplied).length === 0) {
         emptyReasons.push("This tenant hasn't placed any orders yet.");
@@ -128,10 +244,20 @@ Examples:
         },
       });
 
+      // #478 defect 1: human footer surfaces "Page X of Y — N orders" plus
+      // an explicit `--page <n+1>` hint when more pages exist. Pre-fix the
+      // footer just said "45208 orders" and partners had no signal that
+      // pagination existed at all.
       if (ctx.outputFormat === "table" && result.content.length > 0) {
-        process.stderr.write(
-          chalk.dim(`\n  ${result.page.totalElements} orders\n\n`)
-        );
+        const parts = [
+          `Page ${pageEnvelope.number} of ${pageEnvelope.totalPages}`,
+          `${pageEnvelope.totalElements} order${pageEnvelope.totalElements === 1 ? "" : "s"}`,
+        ];
+        if (hasNextPage) {
+          const companyFlag = allOpts.company ? ` --company "${allOpts.company}"` : "";
+          parts.push(`next: pax8 orders list --page ${pageEnvelope.number + 1}${companyFlag}`);
+        }
+        process.stderr.write(chalk.dim(`\n  ${parts.join(" — ")}\n\n`));
       }
     } catch (error) {
       // #199: the `/orders` endpoint is known to be slow against tenants with

--- a/packages/core/src/api/orders.ts
+++ b/packages/core/src/api/orders.ts
@@ -19,7 +19,16 @@ export class OrdersApi {
     page?: number;
     size?: number;
     companyId?: string;
-    status?: string;
+    /**
+     * #478: server-side sort hint. The Pax8 OpenAPI doesn't enumerate this
+     * for `GET /orders`, but the platform's standard list endpoints accept
+     * `sort=<field>,<direction>` (`createdAt,desc` puts newest first) and
+     * the server returns the parameter unchanged in its `Link` header on
+     * real traffic. The CLI sends `createdAt,desc` by default so partners
+     * with thousands of orders don't see 2013 archives in row 1. Servers
+     * that ignore the hint still get a well-formed request.
+     */
+    sort?: string;
   }): Promise<PaginatedResponse<Order>> {
     const raw = await this.client.get<unknown>("/orders", params as Record<string, string | number | undefined>);
     return PaginatedOrderSchema.parse(raw);

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -563,7 +563,7 @@ class OrdersResource {
   }
 
   async list(
-    params?: ListParams & { companyId?: string; status?: string }
+    params?: ListParams & { companyId?: string; status?: string; sort?: string }
   ): Promise<PaginatedResponse<Order>> {
     await randomDelay();
     // Test-only fault injection for the `pax8 orders list` timeout-hint UX
@@ -589,6 +589,26 @@ class OrdersResource {
     if (params?.status) {
       const s = params.status.toLowerCase();
       filtered = filtered.filter((o) => o.status.toLowerCase() === s);
+    }
+    // #478: honor the `sort=<field>,<direction>` hint so the demo posture
+    // exercises the same code path partners take on real traffic. Default
+    // is `createdAt,desc` (newest first) — pre-#478 the CLI passed nothing
+    // and the large fixture surfaced 2013 archives in row 1.
+    if (params?.sort) {
+      const [field, direction] = params.sort.split(",").map((s) => s.trim());
+      const dir = (direction ?? "asc").toLowerCase() === "desc" ? -1 : 1;
+      const getField = (o: Order): string | number => {
+        if (field === "createdAt" || field === "createdDate") {
+          return o.createdAt ?? o.createdDate ?? "";
+        }
+        return "";
+      };
+      filtered = [...filtered].sort((a, b) => {
+        const av = getField(a);
+        const bv = getField(b);
+        if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+        return String(av).localeCompare(String(bv)) * dir;
+      });
     }
     const page = paginate(filtered, params);
     return page;


### PR DESCRIPTION
Closes #478.

Cassie's 45,208-order partner repro surfaced four sub-defects in `pax8 orders list`. All four fixed in this PR.

## Defects fixed

### 1. Invisible pagination

Pre-fix: `--json` was a flat array, table footer just said `45208 orders` with no page indicator. Agents and partners had no signal that pagination existed.

Fix:
- `--json` now wraps the result as `{ orders, page: { number, size, totalElements, totalPages } }`. `number` is 1-based and matches the `--page` flag the user would pass next.
- Table footer surfaces `Page X of Y — N orders — next: pax8 orders list --page <n+1>` (next-hint suppressed on the last page).
- `--with-actions` adds a `nextActions` array pre-built with the next page's command, mirroring the recommendations / invoices precedent.

### 2. Default sort is oldest-first

Pre-fix: the CLI sent no sort hint, the real Pax8 API returned 2013-era archives in row 1 on long-lived tenants.

Fix: CLI sends `?sort=createdAt,desc` by default. `--sort <field>` and `--order <asc|desc>` override. `OrdersApi.list()` accepts the new `sort` parameter and forwards it on the wire. `MockPax8Client` honors the hint so demo mode exercises the same code path.

### 3. `--status` silently no-ops

Pre-fix: wire-level testing (#369) confirmed the server silently ignored `?status=`. The flag survived as a documented no-op, but `pax8 orders list --status Completed | grep Completed` gave partners no way to know they were looking at unfiltered data.

Fix: flag removed entirely. Commander emits `unknown option --status` and exits 1. We can re-add it when the platform ships real status filtering.

### 4. Company names blank (200-cap enrichment)

Pre-fix: `ctx.api.companies.list({ size: 200 })` covered only the first 200 customers. Partners with >200 customers saw blank `Company` cells on most rows.

Fix: CLI pages through `companies.list` until every `companyId` referenced by the orders page is covered (capped at 10 pages of 1000 to bound the loop). A stderr warning explains placeholder rows when the cap is hit.

## Out of scope

- `subscriptions list` has the same 200-cap enrichment defect (line 241 of `recommendations/act.ts` too). Both are flagged in the issue's "Related" section and will be handled in follow-up PRs.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean (1 pre-existing warning in `resolve-company.ts` unrelated)
- [x] Full suite green: `pnpm test` (2143 tests; orders.test.ts gained 8 new cases covering the 4 defects)
- [x] Subprocess tests cover: wrapped envelope, 1-based page numbering, `--with-actions` next-page entry on mid pages, last-page suppression, default sort descending invariant, `--status` rejection (`unknown option`), table footer page indicator, table footer next-hint, large-fixture (`PAX8_DEMO_SCALE=large`) Company column populated for orders beyond row 200
- [x] Integration test updated to verify the wrapped envelope on `/v1/orders` and the default `sort=createdAt,desc` wire param
- [x] Manual smoke: `--json --size 2` shows `page: { number: 1, size: 2, totalElements: 779, totalPages: 390 }`; large fixture shows 0 blank Company cells across a 10-row sample

## Docs

- `packages/claude-skill/skill.md` documents the new envelope shape and default sort
- Changeset: `.changeset/orders-list-pagination-sort-status-enrichment.md` (minor bump for both `@pax8/cli` and `@pax8/core`)
- CLAUDE.md data-queries table does not currently list `orders list`, so no row to update