### PR TITLE
fix(test): update loader.test.ts to match opt-in cache default from #557

### DIFF
--- a/.changeset/loader-cache-default-test.md
+++ b/.changeset/loader-cache-default-test.md
@@ -1,0 +1,7 @@
+---
+"@pax8/core": patch
+---
+
+Fix test regression introduced by #557 (opt-in caching). Two assertions in `packages/core/src/config/loader.test.ts` still expected `cache.enabled` to default to `true`, but #557 intentionally flipped the default to `false` (opt-in caching) without updating the matching test expectations. Tests now match the shipped behavior. No code change to the loader itself — the production behavior is correct, only the test was stale.
+
+This was blocking CI on every PR opened after #557 landed, because PR build matrices evaluate the merge commit against `main` and inherit `main`'s broken test suite.

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -30,7 +30,10 @@ describe("config/loader", () => {
     expect(config.defaults.output_format).toBe("table");
     expect(config.defaults.page_size).toBe(50);
     expect(config.defaults.confirm_destructive).toBe(true);
-    expect(config.cache.enabled).toBe(true);
+    // #557 flipped `cache.enabled` to opt-in (default false). The previous
+    // default-true value got partners on every command path before they'd
+    // explicitly chosen to cache; opt-in is the durable posture.
+    expect(config.cache.enabled).toBe(false);
     expect(config.cache.ttl_hours).toBe(24);
     expect(config.telemetry.enabled).toBe(false);
   });
@@ -53,7 +56,8 @@ defaults:
     expect(config.defaults.page_size).toBe(25);
     // Defaults should be applied for missing fields
     expect(config.defaults.confirm_destructive).toBe(true);
-    expect(config.cache.enabled).toBe(true);
+    // #557: opt-in caching — cache.enabled defaults to false.
+    expect(config.cache.enabled).toBe(false);
   });
 
   it("should save and reload config", async () => {


### PR DESCRIPTION
## Summary

- PR #557 flipped `cache.enabled` to default `false` (opt-in caching, closes #253) but left two assertions in `packages/core/src/config/loader.test.ts` (lines 33 and 56) expecting the old default. CI on `main` has been red since #557 merged on 2026-05-28.
- Every PR opened against `main` since then inherits the failure when GitHub computes the merge commit. PRs #564 / #565 / #566 all show red build-and-test for this reason — not because of their own changes.
- This patch updates the two assertions to match the shipped, intentional behavior. No loader code change; the production behavior is correct.

## Test plan

- [x] Reproduced the failure locally: `pnpm test -- packages/core/src/config/loader.test.ts` on `main` fails at line 56 (`expect(config.cache.enabled).toBe(true)`).
- [x] Confirmed fix locally: same command passes (7/7) after the assertion swap.
- [x] Full suite green: `pnpm test` runs 2160 tests, 0 failures.
- [x] No other tests in the workspace assert `cache.enabled: true` as a default (grep confirmed).

Unblocks #564, #565, #566 and any future PR that branches off post-#557 `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)