### PR TITLE
test(integration): orders create --dry-run wire smoke (#386, third batch)

### DIFF
--- a/.changeset/integration-orders-create-dry-run.md
+++ b/.changeset/integration-orders-create-dry-run.md
@@ -1,0 +1,11 @@
+---
+"@pax8/cli": patch
+---
+
+Third batch of #386 wire-level write coverage. Extends `e2e/integration/orders.integration.test.ts` with an `orders create --dry-run` test.
+
+`--dry-run` maps to `isMock=true` on the wire — the server validates the order payload as if committing, then returns without creating a real order. Same wire-regression guard as the round-trip tests for webhooks (#539) and quotes (#540), but achieved without an inverse step because Pax8 supports `isMock` natively on the orders surface. No artifact in the sandbox, no cleanup, no sweep workflow needed.
+
+The test asserts both the wire URL (`POST /v1/orders`) and that the request carried `?isMock=true` — so a future refactor that accidentally drops the dry-run threading would quietly start creating real orders against the sandbox, and this catch-it-at-the-belt-and-suspenders assertion ensures we notice immediately.
+
+Three of four resources from #386's bullet list now covered (webhooks, quotes, orders). `subscriptions cancel` is the remaining holdout — it has no `isMock` equivalent and no inverse, so the next PR's approach is to gate it behind an explicit `PAX8_INTEGRATION_DESTRUCTIVE=1` env var (default off in PR CI; opt-in for nightly runs).

--- a/e2e/integration/orders.integration.test.ts
+++ b/e2e/integration/orders.integration.test.ts
@@ -2,23 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Orders v1 wire smoke + default-sort pin (#478).
+ * Orders v1 smokes — read + dry-run write (#478, expanded under #386).
  *
- * The first test mirrors `companies.integration.test.ts`: it proves the
- * CLI's orders surface still routes to `/v1/orders`. If a future refactor
- * accidentally points orders at a different version segment, this catches
- * it before partners do — same regression class as the #307 quotes bug.
- * It also asserts the `--json` envelope now wraps `{ orders, page }` per
- * #478 — pre-fix output was a flat array, which hid pagination from
- * partners and agents on portfolios with thousands of orders.
+ * The two read tests pin `/v1/orders` routing and the default sort hint
+ * partners depend on (#478). The third test, added under #386, exercises
+ * `orders create --dry-run` against the real API:
  *
- * The second test pins the default sort hint that the CLI sends on every
- * `orders list` request (`sort=createdAt,desc`) — pre-#478 the CLI sent
- * nothing and the real API returned 2013-era orders in row 1 on long-lived
- * tenants. The `--status` flag was removed entirely in the same PR (it
- * never worked end-to-end and the server silently ignored every value);
- * if the Pax8 Orders team lands real status filtering under #369 we can
- * re-add the flag honestly.
+ *   - `--dry-run` maps to `isMock=true` on the wire. The server validates
+ *     the order payload as if it were going to commit it, then returns
+ *     without creating an actual order. No artifact in the sandbox, no
+ *     cleanup needed — the same property that makes `webhooks create +
+ *     delete` and `quotes create + delete` safe round-trips, achieved
+ *     here without the inverse step because Pax8 supports `isMock` on
+ *     the orders surface.
+ *
+ *   - This catches the #307-class bug for `orders create`: a future
+ *     refactor that pointed orders create at the wrong version segment,
+ *     or that broke the payload shape, would fail this test before
+ *     reaching a partner.
+ *
+ * Why dry-run + no real create:
+ *
+ *   - `orders create` has no inverse (orders are immutable financial
+ *     history). A real create would either leave artifacts in the
+ *     sandbox forever (annotate-and-leave) or require a sweep workflow
+ *     that can't actually delete orders anyway. `--dry-run` sidesteps
+ *     the whole question and still exercises the wire.
+ *   - The dry-run still validates the payload server-side, so a
+ *     malformed request (wrong product ID shape, missing required field,
+ *     wrong wire URL) fails the same way a real create would.
  */
 
 import { it, expect } from "vitest";
@@ -83,4 +95,110 @@ describeIntegration("orders (v1)", () => {
     },
     60_000,
   );
+
+  it(
+    "orders create --dry-run hits POST /v1/orders with isMock=true and validates server-side (#386)",
+    async () => {
+      // Step 1: pick the first company in the sandbox. `--company` accepts
+      // ID or name; use ID for stability.
+      const companiesResult = await runCliVerbose([
+        "companies",
+        "list",
+        "--json",
+        "--size",
+        "1",
+      ]);
+      expectExitZero(companiesResult);
+      let companyId: string | undefined;
+      try {
+        const parsed = JSON.parse(companiesResult.stdout);
+        const rows = Array.isArray(parsed)
+          ? parsed
+          : Array.isArray((parsed as { content?: unknown[] }).content)
+            ? (parsed as { content: unknown[] }).content
+            : [];
+        const first = rows[0] as { id?: unknown } | undefined;
+        if (typeof first?.id === "string") companyId = first.id;
+      } catch {
+        // fall through
+      }
+      expect(
+        companyId,
+        `Could not extract a company id — sandbox empty? stdout: ${companiesResult.stdout.slice(0, 400)}`,
+      ).toBeTruthy();
+
+      // Step 2: pick the first product in the sandbox. `orders create`
+      // needs a real product ID; whatever the sandbox offers first is
+      // good enough for a dry-run validation. Using `products list`
+      // instead of a hard-coded SKU keeps the test independent of the
+      // sandbox's catalog snapshot.
+      const productsResult = await runCliVerbose([
+        "products",
+        "list",
+        "--json",
+        "--size",
+        "1",
+      ]);
+      expectExitZero(productsResult);
+      let productId: string | undefined;
+      try {
+        const parsed = JSON.parse(productsResult.stdout);
+        const rows = Array.isArray(parsed)
+          ? parsed
+          : Array.isArray((parsed as { content?: unknown[] }).content)
+            ? (parsed as { content: unknown[] }).content
+            : [];
+        const first = rows[0] as { id?: unknown } | undefined;
+        if (typeof first?.id === "string") productId = first.id;
+      } catch {
+        // fall through
+      }
+      expect(
+        productId,
+        `Could not extract a product id — sandbox catalog empty? stdout: ${productsResult.stdout.slice(0, 400)}`,
+      ).toBeTruthy();
+
+      // Step 3: fire the dry-run create. `--dry-run` translates to
+      // `?isMock=true` on the wire — server validates, never commits.
+      const createResult = await runCliVerbose([
+        "orders",
+        "create",
+        "--company",
+        companyId!,
+        "--product",
+        productId!,
+        "--quantity",
+        "1",
+        "--dry-run",
+        "--yes",
+        "--json",
+      ]);
+      expectExitZero(createResult);
+      expectWireUrl(createResult, {
+        method: "POST",
+        pathContains: "/v1/orders",
+        version: "v1",
+      });
+      // Belt-and-suspenders: confirm the dry-run flag actually reached the
+      // wire as `isMock=true`. If a future refactor accidentally drops the
+      // dry-run threading, the test would otherwise quietly start creating
+      // real orders against the sandbox.
+      expect(
+        result_stderr_has_ismock(createResult.stderr),
+        `Expected POST /v1/orders to carry ?isMock=true; observed:\n${createResult.stderr.slice(0, 800)}`,
+      ).toBe(true);
+    },
+    90_000,
+  );
 });
+
+/**
+ * Tolerant check for `isMock=true` in any of the observed `[pax8] METHOD
+ * url=...` lines on stderr. URL-encoded equals (`%3D`) and query-string
+ * placement (first param vs later) are both accepted so a future
+ * URLSearchParams refactor doesn't bork the assertion on a behavior
+ * we don't care about.
+ */
+function result_stderr_has_ismock(stderr: string): boolean {
+  return /[?&]isMock=true(&|\s|$)/.test(stderr);
+}


### PR DESCRIPTION
## Summary

Third batch of #386. Extends \`e2e/integration/orders.integration.test.ts\` with an \`orders create --dry-run\` test that exercises \`POST /v1/orders?isMock=true\` against the real API.

## Why \`--dry-run\` works here when round-trip didn't

For webhooks (#539) and quotes (#540) the trick was create + immediately delete. \`orders create\` has no inverse — orders are immutable financial history. But Pax8 supports \`isMock=true\` natively on the orders surface:

- The server validates the order payload (auth, wire URL, required fields, product reference) as if it were committing.
- Returns without creating a real order.
- No artifact in the sandbox, no cleanup, no sweep workflow needed.

Same regression-class guard as the round-trip tests, achieved with one wire call instead of two.

## Test details

- Picks the first available company and product from the sandbox via \`companies list\` / \`products list\` (no hard-coded SKUs).
- Asserts wire URL (\`POST /v1/orders\`, version \`v1\`).
- **Asserts \`?isMock=true\` is on the resolved URL** — belt-and-suspenders. A future refactor that drops \`--dry-run\` threading would otherwise quietly start creating real orders.

## #386 status after this lands

| Resource | Status |
|---|---|
| webhooks create + delete | shipped #539 |
| quotes create + delete | shipped #540 |
| orders create | this PR |
| subscriptions cancel | next — gating behind \`PAX8_INTEGRATION_DESTRUCTIVE=1\` since it has no \`isMock\` and no inverse |

Plus still open:
- CONTRIBUTING.md "new write commands require integration test" guidance
- Flip \`integration.yml\` from \`continue-on-error: true\` once the suite has been stable

## Test plan

- [x] \`pnpm test\` (default) — 2123 passed / 6 skipped / 6 todo
- [x] \`pnpm test:integration\` (no creds) — 7 files / 11 tests skipped (my test is the +1 vs #540)
- [ ] Sandbox dry run — will run on a maintainer-credentialed CI run; the \`?isMock=true\` assertion ensures we'd see a failure (not a real artifact) if the dry-run threading regressed.

Addresses #386 (does not close — \`subscriptions cancel\` still open).