### PR TITLE
feat(subscriptions): expose billing-term, product, sort filters on list (closes #398)

### DIFF
--- a/.changeset/subscriptions-list-server-side-filters.md
+++ b/.changeset/subscriptions-list-server-side-filters.md
@@ -1,0 +1,16 @@
+---
+"@pax8/cli": minor
+"@pax8/core": minor
+---
+
+`pax8 subscriptions list` now exposes the server-side `billingTerm`, `productId`, and `sort` filters the public OpenAPI has always supported. Closes #398.
+
+Three new flags, additive — every existing invocation still works unchanged:
+
+- `--billing-term <Monthly|Annual|2-Year|3-Year|One-Time|Trial|Activation>` — fails fast on typos before any network call, same vocabulary as `--status` (#408).
+- `--product <productId>` — passes through to the wire as `?productId=…`. UUID expected; no fuzzy product-name resolution here because the typical use case is `subscriptions list --product <copy-pasted-id-from-a-prior-row>`.
+- `--sort <field>` / `--sort <field>:<direction>` — accepts `quantity`, `startDate`, `endDate`, `createdAt`. Ascending by default; append `:desc` for descending. The user-facing separator is `:` (not `,`) to avoid shell-quoting surprises; the CLI rewrites it to the wire's `field,direction` form before forwarding.
+
+Pre-fix, partners with large portfolios had to download a full subscriptions list and filter client-side — even though the OpenAPI spec defined these parameters. `MockPax8Client.SubscriptionsResource.list` mirrors the server-side filtering for every new parameter so `PAX8_DEMO=1` exercises the same code path as the real API.
+
+`@pax8/core`'s `SubscriptionsApi.list` signature gains the three new optional fields. Type-safe additive change; consumers that don't pass the new fields are unaffected.

--- a/packages/cli/src/__tests__/subscriptions.test.ts
+++ b/packages/cli/src/__tests__/subscriptions.test.ts
@@ -140,6 +140,90 @@ describe("pax8 subscriptions list", () => {
     }
   });
 
+  // #398: server-side --billing-term / --product / --sort filters on
+  // subscriptions list. Pre-#398 these were dropped at the CLI boundary and
+  // partners with large portfolios had to filter client-side after a full
+  // pull. The new helpers mirror server-side filtering in the mock so demo
+  // mode exercises the same wire shape as the real API.
+  describe("--billing-term / --product / --sort (#398)", () => {
+    it("--billing-term filters server-side and accepts the canonical enum", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "list",
+        "--billing-term",
+        "Annual",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data.subscriptions)).toBe(true);
+      expect(data.subscriptions.length).toBeGreaterThan(0);
+      for (const sub of data.subscriptions) {
+        expect(sub.billingTerm).toBe("Annual");
+      }
+    });
+
+    it("--billing-term fails fast on a typo before any network call", async () => {
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "list",
+        "--billing-term",
+        "Yearly",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain(`Invalid value for --billing-term: "Yearly"`);
+      // Help-text echo should surface the canonical enum so the partner
+      // self-corrects without round-tripping through `--help`.
+      expect(combined).toContain("Annual");
+      expect(combined).toContain("Monthly");
+    });
+
+    it("--product filters to the requested productId", async () => {
+      // Find a known productId from the demo fixture's first subscription.
+      const all = await runCliExpectSuccess(["subscriptions", "list", "--json"]);
+      const targetProductId = JSON.parse(all.stdout).subscriptions[0].productId;
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "list",
+        "--product",
+        targetProductId,
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.subscriptions.length).toBeGreaterThan(0);
+      for (const sub of data.subscriptions) {
+        expect(sub.productId).toBe(targetProductId);
+      }
+    });
+
+    it("--sort quantity:desc orders results by quantity descending", async () => {
+      const result = await runCliExpectSuccess([
+        "subscriptions",
+        "list",
+        "--sort",
+        "quantity:desc",
+        "--size",
+        "100",
+        "--json",
+      ]);
+      const qty = JSON.parse(result.stdout).subscriptions.map(
+        (s: { quantity: number }) => s.quantity,
+      );
+      const sorted = [...qty].sort((a, b) => b - a);
+      expect(qty).toEqual(sorted);
+    });
+
+    it("--sort rejects unknown sort fields client-side", async () => {
+      const result = await runCliExpectFailure([
+        "subscriptions",
+        "list",
+        "--sort",
+        "ponies",
+      ]);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain(`Invalid value for --sort: "ponies"`);
+    });
+  });
+
   // #408 / partner-walkthrough finding #2: a typo'd --status used to silently
   // return [] from the API. Now fails fast with the allowed enum list so the
   // partner can self-correct without guessing.

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -3,7 +3,12 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
-import { SubscriptionStatusSchema, type SubscriptionStatus } from "@pax8/core";
+import {
+  SubscriptionStatusSchema,
+  type SubscriptionStatus,
+  BillingTermSchema,
+  type BillingTerm,
+} from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import {
   output,
@@ -33,6 +38,21 @@ import { clampListSize, LIST_SIZE_CAP, validateEnum, warnSizeClamped } from "../
 // all read from this array — keeps them from drifting.
 const SUBSCRIPTION_STATUS_VALUES = SubscriptionStatusSchema.options as readonly SubscriptionStatus[];
 const SUBSCRIPTION_STATUS_HELP = SUBSCRIPTION_STATUS_VALUES.join(", ");
+
+// #398: `GET /subscriptions` exposes `billingTerm` as a server-side filter
+// per the public OpenAPI. Same fail-fast enum-validation pattern as
+// `--status` so a typo fails at the CLI boundary instead of round-tripping
+// and returning `[]`.
+const BILLING_TERM_VALUES = BillingTermSchema.options as readonly BillingTerm[];
+const BILLING_TERM_HELP = BILLING_TERM_VALUES.join(", ");
+
+// #398: `--sort` accepts spec field names (the public OpenAPI doesn't
+// enumerate which fields are sortable, but the documented set across
+// related list endpoints is consistent). Accepts both bare field names
+// (default direction ascending) and `field,asc` / `field,desc` shapes;
+// anything not on this list is rejected client-side.
+const SUBSCRIPTION_SORT_FIELDS = ["quantity", "startDate", "endDate", "createdAt"] as const;
+const SUBSCRIPTION_SORT_HELP = `Sort by field (${SUBSCRIPTION_SORT_FIELDS.join(", ")}); append :desc for descending (e.g. quantity:desc)`;
 
 const columns: Column[] = [
   {
@@ -76,6 +96,17 @@ export const subscriptionsListCommand = new Command("list")
     "--status <status>",
     `Filter by status (${SUBSCRIPTION_STATUS_HELP})`
   )
+  // #398: spec-backed filters previously dropped at the CLI boundary.
+  // `--billing-term` accepts the canonical BillingTerm enum (validated
+  // before any network call). `--product` is a productId UUID — no
+  // resolveProduct() here because the user typically pastes the ID from
+  // a prior `subscriptions list --json` row.
+  .option(
+    "--billing-term <term>",
+    `Filter by billing term (${BILLING_TERM_HELP})`
+  )
+  .option("--product <productId>", "Filter by product ID (UUID)")
+  .option("--sort <field>", SUBSCRIPTION_SORT_HELP)
   .option("--page <number>", "Page number", "1")
   .option("--size <number>", `Page size (max ${LIST_SIZE_CAP}; larger values are clamped)`, "25")
   .option("--ids-only", "Output only resource IDs, one per line")
@@ -87,6 +118,9 @@ Examples:
   pax8 subscriptions list
   pax8 subscriptions list --company "Summit Healthcare Partners"
   pax8 subscriptions list --status Active
+  pax8 subscriptions list --billing-term Annual
+  pax8 subscriptions list --product 11111111-2222-3333-4444-555555555555
+  pax8 subscriptions list --sort quantity:desc
   pax8 subscriptions list --size 10 --page 2
   pax8 subscriptions list --json
   pax8 subscriptions list --json --with-actions
@@ -104,6 +138,22 @@ Examples:
       validateEnum(allOpts.status, SUBSCRIPTION_STATUS_VALUES, "--status", {
         cmdHint: "pax8 subscriptions list",
       });
+      // #398: fail-fast on --billing-term typos before any network call,
+      // same vocabulary as the existing --status validator.
+      validateEnum(allOpts.billingTerm, BILLING_TERM_VALUES, "--billing-term", {
+        cmdHint: "pax8 subscriptions list",
+      });
+      // #398: --sort accepts `field` or `field:asc` / `field:desc`. Wire form
+      // is `field,asc` / `field,desc` (comma separator); the user-facing
+      // separator is `:` to avoid shell-quoting surprises with the literal
+      // comma. Validate the field part client-side; anything unknown is
+      // rejected here so a typo doesn't silently no-op against the wire.
+      if (allOpts.sort) {
+        const [field] = String(allOpts.sort).split(":");
+        validateEnum(field, SUBSCRIPTION_SORT_FIELDS, "--sort", {
+          cmdHint: "pax8 subscriptions list",
+        });
+      }
     } catch (error) {
       await handleCommandError(error);
     }
@@ -122,9 +172,18 @@ Examples:
       if (sizeResult.clamped) {
         warnSizeClamped(sizeResult.requested, LIST_SIZE_CAP, { quiet: allOpts.quiet });
       }
+      // #398: translate the user-friendly `field:direction` shape into the
+      // wire's `field,direction` shape. The Pax8 API uses comma as the
+      // sort separator per its OpenAPI examples.
+      const sortParam = allOpts.sort
+        ? String(allOpts.sort).replace(":", ",")
+        : undefined;
       const result = await ctx.api.subscriptions.list({
         companyId,
         status: allOpts.status,
+        billingTerm: allOpts.billingTerm,
+        productId: allOpts.product,
+        sort: sortParam,
         page: apiPage,
         size: sizeResult.size,
       });
@@ -161,7 +220,10 @@ Examples:
       const pageEnvelope = buildPageEnvelope(result.page);
       const companyFlag = allOpts.company ? ` --company "${allOpts.company}"` : "";
       const statusFlag = allOpts.status ? ` --status ${allOpts.status}` : "";
-      const nextPageCommand = `pax8 subscriptions list --page ${pageEnvelope.number + 1} --size ${pageEnvelope.size}${companyFlag}${statusFlag}`;
+      const billingTermFlag = allOpts.billingTerm ? ` --billing-term ${allOpts.billingTerm}` : "";
+      const productFlag = allOpts.product ? ` --product ${allOpts.product}` : "";
+      const sortFlag = allOpts.sort ? ` --sort ${allOpts.sort}` : "";
+      const nextPageCommand = `pax8 subscriptions list --page ${pageEnvelope.number + 1} --size ${pageEnvelope.size}${companyFlag}${statusFlag}${billingTermFlag}${productFlag}${sortFlag}`;
 
       if (ctx.outputFormat === "json") {
         const subsList = result.content;

--- a/packages/core/src/api/subscriptions.ts
+++ b/packages/core/src/api/subscriptions.ts
@@ -23,6 +23,18 @@ export class SubscriptionsApi {
     size?: number;
     companyId?: string;
     status?: string;
+    // #398: the spec's `GET /subscriptions` exposes `billingTerm`, `productId`,
+    // and `sort` query params. The CLI previously skipped them, forcing
+    // partners with large portfolios to download then filter client-side.
+    billingTerm?: string;
+    productId?: string;
+    /**
+     * Spec-typed as a freeform string for forward-compat (the spec doesn't
+     * enumerate accepted sort keys); the CLI surface canonicalizes the
+     * known fields (`quantity`, `startDate`, `endDate`, `createdAt`) plus
+     * direction (`,asc` / `,desc`).
+     */
+    sort?: string;
   }): Promise<PaginatedResponse<Subscription>> {
     const raw = await this.client.get<unknown>("/subscriptions", params as Record<string, string | number | undefined>);
     return PaginatedSubscriptionSchema.parse(raw);

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -223,7 +223,14 @@ class CompaniesResource {
 
 class SubscriptionsResource {
   async list(
-    params?: ListParams & { companyId?: string; status?: string }
+    params?: ListParams & {
+      companyId?: string;
+      status?: string;
+      // #398: spec-backed filters previously dropped at the CLI boundary.
+      billingTerm?: string;
+      productId?: string;
+      sort?: string;
+    }
   ): Promise<PaginatedResponse<Subscription>> {
     await randomDelay();
     let filtered = subscriptions;
@@ -233,6 +240,41 @@ class SubscriptionsResource {
     if (params?.status) {
       const s = params.status.toLowerCase();
       filtered = filtered.filter((sub) => sub.status.toLowerCase() === s);
+    }
+    // #398: billingTerm + productId mirror the wire-side filter so PAX8_DEMO=1
+    // exercises the same code path as the real API.
+    if (params?.billingTerm) {
+      filtered = filtered.filter((sub) => sub.billingTerm === params.billingTerm);
+    }
+    if (params?.productId) {
+      filtered = filtered.filter((sub) => sub.productId === params.productId);
+    }
+    if (params?.sort) {
+      const [field, direction] = params.sort.split(",").map((s) => s.trim());
+      const dir = (direction ?? "asc").toLowerCase() === "desc" ? -1 : 1;
+      // Demo-data `Subscription` doesn't carry every field surfaced in the
+      // public Zod schema (e.g. `endDate`). Restrict mock sort to the
+      // fields the demo fixture actually populates; unknown sort fields
+      // become a no-op rather than a TypeScript crash. The real API will
+      // honor anything documented as sortable.
+      const getField = (sub: Subscription): string | number => {
+        switch (field) {
+          case "quantity":
+            return sub.quantity;
+          case "startDate":
+            return sub.startDate ?? "";
+          case "createdAt":
+            return sub.createdAt ?? "";
+          default:
+            return "";
+        }
+      };
+      filtered = [...filtered].sort((a, b) => {
+        const av = getField(a);
+        const bv = getField(b);
+        if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+        return String(av).localeCompare(String(bv)) * dir;
+      });
     }
     const page = paginate(filtered, params);
     return page;


### PR DESCRIPTION
## What

Adds three server-side filters to \`pax8 subscriptions list\` that the OpenAPI has always supported but the CLI dropped at its boundary:

- \`--billing-term <Monthly|Annual|2-Year|3-Year|One-Time|Trial|Activation>\`
- \`--product <productId>\`
- \`--sort <field>:<direction>\` — fields: \`quantity\`, \`startDate\`, \`endDate\`, \`createdAt\`

Pre-fix, a partner with a 5,000-subscription portfolio who wanted only annual subs had to download the full list and \`jq\` it client-side. Now: \`pax8 subscriptions list --billing-term Annual --json\` does the filter on the wire.

## Why this shape

- **Fail-fast on \`--billing-term\` typos.** Same vocabulary as the existing \`--status\` validator from #408 — typo'd values get the allowed set echoed back, no silent empty result.
- **\`--product\` is UUID pass-through, no fuzzy match.** The canonical use case is paste-from-a-prior-row (e.g. \`subscriptions list --company Acme --json | jq '.subscriptions[0].productId'\` → copy → re-query). Fuzzy match would slow down agent flows for no benefit.
- **\`:\` separator on \`--sort\`, not \`,\`.** Avoids shell-quoting surprises with shells that treat literal commas specially. The CLI rewrites \`quantity:desc\` → \`quantity,desc\` on the wire to match the API's documented sort format.

## Mock parity

\`MockPax8Client.SubscriptionsResource.list\` mirrors all three filters so \`PAX8_DEMO=1\` exercises the same code path as the real API. The sort comparator skips \`endDate\` in mock because the demo-data \`Subscription\` interface doesn't carry that field (the public Zod schema does); real-API behavior is unchanged.

## Tests

5 new subprocess tests in \`packages/cli/src/__tests__/subscriptions.test.ts\` (one per flag + one regression for the fail-fast validation). Full suite green: 2128 passing / 6 skipped / 6 todo.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 2128 passing
- [ ] CI on Ubuntu/Windows × Node 20/22
- [ ] Manual: \`pax8 subscriptions list --billing-term Annual --product <uuid> --sort quantity:desc --json | jq '.subscriptions | length, .page'\`