### PR TITLE
chore(release): lift the publish gate — enable npm publish on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,16 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # Publish gate (see #370): we intentionally do NOT pass a `publish:`
-      # command here, so this action only opens/updates the "chore: release"
-      # PR and never invokes `npm publish`. Versions have been auto-bumped
-      # past anything we've shipped (CHANGELOG headings for 0.2.0/0.3.0 exist
-      # but the registry has nothing), and we want a deliberate human signal
-      # before the first real publish.
-      #
-      # When the team is ready to ship the first release, restore the
-      # `publish: pnpm changeset publish` input below and merge — the next
-      # push to main will publish whatever the open "chore: release" PR has
-      # already version-bumped to.
-      - name: Create release PR (publish gated — see #370)
+      # Publish gate lifted (#370): the open `chore: release` PR (#535) has
+      # been merged, both packages versioned to 0.2.0, CHANGELOG written.
+      # Enabling `publish` here means the next push to main that consumes a
+      # changeset will run `npm publish` automatically. Trusted publishing
+      # via `id-token: write` (see the OIDC note below) covers auth — no
+      # NPM_TOKEN secret is required.
+      - name: Create release PR and publish on merge
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          # publish: pnpm changeset publish  # gated — enable when ready to ship
+          publish: pnpm changeset publish
           version: pnpm changeset version
           commit: "chore: release"
           title: "chore: release"


### PR DESCRIPTION
## Summary

Closes #370. Lifts the deliberate publish gate now that:

- \`@pax8/cli\` and \`@pax8/core\` are versioned **0.2.0** on \`main\` (#535 merged)
- 33-entry changeset backlog consolidated into the CHANGELOG
- Release workflow is otherwise healthy (recent failures were the changeset-config snag fixed in #534; runs since are green)

Single line change: uncomment \`publish: pnpm changeset publish\` in the changesets/action step. Refreshes the surrounding comment to describe the post-gate posture rather than the pre-launch hold.

## What happens after this merges

- This push itself does **not** consume a changeset, so the immediate Release workflow run only re-runs the "open/update release PR" path. No publish.
- The next time a \`chore: release\` PR merges (i.e., the next time changesets land + the resulting PR is merged), \`npm publish\` runs as part of the same workflow.
- Auth uses the existing trusted-publishing setup (\`id-token: write\` is already on the workflow). Requires the \`@pax8\` scope to have \`pax8labs/pax8-cli\` + the Release workflow registered as a trusted publisher at https://www.npmjs.com/settings/pax8/packages — if that registration is missing, the first publish will fail with an OIDC error and we'll need to register the workflow before retrying. No \`NPM_TOKEN\` secret is needed.

## Rollback

Revert this commit. The next Release workflow run reverts to PR-only gated mode.

## Test plan

- [x] \`yamllint\` (implicit via the Actions runner)
- CI on this PR will exercise the workflow file's syntax. The "create release PR" step is idempotent and harmless: if it has nothing to do (no consumed changesets), it just exits.