### PR TITLE
docs(prd): reflect the post-#443 reshape (closes #460)

### DIFF
--- a/.changeset/prd-post-rename-cleanup.md
+++ b/.changeset/prd-post-rename-cleanup.md
@@ -1,0 +1,12 @@
+---
+"@pax8/cli": patch
+---
+
+`docs/PRD.md`: update the post-#443 reshape so the document matches the
+current `pax8 report subscriptions` / `pax8 report concentration` /
+`pax8 report renewals` surface instead of the retired `pax8 report mrr` /
+`pax8 report growth` framing. Closes #460.
+
+`AGENTS.md` and `README.md` were already clean of stale `report mrr` /
+`PAX8_API_TIMEOUT` references; the lingering README mention is
+explicitly historical and conforms to #460's AC #3. No code change.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -284,12 +284,24 @@ pax8 webhooks delete <id>
 
 ### Reports (computed — fills API gap)
 
+The original PRD enumerated four `pax8 report …` commands (mrr / renewals /
+growth / licenses) framed around partner-revenue MRR. That framing was
+retired pre-v0.1.0 review (#443 — Bret Pittenger reshape) because Pax8's
+internal Unified Semantic Layer (Voyager Alliance) reserves the
+"Partner Gross MRR" term for the partner's **cost paid to Pax8**, not
+their resale revenue. The current surface mirrors that taxonomy:
+
 ```
-pax8 report mrr [--by company|product|vendor]     # Monthly recurring revenue
-pax8 report renewals [--within <days>]             # Renewal calendar
-pax8 report growth [--months <n>]                  # MRR trend over time
-pax8 report licenses [--underutilized]             # License count analysis
+pax8 report subscriptions --by company|product|vendor  # Pax8-cost grouped
+pax8 report concentration                              # Customer-concentration risk
+pax8 report renewals [--within <days>]                 # Renewal calendar
+pax8 subscriptions renewals                            # Same surface, daily-workflow shape
+pax8 dashboard                                         # Portfolio Pax8-cost summary
 ```
+
+Historical `pax8 report mrr` and `pax8 report growth` were removed in
+#443; `computeMrr` / `computeGrowth` remain in `@pax8/core` for
+embeddable reuse (v0.2 reporting work).
 
 ### Configuration
 
@@ -412,7 +424,7 @@ These are limitations of the Pax8 API that the CLI works around with local compu
 |-----|-------------|----------------|
 | **No future-dated changes** | Local scheduler: `pax8 subscriptions schedule` stores intent, executes via cron at target date | `scheduler.ts` — SQLite or JSON state file, `pax8 scheduler run` for cron execution |
 | **No bulk/batch API** | Parallel executor with rate-limit awareness: `pax8 orders create --from bulk.yaml` | `bulk-executor.ts` — concurrent API calls with configurable parallelism (default 5), automatic backoff on 429 |
-| **No reporting/analytics** | Computed reports: `pax8 report mrr`, `pax8 report growth`, `pax8 report renewals` | `analytics.ts` — pulls raw subscription/invoice data, computes MRR/ARR/churn/growth client-side |
+| **No reporting/analytics** | Computed reports: `pax8 report subscriptions`, `pax8 report concentration`, `pax8 report renewals` (Pax8-cost framed per #443) | `analytics.ts` — pulls raw subscription/invoice data, computes Pax8 cost / renewal exposure / concentration client-side |
 | **No renewal intelligence** | `pax8 subscriptions renewals` — parses `commitmentTermEndDate` across all subscriptions | `renewal-tracker.ts` — aggregates subscription data, sorts by urgency, flags action-required items |
 | **No billing reconciliation** | `pax8 invoices audit` — diffs invoice line items against active subscription quantities | `invoice-auditor.ts` — cross-references invoice items with subscription state, flags discrepancies |
 | **No product search** | `pax8 products search` — local full-text search over cached product catalog | `cache.ts` — daily product catalog sync, fuzzy matching |


### PR DESCRIPTION
## What

\`docs/PRD.md\` still described the original \`pax8 report mrr\` / \`pax8 report growth\` surface from before the #443 Pax8-cost taxonomy reshape. Two sites updated to match what actually ships today.

## Why

\`AGENTS.md\` and \`README.md\` were already clean — the drift only lived in PRD.md. Per #460 AC #3 (\"removed \`report mrr\` / \`report growth\` guidance is removed or explicitly marked historical\"), the lingering README.md:440 mention is explicitly historical and conforms.

## Surfaces checked
- [x] \`AGENTS.md\` — no live recommendations for retired commands.
- [x] \`README.md\` — only a historical retrospective remains, properly worded.
- [x] \`docs/PRD.md\` — **updated by this PR.**
- [x] \`PAX8_API_TIMEOUT\` — zero residual across all \`*.md\` files.
- [x] CHANGELOG.md entries — historical record, left intact.

## Test plan

- [x] \`grep -rn \"pax8 report mrr\\|pax8 report growth\" docs/PRD.md\` → only the historical-explainer remains.
- [x] \`grep -rn \"PAX8_API_TIMEOUT\" --include=\"*.md\"\` → zero matches.