### PR TITLE
test(cli): smoke coverage for init / completions / coffee / moo (closes #395)

### DIFF
--- a/.changeset/smoke-tests-init-completions-easter-eggs.md
+++ b/.changeset/smoke-tests-init-completions-easter-eggs.md
@@ -1,0 +1,15 @@
+---
+"@pax8/cli": patch
+---
+
+Add subprocess smoke coverage for `pax8 init`, `pax8 completions`, and the `coffee` / `moo` easter eggs — the four CLI surfaces previously listed in the partner-readiness audit as having zero test references. Closes #395.
+
+`packages/cli/src/__tests__/smoke-misc.test.ts` (new file, 9 tests):
+- `init` — `--help` output, default-config creation in a tmp `PAX8_CONFIG_DIR`, `--demo` / `--demo off` toggle round-trip via the on-disk config file.
+- `completions` — bash + zsh script generation, plus the `--help` smoke.
+- `coffee` — asserts the final "Your coffee is ready" line lands on stdout (the 6-second progress-bar simulation runs end-to-end; per-test timeout bumped to 15s rather than globally so the rest of the smoke suite stays fast).
+- `moo` — asserts the ASCII cow's `(oo)` fingerprint + the quoted fortune-line pattern.
+
+`time-quip` is an internal helper (no command surface) and isn't covered here — it's already exercised indirectly by the welcome-screen tests. `report-bug` was on the original issue list but already had thorough coverage in `report-bug.test.ts`; no additions needed.
+
+Full suite: 2144 passing (+9 from this PR).

--- a/packages/cli/src/__tests__/smoke-misc.test.ts
+++ b/packages/cli/src/__tests__/smoke-misc.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runCliExpectSuccess } from "./test-utils.js";
+
+// #395: subprocess coverage for the five commands that previously had no
+// (or only minimal) test references — `init`, `completions`, the three
+// easter eggs (`coffee`, `moo`), plus the existing `report-bug.test.ts`
+// surface that's already thoroughly covered. Each test here is a smoke
+// assertion: command exits 0, emits the expected shape on stdout, doesn't
+// crash. Per the issue's acceptance criteria — minimal coverage is the
+// bar, not exhaustive contract pinning.
+
+describe("pax8 init", () => {
+  // Each test gets a unique config-dir so concurrent runs don't collide
+  // and we don't pollute the host's real ~/.pax8.
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-init-test-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("--help describes the init command", async () => {
+    const result = await runCliExpectSuccess(["init", "--help"]);
+    expect(result.stdout).toContain("Initialize configuration");
+    expect(result.stdout).toContain("--demo");
+    expect(result.stdout).toContain("--force");
+    expect(result.stdout).toContain("Examples:");
+  });
+
+  it("creates a default config when none exists", async () => {
+    const result = await runCliExpectSuccess(["init"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    // Either a "config written" success message or the file shows up on disk —
+    // assert the file is what matters (downstream commands read it, not the
+    // human text).
+    const configPath = path.join(tmpDir, "config.yaml");
+    const stat = await fs.stat(configPath);
+    expect(stat.isFile()).toBe(true);
+    // Side-effect message goes to stdout (init is informational).
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
+
+  it("--demo enables persistent demo mode", async () => {
+    await runCliExpectSuccess(["init", "--demo"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    const config = await fs.readFile(path.join(tmpDir, "config.yaml"), "utf-8");
+    expect(config).toMatch(/demo:\s*true/);
+  });
+
+  it("--demo off disables persistent demo mode", async () => {
+    // Enable first, then disable — verifies the toggle in both directions.
+    await runCliExpectSuccess(["init", "--demo"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    await runCliExpectSuccess(["init", "--demo", "off"], {
+      PAX8_CONFIG_DIR: tmpDir,
+    });
+    const config = await fs.readFile(path.join(tmpDir, "config.yaml"), "utf-8");
+    expect(config).toMatch(/demo:\s*false/);
+  });
+});
+
+describe("pax8 completions", () => {
+  it("emits valid bash completion script for `bash`", async () => {
+    const result = await runCliExpectSuccess(["completions", "bash"]);
+    // The completion script must define the bash function commander expects,
+    // and the `complete -F` registration line.
+    expect(result.stdout).toContain("_pax8_completions");
+    expect(result.stdout).toContain("complete -F _pax8_completions pax8");
+    // Should also enumerate at least the top-level commands; absence would
+    // mean a future refactor silently dropped the catalog.
+    expect(result.stdout).toContain("clients");
+    expect(result.stdout).toContain("subscriptions");
+  });
+
+  it("emits zsh completion when asked", async () => {
+    const result = await runCliExpectSuccess(["completions", "zsh"]);
+    // The zsh script should reference compdef and the same top-level catalog.
+    expect(result.stdout.length).toBeGreaterThan(0);
+    // Don't pin the exact shape — different shells have different syntax;
+    // smoke check that we got non-empty output for the requested shell.
+  });
+
+  it("--help describes the completions command", async () => {
+    const result = await runCliExpectSuccess(["completions", "--help"]);
+    expect(result.stdout).toContain("completion");
+  });
+});
+
+describe("pax8 easter eggs", () => {
+  // `coffee` simulates a progress bar with sleeps; the full run is ~6 seconds.
+  // We bump the timeout per-test rather than globally so the rest of the
+  // smoke suite stays fast.
+  it(
+    "coffee renders the progress bar and the final ready-message",
+    async () => {
+      const result = await runCliExpectSuccess(["coffee"]);
+      // The terminal-control bytes (\r) and the progress glyphs are platform-
+      // varying; assert the stable end-state instead — partners always see the
+      // "ready" line + the coffee emoji.
+      expect(result.stdout).toContain("Your coffee is ready");
+    },
+    15_000,
+  );
+
+  it("moo renders the ASCII cow + a quote", async () => {
+    const result = await runCliExpectSuccess(["moo"]);
+    // The cow ASCII includes `(oo)` — that's the unambiguous fingerprint
+    // a future refactor that broke the rendering would miss.
+    expect(result.stdout).toContain("(oo)");
+    // The quote line is wrapped in double quotes around random fortune text.
+    expect(result.stdout).toMatch(/"[^"]+"/);
+  });
+});


### PR DESCRIPTION
## What

\`packages/cli/src/__tests__/smoke-misc.test.ts\` — new subprocess smoke file, 9 tests, covering the four CLI surfaces listed in the partner-readiness audit (#395) as having zero test references.

## Tests

| Command | Coverage |
|---|---|
| \`pax8 init\` | \`--help\`; default-config creation in tmp \`PAX8_CONFIG_DIR\`; \`--demo\` / \`--demo off\` toggle round-trip via on-disk config |
| \`pax8 completions bash\` | Function definition + \`complete -F\` registration line + top-level command catalog |
| \`pax8 completions zsh\` | Non-empty output |
| \`pax8 completions --help\` | Smoke |
| \`pax8 coffee\` | "Your coffee is ready" final line (15s per-test timeout — the progress-bar simulation runs ~6s of randomized sleeps) |
| \`pax8 moo\` | \`(oo)\` ASCII cow fingerprint + double-quoted fortune-line pattern |

## Out of scope (with reasoning)

- **\`time-quip\`** — internal helper, no command surface. Already exercised indirectly via the welcome-screen tests.
- **\`report-bug\`** — the original issue listed it as "minimal coverage" but \`report-bug.test.ts\` is already ~250 lines covering envelope round-trip, redaction, \`--print\` / \`--json\` / \`--yes\` branches, and the positional-arg leakage regression from #170. The issue text is stale; no additions warranted.

## Tests

- [x] \`pnpm build\` clean
- [x] \`pnpm vitest run packages/cli/src/__tests__/smoke-misc.test.ts\` — 9/9 in 8.5s
- [x] Full suite: **2144 passing** / 6 skipped / 6 todo (+9 from this PR)
- [ ] CI green