### PR TITLE
fix(cache): make response caching opt-in, add PAX8_NO_CACHE, pax8 cache commands (#253)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,8 @@ PAX8_CLIENT_SECRET=
 # Demo mode (no real API calls)
 # PAX8_DEMO=1
 
+# Response caching (opt-in; set cache.enabled: true in ~/.pax8/config.yaml to enable)
+# PAX8_NO_CACHE=1
+
 # Telemetry (opt-in by default; uncomment to ensure off)
 # PAX8_TELEMETRY_DISABLED=1

--- a/docs/UX_GUIDE.md
+++ b/docs/UX_GUIDE.md
@@ -459,7 +459,44 @@ If you add a new list command and the sort order isn't obvious from the API docs
 
 ---
 
-## 13. Checklist for a new command
+## 13. Response caching
+
+### Overview
+
+Response caching is **opt-in**. By default no API responses are written to disk. To enable caching, add the following to `~/.pax8/config.yaml`:
+
+```yaml
+cache:
+  enabled: true
+  ttl_hours: 24   # optional, default is 24
+```
+
+When enabled, successful `GET` responses are stored under `~/.pax8/cache/` and served from disk until the TTL expires. Writes (`orders create`, `subscriptions cancel`, etc.) clear the entire cache via `invalidateCacheAfterWrite()`.
+
+### Env vars
+
+| Env var | Effect |
+|---|---|
+| `PAX8_NO_CACHE=1` | Disable caching for a single invocation, overriding `config.yaml` |
+
+### User-facing commands
+
+```
+pax8 cache status   # show enabled/disabled, TTL, dir, entry count and size
+pax8 cache clear    # remove all cached responses
+```
+
+`pax8 doctor` also reports cache status (enabled/disabled, dir size) as one of its checks.
+
+### For contributors
+
+- Caching is implemented in `Pax8Client` via `packages/core/src/services/cache.ts`. Passing `cacheTtlMs: 0` to the constructor disables it entirely (sets `this.cache = null`).
+- `buildContext()` in `packages/cli/src/lib/context.ts` reads `config.cache.enabled` and `config.cache.ttl_hours` and derives `cacheTtlMs`. It also checks `PAX8_NO_CACHE`.
+- Do not add per-command cache bypass flags. Use `PAX8_NO_CACHE=1` as the escape hatch.
+
+---
+
+## 14. Checklist for a new command
 
 Before opening the PR:
 

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -39,9 +39,9 @@ describe("pax8 doctor", () => {
     expect(result.stdout).toContain("Skipped");
   });
 
-  it("reports cache directory writable", async () => {
+  it("reports cache status", async () => {
     const result = await runCliExpectSuccess(["doctor"], TABLE);
-    expect(result.stdout).toMatch(/✓.*Cache directory writable/);
+    expect(result.stdout).toMatch(/✓.*Cache/);
   });
 
   // Regression for #220: env-var auth and demo mode are equally valid

--- a/packages/cli/src/commands/cache/index.ts
+++ b/packages/cli/src/commands/cache/index.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getConfigDir, loadConfig } from "@pax8/core";
+
+const CACHE_DIR = path.join(getConfigDir(), "cache");
+
+const cacheStatusCommand = new Command("status")
+  .description("Show response cache status, location, and size")
+  .action(async () => {
+    const noCache = process.env.PAX8_NO_CACHE === "1" || process.env.PAX8_NO_CACHE === "true";
+    let cacheEnabled = false;
+    let ttlHours = 24;
+    if (!noCache) {
+      try {
+        const cfg = await loadConfig();
+        cacheEnabled = cfg.cache?.enabled ?? false;
+        ttlHours = cfg.cache?.ttl_hours ?? 24;
+      } catch {
+        // config unreadable — treat as disabled
+      }
+    }
+
+    let entryCount = 0;
+    let totalBytes = 0;
+    try {
+      const files = await fs.readdir(CACHE_DIR);
+      const jsonFiles = files.filter((f) => f.endsWith(".json"));
+      entryCount = jsonFiles.length;
+      for (const f of jsonFiles) {
+        try {
+          const stat = await fs.stat(path.join(CACHE_DIR, f));
+          totalBytes += stat.size;
+        } catch {
+          // skip
+        }
+      }
+    } catch {
+      // cache dir doesn't exist yet
+    }
+
+    const kb = (totalBytes / 1024).toFixed(1);
+    const active = !noCache && cacheEnabled;
+
+    process.stdout.write("\n");
+    process.stdout.write(
+      `  Cache:    ${active ? chalk.green("enabled") : chalk.yellow("disabled")}\n`,
+    );
+    if (noCache) {
+      process.stdout.write(`  Reason:   PAX8_NO_CACHE env var is set\n`);
+    } else if (!cacheEnabled) {
+      process.stdout.write(
+        `  To enable: set ${chalk.dim("cache.enabled: true")} in ~/.pax8/config.yaml\n`,
+      );
+    } else {
+      process.stdout.write(`  TTL:      ${ttlHours}h\n`);
+    }
+    process.stdout.write(`  Location: ${CACHE_DIR}\n`);
+    process.stdout.write(
+      `  Entries:  ${entryCount > 0 ? `${entryCount} (${kb} KB)` : "empty"}\n`,
+    );
+    if (entryCount > 0) {
+      process.stdout.write(
+        `\n  Run ${chalk.dim("pax8 cache clear")} to remove all cached responses.\n`,
+      );
+    }
+    process.stdout.write("\n");
+  });
+
+const cacheClearCommand = new Command("clear")
+  .description("Remove all cached API responses")
+  .action(async () => {
+    try {
+      const files = await fs.readdir(CACHE_DIR);
+      const jsonFiles = files.filter((f) => f.endsWith(".json"));
+      if (jsonFiles.length === 0) {
+        process.stdout.write("\n  Cache is already empty.\n\n");
+        return;
+      }
+      await Promise.all(
+        jsonFiles.map((f) => fs.unlink(path.join(CACHE_DIR, f)).catch(() => {})),
+      );
+      process.stdout.write(
+        `\n  ${chalk.green("✓")} Cleared ${jsonFiles.length} cached ${jsonFiles.length === 1 ? "entry" : "entries"}.\n\n`,
+      );
+    } catch {
+      process.stdout.write("\n  Cache is already empty.\n\n");
+    }
+  });
+
+export function registerCacheCommands(program: Command): void {
+  const cache = new Command("cache").description("Manage the local API response cache");
+  cache.addCommand(cacheStatusCommand);
+  cache.addCommand(cacheClearCommand);
+  program.addCommand(cache);
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -318,16 +318,55 @@ async function checkTelemetry(): Promise<CheckResult> {
 }
 
 async function checkCacheDir(): Promise<CheckResult> {
+  const noCache = process.env.PAX8_NO_CACHE === "1" || process.env.PAX8_NO_CACHE === "true";
+  let cacheEnabled = false;
+  let ttlHours = 24;
+  if (!noCache) {
+    try {
+      const { loadConfig } = await import("@pax8/core");
+      const cfg = await loadConfig();
+      cacheEnabled = cfg.cache?.enabled ?? false;
+      ttlHours = cfg.cache?.ttl_hours ?? 24;
+    } catch {
+      // config unreadable — treat as disabled
+    }
+  }
+
+  let entryCount = 0;
+  let totalBytes = 0;
+  try {
+    const files = await fs.readdir(CACHE_DIR);
+    const jsonFiles = files.filter((f) => f.endsWith(".json"));
+    entryCount = jsonFiles.length;
+    for (const f of jsonFiles) {
+      try {
+        const stat = await fs.stat(path.join(CACHE_DIR, f));
+        totalBytes += stat.size;
+      } catch {
+        // skip unreadable files
+      }
+    }
+  } catch {
+    // cache dir doesn't exist yet — that's fine
+  }
+
+  const kb = (totalBytes / 1024).toFixed(1);
+  const sizeStr = entryCount > 0 ? `, ${entryCount} entries (${kb} KB)` : ", empty";
+  const detail = noCache
+    ? "disabled via PAX8_NO_CACHE"
+    : cacheEnabled
+      ? `enabled — ${ttlHours}h TTL${sizeStr}`
+      : "disabled — set cache.enabled: true in ~/.pax8/config.yaml to enable";
+
   try {
     await fs.mkdir(CACHE_DIR, { recursive: true });
-    // Try writing a test file
     const testFile = path.join(CACHE_DIR, ".write-test");
     await fs.writeFile(testFile, "test");
     await fs.unlink(testFile);
-    return { name: "Cache directory writable", passed: true, detail: CACHE_DIR };
+    return { name: "Cache", passed: true, detail };
   } catch {
     return {
-      name: "Cache directory writable",
+      name: "Cache",
       passed: false,
       detail: `Cannot write to ${CACHE_DIR}`,
     };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import { registerInvoicesCommands } from "./commands/invoices/index.js";
 import { registerOrdersCommands } from "./commands/orders/index.js";
 import { registerRecommendationsCommands } from "./commands/recommendations/index.js";
 import { registerTelemetryCommands } from "./commands/telemetry/index.js";
+import { registerCacheCommands } from "./commands/cache/index.js";
 import { registerUsageCommands } from "./commands/usage/index.js";
 import { registerWebhooksCommands } from "./commands/webhooks/index.js";
 import { registerContactsCommands } from "./commands/contacts/index.js";
@@ -103,6 +104,7 @@ export function createProgram(): Command {
   registerOrdersCommands(program);
   registerRecommendationsCommands(program);
   registerTelemetryCommands(program);
+  registerCacheCommands(program);
   registerUsageCommands(program);
   registerWebhooksCommands(program);
   registerContactsCommands(program);

--- a/packages/cli/src/lib/context.test.ts
+++ b/packages/cli/src/lib/context.test.ts
@@ -334,6 +334,35 @@ describe("buildContext", () => {
       }
     });
 
+    it("PAX8_NO_CACHE=1 overrides config.cache.enabled and passes cacheTtlMs=0", async () => {
+      delete process.env.PAX8_DEMO;
+      process.env.PAX8_NO_CACHE = "1";
+      const core = await import("@pax8/core");
+      const loadSpy = vi.spyOn(core, "loadConfig").mockResolvedValue({
+        version: "1.0",
+        defaults: { output_format: "table", page_size: 50, confirm_destructive: true },
+        cache: { enabled: true, ttl_hours: 6 },
+        telemetry: { enabled: false },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial config for tests
+      } as any);
+      const getCredSpy = vi
+        .spyOn(core.CredentialStore.prototype, "getCredentials")
+        .mockResolvedValue({ clientId: "id-x", clientSecret: "secret-y" });
+      const ctorSpy = vi.spyOn(core, "Pax8Client");
+
+      try {
+        await buildContext({ json: true });
+        expect(ctorSpy).toHaveBeenCalledTimes(1);
+        const opts = ctorSpy.mock.calls[0][0];
+        expect(opts.cacheTtlMs).toBe(0);
+      } finally {
+        delete process.env.PAX8_NO_CACHE;
+        loadSpy.mockRestore();
+        getCredSpy.mockRestore();
+        ctorSpy.mockRestore();
+      }
+    });
+
     it("passes cacheTtlMs=0 when config.cache.enabled is false", async () => {
       delete process.env.PAX8_DEMO;
       const core = await import("@pax8/core");

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -173,7 +173,7 @@ export async function buildContext(
       page_size: 50,
       confirm_destructive: true,
     },
-    cache: { enabled: true, ttl_hours: 24 },
+    cache: { enabled: false, ttl_hours: 24 },
     telemetry: { enabled: false },
   }));
 
@@ -219,7 +219,9 @@ export async function buildContext(
     // `cache.enabled: false` in `~/.pax8/config.yaml` still got caching with
     // the constructor's hard-coded 1h default. `cacheTtlMs: 0` disables the
     // FileCache entirely inside `Pax8Client`.
-    const cacheEnabled = config.cache?.enabled ?? true;
+    const envNoCache = process.env.PAX8_NO_CACHE;
+    const noCache = envNoCache === "1" || envNoCache === "true";
+    const cacheEnabled = !noCache && (config.cache?.enabled ?? false);
     const cacheTtlHours = config.cache?.ttl_hours ?? 24;
     const cacheTtlMs = cacheEnabled ? cacheTtlHours * 3_600_000 : 0;
 

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -20,7 +20,7 @@ export const ConfigSchema = z.object({
     .default({}),
   cache: z
     .object({
-      enabled: z.boolean().default(true),
+      enabled: z.boolean().default(false),
       ttl_hours: z.number().default(24),
     })
     .default({}),


### PR DESCRIPTION
## Summary

Closes #253. Three of the four proposed fixes from the issue — the cache warmer removal was already done in #466.

- **Flip `cache.enabled` default to `false`** — caching is now opt-in. Users set `cache.enabled: true` in `~/.pax8/config.yaml` to enable it. Previously the config field was documented but the default wrote API responses to disk unconditionally for all users.
- **Wire `PAX8_NO_CACHE=1` env override** — disables caching for a single invocation, overriding config. Useful in scripts, CI, or when you want fresh data without editing config.
- **Add `pax8 cache status` / `pax8 cache clear` commands** — users can now see whether caching is enabled, the cache location, TTL, entry count and size, and clear it without touching the filesystem manually.
- **Enhance `pax8 doctor` cache check** — now reports enabled/disabled state, TTL, and entry count instead of just "Cache directory writable".
- **Document caching end-to-end** — new §13 in UX_GUIDE.md covers behavior, env vars, user commands, and contributor notes. `.env.example` documents `PAX8_NO_CACHE`.

## What was already done before this PR

- `cache.enabled` / `cache.ttl_hours` plumbing through to `Pax8Client` (done in a prior commit — context.ts already reads the config correctly)
- `spawnCacheWarmer` removal (done in #466 — no subprocesses spawn per command)

## Test plan

- [ ] `pnpm test -- "context"` — 35 tests pass including new `PAX8_NO_CACHE=1` assertion
- [ ] `pnpm test -- "doctor"` — 14 tests pass including updated cache check name
- [ ] `PAX8_DEMO=1 pax8 cache status` — shows disabled + empty
- [ ] `PAX8_DEMO=1 pax8 cache clear` — shows "Cache is already empty"
- [ ] `PAX8_DEMO=1 pax8 doctor` — shows `✓ Cache (disabled — set cache.enabled: true ...)`
- [ ] Set `cache.enabled: true` in config, run a read command, then `pax8 cache status` shows entry count > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)