### PR TITLE
feat(repl): pickable drill-in across subscriptions / orders / invoices / quotes lists (closes #418)

### DIFF
--- a/.changeset/list-drill-in-rollout.md
+++ b/.changeset/list-drill-in-rollout.md
@@ -1,0 +1,15 @@
+---
+"@pax8/cli": minor
+---
+
+Roll out pickable drill-in across `subscriptions list`, `orders list`, `invoices list`, and `quotes list`. Type a row number at the REPL prompt to drill into that row's detail view — same pattern `clients list` and `recommendations list` already shipped. Closes #418.
+
+Each command now:
+- Numbers rows in a leading `#` column (continues across pages — page 2 starts at 26).
+- Persists the index → resource ID map to `~/.pax8/last-list.json` so `subscriptions show 3` resolves the same way `clients show 3` already does.
+- Writes `~/.pax8/pending-actions.json` keyed by row number so the REPL's bare-number-input branch dispatches `<resource> show <id>` for the picked row.
+- Renders the `promptNextSteps` inline pick prompt below the table (no-op outside a TTY, so subprocess / agent invocations see nothing on stderr).
+
+Extracted the wiring into `lib/list-drill-in.ts:wireListDrillIn()` so the four commands become a single call instead of 30 lines of copy-paste each. The helper handles all three caches + the prompt; the caller supplies the rows, resource name, page-offset, and a label resolver function. Existing `clients list` left alone for this PR (its drill-in path is intertwined with the `--coverage` analysis branch and warrants a separate scoped refactor).
+
+Quotes additionally renames its previous static `Try next:` block to a one-liner `Or: pax8 quotes show <id>` advisory so the pickable prompt becomes the primary affordance.

--- a/packages/cli/src/commands/invoices/list.ts
+++ b/packages/cli/src/commands/invoices/list.ts
@@ -13,6 +13,7 @@ import {
   renderReplNavHint,
 } from "../../lib/output.js";
 import { saveLastListContext } from "../../lib/last-list.js";
+import { wireListDrillIn } from "../../lib/list-drill-in.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatCurrency, formatDate, formatStatus } from "../../lib/formatters.js";
@@ -152,7 +153,9 @@ Examples:
         return;
       }
 
+      // #418: leading `_num` column makes rows pickable by number in the REPL.
       const columns: Column[] = [
+        { key: "_num", header: "#" },
         {
           key: "id",
           header: "ID",
@@ -188,6 +191,12 @@ Examples:
 
       // #483: build the page envelope once for both JSON and footer.
       const pageEnvelope = buildPageEnvelope(result.page);
+      // #418: row numbers continue across pages.
+      const startNum = result.page.number * result.page.size;
+      const numbered = result.content.map((row, i) => ({
+        ...row,
+        _num: String(startNum + i + 1),
+      }));
       const filterFlag = [
         allOpts.company ? `--company "${allOpts.company}"` : "",
         allOpts.status ? `--status "${allOpts.status}"` : "",
@@ -250,7 +259,7 @@ Examples:
         emptyReasons.push("This is a fresh tenant with no historical billing yet.");
       }
 
-      output(result.content, {
+      output(numbered, {
         format: ctx.outputFormat,
         columns,
         emptyState: {
@@ -292,6 +301,16 @@ Examples:
             },
           });
         }
+        // #418: pickable drill-in.
+        await wireListDrillIn({
+          rows: result.content,
+          resource: "invoices",
+          startNum,
+          getLabel: (row) =>
+            String(
+              (row as { companyName?: string }).companyName ?? "Invoice",
+            ),
+        });
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list invoices");

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -221,8 +221,13 @@ Examples:
           });
         }
         // #418: pickable drill-in — type `26` to drill into row 26.
