### PR TITLE
chore(release): reset pre-release version to 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
 
       # Publish gate (see #370): we intentionally do NOT pass a `publish:`
       # command here, so this action only opens/updates the "chore: release"
-      # PR and never invokes `npm publish`. Versions have been auto-bumped
-      # past anything we've shipped (CHANGELOG headings for 0.2.0/0.3.0 exist
-      # but the registry has nothing), and we want a deliberate human signal
-      # before the first real publish.
+      # PR and never invokes `npm publish`. Nothing has been published to the
+      # registry yet, and we want a deliberate human signal before the first
+      # real publish. Per-package versions are held at 0.1.0 through the
+      # pre-release window.
       #
       # When the team is ready to ship the first release, restore the
       # `publish: pnpm changeset publish` input below and merge — the next

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,13 @@
 # @pax8/cli
 
-## 0.4.0
+<!--
+  Pre-release window: all entries below accumulate under 0.1.0 until the first
+  public release (publish gate: #370). The phantom 0.2.0 / 0.3.0 / 0.4.0
+  version headings written by `changeset version` PRs have been collapsed.
+  Substance preserved; only the section headings were removed.
+-->
+
+## Unreleased
 
 ### Minor Changes
 
@@ -114,8 +121,6 @@
 - Updated dependencies [[`c56eb06`](https://github.com/pax8labs/pax8-cli/commit/c56eb060d996c3ac248487ad3ab3ad22d5127315), [`9842846`](https://github.com/pax8labs/pax8-cli/commit/98428464403624b833a2af8b63d62ed1137e97e2), [`2f3b657`](https://github.com/pax8labs/pax8-cli/commit/2f3b6571842cc3080351bbfd3d24d62d131b6848)]:
   - @pax8/core@0.4.0
 
-## 0.3.0
-
 ### Minor Changes
 
 - [#543](https://github.com/pax8labs/pax8-cli/pull/543) [`e7ef4a7`](https://github.com/pax8labs/pax8-cli/commit/e7ef4a72a15ec7e491e4c948ae571a0340ffc8df) Thanks [@jidulberger](https://github.com/jidulberger)! - **Breaking** (`--json` shape across every list command, pre-publish): every `--json` list command now emits a wrapped envelope `{ <resource>: [...], page: { number, size, totalElements, totalPages } }` instead of a flat array. Per [#370](https://github.com/pax8labs/pax8-cli/issues/370) the package isn't published yet, so no deprecation cycle is owed; consumers switch `JSON.parse(out)` → `JSON.parse(out).<resource>`. Closes [#483](https://github.com/pax8labs/pax8-cli/issues/483).
@@ -190,8 +195,6 @@
 
 - Updated dependencies [[`e7ef4a7`](https://github.com/pax8labs/pax8-cli/commit/e7ef4a72a15ec7e491e4c948ae571a0340ffc8df), [`74cd0e4`](https://github.com/pax8labs/pax8-cli/commit/74cd0e44120aebe49baa0f154cffb6d039840b38)]:
   - @pax8/core@0.3.0
-
-## 0.2.0
 
 ### Minor Changes
 
@@ -445,8 +448,6 @@
 - Updated dependencies [[`830774a`](https://github.com/pax8labs/pax8-cli/commit/830774a8845058541f6cc01afc16dc147694cdbe), [`3796bf9`](https://github.com/pax8labs/pax8-cli/commit/3796bf9f1028bef64bf6cc6fcb24042466644740), [`2788c73`](https://github.com/pax8labs/pax8-cli/commit/2788c73c6fcd83aba6f1d9aa32fb25e2e374f963), [`788c83a`](https://github.com/pax8labs/pax8-cli/commit/788c83a01906095882bc53110ee8df285eb9da20), [`bcd6fec`](https://github.com/pax8labs/pax8-cli/commit/bcd6fecc81ff470124382bae3bddd82afb27cb32), [`d20b113`](https://github.com/pax8labs/pax8-cli/commit/d20b1137ec74e81c9745f5f8f76484086a2f44e8), [`93a7405`](https://github.com/pax8labs/pax8-cli/commit/93a7405e34556d62ef89dcfe1c2b13c693d5de95), [`45fe0d1`](https://github.com/pax8labs/pax8-cli/commit/45fe0d1db00d678c73b709a6137f2e64d69038f6), [`5617161`](https://github.com/pax8labs/pax8-cli/commit/561716145e254eaf91d75c00c8b6e371c8856c22), [`75591cb`](https://github.com/pax8labs/pax8-cli/commit/75591cb57b4b8cda6ada2cddde179c53890719e6), [`d71a0f2`](https://github.com/pax8labs/pax8-cli/commit/d71a0f2e600332167587a2fffbf4198a32fa9e8b), [`d88ce13`](https://github.com/pax8labs/pax8-cli/commit/d88ce13c6a0b2166f70c3d87b2320376286d0c06), [`32cb6c8`](https://github.com/pax8labs/pax8-cli/commit/32cb6c82f920358660a027d52151a5a0656f9339), [`99ff0a2`](https://github.com/pax8labs/pax8-cli/commit/99ff0a2a78b63998ca05c8fded9b41b885bdb0d3), [`224f16a`](https://github.com/pax8labs/pax8-cli/commit/224f16a6030b8d89bfe67d1ba989b49d0fae8130), [`8590150`](https://github.com/pax8labs/pax8-cli/commit/8590150a98e9779e1b17d9fc4dd0f0c9b587b1f2)]:
   - @pax8/core@0.2.0
 
-## 0.3.0
-
 ### Minor Changes
 
 - [#353](https://github.com/pax8labs/pax8-cli/pull/353) [`5faf8a3`](https://github.com/pax8labs/pax8-cli/commit/5faf8a3b91688651afd1a12097c89e28ce65a20a) Thanks [@jidulberger](https://github.com/jidulberger)! - `pax8 contacts {create,update}`: align request bodies with the public OpenAPI contract.
@@ -590,8 +591,6 @@
 
 - Updated dependencies [[`a6cea7f`](https://github.com/pax8labs/pax8-cli/commit/a6cea7fea15bbe63efa9aaf2223737057c44f6d9), [`758eb98`](https://github.com/pax8labs/pax8-cli/commit/758eb98ed058e53a8961defb7492ecf710ebb6f2), [`5faf8a3`](https://github.com/pax8labs/pax8-cli/commit/5faf8a3b91688651afd1a12097c89e28ce65a20a), [`8108ea0`](https://github.com/pax8labs/pax8-cli/commit/8108ea096d2ea82d24fc4cbb8f374952976fe9be), [`87dd835`](https://github.com/pax8labs/pax8-cli/commit/87dd8350cf2ec89232bd527d6284421cc05dcaf1), [`d3d8316`](https://github.com/pax8labs/pax8-cli/commit/d3d8316998343e11d3c0057bb44add7cbeff55e7), [`828444e`](https://github.com/pax8labs/pax8-cli/commit/828444e5669e1f05a674fafec8ea72428ff3f9a1), [`629011f`](https://github.com/pax8labs/pax8-cli/commit/629011f861cf8c052e9eaea00bc360e0b58b42e1), [`1dcf2d9`](https://github.com/pax8labs/pax8-cli/commit/1dcf2d9beb25cb78bd39b2be184111aa189225a3), [`e307132`](https://github.com/pax8labs/pax8-cli/commit/e3071321aaf0dd6a4a36bbe76882b8ccd47f28f4), [`41c13e6`](https://github.com/pax8labs/pax8-cli/commit/41c13e6677b5781236c2ba21bde56d4464d40057), [`db00533`](https://github.com/pax8labs/pax8-cli/commit/db005336a163b6028d7d75a5628d6a9f0d824278), [`18e2e1f`](https://github.com/pax8labs/pax8-cli/commit/18e2e1f3e64e110be3d470e736c60941555aa1a8), [`3b9026b`](https://github.com/pax8labs/pax8-cli/commit/3b9026ba3b56cf6b2f331b4aa5982d6631dfd6b0), [`cc7b004`](https://github.com/pax8labs/pax8-cli/commit/cc7b0046e6d87173d554c54b9e2f32e0c1b4ac5e), [`aaa56e1`](https://github.com/pax8labs/pax8-cli/commit/aaa56e12355abf8d247346b5d1f4e70ab1af3192), [`e507f77`](https://github.com/pax8labs/pax8-cli/commit/e507f7702b1b9e281534ef396d91fc61cca87ede), [`e179b35`](https://github.com/pax8labs/pax8-cli/commit/e179b35b9ea4fe0bfd5cad4339ca183e5666c6c2)]:
   - @pax8/core@0.3.0
-
-## 0.2.0
 
 ### Minor Changes
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pax8/cli",
-  "version": "0.4.0",
+  "version": "0.1.0",
   "description": "Pax8 open source CLI for MSPs to manage cloud marketplace operations",
   "type": "module",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,13 @@
 # @pax8/core
 
-## 0.4.0
+<!--
+  Pre-release window: all entries below accumulate under 0.1.0 until the first
+  public release (publish gate: #370). The phantom 0.2.0 / 0.3.0 / 0.4.0
+  version headings written by `changeset version` PRs have been collapsed.
+  Substance preserved; only the section headings were removed.
+-->
+
+## Unreleased
 
 ### Patch Changes
 
@@ -32,8 +39,6 @@
 
   Historical per-package CHANGELOGs (`packages/cli/CHANGELOG.md`, `packages/core/CHANGELOG.md`) deliberately left alone — they're append-only release-note records.
 
-## 0.3.0
-
 ### Minor Changes
 
 - [#544](https://github.com/pax8labs/pax8-cli/pull/544) [`74cd0e4`](https://github.com/pax8labs/pax8-cli/commit/74cd0e44120aebe49baa0f154cffb6d039840b38) Thanks [@jidulberger](https://github.com/jidulberger)! - `pax8 subscriptions list` now exposes the server-side `billingTerm`, `productId`, and `sort` filters the public OpenAPI has always supported. Closes [#398](https://github.com/pax8labs/pax8-cli/issues/398).
@@ -59,8 +64,6 @@
   Mock fixtures (`packages/core/src/mock/mock-client.ts`) updated to the spec shape too, so `PAX8_DEMO=1` and the real API now exercise the same code path. **Breaking** to `provisioningDetails` JSON shape (was a single object with `productId/vendorPrerequisites/fields`; now a `ProvisioningDetail[]` array) — pre-publish, no deprecation owed.
 
   Threading provision details into orders / subscriptions write paths per Fred's "safest bet is to always add provision details to each line item" guidance is tracked separately as Candidate H Option B.
-
-## 0.2.0
 
 ### Minor Changes
 
@@ -234,8 +237,6 @@
 
   Closes [#458](https://github.com/pax8labs/pax8-cli/issues/458), [#469](https://github.com/pax8labs/pax8-cli/issues/469), [#475](https://github.com/pax8labs/pax8-cli/issues/475), [#459](https://github.com/pax8labs/pax8-cli/issues/459).
 
-## 0.3.0
-
 ### Minor Changes
 
 - [#353](https://github.com/pax8labs/pax8-cli/pull/353) [`5faf8a3`](https://github.com/pax8labs/pax8-cli/commit/5faf8a3b91688651afd1a12097c89e28ce65a20a) Thanks [@jidulberger](https://github.com/jidulberger)! - `pax8 contacts {create,update}`: align request bodies with the public OpenAPI contract.
@@ -371,8 +372,6 @@
   - `--events` continues to work as a deprecated alias for `--topics`.
 
   Per-topic `filters` are accepted by the spec but not yet exposed on the CLI surface — each topic ships with an empty filter array, which the server treats as "deliver every event for this topic". A structured filter-authoring UX is tracked separately.
-
-## 0.2.0
 
 ### Minor Changes
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pax8/core",
-  "version": "0.4.0",
+  "version": "0.1.0",
   "description": "Core API client, auth, services, and types for Pax8",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Hold `@pax8/cli` and `@pax8/core` at **0.1.0** through the pre-release window. Changeset version PRs had drifted the published packages to `0.4.0` even though nothing has been published to npm yet (publish is gated per #370). Resetting now so the first real version computes from `0.1.0` at launch.

## Changes

- `packages/cli/package.json`, `packages/core/package.json` — version `0.4.0` → `0.1.0`. The cli ↔ core link in `.changeset/config.json` keeps them in lockstep.
- `packages/cli/CHANGELOG.md`, `packages/core/CHANGELOG.md` — collapse the phantom `0.2.0` / `0.3.0` / `0.4.0` section headings under a single `## Unreleased` heading. **Substance preserved** — every entry, commit SHA, and "Updated dependencies" cross-link is intact; only the version headings themselves were removed. A short HTML-comment preamble explains the collapse to future readers.
- `.github/workflows/release.yml` — the publish-gate comment named the now-deleted `0.2.0/0.3.0` headings; rewrote it to just describe the gate.

## Untouched (intentionally)

- `packages/claude-skill/package.json` — listed in `.changeset/config.json` `ignore`; already `0.1.0`.
- Root `package.json` — `private: true`, already `0.1.0`.
- `packages/cli` dep on `@pax8/core` is `workspace:*` — version-agnostic, no fix needed.
- `pnpm-lock.yaml` — no changes (workspace protocol).
- Pending changesets — none currently; the user's instruction to preserve any pending `.changeset/*.md` was a no-op for this run.

## Test plan

- [x] `pnpm build` — both packages built clean
- [x] `pnpm -r exec tsc --noEmit` — typecheck clean (no root `typecheck` script exists)
- [x] `pnpm lint` — 0 errors, 1 pre-existing warning unrelated to this change
- [x] `PAX8_DEMO=1 NO_COLOR=1 pnpm test` — **2176 passed**, 6 skipped, 6 todo (126 files)
- [x] `npm pack --dry-run` for `@pax8/cli` → `pax8-cli-0.1.0.tgz`
- [x] `npm pack --dry-run` for `@pax8/core` → `pax8-core-0.1.0.tgz`
- [x] Built CLI: `pax8 --version` prints `0.1.0`; `pax8 version` prints `pax8-cli 0.1.0`

No `changeset version` was run, no `npm publish` was invoked, no merge performed.