### PR TITLE
fix(cli): drill-in reuses the active CLI entrypoint, not `pax8` on PATH (closes #457)

### DIFF
--- a/.changeset/next-step-reuse-cli-entrypoint.md
+++ b/.changeset/next-step-reuse-cli-entrypoint.md
@@ -1,0 +1,9 @@
+---
+"@pax8/cli": patch
+---
+
+`promptNextSteps()` now reuses the active CLI entrypoint when drilling into a numbered option, matching the REPL's behavior. Closes #457.
+
+Pre-fix, the inline numeric-pick prompt rendered by `clients list`, `subscriptions renewals`, `contacts list`, `usage list`, and several others called `spawn("pax8", ...)` — which silently no-ops or fails when the CLI is launched via `node packages/cli/dist/index.js`, a yarn `-g` install in a non-standard prefix, or a linked local binary that isn't on `$PATH`. The REPL itself had the right pattern via `resolveCliPath(process.argv[1])` (see `lib/repl.ts`); this aligns the drill-in path with that.
+
+Implementation: `lib/next-step.ts` now imports `resolveCliPath` from `lib/repl.ts` and spawns `node <cliPath> <args>` instead of `pax8 <args>`. A best-effort fallback to the legacy `spawn("pax8", ...)` shape is kept for the edge case where `process.argv[1]` is empty (e.g. a future embedded caller in an MCP wrapper).

--- a/packages/cli/src/lib/next-step.test.ts
+++ b/packages/cli/src/lib/next-step.test.ts
@@ -16,13 +16,13 @@ vi.mock("readline", () => ({
 
 // Mock spawn so we don't actually launch a child process in tests where
 // the user "selects" a step.
-const spawnedCommands: Array<{ args: string[] }> = [];
+const spawnedCommands: Array<{ cmd: string; args: string[] }> = [];
 vi.mock("child_process", async (importActual) => {
   const actual = await importActual<typeof import("child_process")>();
   return {
     ...actual,
-    spawn: (_cmd: string, args: string[]) => {
-      spawnedCommands.push({ args });
+    spawn: (cmd: string, args: string[]) => {
+      spawnedCommands.push({ cmd, args });
       const handlers: Record<string, () => void> = {};
       // Synchronously invoke the close handler on next tick.
       const obj = {
@@ -147,7 +147,7 @@ describe("promptNextSteps", () => {
     expect(spawnedCommands).toHaveLength(0);
   });
 
-  it("spawns the picked step's command when the user enters a valid key", async () => {
+  it("spawns the picked step's command via the active CLI entrypoint (#457)", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       value: true,
       writable: true,
@@ -163,6 +163,14 @@ describe("promptNextSteps", () => {
     await promptNextSteps(steps);
 
     expect(spawnedCommands).toHaveLength(1);
-    expect(spawnedCommands[0].args).toEqual(["subscriptions", "list"]);
+    // #457: drill-in launches `node <cliPath> <args>` instead of `pax8 <args>`,
+    // so a CLI launched without `pax8` on PATH still drills in correctly.
+    // First element after the cliPath is the resource; the rest are the
+    // command's args verbatim.
+    expect(spawnedCommands[0].cmd).toBe("node");
+    const [cliPath, ...args] = spawnedCommands[0].args;
+    expect(typeof cliPath).toBe("string");
+    expect(cliPath.length).toBeGreaterThan(0);
+    expect(args).toEqual(["subscriptions", "list"]);
   });
 });

--- a/packages/cli/src/lib/next-step.ts
+++ b/packages/cli/src/lib/next-step.ts
@@ -4,6 +4,7 @@
 import chalk from "chalk";
 import { createInterface } from "readline";
 import { spawn } from "child_process";
+import { resolveCliPath } from "./repl.js";
 
 export interface NextStep {
   key: string;
@@ -74,8 +75,29 @@ export async function promptNextSteps(
 
   process.stderr.write("\n");
 
+  // #457: reuse the active CLI entrypoint instead of hardcoding `pax8` on
+  // PATH. The REPL already does this via `resolveCliPath(process.argv[1])`
+  // (see lib/repl.ts) — drill-in from a non-PATH launch (`node dist/index.js`,
+  // a yarn -g install in an unusual prefix, etc.) was the only remaining
+  // call site that assumed `pax8` was discoverable.
+  let cliPath: string;
+  try {
+    cliPath = resolveCliPath(process.argv[1]);
+  } catch {
+    // Best-effort fallback to the legacy behavior when we can't resolve
+    // process.argv[1] (e.g. embedded callers in a future MCP wrapper).
+    return new Promise<void>((resolve) => {
+      const child = spawn("pax8", picked.command, {
+        stdio: "inherit",
+        env: process.env,
+      });
+      child.on("error", () => resolve());
+      child.on("close", () => resolve());
+    });
+  }
+
   return new Promise<void>((resolve, _reject) => {
-    const child = spawn("pax8", picked.command, {
+    const child = spawn("node", [cliPath, ...picked.command], {
       stdio: "inherit",
       env: process.env,
     });


### PR DESCRIPTION
## What

\`promptNextSteps()\` now spawns the picked step via \`node <cliPath> <args>\` instead of \`spawn(\"pax8\", ...)\`, matching the REPL's existing entrypoint resolution.

## Why

The inline numeric-pick prompt (rendered by \`clients list\`, \`subscriptions renewals\`, \`contacts list\`, \`usage list\`, and a few others) silently no-ops or fails when the CLI is launched via:

- \`node packages/cli/dist/index.js\`
- a yarn \`-g\` install in a non-standard prefix
- a linked local binary that isn't on \`\$PATH\`

The REPL itself (lib/repl.ts) had the right pattern via \`resolveCliPath(process.argv[1])\` for a while; the drill-in path was the only remaining call site that assumed \`pax8\` was discoverable. Cassie surfaced this — pre-fix she had to alias \`pax8\` manually before the drill-in worked.

## How

\`lib/next-step.ts\` imports \`resolveCliPath\` from \`lib/repl.ts\` and spawns \`node <cliPath> <args>\` instead of \`pax8 <args>\`. Best-effort fallback to \`spawn(\"pax8\", ...)\` preserved for the edge case where \`process.argv[1]\` is empty (e.g. a future embedded caller in an MCP wrapper).

## Tests

\`packages/cli/src/lib/next-step.test.ts:150-176\` updated to assert the new shape — spawn cmd is \`\"node\"\`, first arg is a non-empty string (the resolved cliPath), remaining args are the picked step's command verbatim. Captures the cmd alongside the args so future regressions to the launch shape are caught.

Full suite green: **2128/2128**.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 2128 passing
- [ ] CI green
- [ ] Manual: \`node packages/cli/dist/index.js clients list\` → type \`1\` → drill-in lands in the right command