### PR TITLE
test(integration): webhooks create + delete round-trip (#386, first batch)

### DIFF
--- a/.changeset/integration-webhooks-write-roundtrip.md
+++ b/.changeset/integration-webhooks-write-roundtrip.md
@@ -1,0 +1,14 @@
+---
+"@pax8/cli": patch
+---
+
+First batch of #386 wire-level write coverage. Adds `e2e/integration/webhooks.integration.test.ts` with two tests:
+
+1. A read smoke (`webhooks list --json`) pinning the resolved URL to the documented `/api/v2/webhooks` path — same regression-class guard as the companies / quotes / orders smokes.
+2. A write round-trip (`webhooks create` → `webhooks delete`) that creates a webhook against a non-routable RFC-6761 `https://example.invalid/...` callback URL, captures the new ID from the create envelope, then immediately fires a delete. No artifacts left in the sandbox tenant on success; on partial failure the worst case is a single dangling row pointing at a non-routable URL that a manual sweep can pick up.
+
+Webhooks was chosen as the safest first write target because: full CRUD exists in the CLI, no billing/order/customer side effects, and the callback URL fixture means nothing on the partner side ever actually fires.
+
+Doesn't fully close #386 — that issue asks for write coverage across at least four resources plus a documented cleanup strategy. Subsequent PRs will follow this pattern for quotes (create + delete), and document cleanup expectations for resources without an inverse operation (orders, subscriptions cancel) in CONTRIBUTING.md.
+
+`integration.yml` still runs with `continue-on-error: true`. Promotion to a required gate is a separate decision once the suite has more breadth.

--- a/e2e/integration/webhooks.integration.test.ts
+++ b/e2e/integration/webhooks.integration.test.ts
@@ -1,0 +1,144 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Webhooks wire smoke + write round-trip (#308 + first batch of #386).
+ *
+ * Two purposes:
+ *
+ * 1. **Read smoke (`webhooks list`).** Same pattern as `companies.integration.test.ts`
+ *    and the v2 quotes/orders smokes — pins the resolved URL to the documented
+ *    `/api/v2/webhooks` path so a future version-segment regression (the #307
+ *    class of bug) gets caught at this layer instead of by a partner.
+ *
+ * 2. **Write round-trip (`webhooks create` → `webhooks delete`).** The first
+ *    wire-level write integration test in the repo (#386). Webhooks were
+ *    chosen as the safest first target because:
+ *
+ *    - Self-contained: webhooks don't affect billing, orders, customers, or
+ *      anything else partners can see. A leaked artifact is annoying, not
+ *      damaging.
+ *    - Full CRUD: the CLI has both `webhooks create` and `webhooks delete`,
+ *      so the test can clean up after itself in-band — no separate cleanup
+ *      pass needed.
+ *    - Non-routable callback URL: `https://example.invalid/...` is reserved
+ *      by RFC 6761; the Pax8 webhook delivery service will never actually
+ *      fire against it, so even if the cleanup fails, no real traffic
+ *      escapes.
+ *    - Topic vocabulary: `quote.created` is a known-good topic (per the
+ *      v2 webhooks-endpoints.json spec) so the API accepts the create
+ *      payload without contention with other resources.
+ *
+ *    Cleanup discipline: the create test captures the new webhook's `id` and
+ *    immediately fires a `delete` for it. If either step fails the test
+ *    fails loudly — and even on partial failure the callback URL is
+ *    non-routable, so the worst case is a single dangling row in the
+ *    sandbox tenant's webhooks list that a manual sweep can pick up. The
+ *    test does NOT leave a `try/finally` cleanup deliberately: if the
+ *    delete is failing systematically we want red CI, not silent green.
+ *
+ * # Adding more write round-trips after this lands (#386 follow-ups)
+ *
+ * The pattern in `webhooks create + delete` below generalizes: identify a
+ * resource with a quick inverse operation (quotes create+delete, contacts
+ * create+delete), use a non-routable / non-billable fixture for any
+ * interpolated identifiers, capture the ID from the create response, fire
+ * the inverse, assert both wire URLs. Resources without an inverse
+ * (orders create has no `orders cancel`; subscriptions cancel has no
+ * inverse) need a different cleanup story — either a dedicated sandbox
+ * tenant + periodic sweep, or annotate-and-leave with a documented
+ * cleanup checklist. Out of scope for this first batch.
+ */
+
+import { it, expect } from "vitest";
+import {
+  describeIntegration,
+  runCliVerbose,
+  expectExitZero,
+  expectWireUrl,
+} from "./harness.js";
+
+describeIntegration("webhooks (v2)", () => {
+  it(
+    "webhooks list --json hits /api/v2/webhooks",
+    async () => {
+      const result = await runCliVerbose(["webhooks", "list", "--json"]);
+
+      expectExitZero(result);
+      expectWireUrl(result, {
+        method: "GET",
+        pathContains: "/api/v2/webhooks",
+      });
+    },
+    60_000,
+  );
+
+  it(
+    "webhooks create + delete round-trip cleans up after itself (#386)",
+    async () => {
+      // The fixture: non-routable callback URL + a known-good topic from
+      // the v2 webhooks-endpoints.json spec. The display name includes a
+      // timestamp so concurrent runs in the same sandbox don't collide on
+      // the API's uniqueness checks (if any).
+      const callbackUrl = `https://example.invalid/pax8-cli-integration-${Date.now()}`;
+      const displayName = `pax8-cli integration test (${new Date().toISOString()})`;
+
+      const createResult = await runCliVerbose([
+        "webhooks",
+        "create",
+        "--url",
+        callbackUrl,
+        "--display-name",
+        displayName,
+        "--topics",
+        "quote.created",
+        "--yes",
+        "--json",
+      ]);
+
+      expectExitZero(createResult);
+      expectWireUrl(createResult, {
+        method: "POST",
+        pathContains: "/api/v2/webhooks",
+      });
+
+      // Pull the new webhook's `id` out of the stdout JSON envelope. The
+      // exact stdout shape is `{ webhook: {...} }` per the create command,
+      // but tolerate the flat-object form too so a future envelope
+      // refactor doesn't bork the test before the assertion runs. If the
+      // ID can't be located the test fails with a useful dump.
+      let createdId: string | undefined;
+      try {
+        const parsed = JSON.parse(createResult.stdout);
+        createdId =
+          parsed?.webhook?.id ??
+          parsed?.id ??
+          parsed?.data?.id ??
+          undefined;
+      } catch {
+        // fall through to the assertion below
+      }
+      expect(
+        createdId,
+        `Could not find created webhook id in stdout — got: ${createResult.stdout.slice(0, 400)}`,
+      ).toBeTruthy();
+
+      // Immediate cleanup. If this fails the test goes red and the sandbox
+      // is left with a single dangling row pointing at a non-routable URL —
+      // safe to sweep manually.
+      const deleteResult = await runCliVerbose([
+        "webhooks",
+        "delete",
+        createdId!,
+        "--yes",
+      ]);
+
+      expectExitZero(deleteResult);
+      expectWireUrl(deleteResult, {
+        method: "DELETE",
+        pathContains: `/api/v2/webhooks/${createdId}`,
+      });
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
## Summary

First wire-level write integration test in the repo. First batch of #386.

Adds \`e2e/integration/webhooks.integration.test.ts\` with two tests:

| Test | What it pins |
|---|---|
| \`webhooks list --json hits /api/v2/webhooks\` | Read smoke — same #307-class guard as the companies / quotes / orders smokes. |
| \`webhooks create + delete round-trip cleans up after itself\` | Wire-level write coverage. Creates a webhook against a non-routable \`https://example.invalid/...\` URL, captures the new ID from the create envelope, immediately fires \`webhooks delete\`. Both wire URLs are asserted. |

## Why webhooks first

The safest first write target on the bullet list in #386:

- **Full CRUD.** The CLI has both \`webhooks create\` and \`webhooks delete\`. The test cleans up its own artifact in-band — no out-of-band cleanup script, no dedicated sweep workflow.
- **Self-contained.** Webhooks don't affect billing, orders, customers, or anything else partners can see. Worst case (delete fails) is a single dangling row in the sandbox tenant's webhooks list.
- **Non-routable callback.** RFC 6761's \`.invalid\` TLD means nothing actually fires against \`https://example.invalid/...\` even if the cleanup misses.
- **Known-good topic.** \`quote.created\` from \`webhooks-endpoints.json\` — no contention with other resources.

## What this PR does NOT do (and what's left for #386)

This is a first batch, not the closeout:

- Adds **one** resource's write coverage. #386 asks for at least four: orders create, quotes create + send, subscriptions cancel, webhooks create + enable/disable.
- Doesn't update \`CONTRIBUTING.md\` with the "new write commands require integration test" expectation.
- Doesn't document a cleanup strategy for resources without an inverse operation (\`orders create\` has no \`orders cancel\`; \`subscriptions cancel\` has no inverse).
- Leaves \`integration.yml\` with \`continue-on-error: true\`. Promotion to a required gate is a separate decision once the suite has more breadth.

Suggested follow-ups (separate PRs):

1. Quotes (also has full CRUD: create draft → delete) — same round-trip pattern.
2. Document cleanup approach for resources without an inverse: dedicated sandbox tenant + periodic sweep, or annotate-and-leave with a checklist.
3. CONTRIBUTING.md update.
4. Flip \`continue-on-error: false\` once the suite has been running cleanly for a stretch.

## Test plan

- [x] \`pnpm test\` (default suite) — 2123 passed / 6 skipped / 6 todo
- [x] \`pnpm test:integration\` (without creds) — 7 files skipped / 9 tests skipped. The new file accounts for the +1 file / +2 tests delta. Self-skips cleanly per the harness pattern.
- [ ] Will not be exercised end-to-end against the sandbox until run by a maintainer with \`PAX8_CLIENT_ID\` / \`PAX8_CLIENT_SECRET\` set. If the first wire run reveals payload-shape drift in the create response (the test parses for \`webhook.id\` / \`id\` / \`data.id\`), tighten the lookup based on the actual shape.

Addresses #386 (does not close — see "What this PR does NOT do" above).