### PR TITLE
test(integration): quotes create + delete round-trip (#386, second batch)

### DIFF
--- a/.changeset/integration-quotes-write-roundtrip.md
+++ b/.changeset/integration-quotes-write-roundtrip.md
@@ -1,0 +1,9 @@
+---
+"@pax8/cli": patch
+---
+
+Second batch of #386 wire-level write coverage. Extends `e2e/integration/quotes.integration.test.ts` with a `quotes create` → `quotes delete` round-trip that follows the pattern proven in #539's webhooks test.
+
+Resource picked for the same reasons as webhooks: full CRUD exists in the CLI, draft-state creates are non-binding (no `quotes send`, so the customer never sees anything), and `--product` is optional so the test can fire the smallest possible write that exercises `POST /v2/quotes`. The test fetches the first row from `companies list --json` rather than hard-coding a company ID, so it runs against any sandbox tenant that has at least one company on file.
+
+Still does not close #386 — that asks for write coverage on at least four resources (orders create, quotes create + send, subscriptions cancel, webhooks create + enable/disable) plus a documented cleanup strategy. Webhooks (#539) and quotes (this PR) are the two resources with full CRUD; the remaining two (orders, subscriptions) lack an inverse operation and need a separate cleanup story before they can land.

--- a/e2e/integration/quotes.integration.test.ts
+++ b/e2e/integration/quotes.integration.test.ts
@@ -2,11 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Seed v2 smoke test (#308). Proves the post-#316 `/v2` routing for quotes
- * reaches the real Pax8 quoting API. This is the test that would have
- * failed for #307 (quote calls hitting `/v1/quotes` instead of `/v2/quotes`)
- * if it had existed before #266 shipped. See `harness.ts` for the extension
- * pattern.
+ * Quotes v2 smokes — read + write (#308, expanded under #386).
+ *
+ * The seed read test (`quotes list`) pins the post-#316 `/v2` routing — it's
+ * the test that would have failed for #307 (quote calls hitting `/v1/quotes`
+ * instead of `/v2/quotes`) if it had existed before #266 shipped.
+ *
+ * The write round-trip (`quotes create` → `quotes delete`) follows the
+ * pattern proven in `webhooks.integration.test.ts` (#386 first batch):
+ * pick the safest possible inputs, capture the new resource's `id`, and
+ * fire the inverse operation in-band so the test cleans up after itself.
+ *
+ * Quotes was chosen as the second write target (after webhooks) because:
+ *
+ *   - Full CRUD: the CLI has both `quotes create` and `quotes delete`.
+ *   - Draft-state creates are non-binding: a quote created without
+ *     `quotes send` never reaches the customer, so even if the delete
+ *     misses there's no partner-visible side effect.
+ *   - `--product` is optional on create: an empty-line-item quote is
+ *     the minimal possible write, with no dependency on a known-good
+ *     product ID in the sandbox.
+ *
+ * Sandbox prerequisite: the tenant must have at least one company
+ * (any status) for the quote to attach to. The test fetches the first
+ * row from `companies list --json` rather than hard-coding an ID so it
+ * runs against any sandbox.
  */
 
 import { it, expect } from "vitest";
@@ -56,5 +76,96 @@ describeIntegration("quotes (v2)", () => {
       }
     },
     60_000,
+  );
+
+  it(
+    "quotes create + delete round-trip cleans up after itself (#386)",
+    async () => {
+      // Step 1: pick the first company in the sandbox to attach the draft
+      // quote to. Using `companies list --size 1` keeps the test
+      // self-sufficient — no hard-coded ID, works against any sandbox
+      // that has at least one company on file.
+      const companiesResult = await runCliVerbose([
+        "companies",
+        "list",
+        "--json",
+        "--size",
+        "1",
+      ]);
+      expectExitZero(companiesResult);
+      let companyId: string | undefined;
+      try {
+        const parsed = JSON.parse(companiesResult.stdout);
+        const rows = Array.isArray(parsed)
+          ? parsed
+          : Array.isArray((parsed as { content?: unknown[] }).content)
+            ? (parsed as { content: unknown[] }).content
+            : [];
+        const first = rows[0] as { id?: unknown } | undefined;
+        if (typeof first?.id === "string") companyId = first.id;
+      } catch {
+        // fall through to assertion below
+      }
+      expect(
+        companyId,
+        `Could not extract a company id from companies list — sandbox empty? stdout: ${companiesResult.stdout.slice(0, 400)}`,
+      ).toBeTruthy();
+
+      // Step 2: create an empty-line-item draft quote attached to that
+      // company. No `--product`, no `--send` — the smallest possible
+      // write that exercises the `POST /v2/quotes` wire surface.
+      const createResult = await runCliVerbose([
+        "quotes",
+        "create",
+        "--company",
+        companyId!,
+        "--yes",
+        "--json",
+      ]);
+      expectExitZero(createResult);
+      expectWireUrl(createResult, {
+        method: "POST",
+        pathContains: "/v2/quotes",
+        version: "v2",
+      });
+
+      // Capture the new quote's id from stdout. Tolerate a `{ quote: {...} }`
+      // envelope or a flat object so a future envelope refactor doesn't
+      // break the test before the assertion fires.
+      let quoteId: string | undefined;
+      try {
+        const parsed = JSON.parse(createResult.stdout);
+        const id =
+          parsed?.quote?.id ??
+          parsed?.id ??
+          parsed?.data?.id ??
+          undefined;
+        if (typeof id === "string") quoteId = id;
+        else if (typeof id === "number") quoteId = String(id);
+      } catch {
+        // fall through
+      }
+      expect(
+        quoteId,
+        `Could not find created quote id in stdout — got: ${createResult.stdout.slice(0, 400)}`,
+      ).toBeTruthy();
+
+      // Step 3: delete the just-created quote. If this fails the test goes
+      // red and the sandbox is left with a single dangling draft quote —
+      // non-binding (never sent) and easy to sweep by name.
+      const deleteResult = await runCliVerbose([
+        "quotes",
+        "delete",
+        quoteId!,
+        "--yes",
+      ]);
+      expectExitZero(deleteResult);
+      expectWireUrl(deleteResult, {
+        method: "DELETE",
+        pathContains: `/v2/quotes/${quoteId}`,
+        version: "v2",
+      });
+    },
+    90_000,
   );
 });


