### PR TITLE
feat(repl): list navigation — back / n / p resume without retyping flags (closes #456)

### DIFF
--- a/.changeset/repl-list-navigation-back-n-p.md
+++ b/.changeset/repl-list-navigation-back-n-p.md
@@ -1,0 +1,21 @@
+---
+"@pax8/cli": minor
+---
+
+REPL list navigation: `back`, `n`, `p` now resume the last list session without retyping flags. Closes #456.
+
+Pre-fix, the REPL flow `clients list` → type `26` → drill into the company → end up back at `pax8>` left the user with no way to continue browsing except retyping `clients list --page 3`. Cassie surfaced this as a daily-workflow paper-cut. Three new REPL shortcuts:
+
+- `back` — re-runs the last list command at the same page (handy after a drill-in: the prior listing is one keystroke away).
+- `n` — pages forward (next page of the last list).
+- `p` — pages backward.
+
+`clients list` is the first surface wired up. After each render in REPL mode (`PAX8_REPL=1`) the command writes `last-list-context.json` containing the argv it ran with and the resolved `{ number, totalPages }` envelope, and the REPL reads that file when `n`/`p`/`back` is typed. Argv rewriting handles both the "user typed `--page N`" case (replace) and the implicit-default case (append). Each list footer in REPL mode prints a one-line `REPL: n=next · p=prev · back=re-run` hint so the affordance is discoverable.
+
+Boundary checks: `n` at the last page and `p` at the first page print a dim "Already on the last/first page" message and re-prompt instead of clobbering state. Missing or corrupt `last-list-context.json` triggers a clean "No recent list to navigate" message — never a spawn with garbage argv.
+
+Shape validation on the loaded context (`loadLastListContext`) defensively rejects tampered files — a tampered or truncated context can't surface an unexpected argv. Wired through `safeWriteFileSync` so the cache file is mode `0o600` and refuses to follow symlinks (same posture as the pre-existing `last-list.json` + `pending-actions.json` writes).
+
+This wires `clients list` only as the proof-of-pattern; the same `saveLastListContext()` call belongs on `subscriptions list`, `invoices list`, `orders list`, `quotes list`, `contacts list`, `webhooks list`, etc. — tracked separately so each rollout can be reviewed cleanly.
+
+Helpers exposed in `lib/last-list.ts` for the rollout: `saveLastListContext`, `loadLastListContext`, `rewriteArgvForPage`, plus the `LastListContext` interface. 7 new unit tests cover round-trip, corruption, shape validation, and argv rewriting (replace + append + no-mutate).

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -24,7 +24,7 @@ import {
   buildNextPageAction,
 } from "../../lib/output.js";
 import { formatStatus, formatCompanyName, formatCurrency } from "../../lib/formatters.js";
-import { saveLastList } from "../../lib/last-list.js";
+import { saveLastList, saveLastListContext } from "../../lib/last-list.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import { enrichProductNames, enrichCompanyNames } from "../../lib/enrich-subscriptions.js";
 import { clampListSize, LIST_SIZE_CAP, validateEnum, warnSizeClamped } from "../../lib/validate.js";
@@ -272,6 +272,23 @@ Examples:
         }))
       );
 
+      // #456: snapshot the argv + paging state so the REPL's `back` / `n` /
+      // `p` commands can resume browsing without retyping flags. The argv
+      // captures the user-facing command (`clients list --status Active
+      // --page 1 --size 25 ...`); the page envelope drives next/prev
+      // navigation. Built from process.argv so we preserve every flag
+      // the user actually typed.
+      const userArgv = process.argv.slice(2);
+      if (userArgv.length > 0 && userArgv[0] !== "back" && userArgv[0] !== "n" && userArgv[0] !== "p") {
+        await saveLastListContext({
+          command: userArgv,
+          page: {
+            number: userPage,
+            totalPages: result.page.totalPages,
+          },
+        });
+      }
+
       // Save pending actions for REPL number input (typing "3" drills into company #3).
       // #458/#469: route through getConfigDir() (so PAX8_CONFIG_DIR is honored)
       // and safeWriteFileSync (mode 0o600, O_NOFOLLOW) — this file contains
@@ -408,6 +425,20 @@ Examples:
           process.stderr.write(
             chalk.dim("  Add ") + chalk.cyan("--coverage") + chalk.dim(" to see portfolio gaps and revenue opportunities\n")
           );