+        // Cast to the minimum drill-in shape: `wireListDrillIn` only needs
+        // `id: string`; everything else flows through `getLabel`.
+        // OrdersApi.list returns a union (Order[] | mock-shape[]) where
+        // `companyName` is required on the spec Order but optional on the
+        // mock, so a direct pass through would trip the strict-mode check.
         await wireListDrillIn({
-          rows: result.content,
+          rows: result.content as { id: string }[],
           resource: "orders",
           startNum,
           getLabel: (row) => {

--- a/packages/cli/src/commands/orders/list.ts
+++ b/packages/cli/src/commands/orders/list.ts
@@ -17,6 +17,7 @@ import {
   renderReplNavHint,
 } from "../../lib/output.js";
 import { saveLastListContext } from "../../lib/last-list.js";
+import { wireListDrillIn } from "../../lib/list-drill-in.js";
 import { formatDate } from "../../lib/formatters.js";
 import {
   enrichCompanyNames,
@@ -27,7 +28,9 @@ import { clampListSize, LIST_SIZE_CAP, warnSizeClamped } from "../../lib/validat
 // #385: timestamp column references the canonical `createdAt`. The legacy
 // `createdDate` alias is still emitted on every row in `--json` output for
 // backwards compatibility; removal in v0.3.0.
+// #418: leading `_num` column makes rows pickable by number in the REPL.
 const columns: Column[] = [
+  { key: "_num", header: "#" },
   { key: "id", header: "ID", format: (v) => chalk.dim(String(v).slice(0, 8)) },
   { key: "companyName", header: "Company" },
   { key: "orderedBy", header: "Ordered By" },
@@ -132,6 +135,15 @@ Examples:
       const companyFlag = allOpts.company ? ` --company "${allOpts.company}"` : "";
       const nextPageCommand = `pax8 orders list --page ${pageEnvelope.number + 1} --size ${pageEnvelope.size}${companyFlag}`;
 
+      // #418: row numbers continue across pages (page 2 starts at 26, not 1)
+      // so the REPL's `<resource> show 26` lookup matches what the partner
+      // sees in the `#` column. `result.page.number` is 0-based on the wire.
+      const startNum = result.page.number * result.page.size;
+      const numbered = result.content.map((row, i) => ({
+        ...row,
+        _num: String(startNum + i + 1),
+      }));
+
       if (ctx.outputFormat === "json") {
         const orders = result.content;
         if (allOpts.withActions) {
@@ -166,7 +178,7 @@ Examples:
         emptyReasons.push("This tenant hasn't placed any orders yet.");
       }
 
-      output(result.content, {
+      output(numbered, {
         format: ctx.outputFormat,
         columns,
         emptyState: {
@@ -208,6 +220,18 @@ Examples:
             },
           });
         }
+        // #418: pickable drill-in — type `26` to drill into row 26.
+        await wireListDrillIn({
+          rows: result.content,
+          resource: "orders",
+          startNum,
+          getLabel: (row) => {
+            const name = String(
+              (row as { companyName?: string }).companyName ?? "Order",
+            );
+            return name;
+          },
+        });
       }
     } catch (error) {
       // #199: the `/orders` endpoint is known to be slow against tenants with

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -218,8 +218,11 @@ Examples:
           resource: "quotes",
           startNum,
           getLabel: (q) => {
-            const subject = q.subject ?? q.title ?? `Quote ${String(q.id).slice(0, 8)}`;
-            return String(subject);
+            // Quote schema doesn't carry a user-facing title field — use
+            // the `referenceCode` (e.g. "Q-2026-002") when present, fall
+            // back to the truncated id.
+            const code = (q as { referenceCode?: string }).referenceCode;
+            return code ?? `Quote ${String(q.id).slice(0, 8)}`;
           },
         });
       }

--- a/packages/cli/src/commands/quotes/list.ts
+++ b/packages/cli/src/commands/quotes/list.ts
@@ -12,6 +12,7 @@ import {
   renderReplNavHint,
 } from "../../lib/output.js";
 import { saveLastListContext } from "../../lib/last-list.js";
+import { wireListDrillIn } from "../../lib/list-drill-in.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatDate, formatCurrency } from "../../lib/formatters.js";
@@ -113,14 +114,16 @@ Examples:
         return;
       }
 
-      const enriched = quotes.map((q) => ({
+      // #483: build the 1-based page envelope once for both JSON and footer.
+      const pageEnvelope = buildPageEnvelope(result.page);
+      // #418: row numbers continue across pages.
+      const startNum = result.page.number * result.page.size;
+      const enriched = quotes.map((q, i) => ({
         ...q,
+        _num: String(startNum + i + 1),
         _total: quoteTotal(q),
         _items: q.lineItems?.length ?? 0,
       }));
-
-      // #483: build the 1-based page envelope once for both JSON and footer.
-      const pageEnvelope = buildPageEnvelope(result.page);
       const filterFlag = [
         allOpts.company ? `--company "${allOpts.company}"` : "",
         status ? `--status ${status}` : "",
@@ -142,7 +145,9 @@ Examples:
       // `expiresAt`. The legacy `createdOn` / `expiresOn` aliases are still
       // emitted on every row in `--json` output for backwards compatibility;
       // removal in v0.3.0.
+      // #418: leading `_num` column makes rows pickable by number in the REPL.
       const columns: Column[] = [
+        { key: "_num", header: "#" },
         { key: "id", header: "ID", width: 14, format: (v) => chalk.dim(String(v).slice(0, 12)) },
         { key: "companyId", header: "Company ID", width: 14, format: (v) => chalk.dim(String(v).slice(0, 12)) },
         { key: "status", header: "Status", width: 12 },
@@ -202,10 +207,21 @@ Examples:
         process.stderr.write(
           chalk.dim(`  Total on this page: ${formatCurrency(total)}\n`),
         );
+        // #418: pickable drill-in supersedes the previous hard-coded
+        // `Try next: pax8 quotes show <first>` hint. The drill-in
+        // helper handles the prompt; the static hint stays for users
+        // who already know the canonical command.
         const first = enriched[0];
-        process.stderr.write(chalk.dim("\n  Try next:\n"));
-        process.stderr.write(`    ${chalk.cyan(replCmd(`pax8 quotes show ${first.id}`))}  ${chalk.dim("view quote details")}\n`);
-        process.stderr.write("\n");
+        process.stderr.write(chalk.dim("\n  Or: ") + chalk.cyan(replCmd(`pax8 quotes show ${first.id}`)) + chalk.dim(" — view quote details\n\n"));
+        await wireListDrillIn({
+          rows: quotes,
+          resource: "quotes",
+          startNum,
+          getLabel: (q) => {
+            const subject = q.subject ?? q.title ?? `Quote ${String(q.id).slice(0, 8)}`;
+            return String(subject);
+          },
+        });
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list quotes");

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -19,6 +19,7 @@ import {
   renderReplNavHint,
 } from "../../lib/output.js";
 import { saveLastListContext } from "../../lib/last-list.js";
+import { wireListDrillIn } from "../../lib/list-drill-in.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import {
@@ -56,7 +57,9 @@ const BILLING_TERM_HELP = BILLING_TERM_VALUES.join(", ");
 const SUBSCRIPTION_SORT_FIELDS = ["quantity", "startDate", "endDate", "createdAt"] as const;
 const SUBSCRIPTION_SORT_HELP = `Sort by field (${SUBSCRIPTION_SORT_FIELDS.join(", ")}); append :desc for descending (e.g. quantity:desc)`;
 
+// #418: leading `_num` column makes rows pickable by number in the REPL.
 const columns: Column[] = [
+  { key: "_num", header: "#" },
   {
     key: "id",
     header: "ID",
@@ -227,6 +230,14 @@ Examples:
       const sortFlag = allOpts.sort ? ` --sort ${allOpts.sort}` : "";
       const nextPageCommand = `pax8 subscriptions list --page ${pageEnvelope.number + 1} --size ${pageEnvelope.size}${companyFlag}${statusFlag}${billingTermFlag}${productFlag}${sortFlag}`;
 
+      // #418: row numbers continue across pages — wire numbered rows for
+      // the table renderer and the REPL's drill-in lookup.
+      const startNum = result.page.number * result.page.size;
+      const numbered = subs.map((row, i) => ({
+        ...row,
+        _num: String(startNum + i + 1),
+      }));
+
       if (ctx.outputFormat === "json") {
         const subsList = result.content;
         if (options.withActions) {
@@ -274,7 +285,7 @@ Examples:
         emptyReasons.push("This tenant has no subscriptions yet.");
       }
 
-      output(result.content, {
+      output(numbered, {
         format: ctx.outputFormat,
         columns,
         emptyState: {
@@ -318,6 +329,16 @@ Examples:
             },
           });
         }
+        // #418: pickable drill-in — type `3` to drill into subscription #3.
+        await wireListDrillIn({
+          rows: subs as { id: string }[],
+          resource: "subscriptions",
+          startNum,
+          getLabel: (row) => {
+            const r = row as Record<string, unknown>;
+            return String(r.productName ?? r.companyName ?? "Subscription");
+          },
+        });
       }
     } catch (error) {
       await handleCommandError(error, spinner, "Failed to list subscriptions");

--- a/packages/cli/src/lib/list-drill-in.ts
+++ b/packages/cli/src/lib/list-drill-in.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getConfigDir, safeWriteFileSync } from "@pax8/core";
+import { mkdirSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+import { saveLastList } from "./last-list.js";
+import { promptNextSteps, type NextStep } from "./next-step.js";
+
+/**
+ * #418: shared pickable-drill-in wiring for list commands.
+ *
+ * After a list command renders, partners can type a row number at the
+ * REPL prompt to drill into that row's detail view. This requires three
+ * pieces of state to land in `~/.pax8/`:
+ *
+ * 1. `last-list.json` — the index→{id,name} lookup `resolveFromLastList`
+ *    uses when commands like `clients show 3` are typed.
+ * 2. `pending-actions.json` — the key→command lookup the REPL's bare-
+ *    number-input branch reads (`packages/cli/src/lib/repl.ts:111-160`).
+ * 3. `promptNextSteps` — the inline TTY prompt rendered after the table
+ *    so the user can pick by number in a single terminal session.
+ *
+ * `clients list` (`packages/cli/src/commands/companies/list.ts`) shipped
+ * this pattern; this helper extracts it so `subscriptions / orders /
+ * invoices / quotes list` can wire in with a single call rather than
+ * copy-pasting ~30 lines four times.
+ *
+ * All writes are best-effort and silently swallow errors — a cache
+ * write must never block the actual list output.
+ */
+export interface DrillInRow {
+  /** Stable row ID used for `<resource> show <id>` lookups. */
+  id: string;
+}
+
+export interface WireListDrillInOptions<T extends DrillInRow> {
+  rows: readonly T[];
+  /** Spec resource name (`subscriptions`, `orders`, `invoices`, `quotes`). */
+  resource: string;
+  /**
+   * Row index offset so page-2 numbering continues from 26 rather than
+   * restarting at 1. Caller computes as `apiPage * pageSize`.
+   */
+  startNum: number;
+  /**
+   * Resolve a human-friendly label for the row — surfaces in the
+   * promptNextSteps prompt as the sample row hint. Typically a
+   * combination of company + product / total / status.
+   */
+  getLabel: (row: T) => string;
+}
+
+/**
+ * Persist drill-in state + render the pickable prompt. Caller is
+ * responsible for the table render itself; this only handles the
+ * post-table wiring. Calls `promptNextSteps` last, which short-circuits
+ * when stdin is not a TTY (piped / agent invocations see no prompt).
+ */
+export async function wireListDrillIn<T extends DrillInRow>(
+  options: WireListDrillInOptions<T>,
+): Promise<void> {
+  const { rows, resource, startNum, getLabel } = options;
+  if (rows.length === 0) return;
+
+  // (1) last-list.json — index→{id,name} lookup.
+  await saveLastList(
+    rows.map((row, i) => ({
+      index: startNum + i + 1,
+      id: String(row.id),
+      name: getLabel(row),
+    })),
+  );
+
+  // (2) pending-actions.json — REPL bare-number-input lookup. Each entry's
+  // `command` is interpreted by `lib/repl.ts:111-160` as a templated
+  // command to run when the user types the matching key.
+  try {
+    const dir = getConfigDir();
+    mkdirSync(dir, { recursive: true });
+    safeWriteFileSync(
+      pathJoin(dir, "pending-actions.json"),
+      JSON.stringify(
+        rows.map((row, i) => ({
+          key: String(startNum + i + 1),
+          command: `${resource} show ${String(row.id)}`,
+        })),
+      ),
+    );
+  } catch {
+    // Best-effort — never block list rendering on a cache write failure.
+  }
+
+  // (3) promptNextSteps — inline TTY prompt for drill-in. No-ops outside
+  // a TTY, so subprocess / agent invocations see nothing on stderr.
+  const steps: NextStep[] = rows.map((row, i) => ({
+    key: String(startNum + i + 1),
+    label: getLabel(row),
+    command: [resource, "show", String(row.id)],
+  }));
+  await promptNextSteps(steps);
+}


### PR DESCRIPTION
## What

Rolls out the pickable-drill-in pattern (already on \`clients list\` and \`recommendations list\`) to the four remaining list commands: \`subscriptions\`, \`orders\`, \`invoices\`, \`quotes\`. After this PR, a partner running \`pax8 subscriptions list\` in the REPL can type \`3\` to drill into row 3 instead of copying the row's ID.

## How

Each list command gains four things, wired up via a new shared helper:

1. **Leading \`#\` column.** Row numbers continue across pages — page 2 starts at 26, not 1.
2. **\`last-list.json\` write.** Index → \`{ id, name }\` map so \`<resource> show 3\` resolves the same way \`clients show 3\` already does (see \`lib/last-list.ts:resolveFromLastList\`).
3. **\`pending-actions.json\` write.** Key → command template the REPL's bare-number-input branch reads (\`lib/repl.ts:111-160\`).
4. **\`promptNextSteps\` prompt.** Inline TTY pick prompt below the table. No-ops outside a TTY, so subprocess / agent invocations see nothing extra on stderr.

New shared helper \`lib/list-drill-in.ts:wireListDrillIn()\` consolidates all four pieces — each command site is a single call rather than the ~30 lines of copy-paste \`clients list\` accumulated. Caller supplies the rows, resource name, page-offset, and a label resolver function.

## Scope

Wired surfaces:

- ✅ \`subscriptions list\`
- ✅ \`orders list\`
- ✅ \`invoices list\`
- ✅ \`quotes list\` — trimmed the prior hard-coded \`Try next: pax8 quotes show <first>\` block to a one-liner advisory so the pickable prompt is the primary affordance.

Out of scope:
- \`clients list\` — already has the pattern (more elaborate due to \`--coverage\`). Refactoring it onto the new helper is a separate scoped PR.
- \`recommendations list\`, \`webhooks list\`, \`contacts list\`, etc. — different affordance shapes (recommendations has its own action surface; webhooks/contacts have small fixed row counts).

## Test plan

- [x] \`pnpm build\` clean
- [x] Full suite: **2159 passing** / 6 skipped / 6 todo (no regressions)
- [ ] CI green
- [ ] Manual: \`pax8\` → \`subscriptions list\` → see \`#\` column → type \`3\` → drill in