### PR TITLE
fix(changeset): drop @pax8/claude-skill from mixed changeset frontmatter

### DIFF
--- a/.changeset/recommendations-top-cap-and-envelope.md
+++ b/.changeset/recommendations-top-cap-and-envelope.md
@@ -1,6 +1,5 @@
 ---
 "@pax8/cli": minor
-"@pax8/claude-skill": minor
 ---
 
 Cap `pax8 recommendations list` at 10 by default and add `--top <n>` (with `--top 0` for unlimited). Closes #521.


### PR DESCRIPTION
## Summary

Every \`Release\` workflow run since the \`recommendations-top-cap-and-envelope\` changeset landed has been failing — that's why no \`chore: release\` PR has appeared despite ~33 changesets queued in \`.changeset/\`.

\`\`\`
🦋  error Error: Found mixed changeset recommendations-top-cap-and-envelope
🦋  error Found ignored packages: @pax8/claude-skill
🦋  error Found not ignored packages: @pax8/cli
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
\`\`\`

\`.changeset/config.json\` has \`"ignore": ["@pax8/claude-skill"]\` — that package is never bumped via changesets (it's not on npm; versioning is tracked separately). When a single changeset lists *both* an ignored and a non-ignored package, \`@changesets/cli\` refuses to assemble a release plan and bails the whole workflow.

Fix: drop the \`@pax8/claude-skill\` line from the changeset's frontmatter. The PR's claude-skill code change still ships as part of that PR's diff; only its package version stays put — which is the whole point of the ignore list.

## Why now

The Release workflow has been silently failing on every push to \`main\` for a couple sessions. No release PR = no released version. Three days of merged changesets sitting in the queue. Unblocking this lets the bot regenerate the \`chore: release\` PR rolling up the full backlog.

## Test plan

- [x] \`pnpm changeset version\` on this branch no longer hits the \"mixed changeset\" assertion (a different, unrelated GitHub-token error appears in local dry-runs but CI has \`GITHUB_TOKEN\` set so it passes there)
- [x] After merge, expect the next \`Release\` workflow run to open or reopen a \`chore: release\` PR