+        }
+
+        // #456: surface REPL navigation affordances when running inside
+        // the REPL (PAX8_REPL=1). Pre-fix, the partner had to retype
+        // `clients list --page N` to page through; now `n`/`p`/`back`
+        // pull from the saved last-list-context.json.
+        if (process.env.PAX8_REPL === "1") {
+          const total = pageEnvelope.totalPages;
+          const cur = pageEnvelope.number;
+          const hints: string[] = [];
+          if (cur < total) hints.push(`${chalk.cyan("n")}=next`);
+          if (cur > 1) hints.push(`${chalk.cyan("p")}=prev`);
+          hints.push(`${chalk.cyan("back")}=re-run`);
+          process.stderr.write(chalk.dim(`  REPL: ${hints.join(" · ")}\n`));
         }
 
         // Interactive: pick a company to drill into

--- a/packages/cli/src/lib/last-list.test.ts
+++ b/packages/cli/src/lib/last-list.test.ts
@@ -5,7 +5,13 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { saveLastList, resolveFromLastList } from "./last-list.js";
+import {
+  saveLastList,
+  resolveFromLastList,
+  saveLastListContext,
+  loadLastListContext,
+  rewriteArgvForPage,
+} from "./last-list.js";
 
 describe("last-list", () => {
   let tmpDir: string;
@@ -84,5 +90,78 @@ describe("last-list", () => {
     await expect(
       saveLastList([{ index: 1, id: "x", name: "y" }])
     ).resolves.toBeUndefined();
+  });
+
+  // #456: REPL list-context navigation. The save/load pair drives the
+  // REPL's `back` / `n` / `p` shortcuts; the rewriter is the helper that
+  // mutates the saved argv to target a different page.
+  describe("list context (#456)", () => {
+    it("round-trips a saved command + page", async () => {
+      await saveLastListContext({
+        command: ["clients", "list", "--status", "Active", "--page", "2", "--size", "25"],
+        page: { number: 2, totalPages: 8 },
+      });
+      const loaded = await loadLastListContext();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.command).toEqual([
+        "clients",
+        "list",
+        "--status",
+        "Active",
+        "--page",
+        "2",
+        "--size",
+        "25",
+      ]);
+      expect(loaded!.page).toEqual({ number: 2, totalPages: 8 });
+    });
+
+    it("returns null when no context has been saved", async () => {
+      expect(await loadLastListContext()).toBeNull();
+    });
+
+    it("returns null when the context file is corrupt", async () => {
+      await fs.writeFile(path.join(tmpDir, "last-list-context.json"), "{ broken", "utf-8");
+      expect(await loadLastListContext()).toBeNull();
+    });
+
+    it("returns null when the saved shape fails validation", async () => {
+      // Tampered file — missing `page`.
+      await fs.writeFile(
+        path.join(tmpDir, "last-list-context.json"),
+        JSON.stringify({ command: ["clients", "list"] }),
+        "utf-8",
+      );
+      expect(await loadLastListContext()).toBeNull();
+    });
+
+    it("rewrites --page when present", () => {
+      const out = rewriteArgvForPage(
+        ["clients", "list", "--status", "Active", "--page", "2", "--size", "25"],
+        5,
+      );
+      expect(out).toEqual([
+        "clients",
+        "list",
+        "--status",
+        "Active",
+        "--page",
+        "5",
+        "--size",
+        "25",
+      ]);
+    });
+
+    it("appends --page when the saved argv didn't carry one", () => {
+      const out = rewriteArgvForPage(["clients", "list"], 3);
+      expect(out).toEqual(["clients", "list", "--page", "3"]);
+    });
+
+    it("rewriting does not mutate the input argv", () => {
+      const input = ["clients", "list", "--page", "1"];
+      const out = rewriteArgvForPage(input, 7);
+      expect(input).toEqual(["clients", "list", "--page", "1"]);
+      expect(out).toEqual(["clients", "list", "--page", "7"]);
+    });
   });
 });

--- a/packages/cli/src/lib/last-list.ts
+++ b/packages/cli/src/lib/last-list.ts
@@ -11,8 +11,25 @@ interface LastListEntry {
   name: string;
 }
 
