### PR TITLE
feat(repl): roll out list navigation across subscriptions / orders / invoices / quotes lists (#456 follow-up)

### DIFF
--- a/.changeset/list-context-rollout.md
+++ b/.changeset/list-context-rollout.md
@@ -1,0 +1,9 @@
+---
+"@pax8/cli": patch
+---
+
+Extend the REPL `back` / `n` / `p` list navigation from #456 across the rest of the list command surface. `subscriptions list`, `orders list`, `invoices list`, and `quotes list` now all save the `last-list-context.json` snapshot after each render and surface the `REPL: n=next · p=prev · back=re-run` footer hint when running under `PAX8_REPL=1`. Closes the rollout slice of #456 that #549 explicitly deferred.
+
+Implementation extracts the `if (process.env.PAX8_REPL === "1") { ... }` block from `companies/list.ts` into a shared `renderReplNavHint(pageEnvelope)` helper in `lib/output.ts` so each command is a one-line addition rather than a copy-paste of the hint rendering. The context-save block stays inline (a few lines per command, with the same `back`/`n`/`p` re-entry guard the original #549 code used).
+
+No behavior change outside the REPL — `PAX8_REPL` env var gates both the hint and the context save's affordance. Full suite green: 2135 passing.

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -22,6 +22,7 @@ import {
   buildPageEnvelope,
   renderPaginationFooter,
   buildNextPageAction,
+  renderReplNavHint,
 } from "../../lib/output.js";
 import { formatStatus, formatCompanyName, formatCurrency } from "../../lib/formatters.js";
 import { saveLastList, saveLastListContext } from "../../lib/last-list.js";
@@ -431,15 +432,7 @@ Examples:
         // the REPL (PAX8_REPL=1). Pre-fix, the partner had to retype
         // `clients list --page N` to page through; now `n`/`p`/`back`
         // pull from the saved last-list-context.json.
-        if (process.env.PAX8_REPL === "1") {
-          const total = pageEnvelope.totalPages;
-          const cur = pageEnvelope.number;
-          const hints: string[] = [];
-          if (cur < total) hints.push(`${chalk.cyan("n")}=next`);
-          if (cur > 1) hints.push(`${chalk.cyan("p")}=prev`);
-          hints.push(`${chalk.cyan("back")}=re-run`);
-          process.stderr.write(chalk.dim(`  REPL: ${hints.join(" · ")}\n`));
-        }
+        renderReplNavHint(pageEnvelope);
 
         // Interactive: pick a company to drill into
         const steps: NextStep[] = result.content.map(

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -10,7 +10,9 @@ import {
   buildPageEnvelope,
   renderPaginationFooter,
   buildNextPageAction,
+  renderReplNavHint,
 } from "../../lib/output.js";
+import { saveLastListContext } from "../../lib/last-list.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatCurrency, formatDate, formatStatus } from "../../lib/formatters.js";
@@ -278,6 +280,18 @@ Examples:
           nextPageCommand,
           rowCount: result.content.length,
         });
+        renderReplNavHint(pageEnvelope);
+        const userArgv = process.argv.slice(2);
+        const first = userArgv[0];
+        if (userArgv.length > 0 && first !== "back" && first !== "n" && first !== "p") {
+          await saveLastListContext({
+            command: userArgv,
+            page: {
+              number: pageEnvelope.number,
+              totalPages: pageEnvelope.totalPages,
+            },
+          });
+        }
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list invoices");

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -14,7 +14,9 @@ import {
   buildPageEnvelope,
   renderPaginationFooter,
   buildNextPageAction,
+  renderReplNavHint,
 } from "../../lib/output.js";
+import { saveLastListContext } from "../../lib/last-list.js";
 import { formatDate } from "../../lib/formatters.js";
 import {
   enrichCompanyNames,
@@ -194,6 +196,18 @@ Examples:
           nextPageCommand,
           rowCount: result.content.length,
         });
+        renderReplNavHint(pageEnvelope);
+        const userArgv = process.argv.slice(2);
+        const first = userArgv[0];
+        if (userArgv.length > 0 && first !== "back" && first !== "n" && first !== "p") {
+          await saveLastListContext({
+            command: userArgv,
+            page: {
+              number: pageEnvelope.number,
+              totalPages: pageEnvelope.totalPages,
+            },
+          });
+        }
       }
     } catch (error) {
       // #199: the `/orders` endpoint is known to be slow against tenants with

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -9,7 +9,9 @@ import {
   type Column,
   buildPageEnvelope,
   renderPaginationFooter,
+  renderReplNavHint,
 } from "../../lib/output.js";
+import { saveLastListContext } from "../../lib/last-list.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatDate, formatCurrency } from "../../lib/formatters.js";
@@ -185,6 +187,18 @@ Examples:
           nextPageCommand,
           rowCount: enriched.length,
         });
