### PR TITLE
docs(history): archive pre-launch proposal and workflow inventory

### DIFF
--- a/docs/history/proposal.md
+++ b/docs/history/proposal.md
@@ -1,0 +1,109 @@
+# Pax8 Marketplace CLI Proposal
+
+> **Historical document.** This is the pre-launch proposal that motivated `pax8-cli`, drafted before the public repo existed. The "prototype" it describes is what shipped as v0.1.0 — for what the tool actually does today, see the [README](../../README.md). The bets, open questions, and surface-comparison framing are preserved here for project archaeology and to document the original strategic intent.
+
+---
+
+## The Opportunity
+
+There is a growing gap between what the Pax8 API provides (raw CRUD operations on subscriptions, invoices, and products) and what MSPs actually need to know (which renewals are at risk, where they're being over-billed, which customers are missing critical products, what their MRR looks like by customer). That gap is currently filled by manual portal work, spreadsheets, or nothing at all.
+
+Agents make this gap more consequential. As MSPs adopt AI assistants (Claude Code, Cursor, Copilot), those agents inherit the same limitation: the API gives them raw data, and they have to re-derive business logic every conversation. Whoever provides the computed, business-logic layer that partners and their agents call is positioned to become the default workflow surface for MSP operations. We see this an opportunity to meet users where they are.
+
+## Who This Serves
+
+Many MSP operators manage multiple customers and are time-constrained; they don't have time to log into the portal, click through each account, and mentally cross-reference renewals against invoices against subscription gaps. The prototype meets them in the terminal with the answers already computed which provides a delightful experience for someone who lives in the terminal to do their job.
+
+Those same terminal commands make AI agents faster and more reliable. An agent calling the raw API would need to reinvent all of the business logic above every conversation, burning tokens on pagination, grouping, and date math, and likely getting edge cases wrong. The prototype encodes the correct logic once and returns the answer.
+
+## The Prototype
+
+We have a working pax8 marketplace CLI that demonstrates this computed layer. Architecturally, the engine (`packages/core`) is a standalone library with zero CLI dependencies. The CLI and a Claude skill are two separate interfaces to the same logic: one for humans, one for agents. Every command supports `--json` for machine consumption.
+
+The prototype covers 7 core partner workflows — from portfolio health checks and billing reconciliation to a closed-loop recommendations → order flow that identifies gaps *and* places the order. It also computes renewals from scratch (no renewals endpoint exists in the API) and MRR/ARR analytics across the full book of business. For the full workflow mapping and coverage status, see [Key Partner Workflows](./workflows.md).
+
+Future work: integrate with forthcoming OpEx recommendations via MCP when it launches.
+
+The prototype ships with a demo mode (`PAX8_DEMO=1`) that runs against synthetic data, so anyone can evaluate it without API credentials.
+
+## Under the hood
+
+With the prototype:
+
+```
+pax8> pax8 invoices audit --json
+  ✨ Demo mode — showing sample data
+[
+  {
+    "discrepancies": [
+      {
+        "companyId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "companyName": "Summit Healthcare Partners",
+        "productName": "Microsoft 365 Business Premium [New Commerce Experience]",
+        "invoicedQuantity": 95,
+        "activeQuantity": 85,
+        "delta": 10,
+        "dollarImpact": 220,
+        "type": "overcharge"
+      },
+      ...
+    ]
+  }
+]
+```
+
+This one command returns every billing discrepancy with dollar impact — overcharges, undercharges, missing line items.
+
+The recommendations flow goes further. `pax8 recommendations list` identifies cross-sell gaps and seat mismatches with estimated MRR uplift. `pax8 recommendations act` walks through them interactively and places the order on confirmation. Most tools stop at the insight — this one closes the loop.
+
+With the raw APIs, the same question takes 13 API calls for 10 invoices (one for auth, one for invoices, one for subscriptions, and one per invoice to fetch line items - there's no bulk endpoint today). Then you still need to build a subscription index, match each line item to its subscription, compare quantities, classify deltas (overcharge, undercharge, unexpected, missing), calculate dollar impact, and sum it all up. And then test it for accuracy. That's a big lift for someone handy with curl, and it's slow and token-heavy for an agent.
+
+And when it comes to agents, the CLI is the minimum viable layer. A Claude Skill teaching an agent which commands to run and when eliminates discovery overhead entirely to enable the agent to go from "figure out the Pax8 API" to "run the audit, cross-reference with renewals, flag churn risks" in a single conversation. An MCP server adds structured input/output contracts for higher reliability at scale. The progression is: raw API (possible but expensive) → CLI (correct logic, encoded once) → Skill (correct workflow, zero discovery) → MCP server (structured contracts, lowest failure rate). Each layer reduces the cost of the next question a partner asks, though as models improve at consuming APIs directly, some of these layers may compress or become unnecessary. The durable asset is the domain knowledge: which questions to ask, what the answers mean, and what to do next — not necessarily the code that computes it or the specific interface. Timelines on when the progression above collapses are speculative at best, but it is clear that in the short to medium term the progression likely holds. And as agents move from read-only queries toward placing orders, CIBA (Client-Initiated Backchannel Authentication) provides the trust model — the partner's approval is cryptographically bound to the exact change, so the agent can't alter it after sign-off. See [Key Partner Workflows](./workflows.md) for more on the agent-initiated order flow.
+
+## The Open Source Approach
+
+Open source gets real MSPs running the prototype against real data without a sales cycle. That does two things: it validates which computed capabilities are worth investing in further, and it builds credibility with Microsoft (and other AI platform vendors) that Pax8 is serious about the developer and agent ecosystem.
+
+## Hypotheses and What to Watch For
+
+This proposal has one core bet: **a meaningful number of Pax8 partners will use a CLI tool that gives them billing, renewal, and upsell answers they can't easily get today.**
+
+If that bet pays off, the rest follows naturally — agent consumption, skills, MCP servers, and eventually first-party API endpoints are all distribution strategies on top of proven value. If it doesn't, the investment is bounded: the business logic in `packages/core` is interface-agnostic and ports directly to a portal feature, a web dashboard, an API endpoint, or any other surface.
+
+It's worth being explicit about the secondary bets and what changes if they don't land:
+
+**Bet: partners prefer CLI-based tooling.** PowerShell is the native language of the MSP world — GitHub is full of partner-authored scripts for M365 management, Azure provisioning, and security automation. We're betting that a CLI meets this audience where they already work. But if Pax8 partners turn out to be more portal-native than terminal-native, the CLI doesn't find an audience. What doesn't change: the underlying business logic is the same regardless of interface. We repackage it, not rebuild it. The CLI is the cheapest way to test the value of the computed layer — if the packaging is wrong, we learn that in weeks and redirect.
+
+**Bet: open source is the fastest path to validation.** We believe zero-friction adoption (`npm install`, run against real data, see value in minutes) gets us to signal faster than a managed service or portal feature. If nobody engages with the repo, we still have a working internal tool and the business logic ports to any distribution model.
+
+**Bet: agents will increasingly consume this type of tooling.** As agentic coding goes mainstream, the same computed layer that serves human CLI users becomes the default surface agents call. If agent adoption among MSPs is slower than expected, the CLI still serves the scripting audience. Agent adoption is upside, not a prerequisite — but it's significant upside: whoever's patterns are in the skill libraries wins the default position.
+
+## Over time: where to invest
+
+Most SaaS companies never build a CLI. The typical path is API → web app, and for good reason — the majority of users live in a browser. But the Pax8 partner audience is different. MSPs are operational people who manage infrastructure through scripts, terminals, and increasingly through AI agents. PowerShell is their native language — GitHub is full of MSP-authored repos covering M365 management, Azure provisioning, and security automation. For this audience, a CLI isn't an unusual investment. It's meeting them where they already work.
+
+The more novel argument is that a CLI is also the fastest way to learn. A web app takes months to ship and each iteration goes through design, frontend, backend, deploy. Due to its natural, forcing constraints, a CLI capability takes weeks, and usage data tells you immediately what's valuable. In a space where we're still discovering which computed capabilities partners actually need, that speed matters more than polish.
+
+The question isn't which interface to build — it's which to build first, and how each one informs the next. Usage patterns from the CLI tell you what's worth investing in next: if 80% of partners run `invoices audit`, that's a signal for where to build a skill, then an MCP server, then maybe a dashboard or a first-party endpoint. Power users will generally want the long tail of commands and composability that a terminal provides, but those features will not always be warranted for the gen-pop in a GUI. But the capabilities that cluster around broad, repeated use are strong candidates for building into a web-app. Each interface is faster and cheaper to justify when the previous one has already validated demand.
+
+| Surface | Consumer | Build cost | Maintenance | Time to first value | Value created |
+|---|---|---|---|---|---|
+| Raw API | Developers, scripts | Already exists | Pax8 owns it | — | Data, not answers. Agent reimplements business logic every session. |
+| CLI | Power users, agents | 2-4 weeks per capability | Low — ship updates, no versioning contract | Days (open source, `npm install`) | Correct answers, encoded once. Validates which capabilities matter. |
+| Claude Skill | Agents | Hours per workflow | Minimal — update when CLI changes | Minutes (drop into agent config) | Zero-discovery agent access. Encodes "what to do next," not just "what command to run." |
+| MCP server | Agents | 2-4 weeks | Medium — typed schemas are a contract | Days (install, configure) | Structured reliability. Agents call typed tools, not parse terminal output. |
+| Web app | Non-technical operators | Months | High — frontend, hosting, auth, UX | Weeks (deploy, onboard users) | Reaches non-technical operators. Only worth it for capabilities with proven, broad demand. |
+| First-party API endpoint | Everyone | Months | High — versioned, backwards-compatible | Weeks (API release cycle) | Server-side computation, universal access. Graduation ceremony for proven capabilities. |
+
+CLI-side logic is valuable in discovery mode. As capabilities stabilize and demand concentrates, the winners graduate to maintained endpoints. The CLI continues as the more composable and expressive surface for agents and power users, and as the R&D layer where the next generation of capabilities gets prototyped, including by outside open source contributors and by agents themselves, before anyone commits to an API contract.
+
+## Open Questions
+
+* Which computed capabilities are highest-signal for promotion to first-party endpoints?
+* Do we eventually invest in a hosted version (MCP server, API gateway) vs. CLI-only distribution?
+* What does adoption look like that tells us this is working? Number of MSPs, command frequency, someone building a workflow on top of it? What's the threshold that justifies further investment?
+* How do we formalize the feedback loop from CLI usage data to the product roadmap?
+
+## See also
+
+* [Pax8 Marketplace CLI — Key Partner Workflows](./workflows.md)

--- a/docs/history/workflows.md
+++ b/docs/history/workflows.md
@@ -1,0 +1,79 @@
+# Pax8 Marketplace CLI — Key Partner Workflows
+
+> **Historical document.** This is the pre-launch workflow inventory that accompanied [`proposal.md`](./proposal.md). Every "Delivered" row maps to commands that shipped in v0.1.0 — for the current command surface see [`docs/UX_GUIDE.md`](../UX_GUIDE.md) and the [README](../../README.md). The "Gaps and next priorities" table reflects roadmap thinking at the time and may have moved into GitHub issues since. Preserved here for project archaeology.
+
+---
+
+MSP operators managing a book of business through Pax8 have a handful of recurring workflows that drive their revenue: monitoring the health of their portfolio, catching billing errors, acting on growth opportunities, and staying ahead of renewals. The Pax8 API provides the raw data to support all of these, but not the answers — the gap between "here are your subscriptions" and "here's who's about to churn" is filled by manual portal work, spreadsheets, or nothing at all.
+
+What follows are those core workflows, what the prototype delivers against each one, and where the gaps remain.
+
+---
+
+## The workflows
+
+### Portfolio health check
+
+A partner managing 50+ customers needs a single-screen answer to "how's my business doing?" — MRR, upcoming renewals, growth opportunities, active trials, recent activity. Today that's a series of portal clicks across multiple pages.
+
+### Customer prioritization
+
+"Which customers need attention today?" Partners need to prioritize across their book — who has coverage gaps, who's underinvesting, where's the easiest MRR to capture. The portal shows individual customer detail but doesn't rank or compare.
+
+### Renewal management
+
+"What's renewing soon and what's at risk?" Revenue defense — catching renewals before they lapse, understanding MRR exposure, knowing which conversations to have this week. There is no renewals endpoint in the Pax8 API today. The data exists across subscriptions (`commitmentTermEndDate`), but nobody's assembling it.
+
+### Billing reconciliation
+
+"Am I being billed correctly?" Overcharges and undercharges hide in the gap between invoice line items and active subscription quantities. Finding them manually means pulling invoices, pulling subscriptions, cross-referencing one by one, and doing the math. Most partners never do this — the discrepancies just accumulate.
+
+### Growth identification
+
+"Where should I be selling?" Which customers have product gaps, where seat counts are mismatched (100 email seats but 20 backup seats?), and what the MRR opportunity looks like — without manually auditing every account.
+
+### Acting on recommendations
+
+Identifying a gap is only half the job. The partner still needs to place the order — and the context switch from "I see the opportunity" to "let me go find this product in the portal, configure it, and submit" is where momentum dies.
+
+### Revenue reporting
+
+MRR by customer, ARR projections, growth trends over time. The numbers a partner brings to a QBR or uses to track their own trajectory. Today it's export-to-Excel-and-pivot.
+
+---
+
+## Prototype coverage
+
+Every command supports `--json` for agent consumption. JSON output includes `nextActions` for tool chaining. All flows verified end-to-end in demo mode (`PAX8_DEMO=1`).
+
+| Workflow | Status | Commands | What the prototype does |
+|---|---|---|---|
+| Portfolio health check | **Delivered** | `pax8 status` | One command, one screen. `nextActions` enables agent follow-up. |
+| Customer prioritization | **Delivered** | `companies list --coverage`, `companies more` | Scores customers on category coverage (N/7), flags gaps, estimates MRR uplift per company. |
+| Renewal management | **Delivered** | `subscriptions renewals` | Computed from scratch — no API endpoint exists. Sorts by urgency, shows MRR at risk. |
+| Billing reconciliation | **Delivered** | `invoices audit` | Encodes 13+ API calls into one command. Returns each discrepancy with dollar impact. |
+| Growth identification | **Delivered** | `recommendations list` | Cross-sell gaps, seat mismatches, estimated uplift, ready-to-execute order commands. |
+| Acting on recommendations | **Delivered** | `recommendations act` | Closed-loop: reviews recs interactively, shows pricing, places the order on confirmation. |
+| Revenue reporting | **Delivered** | `report mrr`, `report growth` | MRR by company with projected ARR. Monthly trend with growth percentages. |
+
+Worth noting: the recommendations → order flow is where the prototype goes beyond analytics into closed-loop workflow. Most tools in this space stop at the insight. `recommendations act` identifies the gap, shows the partner exactly what it will cost, and places the order. That's the kind of capability that changes how a partner thinks about the tool — it's not a dashboard, it's an operating surface.
+
+---
+
+## Gaps and next priorities
+
+| Workflow | Status | Why it's next |
+|---|---|---|
+| Churn risk scoring | **Not started** | The pieces exist — renewals, billing anomalies, seat trends — but there's no unified signal. This connects "this renewal is coming up" with "this customer is showing warning signs." Highest-value extension of what's already built. |
+| Bulk operations | **Not started** | "Apply this recommendation across all companies matching X." Extends the recommendations → order flow from single-customer to portfolio scale. |
+| Export to CSV/PDF | **Not started** | Partners hand things to clients and accountants. Natural extension of reporting. |
+| Alerting / webhooks | **Not started** | "Tell me when a renewal is 30 days out." Moves renewal and billing workflows from pull to push. Bigger lift — requires a persistent process or integration point. |
+| MCP server for recommendations | **Blocked — Pax8 API** | The recommendations flow is CLI-only today because the Pax8 API doesn't expose a recommendations endpoint. Once it does, this becomes an MCP tool with typed schemas — agents call it directly rather than through the CLI. |
+
+---
+
+## Agent consumption
+
+Every workflow above works identically for a human at the terminal and an AI agent calling it programmatically — `--json`, `nextActions`, structured errors with recovery suggestions in the Claude skill. An agent conversation that would otherwise require 13+ API calls, pagination logic, and reimplemented business logic becomes: run the command, read the JSON, follow `nextActions`. And the more interesting capabilities on the roadmap — churn risk scoring, alerting — are the ones where an agent doesn't just run commands faster, it runs them *before the partner thinks to ask*.
+
+One thing we haven't built yet: agent-initiated orders. Today `recommendations act` is human-in-the-loop — the partner confirms each order interactively. That's the right starting point. The interesting next step is CIBA (Client-Initiated Backchannel Authentication) — an OAuth 2.0 flow where the agent constructs the order, pushes an approval request to the partner's device, and the partner's authorization is cryptographically bound to that exact change. The agent can't alter the order after approval, not even by a single seat. It's a stronger model than a simple `--confirm` flag because the approval is out-of-band, scoped to the exact payload, and cryptographically verifiable — not just "the agent says the user said yes." This is also a natural place to experiment with approval thresholds: orders under $X go through automatically, orders above require CIBA sign-off. For the full API → CLI → Skill → MCP progression and where this fits, see the [main proposal](./proposal.md).


### PR DESCRIPTION
## Summary

Adds the two pre-launch memos that motivated `pax8-cli` to the existing `docs/history/` archive alongside [`BUILD.md`](docs/history/BUILD.md) (the autonomous-build prompt archived in #568). Both files predate the public repo and were drafted while the project was still an internal prototype.

## Files

- **`docs/history/proposal.md`** — original strategic proposal: opportunity framing, audience, prototype description, bets / hypotheses, the API → CLI → Skill → MCP → web → first-party surface progression table, and open questions.
- **`docs/history/workflows.md`** (renamed from `command-reference.md`, which was a misnomer — the file is a workflow inventory, not a command reference) — the 7 core partner workflows, prototype coverage table mapping each to the commands that shipped in v0.1.0, gaps / next priorities, and agent-consumption + CIBA discussion.

## Cleanup applied on the way in

- Each file gets a "Historical document" admonition block at the top matching [`BUILD.md`](docs/history/BUILD.md)'s pattern — points readers at the current [README](README.md) / [`docs/UX_GUIDE.md`](docs/UX_GUIDE.md) for live information, and frames the archived content as project archaeology rather than current guidance.
- Cross-references between the two files (previously Notion-style bracket links: `[Key Partner Workflows]` and `[main proposal]`) are rewritten as relative repo paths so they resolve in any markdown viewer.
- `command-reference.md` → `workflows.md` rename (misnomer; file contains no command reference).

## Test plan

- [x] `docs/history/proposal.md` and `docs/history/workflows.md` render with working internal links
- [x] `grep -n "Key Partner Workflows\|main proposal" docs/history/*.md` — all references now end in `.md)`, no bare Notion-style bracket links remain
- [x] Docs-only PR — no code or build changes; no need to re-run the test suite