+/**
+ * #456: snapshot of the argv + paging state of the most recent list-style
+ * command. Lets the REPL implement `back` / `n` / `p` so the user doesn't
+ * have to retype `clients list --page 3` after drilling into a row.
+ *
+ * `command` is the argv WITHOUT the leading `pax8`; the REPL prepends it
+ * via the same `node <cliPath> ...` spawn path as a normal typed command.
+ */
+export interface LastListContext {
+  command: string[];
+  page: { number: number; totalPages: number };
+}
+
 function filePath(): string {
   return path.join(getConfigDir(), "last-list.json");
+}
+
+function contextPath(): string {
+  return path.join(getConfigDir(), "last-list-context.json");
 }
 
 /**
@@ -31,6 +48,80 @@ export async function saveLastList(items: LastListEntry[]): Promise<void> {
   } catch {
     // Non-fatal — don't break the CLI if cache write fails
   }
+}
+
+/**
+ * #456: persist the command + paging state that produced the most recent
+ * list. Lets the REPL implement `back` / `n` / `p` without making the
+ * user retype `--page N` flags. Best-effort — failure to write doesn't
+ * break the list command.
+ *
+ * Same safe-write posture as `saveLastList` (`safeWriteFileSync`,
+ * mode `0o600`, refuses to follow a symlink).
+ */
+export async function saveLastListContext(ctx: LastListContext): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(contextPath()), { recursive: true });
+    safeWriteFileSync(contextPath(), JSON.stringify(ctx));
+  } catch {
+    // Non-fatal — don't break the CLI if cache write fails.
+  }
+}
+
+/**
+ * Load the most recent list-context snapshot, or `null` if it doesn't
+ * exist / is corrupt / fails shape validation. Shape-validates the
+ * contents defensively — a tampered file should never let a typed
+ * `n` / `p` / `back` execute an unexpected argv.
+ */
+export async function loadLastListContext(): Promise<LastListContext | null> {
+  try {
+    const content = await fs.readFile(contextPath(), "utf-8");
+    const raw = JSON.parse(content) as Record<string, unknown>;
+    if (
+      !raw ||
+      typeof raw !== "object" ||
+      !Array.isArray(raw.command) ||
+      !raw.command.every((s) => typeof s === "string") ||
+      raw.command.length === 0 ||
+      typeof raw.page !== "object" ||
+      raw.page === null ||
+      typeof (raw.page as Record<string, unknown>).number !== "number" ||
+      typeof (raw.page as Record<string, unknown>).totalPages !== "number"
+    ) {
+      return null;
+    }
+    return raw as unknown as LastListContext;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * #456: rewrite the saved list-command argv to target a specific page
+ * number. Replaces any existing `--page <n>` pair; appends one when the
+ * saved command didn't carry an explicit `--page` (the default page is
+ * 1, which the user never types, so navigating from page 1 → page 2
+ * needs the flag to be inserted).
+ *
+ * Returns a new argv — does not mutate the input.
+ */
+export function rewriteArgvForPage(command: string[], targetPage: number): string[] {
+  const out: string[] = [];
+  let replaced = false;
+  for (let i = 0; i < command.length; i++) {
+    if (command[i] === "--page" && i + 1 < command.length) {
+      out.push("--page", String(targetPage));
+      i++;
+      replaced = true;
+    } else {
+      out.push(command[i]);
+    }
+  }
+  if (!replaced) {
+    out.push("--page", String(targetPage));
+  }
+  return out;
 }
 
 /**

--- a/packages/cli/src/lib/repl.ts
+++ b/packages/cli/src/lib/repl.ts
@@ -108,6 +108,71 @@ export async function startRepl(createProgram: () => Command): Promise<void> {
       args.shift();
     }
 
+    // #456: REPL list-navigation shortcuts. After a list command saves
+    // `last-list-context.json`, the user can type `back` to re-run it,
+    // or `n` / `p` to page forward/backward without retyping flags. The
+    // shortcut is rewritten to a full argv before the spawn — no special
+    // dispatch path — so the underlying list command runs unchanged.
+    if (args.length === 1 && (args[0] === "back" || args[0] === "n" || args[0] === "p")) {
+      try {
+        const ctxPath = pathJoin(getConfigDir(), "last-list-context.json");
+        const ctxRaw = JSON.parse(fs.readFileSync(ctxPath, "utf-8")) as Record<string, unknown>;
+        const cmd = ctxRaw.command;
+        const page = ctxRaw.page as Record<string, unknown> | undefined;
+        const validCmd =
+          Array.isArray(cmd) && cmd.length > 0 && cmd.every((s) => typeof s === "string");
+        const validPage =
+          page !== undefined &&
+          page !== null &&
+          typeof page.number === "number" &&
+          typeof page.totalPages === "number";
+        if (validCmd && validPage) {
+          const command = cmd as string[];
+          const pageNum = (page as { number: number }).number;
+          const totalPages = (page as { totalPages: number }).totalPages;
+          let target = pageNum;
+          if (args[0] === "n") {
+            if (pageNum >= totalPages) {
+              process.stderr.write(chalk.dim(`  Already on the last page (${pageNum} of ${totalPages}).\n\n`));
+              rl.prompt();
+              return;
+            }
+            target = pageNum + 1;
+          } else if (args[0] === "p") {
+            if (pageNum <= 1) {
+              process.stderr.write(chalk.dim(`  Already on the first page.\n\n`));
+              rl.prompt();
+              return;
+            }
+            target = pageNum - 1;
+          }
+          // Rewrite argv to the target page. For `back`, target === pageNum
+          // so the original page is re-run verbatim.
+          const out: string[] = [];
+          let replaced = false;
+          for (let i = 0; i < command.length; i++) {
+            if (command[i] === "--page" && i + 1 < command.length) {
+              out.push("--page", String(target));
+              i++;
+              replaced = true;
+            } else {
+              out.push(command[i]);
+            }
+          }
+          if (!replaced) out.push("--page", String(target));
+          args = out;
+        } else {
+          process.stderr.write(chalk.dim("  No recent list to navigate. Run a list command first.\n\n"));
+          rl.prompt();
+          return;
+        }
+      } catch {
+        process.stderr.write(chalk.dim("  No recent list to navigate. Run a list command first.\n\n"));
+        rl.prompt();
+        return;
+      }
+    }
+
     // Handle bare number input — check for pending actions from last list/recommendations
     if (args.length === 1 && /^\d+$/.test(args[0])) {
       try {


### PR DESCRIPTION
## What

Adds three REPL shortcuts that resume the last list session without retyping flags:

- \`back\` — re-runs the last list command verbatim (same page).
- \`n\` — pages forward.
- \`p\` — pages backward.

Pre-fix, the REPL flow \`clients list\` → \`26\` (drill in) → end up at \`pax8>\` left the user with no way to keep browsing except retyping \`clients list --page 3 --status Active …\` from scratch. Cassie surfaced this as a daily-workflow paper-cut.

## How

1. **\`lib/last-list.ts\`** gains \`LastListContext\`, \`saveLastListContext\`, \`loadLastListContext\`, \`rewriteArgvForPage\`. New \`last-list-context.json\` cache stores \`{ command: string[], page: { number, totalPages } }\` — the argv the user actually typed + the resolved page envelope from #483.
2. **\`lib/repl.ts\`** recognizes \`back\`/\`n\`/\`p\` BEFORE the existing numeric-pick branch, loads the context, validates its shape defensively (tampered files can't surface an unexpected argv), rewrites \`--page\` to the target, and re-spawns through the same \`node <cliPath> …\` path as any normal typed command. No special dispatch — just a rewrite-then-spawn.
3. **\`companies/list.ts\`** writes the context after each render and prints a footer hint when \`PAX8_REPL=1\`:

   \`\`\`
     REPL: n=next · p=prev · back=re-run
   \`\`\`

## Boundary handling

- \`n\` at the last page → \`Already on the last page (3 of 3).\` + re-prompt.
- \`p\` at page 1 → \`Already on the first page.\` + re-prompt.
- No saved context → \`No recent list to navigate. Run a list command first.\`
- Corrupt / shape-failing context → same fallback. **Never** a spawn with garbage argv.

## Security

- Cache file uses \`safeWriteFileSync\` (mode 0o600, refuses to follow symlinks) — same posture as \`last-list.json\` / \`pending-actions.json\`.
- \`loadLastListContext\` shape-validates the file before returning. A tampered file with arbitrary JSON can't make the REPL spawn an unexpected argv.

## Scope

This PR wires \`clients list\` as the pattern proof. Rollout to \`subscriptions list\`, \`invoices list\`, \`orders list\`, \`quotes list\`, \`contacts list\`, \`webhooks list\` tracked separately so each can be reviewed cleanly — one-line addition per command (\`saveLastListContext({ command: process.argv.slice(2), page: pageEnvelope })\`).

## Tests

7 new unit tests in \`lib/last-list.test.ts\`:
- Round-trip (save → load matches).
- Returns \`null\` when no context saved.
- Returns \`null\` when file is corrupt.
- Returns \`null\` when shape validation fails (missing \`page\`).
- Argv rewriter replaces existing \`--page N\`.
- Argv rewriter appends \`--page N\` when not present.
- Argv rewriter doesn't mutate input.

Full suite green: **2135 passing / 6 skipped / 6 todo**.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 2135 passing
- [ ] CI green
- [ ] Manual: \`pax8\` → \`clients list\` → see footer hint → \`n\` → page 2 → \`back\` → page 2 again → \`p\` → page 1