+        renderReplNavHint(pageEnvelope);
+        const userArgv = process.argv.slice(2);
+        const first0 = userArgv[0];
+        if (userArgv.length > 0 && first0 !== "back" && first0 !== "n" && first0 !== "p") {
+          await saveLastListContext({
+            command: userArgv,
+            page: {
+              number: pageEnvelope.number,
+              totalPages: pageEnvelope.totalPages,
+            },
+          });
+        }
         process.stderr.write(
           chalk.dim(`  Total on this page: ${formatCurrency(total)}\n`),
         );

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -16,7 +16,9 @@ import {
   buildPageEnvelope,
   renderPaginationFooter,
   buildNextPageAction,
+  renderReplNavHint,
 } from "../../lib/output.js";
+import { saveLastListContext } from "../../lib/last-list.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import {
@@ -302,6 +304,20 @@ Examples:
           nextPageCommand,
           rowCount: result.content.length,
         });
+        renderReplNavHint(pageEnvelope);
+        // #456: persist context for REPL back/n/p navigation. Guarded
+        // against re-entry from the REPL's own rewrite of those shortcuts.
+        const userArgv = process.argv.slice(2);
+        const first = userArgv[0];
+        if (userArgv.length > 0 && first !== "back" && first !== "n" && first !== "p") {
+          await saveLastListContext({
+            command: userArgv,
+            page: {
+              number: pageEnvelope.number,
+              totalPages: pageEnvelope.totalPages,
+            },
+          });
+        }
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list subscriptions");

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -395,6 +395,24 @@ export function renderPaginationFooter(
 }
 
 /**
+ * #456: render the REPL navigation hint after a list command when
+ * running inside the REPL (`PAX8_REPL=1`). No-op outside the REPL —
+ * normal shell sessions shouldn't see the `n`/`p`/`back` affordance.
+ *
+ * Caller has already written the pagination footer + any
+ * command-specific hints; this adds a single-line hint advertising
+ * the saved-context shortcuts.
+ */
+export function renderReplNavHint(page: PageEnvelope): void {
+  if (process.env.PAX8_REPL !== "1") return;
+  const hints: string[] = [];
+  if (page.number < page.totalPages) hints.push(`${chalk.cyan("n")}=next`);
+  if (page.number > 1) hints.push(`${chalk.cyan("p")}=prev`);
+  hints.push(`${chalk.cyan("back")}=re-run`);
+  process.stderr.write(chalk.dim(`  REPL: ${hints.join(" · ")}\n`));
+}
+
+/**
  * Build the standard "fetch next page" nextActions entry, or `null` when
  * the supplied envelope is already on the last page. Callers compose
  * additional `nextActions` entries (e.g. "drill into the first row") on


### PR DESCRIPTION
## What

Extends the REPL \`back\` / \`n\` / \`p\` navigation from #549 across the remaining list command surface. After this PR, every major list command (\`clients\`, \`subscriptions\`, \`orders\`, \`invoices\`, \`quotes\`) writes \`last-list-context.json\` after each render and shows the \`REPL: n=next · p=prev · back=re-run\` footer when running under \`PAX8_REPL=1\`.

#549 deliberately deferred this rollout to land the helper machinery cleanly first. With the machinery in main, the per-command addition is mechanical.

## How

Extracts the inline REPL hint block from \`companies/list.ts\` into a shared \`renderReplNavHint(pageEnvelope)\` helper in \`lib/output.ts\`. Each command becomes:

\`\`\`ts
renderPaginationFooter(pageEnvelope, { ... });
renderReplNavHint(pageEnvelope);  // NEW — one-liner
const userArgv = process.argv.slice(2);
const first = userArgv[0];
if (userArgv.length > 0 && first !== "back" && first !== "n" && first !== "p") {
  await saveLastListContext({ command: userArgv, page: { ... } });
}
\`\`\`

The context-save block stays inline (matches the #549 pattern; same back/n/p re-entry guard).

## Scope

- ✅ \`subscriptions list\`
- ✅ \`orders list\`
- ✅ \`invoices list\`
- ✅ \`quotes list\`
- ✅ \`companies list\` — refactored to use the new helper (no behavior change)

Out of scope (smaller surfaces, less-pressing): \`invoices items\`, \`contacts list\`, \`usage list\`, \`webhooks list\`, \`webhooks logs\`, \`products list\`, \`products search\`, \`subscriptions renewals\`, \`recommendations list\`, \`webhooks topics list\`. These can be added with the same one-liner when the partner-walkthrough surfaces a need.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` — 2135 passing
- [ ] CI green
- [ ] Manual: \`pax8\` REPL → \`subscriptions list\` → \`n\` pages forward; \`back\` re-runs