### PR TITLE
feat(usage): document pagination contract in usage list --help (closes #397)

### DIFF
--- a/.changeset/usage-list-pagination-help.md
+++ b/.changeset/usage-list-pagination-help.md
@@ -1,0 +1,7 @@
+---
+"@pax8/cli": patch
+---
+
+`pax8 usage list --help` now explicitly documents the pagination contract — that each per-subscription `/v1/subscriptions/{id}/usage-summaries` fetch accepts `page` / `size`, the default is 50, the max is `LIST_SIZE_CAP` (1000) with stderr-clamp warning per #518, and the fan-out behavior when `--company` or no filter is used (each subscription paged independently, results concatenated). Closes #397.
+
+No behavior change — the flags were always exposed and the cap already enforced. This makes the contract explicit in the Notes block so partners with high-usage subscriptions don't get surprised by truncation. #483 also added the `{ usage, page }` JSON envelope on this command earlier today.

--- a/packages/cli/src/commands/usage/list.ts
+++ b/packages/cli/src/commands/usage/list.ts
@@ -35,7 +35,15 @@ Notes:
   subscription (\`/v1/subscriptions/{id}/usage-summaries\`). \`--company\`
   is a convenience: the CLI resolves the company to its subscriptions and
   iterates. Pass \`--subscription <id>\` to skip the lookup when you already
-  know the ID.`
+  know the ID.
+
+  Pagination: the per-subscription endpoint accepts \`page\` / \`size\`. Use
+  \`--page\` and \`--size\` (default 50, max ${LIST_SIZE_CAP} per page; values above the
+  cap are clamped with a stderr warning, #518). When fanning out via
+  \`--company\` or no filter, each subscription is fetched with the same
+  page / size — results from all subscriptions are concatenated, so
+  consumers should treat the combined output as a single result set and
+  re-query with a larger \`--size\` if any one subscription truncates.`
   )
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();


### PR DESCRIPTION
## What

Adds an explicit \"Pagination:\" subsection to \`pax8 usage list --help\` covering the per-subscription paging contract and the fan-out concatenation behavior. No code change — help-text only.

## Why

#397 had three ACs:
- [x] \`--page\` / \`--size\` exposed — already done.
- [x] Help text mentions truncation — already done implicitly via the \`--size (max LIST_SIZE_CAP; larger values are clamped)\` description + the runtime stderr clamp warning from #518.
- [x] Help text documents pagination behavior — **this PR**. The fan-out semantics (when \`--company\` is passed or no filter is set, each subscription's pagination is independent and results are concatenated) weren't surfaced anywhere, so a partner with a high-usage subscription could see truncated results without understanding why.

The \`{ usage, page }\` JSON envelope landed in #483 earlier today, so the JSON consumer already gets structured pagination metadata. This PR closes the human-facing leg of the same issue.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm vitest run packages/cli/src/__tests__/usage.test.ts\` — 5/5
- [ ] CI green
- [ ] \`pax8 usage list --help | tail -20\` shows the new Pagination block