### PR DESCRIPTION
## Summary

Second batch of #386 — extends \`e2e/integration/quotes.integration.test.ts\` with a \`quotes create\` → \`quotes delete\` round-trip. Follows the pattern proven in #539 (webhooks): pick the smallest possible write, capture the new resource's id, fire the inverse, assert both wire URLs. Self-cleans in-band.

## Why quotes is the second-safest write target

| Property | Why it matters |
|---|---|
| Full CRUD on the CLI | \`quotes create\` + \`quotes delete\` both exist, so the test cleans up its own artifact. |
| Draft-state creates are non-binding | No \`quotes send\` in the test, so the customer never sees anything. Even if the delete misses, no partner-visible side effect. |
| \`--product\` is optional on create | Empty-line-item draft is the minimal possible write to exercise \`POST /v2/quotes\`. |
| No hard-coded sandbox state | The test fetches the first row from \`companies list --json --size 1\` so it runs against any sandbox with at least one company on file. |

## What this PR does NOT close

#386's bullet list asks for write coverage on at least four resources:

- ✅ Webhooks (create + delete) — landed in #539
- ✅ Quotes (create + delete) — this PR
- ⏳ Orders create — has no inverse operation; needs a cleanup strategy decision before it can land
- ⏳ Subscriptions cancel — same, no inverse

Plus still open from the issue's acceptance criteria:

- ⏳ CONTRIBUTING.md "new write commands require integration test" guidance
- ⏳ Cleanup strategy doc for inverse-less resources (dedicated sandbox tenant + sweep, vs annotate-and-leave with a checklist)
- ⏳ Promote \`integration.yml\` from \`continue-on-error: true\` to required gating once stable

## Test plan

- [x] \`pnpm test\` (default suite) — 2123 passed / 6 skipped / 6 todo
- [x] \`pnpm test:integration\` (no creds) — 6 files / 8 tests skipped; my round-trip is the +1 vs the previous suite count. Self-skips cleanly per the harness pattern.
- [ ] Will not be exercised against the real sandbox until run by a maintainer with \`PAX8_CLIENT_ID\` / \`PAX8_CLIENT_SECRET\` set. The id-extraction tolerates \`{quote:{id}}\` and flat-\`{id}\` shapes; if the actual create response uses a different shape, tighten the lookup based on the first real run.

Addresses #386 (does not close — see "What this PR does NOT close").