### PR TITLE
chore(changeset): add missing changesets for #483 envelope rollout + #451 provision-details

### DIFF
--- a/.changeset/list-envelope-and-uncapped-enrichment.md
+++ b/.changeset/list-envelope-and-uncapped-enrichment.md
@@ -1,0 +1,13 @@
+---
+"@pax8/cli": minor
+---
+
+**Breaking** (`--json` shape across every list command, pre-publish): every `--json` list command now emits a wrapped envelope `{ <resource>: [...], page: { number, size, totalElements, totalPages } }` instead of a flat array. Per #370 the package isn't published yet, so no deprecation cycle is owed; consumers switch `JSON.parse(out)` → `JSON.parse(out).<resource>`. Closes #483.
+
+Ports the pattern proven in #478 (orders list) across the remaining list surface — `subscriptions list`, `clients list`, `invoices list`, `invoices items`, `quotes list`, `contacts list`, `products list`, `products search`, `usage list`, `webhooks list`, `webhooks logs`, `webhooks topics list`, `subscriptions renewals`. `recommendations list` was already wrapped as `{ recommendations, totalAvailable }` per #521 and is left untouched. Endpoints without server-side pagination (webhooks, usage, products search, renewals) get a `singlePageEnvelope(rowCount)` synthesized so the shape stays consistent.
+
+`page.number` is 1-based — matches what the user would pass as `--page` next. Compare `<resource>.length` to `page.totalElements` to detect pagination. With `--with-actions`, a `nextActions` array is added (including a next-page entry when more pages exist). Table footers consolidated onto a single format: `Page N of M — K records — next: pax8 <cmd> --page N+1 …` (suppressed on the last page; suppressed entirely on empty result sets so the empty-state message stands alone).
+
+**Uncapped name enrichment.** `companies.list({ size: 200 })` callsites in `subscriptions list`, `subscriptions renewals`, and `recommendations list` replaced with `buildCompanyNameMap` / `fetchAllCompanies` from `lib/enrich-subscriptions.ts`. Pre-fix, partners with >200 customers saw blank Company cells in those views; post-fix the helper pages through `companies.list` until every referenced ID is resolved or a 10×1000 guardrail trips. Remaining 200-cap sites (dashboard, recommendations/act, recommendations/upsell, report/*) are tracked for follow-up — each carries its own product semantics worth a focused PR.
+
+Helpers exposed for future list commands: `buildPageEnvelope(wirePage)`, `renderPaginationFooter(env, opts)`, `buildNextPageAction(env, cmd, resource)`, `singlePageEnvelope(rowCount)`, `buildCompanyNameMap(ctx, rows, opts)`, `fetchAllCompanies(ctx)`. `CLAUDE.md` and `docs/UX_GUIDE.md` §6 updated to document the envelope contract as a stable agent-facing surface.

--- a/.changeset/products-provision-details-fix.md
+++ b/.changeset/products-provision-details-fix.md
@@ -1,0 +1,16 @@
+---
+"@pax8/cli": patch
+"@pax8/core": patch
+---
+
+`pax8 products show <id> --provisioning` now hits the correct Pax8 endpoint and parses the response shape per the spec. Closes #443 (Candidate H from `docs/triage/v0.1.0-candidates.md`), surfaced by Fred Lintz's correction during domain review.
+
+Three bugs fixed in lockstep — the half-implementation worked under `PAX8_DEMO=1` (the mock matched the hallucination) but would 404 against the real API and then throw a Zod parse error after the path:
+
+1. **Endpoint path.** `/products/{id}/provisioning-details` → `/products/{id}/provision-details` (the Pax8 spec uses the singular form per `findProvisionDetailsByProductId`).
+2. **Response shape.** The endpoint returns `{ content: ProvisioningDetail[] }` (envelope-wrapped array). `getProvisioningDetails` now returns `ProvisioningDetail[]`; `products show --provisioning --json` emits a top-level `provisioningDetails` array, not the previous single object.
+3. **Schema.** Replaced the hallucinated `{ productId, vendorPrerequisites, fields[{ name, label, type, required, options }] }` with the spec shape: `{ key?, label?, description?, valueType?: "Input" | "Single-Value" | "Multi-Value", possibleValues?, values? }`. The schema is now shared with the `orders create` and `subscriptions update` write paths — same component on the wire, same shape in `@pax8/core`.
+
+Mock fixtures (`packages/core/src/mock/mock-client.ts`) updated to the spec shape too, so `PAX8_DEMO=1` and the real API now exercise the same code path. **Breaking** to `provisioningDetails` JSON shape (was a single object with `productId/vendorPrerequisites/fields`; now a `ProvisioningDetail[]` array) — pre-publish, no deprecation owed.
+
+Threading provision details into orders / subscriptions write paths per Fred's "safest bet is to always add provision details to each line item" guidance is tracked separately as Candidate H Option B.


### PR DESCRIPTION
## What

Two PRs merged this week without changesets — both are user-visible (one breaking, one schema-shape fix). This adds the missing entries so the next release-please bundle surfaces them correctly.

### #542 (#483 — list-command envelope rollout)
\`minor\`. Every list command's \`--json\` shape changed from a flat array to \`{ <resource>, page }\`. Companies enrichment uncapped for subscriptions list/renewals + recommendations list. Helpers extracted in \`lib/output.ts\` + \`lib/enrich-subscriptions.ts\`. \`CLAUDE.md\` and \`docs/UX_GUIDE.md\` updated.

### #451 (products provision-details fix)
\`patch\` on both \`@pax8/cli\` + \`@pax8/core\`. Three wire-shape bugs fixed in lockstep: endpoint path (\`/provisioning-details\` → \`/provision-details\`), response envelope (\`ProvisioningDetail[]\` not single object), schema (spec shape, not the hallucinated \`{ productId, vendorPrerequisites, fields[] }\`).

## Why

The package is pre-npm-publish per #370. The changelog is what we'll publish *with* when the gate opens — these gaps would silently hide today's biggest user-visible changes from anyone reading the release notes.

## Test plan

- [x] No code change — files are pure changeset metadata.
- [x] \`pnpm build\` clean.
- [ ] CI green.
- [ ] After merge: confirm release-please updates #538 to include the new entries.