### PR TITLE
docs: pre-launch cleanup — README structure, CHANGELOG reconciliation, BUILD.md archive

### DIFF
--- a/.changeset/docs-pre-launch-cleanup.md
+++ b/.changeset/docs-pre-launch-cleanup.md
@@ -1,0 +1,11 @@
+---
+"@pax8/cli": patch
+---
+
+Pre-launch documentation cleanup, no code changes:
+
+- **`README.md`** — restructured Quick Start into explicit "Install / Run / Authenticate" steps with three documented invocation paths (`node dist/index.js`, `npm link`'d `pax8`, `pnpm dev`); de-duplicated the pre-release banner (was repeated three times); expanded the Commands section to surface `contacts`, `quotes`, `webhooks`, `usage`, `config`, `report`, `init`, `completions`, `version`, `report-bug`, `telemetry` (the existing surface but only the prominent commands were documented); fixed the `report mrr` / `report growth` paragraph that still said "v0.2 reporting work will rebuild" when `pax8 report renewals|concentration|subscriptions` already shipped; rebuilt the REPL Mode section to show the welcome banner and document `back` / `n` / `p` shortcuts; replaced the Documentation section's BUILD.md link with current contributor / partner-facing pointers.
+- **`SUPPORT.md`** — added `pax8 version` and `PAX8_DEMO=1` reproduction tips to "Try first".
+- **`CHANGELOG.md`** — converted the root file from a duplicate-of-truth into a pointer to the changesets-managed per-package CHANGELOGs (`packages/cli/CHANGELOG.md`, `packages/core/CHANGELOG.md`). The v0.1.0 release entry stays for archaeology; the unmaintained "Unreleased" section that was lagging behind 0.2.x / 0.3.0 is gone.
+- **`docs/BUILD.md` → `docs/history/BUILD.md`** — moved the autonomous-build prompt out of the user-facing docs path. Added a "Historical document" banner explaining what it is. Updated the two references in `CLAUDE.md`.
+- **`docs/release/CHECKLIST.md`** — new working doc for the public OSS launch, structured by phase (decisions, code/test gates, infra, release mechanics, comms, post-launch ops). The release plan lives in chat-transcript context; this file is the executable form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,40 +2,18 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Source of truth
 
-### Added
+Per-package CHANGELOGs are the canonical release record. They are generated and updated automatically by [Changesets](https://github.com/changesets/changesets) on every release PR — see [CONTRIBUTING.md → Releases](CONTRIBUTING.md#releases) for the workflow.
 
-- **Vocabulary alignment with Pax8 canonical terms** (#298) — Pax8-internal research surfaced six places where CLI vocabulary diverges from canonical Pax8 vocabulary. Help-text disclaimers added to clarify scope: `pax8 subscriptions renewals` (renewal exposure ≠ Revenue at Risk Predictor), `pax8 recommendations list` (cross_sell collapses multiple Opportunity Explorer types; seat_gap is a CLI-invented heuristic, not Seat Utilization; estimatedMrrUplift is upper-bound, not PMRR), `pax8 invoices audit` (partner-side reconciliation, not vendor-side), and `pax8 subscriptions show` (`provisioningStatus` is the API's coarse-grained state, not internal pipeline detail). README "Metric definitions" expanded with renewal-exposure and coverage-gap sections.
-- **`Company.externalId`** surfaced in `pax8 companies show` (table + `--json`). Partner-side identifier returned by the API, useful for bridging Pax8 ↔ PSA records (#273).
-- **`Subscription.currencyCode`** surfaced in `pax8 subscriptions list/show`. Always present in `--json`; appended to the price column in table view only when the value is non-`USD`, to keep the common case uncluttered (#273).
-- **Per-command e2e UX matrix** (`e2e/per-command.test.ts` + `e2e/command-inventory.ts`): every CLI command runs through a fixed set of layers under `PAX8_DEMO=1` — smoke (exits 0, no stack traces), cross-cutting invariants (no `undefined` / `[object Object]` / debug-token leaks), per-command semantic checks (expected/forbidden output fragments), JSON contract (`--json` parses, required fields per spec, minRows for list shapes), and `--help` (exits 0, mentions command name). The inventory is the single source of truth — adding a new command means adding one entry. Catalogued bugs are marked `knownBroken` with issue links rather than papering over with weakened assertions, so regressions stay visible in CI output (#193 / #207).
+- [`@pax8/cli` changelog](packages/cli/CHANGELOG.md) — user-facing CLI
+- [`@pax8/core` changelog](packages/core/CHANGELOG.md) — embeddable business-logic library
 
-### Changed
+`@pax8/claude-skill` is not versioned independently.
 
-- **`Product.vendor`** removed from the schema — it duplicated `vendorName`. Only `vendorName` remains, matching the public API (#273).
-- **`--json` field names aligned with the public Pax8 API** — `InvoiceItem.subtotal` → `subTotal`, `InvoiceItem.unitPrice` → `price`, `Company.modified` → `updatedDate`, `Quote.expirationDate` → `expiresOn`, `Quote.createdDate` → `createdOn`. Breaking for `--json` consumers; acceptable pre-1.0 since partners reading both surfaces no longer have to translate. The `--expiration-date` CLI flag on `pax8 quotes create`/`update` is intentionally unchanged — flag vocabulary and field vocabulary are separate concerns (#273).
-- **Display labels** — `report-bug` no-prior-error now exits 0 with a manual-file-a-bug pointer instead of exiting 1 silently; the with-context flow (sanitize, prompt, submit) is unchanged (#209).
-- **`auth status --json`** now emits valid JSON (`{ authenticated, mode, clientIdMasked? }`) and respects the agent-first non-TTY contract; previously it printed human-formatted text regardless of `--json` (#210).
+The entries below predate Changesets adoption and are retained for historical context. After 0.1.0, consult the per-package files.
 
-### Deprecated
-
-- **`mrrAtRisk` / `arrAtRisk` / `totalMrrAtRisk` / `totalArrAtRisk`** renamed to `mrrRenewing` / `arrRenewing` / `totalMrrRenewing` / `totalArrRenewing` (#298). The original "at risk" naming silently conflated with Pax8's patent-filed Revenue at Risk Predictor (an ML churn-likelihood model); the CLI metric is a temporal filter (subscriptions renewing within a window), not a churn-risk prediction. New canonical names emit alongside the old names with identical values for one minor version cycle so existing scripts don't break; the deprecated aliases will be removed in a future minor release. Surfaces affected: `pax8 subscriptions renewals --json`, `pax8 dashboard --json` (renewals block), and the `RenewalReport` / `RenewalItem` types in `@pax8/core`. Human-render copy updated (e.g. "MRR at risk" → "MRR renewing"). Recommendation engine `seat_gap` titles also re-worded ("uncovered seats" → "mismatched seats") to disambiguate from Pax8's canonical Seat Utilization metric.
-- **`pax8 webhooks create --events`** renamed to `--topics` to match the API field name (`webhookTopics`) and the CLI's own `Webhook.topics[]` output. `--events` continues to function as a deprecated alias and prints a one-line deprecation notice on stderr; it will be removed in v1.0. Passing both `--topics` and `--events` is rejected with `ERROR_INVALID_INPUT` (#273).
-- **`pax8 status`** renamed to `pax8 dashboard`. The previous name collided semantically with `pax8 auth status` (an auth-credential check) and was generically named for what is actually a portfolio dashboard. `pax8 status` continues to function as a deprecated alias and prints a one-line deprecation notice on stderr (`warning: \`status\` is deprecated; use \`dashboard\`. Will be removed in v1.0.`); it is hidden from `pax8 --help`. Same deprecation pattern as the `--events` → `--topics` rename above; will be removed in v1.0.
-
-### Fixed
-
-- **`orders show <id>`** — rendered "Company: undefined" and an empty Line Items section. Now joins `companyId` → company name (matching `subscriptions show`/`invoices show` pattern) and resolves `orderItems[].productId` → product name; adds per-line-item unit price column. Same enrichment in human and `--json` output (#194).
-- **`<group> show <id> --json`** — every show command (`subscriptions`, `invoices`, `quotes`, `usage`, `products`, `contacts`) wrapped the singular resource in a length-1 array (`[{...}]`) instead of emitting a single object — agent-contract violation that broke `--json | jq '.id'` style scripting (#208).
-- **`pax8 cost sim` README examples** used shorthand product names ("M365 Business Premium", "AvePoint Cloud Backup") that didn't prefix-match the demo catalog. First-run users walking the docs hit "Product not found" (#211).
-- **List-table rendering** (`pax8 companies list`, etc.) — dropped per-row inter-row dividers and the duplicated 50-line per-row drill-in footer; lists now render cleanly with one drill-in hint at the bottom of the table (#192).
-
-### Internal
-
-- Scheduled API-drift watcher (`.github/workflows/api-watch.yml`) opens maintainer issues when `ERROR_API_VALIDATION` spikes are detected in telemetry. First layer of the api-resilience plan tracked at #176 (#178).
-- Added `windows-latest` to the CI matrix; the test suite now runs on Windows under PowerShell on every PR. Added `fail-fast: false` so a Windows-only regression doesn't mask Ubuntu signal. Coverage step gated to `ubuntu-latest` + Node 22 only (#186 / #188).
-- **`e2e/test-utils.ts`** — `runCli()` now uses an isolated `PAX8_CONFIG_DIR` (mkdtemp) per call so e2e tests don't inherit the developer's `~/.pax8/last-error.json` between cases (load-bearing for the new `report-bug` live-run; general hygiene).
+---
 
 ## [0.1.0] — 2026-05-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ For project background, install instructions, the human demo flow, and how this 
 
 ## Autonomous Build Mode
 
-This mode applies **only** when you're explicitly following `docs/BUILD.md` (or a similar mode-specific prompt). Default behavior is conservative — confirm before destructive or shared-state actions and surface uncertainty.
+This mode applies **only** when you're explicitly following `docs/history/BUILD.md` (or a similar mode-specific prompt). Default behavior is conservative — confirm before destructive or shared-state actions and surface uncertainty.
 
-When following `docs/BUILD.md`, operate fully autonomously with ZERO human interaction:
+When following `docs/history/BUILD.md`, operate fully autonomously with ZERO human interaction:
 
 - NEVER ask questions, for permission, or for confirmation.
 - NEVER stop to explain what you're about to do. Just do it.
@@ -112,7 +112,7 @@ Adding a new command? Lives at `packages/cli/src/commands/<resource>/<action>.ts
 - `README.md` — what the project is, install/quick-start, MCP comparison
 - `docs/UX_GUIDE.md` — command patterns, output contracts, agent-facing rules (canonical for conventions)
 - `docs/PRD.md` — product requirements and API gap analysis
-- `docs/BUILD.md` — autonomous build-mode execution plan
+- `docs/history/BUILD.md` — autonomous build-mode execution plan
 - `packages/core/README.md` — `@pax8/core` as a standalone embeddable library
 - `packages/claude-skill/skill.md` — agent-facing skill manifest + read/write safety contract
 - `CONTRIBUTING.md` — DCO sign-off, Conventional Commits, PR workflow

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An open-source CLI for managing Pax8 cloud marketplace operations. Built for MSP
 
 This is an early-stage open-source experiment. We're using engagement signals (installs, issues, command usage) to learn which capabilities are worth investing in further. Feedback, issues, and PRs are welcome.
 
-> **Pre-release.** `@pax8/cli` is not yet published to npm — `npm install -g @pax8/cli` will work once v0.1.0 ships. Until then, install from source: see [Quick Start → Running from source](#running-from-source).
+> **Pre-release.** `@pax8/cli` is not yet published to npm — `npm install -g @pax8/cli` works once v0.1.0 ships. Install from source today: see [Quick Start](#quick-start).
 
 ## Highlights
 
@@ -34,47 +34,59 @@ Pax8 publishes a hosted MCP server at `mcp.pax8.com` for AI assistants — see t
 
 ## Quick Start
 
-> ***Pre-release: `@pax8/cli` is not yet on npm.*** Install from source today (see [Running from source](#running-from-source) below). The `npm install -g @pax8/cli` path will start working once v0.1.0 ships.
+Requires Node.js 20+ and [pnpm](https://pnpm.io/installation) 9+. Tested on macOS, Linux, and Windows under PowerShell.
 
-Tested on macOS, Linux, and Windows under PowerShell. Requires Node.js 20+ and [pnpm](https://pnpm.io/installation) 9+.
-
-### Running from source
-
-Install from source — copy-pasteable, under 5 minutes on a fresh checkout:
+### 1. Install and build
 
 ```bash
 git clone https://github.com/pax8labs/pax8-cli
 cd pax8-cli
 pnpm install
 pnpm build
+```
 
-# Try it without credentials (demo data, no API calls)
+### 2. Run it
+
+Three ways to invoke the CLI, pick whichever matches your workflow:
+
+**(a) Direct from `dist/`** — works after `pnpm build`, no further setup:
+
+```bash
 PAX8_DEMO=1 node packages/cli/dist/index.js dashboard
+```
 
-# Or expose `pax8` globally from your checkout so every example in this
-# README works as-is (the REPL and cache-warmer also need `pax8` on PATH)
-cd packages/cli && npm link
+**(b) `pax8` on PATH** *(recommended)* — makes every example in this README copy-pasteable, and is required for the REPL and cache-warmer:
+
+```bash
+cd packages/cli && npm link && cd ../..
 PAX8_DEMO=1 pax8 dashboard
 ```
 
-For watch mode, tests, and the rest of the contributor workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
+**(c) Dev mode (no rebuild needed)** — runs the TypeScript sources directly via `tsx`; pass command args after `--`:
+
+```bash
+PAX8_DEMO=1 pnpm dev -- dashboard
+PAX8_DEMO=1 pnpm dev -- clients list
+```
+
+### 3. Authenticate (or stay in demo)
+
+```bash
+pax8 auth login                  # interactive prompt
+# ...or skip auth entirely:
+PAX8_DEMO=1 pax8 dashboard       # in-memory fixture, no API calls
+```
+
+For watch mode, tests, and the full contributor workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### From npm (coming soon)
 
-Once v0.1.0 ships, the documented path will be:
+Once v0.1.0 ships to npm, the documented path will be:
 
 ```bash
-# Install (not yet published — tracked in repo Status section above)
 npm install -g @pax8/cli
-
-# Authenticate
 pax8 auth login
-
-# See how your business is doing
 pax8 dashboard
-
-# Or try with demo data (no credentials needed)
-PAX8_DEMO=1 pax8 dashboard
 ```
 
 ## Demo Flow (90 seconds)
@@ -88,6 +100,8 @@ pax8 clients more "Acme Corp"            # Full customer summary
 ```
 
 ## Commands
+
+`pax8 --help` is the canonical inventory; every command and subcommand documents its flags via `pax8 <command> --help`. The sections below cover the most-used surface; the [More commands](#more-commands) section near the end lists the rest.
 
 ### Dashboard
 
@@ -173,11 +187,43 @@ pax8 products search "Microsoft 365"                   # Search catalog
 pax8 products show <id>                                # Product details + pricing
 ```
 
+### Reports
+
+Pax8-cost reporting surface — what's renewing, where your spend is concentrated, and grouped subscription rollups.
+
+```bash
+pax8 report renewals --within 90                       # Subscriptions ending in the next 90 days
+pax8 report concentration --by client --top 5          # Top customers by Pax8 cost
+pax8 report concentration --by vendor --json           # Concentration by vendor
+pax8 report subscriptions --by billing-term            # Active subs grouped by billing term
+pax8 report subscriptions --by vendor --json           # Pax8 cost rollup by vendor
+```
+
+All values are Pax8 cost (what Pax8 charges you), emitted as `{ amount, currency }` envelopes. For partner-side resale revenue, combine with sell-through pricing from your PSA.
+
 ### Diagnostics
 
 ```bash
-pax8 doctor                    # Node, auth, API endpoints (5/5), cache, telemetry
+pax8 doctor                    # Node, auth, API endpoints, cache, telemetry
 pax8 auth status               # Check credentials
+pax8 version                   # CLI version
+```
+
+### More commands
+
+The full surface also includes these less-prominent command groups — see `pax8 <group> --help` for flags and examples:
+
+```bash
+pax8 contacts list|show|create|update|delete           # Per-company contacts (Admin/Billing/Technical)
+pax8 quotes list|show|create|update|send|delete        # Sales quotes (v2 API)
+pax8 webhooks list|create|update|delete|enable|disable # Subscription endpoints
+pax8 webhooks logs|test|topics                         # Delivery history, fire test deliveries, list topics
+pax8 usage list|show                                   # Metered usage (Azure consumption, etc.)
+pax8 config init|show|set|path                         # Config file management
+pax8 init                                              # First-run setup wizard
+pax8 completions bash                                  # Shell completions (bash/zsh/fish/powershell)
+pax8 report-bug                                        # File a sanitized GitHub issue from the last failure (see Reporting bugs)
+pax8 telemetry enable|disable|status                   # Opt-in usage telemetry (see Telemetry)
 ```
 
 ## Output Formats
@@ -204,18 +250,48 @@ pax8 dashboard --json 2>/dev/null > today.json
 
 ## REPL Mode
 
-Run `pax8` with no arguments to enter the interactive REPL:
+Run the CLI with no arguments to enter the interactive REPL — works with any of the three invocation paths from [Quick Start](#2-run-it):
+
+```bash
+pax8                                    # if linked via npm link
+node packages/cli/dist/index.js         # from a built checkout
+pnpm dev                                # dev mode (tsx)
+```
+
+You'll see the Pax8 ASCII banner with a tagline, your CLI version, and a "Common commands" cheat sheet — then a `pax8>` prompt:
 
 ```
 $ pax8
+
+  ────────────────────────────────────────────────
+
+      ██████╗  █████╗ ██╗  ██╗ █████╗
+      ██╔══██╗██╔══██╗╚██╗██╔╝██╔══██╗
+      ██████╔╝███████║ ╚███╔╝ ╚█████╔╝
+      ██╔═══╝ ██╔══██║ ██╔██╗ ██╔══██╗
+      ██║     ██║  ██║██╔╝ ██╗╚█████╔╝
+      ╚═╝     ╚═╝  ╚═╝╚═╝  ╚═╝ ╚════╝
+
+      C O M M A N D   L I N E
+
+  Common commands:
+    dashboard               Portfolio at a glance
+    subscriptions renewals  What's renewing in 30 days
+    recommendations         Upsell opportunities
+    invoices audit          Reconcile invoices vs subscriptions
+
+  Type a command, or help / exit
+
 pax8> dashboard
 pax8> clients list
 pax8> 3                          # Drill into client #3
+pax8> back                       # Re-run the last list command
+pax8> n                          # Next page; p for previous
 pax8> recommendations act        # Multi-select picker → batch order
 pax8> exit
 ```
 
-No `pax8` prefix needed. Numbered shortcuts work after list commands.
+No `pax8` prefix needed inside the REPL. Numbered shortcuts work after any list command (pick the row by position). The cheat-sheet adapts to your auth state: if you're not yet authenticated, you'll see `init --demo` / `auth login` / `doctor` instead of the common-commands list.
 
 ## Authentication
 
@@ -437,7 +513,7 @@ for (const r of report.items.slice(0, 5)) {
 }
 ```
 
-The same pattern works for `auditInvoices(...)`, `computeMrr(...)`, `computeGrowth(...)`, and `getRecommendations(...)` — see [`packages/core/README.md`](packages/core/README.md) for the full surface. `computeMrr` / `computeGrowth` are retained in `@pax8/core` for embeddable reuse (v0.2 reporting work will rebuild a CLI-side reporting surface on top of them with Pax8-cost framing); only the previous `pax8 report mrr` / `pax8 report growth` CLI commands were removed.
+The same pattern works for `auditInvoices(...)`, `computeMrr(...)`, `computeGrowth(...)`, and `getRecommendations(...)` — see [`packages/core/README.md`](packages/core/README.md) for the full surface. `computeMrr` / `computeGrowth` are retained in `@pax8/core` for embeddable reuse; the CLI-side reporting surface is now `pax8 report renewals|concentration|subscriptions` (Pax8-cost framed, emits `AmountCurrency` envelopes). The previous `pax8 report mrr` / `pax8 report growth` CLI commands were removed because they framed Pax8-cost data as partner-side MRR.
 
 ## Known Limitations
 
@@ -544,10 +620,14 @@ who only see `--json` output.
 
 ## Documentation
 
-- [Credential Setup Guide](docs/credential-setup.md)
-- [Product Requirements](docs/PRD.md)
-- [Build Prompt](docs/BUILD.md)
-- [Pax8 API Reference](https://devx.pax8.com/)
+- [Credential Setup Guide](docs/credential-setup.md) — get API credentials and configure the CLI
+- [Contributing](CONTRIBUTING.md) — dev setup, demo fixtures, tests, releases, DCO sign-off
+- [Support](SUPPORT.md) — troubleshooting, bug reports, security disclosure path
+- [Agents](AGENTS.md) — entry point for Cursor, aider, OpenCode, and other AI runtimes
+- [Product Requirements](docs/PRD.md) — internal product context
+- [UX Guide](docs/UX_GUIDE.md) — command patterns and agent-facing contract (contributor reference)
+- [`@pax8/core` library](packages/core/README.md) — using the business logic without the CLI
+- [Pax8 API Reference](https://devx.pax8.com/) — upstream API docs
 
 ## Contributing
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,6 +7,8 @@ Looking for help with `pax8-cli`? Here's where to start.
 - **`pax8 doctor`** — runs diagnostics on your setup (Node version, credentials, API reachability, config file)
 - **`pax8 <command> --help`** — every command documents its flags and gives runnable examples
 - **`pax8 --verbose <command>`** — prints the API path and method to stderr; helpful for troubleshooting
+- **`pax8 version`** — print the installed CLI version (include in every bug report)
+- **`PAX8_DEMO=1 pax8 <command>`** — reproduce against an in-memory fixture to confirm whether the issue is your data or the CLI
 
 ## Bug reports and feature requests
 

--- a/docs/history/BUILD.md
+++ b/docs/history/BUILD.md
@@ -1,5 +1,9 @@
 # Autonomous Build Prompt — pax8-cli MVP
 
+> **Historical document.** This is the autonomous-build prompt used to scaffold the initial MVP. Dependency versions, command names, and command surface have evolved since — do not use this as a current build guide. For installing and building today, see the [README Quick Start](../../README.md#quick-start); for the contributor workflow see [CONTRIBUTING.md](../../CONTRIBUTING.md). Preserved here for project archaeology.
+
+---
+
 You are building `pax8-cli`, an open-source CLI for MSPs to manage Pax8 cloud marketplace operations.
 
 **Read `docs/PRD.md` for full product context. This document is your execution plan.**

--- a/docs/release/CHECKLIST.md
+++ b/docs/release/CHECKLIST.md
@@ -1,0 +1,254 @@
+# Public OSS launch checklist
+
+Working doc for the public OSS release of `pax8-cli`. Source plan lives in chat-transcript context as of 2026-05-29; this file is the executable checklist. Mark items off as they complete. Add issue links inline where work is tracked elsewhere.
+
+> **Status legend:** ✅ done · 🟡 in flight · ❌ blocked · ⬜ not started · ⏭️ deferred (with owner + date)
+
+---
+
+## Phase 0 — Decisions to lock (blocks everything downstream)
+
+| # | Decision | Status | Owner | Notes / link |
+|---|---|---|---|---|
+| 0.1 | Public repo location: `pax8labs/pax8-cli` (flip) vs. fresh `pax8-oss/pax8-cli` | ⬜ | | #141; Tier-2 approval doc §8 recommends fresh |
+| 0.2 | Initial public version: continue 0.3.x vs. cut 0.3.1 as launch tag vs. 1.0.0 | ⬜ | | Recommend 0.3.x or 0.3.1 (honest about maturity) |
+| 0.3 | Git history: preserve vs. squash | ⬜ | | Recommend preserve after #461/#489 scrub confirmed clean |
+| 0.4 | License sign-off (Apache-2.0) | ⬜ | Legal | Confirm SPDX headers complete (#169) |
+| 0.5 | DCO vs. CLA | ⬜ | | Default: keep DCO (already wired) |
+| 0.6 | npm `@pax8` scope claimed + trusted-publisher registered | ⬜ | | Workflow expects this — see CONTRIBUTING.md maintainer note |
+| 0.7 | GitHub Discussions enabled before flip | ⬜ | | Required to drop the hedge in SUPPORT.md |
+| 0.8 | Launch comms scope: soft (internal + blog) vs. broad (corporate social + partner email) | ⬜ | Marketing/DevRel | Drives polish bar and day-of-launch load |
+
+**Gate to Phase 1:** all eight rows ✅.
+
+---
+
+## Phase 1 — Code & test readiness gate
+
+### 1.1 Clear the merge queue
+
+| # | Task | Status | Link |
+|---|---|---|---|
+| 1.1.a | Triage open dependabot PRs (#558, #559, #560, #550, #551, #552) | ⬜ | |
+| 1.1.b | Investigate "Claude Code Review" failure on #560 | ⬜ | |
+| 1.1.c | Merge or refresh stalled `chore: release` PR #546 | ⬜ | 9 changesets stacked since 2026-05-21 |
+
+### 1.2 Address open external issues
+
+| # | Task | Status | Link |
+|---|---|---|---|
+| 1.2.a | Decide #233 (persist OAuth token to disk): fix / defer / close | ⬜ | Only open external-reviewer issue |
+
+### 1.3 Quality matrix on a clean checkout
+
+Run on macOS, Linux, and Windows PowerShell:
+
+| # | Check | macOS | Linux | Windows |
+|---|---|---|---|---|
+| 1.3.a | `git clone` → `pnpm install` → `pnpm build` no warnings | ⬜ | ⬜ | ⬜ |
+| 1.3.b | `pnpm test` all pass | ⬜ | ⬜ | ⬜ |
+| 1.3.c | `pnpm test:coverage` — core ≥80%, cli ≥70% | ⬜ | ⬜ | ⬜ |
+| 1.3.d | `pnpm test:integration` against **production** Pax8 API | ⬜ | ⬜ | ⬜ |
+| 1.3.e | `pnpm dev` → REPL launches with intro graphics | ⬜ | ⬜ | ⬜ |
+| 1.3.f | `node packages/cli/dist/index.js` → REPL launches with intro graphics | ⬜ | ⬜ | ⬜ |
+| 1.3.g | `npm link` → `pax8` on PATH → every README example works | ⬜ | ⬜ | ⬜ |
+| 1.3.h | `PAX8_DEMO=1 pax8 <every command>` — no errors, no UUID leaks, no `[object Object]` | ⬜ | ⬜ | ⬜ |
+
+Reconcile test-count claim (README says 800+, CHANGELOG says 1022+; pick the actual current number).
+
+### 1.4 Security pass
+
+| # | Check | Status | Link |
+|---|---|---|---|
+| 1.4.a | `pnpm audit` — zero high/critical | ⬜ | |
+| 1.4.b | CodeQL latest run on `main` — zero new findings | ⬜ | Code Scanning still disabled per #138 — enable it |
+| 1.4.c | Run security-review skill on diff between v0.1.0 tag and current `main` | 🟡 | In progress this session |
+| 1.4.d | Verify report-bug redactor catches all cases in `redactor.test.ts` | ⬜ | |
+| 1.4.e | Scrub internal hostnames, IPs, ticket prefixes, employee names from source/tests/CHANGELOGs | ⬜ | #461/#489 close; verify still clean |
+| 1.4.f | Network-egress allowlist verification (4 documented hosts, no others) | ⬜ | Run in network-namespaced container |
+
+---
+
+## Phase 2 — Documentation final pass
+
+### 2.1 README accuracy
+
+| # | Task | Status |
+|---|---|---|
+| 2.1.a | Remove "Pre-release" banner | ⬜ |
+| 2.1.b | Promote `From npm` to recommended path; demote source install to contributor subsection | ⬜ |
+| 2.1.c | Fix welcome-screen version fallback (currently hard-codes `"0.1.0"`) | ⬜ |
+| 2.1.d | Replace remaining "pre-launch" prose with neutral language | ⬜ |
+| 2.1.e | Update test-count claim to actual current value | ⬜ |
+| 2.1.f | Re-run every code-block example in a fresh terminal; fix drift | ⬜ |
+
+### 2.2 Cross-doc sweep
+
+| # | Task | Status |
+|---|---|---|
+| 2.2.a | SUPPORT.md: remove "if Discussions isn't enabled yet" hedge | ⬜ |
+| 2.2.b | AGENTS.md / CLAUDE.md: re-read for internal-system references | ⬜ |
+| 2.2.c | `packages/core/README.md`: verify standalone-library example works | ⬜ |
+| 2.2.d | `packages/claude-skill/skill.md`: self-contained verification | ⬜ |
+
+### 2.3 Repo metadata
+
+| # | Task | Status |
+|---|---|---|
+| 2.3.a | GitHub repo description, homepage, topics, social preview | ⬜ |
+| 2.3.b | npm `package.json` repository/homepage/bugs URLs → final public repo | ⬜ |
+| 2.3.c | LICENSE, CODE_OF_CONDUCT, SECURITY, CONTRIBUTING, SUPPORT present | ✅ | |
+| 2.3.d | `.github/ISSUE_TEMPLATE/` + `pull_request_template.md` partner-facing | ⬜ |
+
+### 2.4 CHANGELOG presentation
+
+| # | Task | Status |
+|---|---|---|
+| 2.4.a | Per-package CHANGELOGs have partner-readable launch summary | ⬜ |
+| 2.4.b | Root CHANGELOG.md points at per-package files | ✅ (done 2026-05-28) |
+
+---
+
+## Phase 3 — Infrastructure for the public flip
+
+### 3.1 Repo creation / transfer
+
+| # | Task | Status |
+|---|---|---|
+| 3.1.a | If fresh repo: create `pax8-oss/pax8-cli`, push `main` | ⬜ |
+| 3.1.b | If flip in place: `gh repo edit pax8labs/pax8-cli --visibility public` (dry-run last) | ⬜ |
+| 3.1.c | Re-seed roadmap-shaped issues on public repo (or leave on private) | ⬜ |
+
+### 3.2 npm trusted publishing
+
+| # | Task | Status |
+|---|---|---|
+| 3.2.a | Confirm OIDC trusted publisher registered for `@pax8/cli` | ⬜ |
+| 3.2.b | Confirm OIDC trusted publisher registered for `@pax8/core` | ⬜ |
+| 3.2.c | Dry-run release to throwaway scope OR private dist-tag | ⬜ |
+
+### 3.3 Branch protection (public repo)
+
+| # | Task | Status |
+|---|---|---|
+| 3.3.a | `main` protected, requires PR + 1 review | ⬜ |
+| 3.3.b | Required checks: Integration, CodeQL, lint, typecheck | ⬜ |
+| 3.3.c | Linear history enforced | ⬜ |
+| 3.3.d | Release workflow allowed to push tags | ⬜ |
+
+### 3.4 GitHub features
+
+| # | Task | Status |
+|---|---|---|
+| 3.4.a | Enable Discussions | ⬜ |
+| 3.4.b | Enable Security advisories | ⬜ |
+| 3.4.c | Enable Code Scanning (closes #138) | ⬜ |
+| 3.4.d | Confirm Dependabot config transfers to public repo | ⬜ |
+| 3.4.e | CODEOWNERS aligned with public org | ⬜ |
+
+### 3.5 npm pre-publish dress rehearsal
+
+| # | Task | Status |
+|---|---|---|
+| 3.5.a | `npm pack` both packages; inspect tarballs for stowaways | ⬜ |
+| 3.5.b | `files` field ships only `dist/` (+ `skill.md` for claude-skill) | ⬜ |
+| 3.5.c | `bin.pax8` entrypoint executable after global install | ⬜ |
+
+---
+
+## Phase 4 — Cutting the release
+
+### 4.1 Final freeze
+
+| # | Task | Status |
+|---|---|---|
+| 4.1.a | 24-hour pre-launch freeze on `main` declared | ⬜ |
+| 4.1.b | Phase 1.3 quality matrix re-run on the exact commit to be tagged | ⬜ |
+
+### 4.2 Release execution (in order)
+
+| # | Task | Status |
+|---|---|---|
+| 4.2.a | Merge final `chore: release` PR | ⬜ |
+| 4.2.b | Confirm release workflow published `@pax8/cli` to npm with provenance | ⬜ |
+| 4.2.c | Confirm release workflow published `@pax8/core` to npm with provenance | ⬜ |
+| 4.2.d | `npm view @pax8/cli` and `npm view @pax8/core` show version + provenance | ⬜ |
+| 4.2.e | Tag release on GitHub with partner-facing summary | ⬜ |
+| 4.2.f | Flip repo visibility / push to public repo | ⬜ |
+| 4.2.g | Smoke `npm install -g @pax8/cli` on fresh macOS, Linux, Windows | ⬜ |
+
+### 4.3 Rollback plan (rehearsed before launch, not after)
+
+| # | Task | Status |
+|---|---|---|
+| 4.3.a | Document `npm deprecate` path | ⬜ |
+| 4.3.b | Document repo re-private procedure | ⬜ |
+| 4.3.c | Document secret-leak response (rotate first, history rewrite is last resort) | ⬜ |
+
+---
+
+## Phase 5 — Launch communications
+
+### 5.1 Day-of artifacts
+
+| # | Task | Status |
+|---|---|---|
+| 5.1.a | GitHub release notes (partner-facing top + full CHANGELOG link) | ⬜ |
+| 5.1.b | README hero — pre-release banner removed, "Get started in 60s" callout | ⬜ |
+| 5.1.c | Internal Slack announce post | ⬜ |
+| 5.1.d | External announce (scope per Phase 0.8) | ⬜ |
+| 5.1.e | DevRel coordination — `devx.pax8.com` updates timed with launch | ⬜ |
+| 5.1.f | Partner-portal mention (if appropriate) | ⬜ |
+
+### 5.2 Onboarding the first 100 users
+
+| # | Task | Status |
+|---|---|---|
+| 5.2.a | Pin a "What this is / how to install / where to file bugs" Discussion | ⬜ |
+| 5.2.b | Maintainer triage rotation for first 2 weeks | ⬜ |
+
+---
+
+## Phase 6 — Post-launch operations (first 2 weeks)
+
+### 6.1 Triage cadence
+
+| # | Task | Status |
+|---|---|---|
+| 6.1.a | Daily issue/PR/Discussions check (first 7 days) | ⬜ |
+| 6.1.b | Confirm `api-watch` workflow routing pages someone post-launch | ⬜ |
+| 6.1.c | PostHog telemetry shows `command_executed` events flowing | ⬜ |
+| 6.1.d | Internal dashboard for engagement metrics | ⬜ |
+
+### 6.2 First patch release
+
+| # | Task | Status |
+|---|---|---|
+| 6.2.a | Plan a 0.3.x+1 patch release within 7-14 days of launch | ⬜ |
+
+### 6.3 Roadmap visibility
+
+| # | Task | Status |
+|---|---|---|
+| 6.3.a | Open-source the `enhancement`-labelled v0.2 / awaiting-pax8-api issues | ⬜ |
+| 6.3.b | File a "Roadmap" Discussion post | ⬜ |
+
+---
+
+## Cross-cutting risk register
+
+| Risk | Severity | Mitigation | Status |
+|---|---|---|---|
+| Internal references leak through to public repo | High | Phase 1.4.e scrub | ⬜ |
+| First-install path broken on Windows | Medium | Phase 1.3 includes Windows | ⬜ |
+| Real production tenants hit edge cases the demo fixture never exercised | Medium | `PAX8_DEMO_SCALE=large` + `api-watch` + oncall capacity | ⬜ |
+| `@pax8` npm scope squatted before launch | High | Claim scope before any public mention | ⬜ |
+| First-impression confusion: CLI vs. agent/MCP framing | Low | README ordering preserved through any marketing rewrite | ⬜ |
+| Telemetry FUD ("they're tracking me") | Low | Opt-in by default; documented prominently | ⬜ |
+
+---
+
+## Working notes (append-only)
+
+- 2026-05-29: Plan drafted in chat. Repo state captured: private at `pax8labs/pax8-cli`, never published to npm, internal version 0.3.0, 9 unreleased changesets, 6 open dependabot PRs, 1 open external issue (#233).
+- 2026-05-30: Checklist file created. Security review of post-#514 changes in progress.


### PR DESCRIPTION
## Summary

Five doc surfaces refreshed for the public OSS launch. No code changes; no behavior changes.

- **`README.md`** — restructured Quick Start into explicit Install / Run / Authenticate steps with three documented invocation paths; de-duplicated the pre-release banner (was repeated three times); expanded the Commands section to surface every command group (contacts, quotes, webhooks, usage, config, report, init, completions, version, report-bug, telemetry — they all exist but only the prominent ones were documented); fixed the v0.2 reporting paragraph (the replacement for `pax8 report mrr/growth` already shipped as `pax8 report renewals|concentration|subscriptions`); rebuilt the REPL Mode section to show the welcome banner and document `back` / `n` / `p` shortcuts; refreshed the Documentation section's pointers.
- **`SUPPORT.md`** — added `pax8 version` and `PAX8_DEMO=1` reproduction tips to "Try first".
- **`CHANGELOG.md`** — converted the root file into a pointer to the changesets-managed per-package CHANGELOGs. The lagging "Unreleased" section that was behind 0.2.x / 0.3.0 is gone; the v0.1.0 release entry stays for archaeology.
- **`docs/BUILD.md` → `docs/history/BUILD.md`** — moved the autonomous-build prompt out of the user-facing docs path and added a "Historical document" banner. Updated the two references in `CLAUDE.md`.
- **`docs/release/CHECKLIST.md`** (new) — working doc for the public OSS launch, structured by phase (decisions, code/test gates, infra, release mechanics, comms, post-launch ops).

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test -- e2e/ux-smoke.test.ts` passes (61 README-snippet smoke tests, which are the main thing this PR could regress — every fenced `pax8 ...` snippet in README must exit 0 against `PAX8_DEMO=1`)
- [x] Full suite: 2167 passing, 2 pre-existing failures unrelated to this PR (the `loader.test.ts` regression that PR #567 fixes)

## Sequencing

Branched from `main` at `ccc5a86`. Inherits the same `loader.test.ts` CI failure as PRs #564 / #565 / #566 — that failure is fixed by PR #567, which should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)