### PR TITLE
fix(mock): drop stale createdDate alias reference (hotfix for main)

### DIFF
--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -598,8 +598,12 @@ class OrdersResource {
       const [field, direction] = params.sort.split(",").map((s) => s.trim());
       const dir = (direction ?? "asc").toLowerCase() === "desc" ? -1 : 1;
       const getField = (o: Order): string | number => {
+        // #385 / #476: `createdAt` is canonical; `createdDate` was the
+        // pre-removal alias. The mock honors both spellings on the
+        // input `sort` param (real Pax8 API still accepts both wire
+        // names) but the underlying Order field is just `createdAt`.
         if (field === "createdAt" || field === "createdDate") {
-          return o.createdAt ?? o.createdDate ?? "";
+          return o.createdAt ?? "";
         }
         return "";
       };


### PR DESCRIPTION
**Hotfix.** Main is currently failing CI on `pnpm build` — needs this to merge fast.

## What happened

PR #531 (orders list redesign, closes #478) merged after #532 (strip deprecated aliases, closes #476). #531 had a fallback in `MockPax8Client.OrdersResource.list`:

```ts
const getField = (o: Order): string | number => {
  if (field === "createdAt" || field === "createdDate") {
    return o.createdAt ?? o.createdDate ?? "";  // ← stale ref
  }
  ...
};
```

`o.createdDate` was a one-cycle alias on the `Order` type that #532 dropped. When #531 merged on top of #532's main, the TypeScript compile broke:

```
src/mock/mock-client.ts(602,35): error TS2551:
  Property 'createdDate' does not exist on type 'Order'. Did you mean 'createdAt'?
```

Cascade: `@pax8/core`'s dts build failed → CLI tests can't import core types properly → 14 orders.test.ts failures + ~10 other broken-build failures (24 total) on main.

## Fix

Drop the `o.createdDate` fallback. The mock still accepts both `createdAt` and `createdDate` as the inbound `sort` **param** value (real Pax8 API tolerates both wire spellings); but the canonical client-side shape on `Order` is only `createdAt` post-#476.

## Why this slipped through

- #531 was rebased on top of #532+#530 main during the merge sequence (`packages/cli/src/__tests__/orders.test.ts` had a real conflict that I resolved by hand). The `mock-client.ts` change auto-merged because there was no textual conflict — `o.createdDate` still parses as TypeScript, just no longer typechecks against the post-#532 `Order` type.
- The rebased branch tests passed in isolation (`pnpm vitest run orders.test.ts` — 46/46) because vitest doesn't fail on tsc errors in the dts build step.
- The full `pnpm build` step caught it as soon as it ran on main.

Lesson: when rebasing across an alias-removal change, also run `pnpm build` (not just `pnpm vitest run <touched-file>`) before pushing.

## Test plan

- [x] `pnpm build` clean
- [x] Full suite: 2115 passing / 6 skipped / 6 todo (back to expected count)
- [ ] Once merged, `main` CI goes green again