### PR TITLE
fix(cli): clarify that auth status only checks credential files on disk

### DIFF
--- a/e2e/command-inventory.ts
+++ b/e2e/command-inventory.ts
@@ -166,9 +166,12 @@ export const COMMAND_INVENTORY: CommandSpec[] = [
     type: "auth",
     demo: {
       // Under PAX8_DEMO=1 this should report demo mode somewhere in output.
-      expectedFragments: [/demo|not authenticated|authenticated/i],
+      // Field/label renamed in #573 from "authenticated" to
+      // "credentialsPresent" / "Credentials present" — the command only
+      // checks for files on disk, never hits /v1/token.
+      expectedFragments: [/demo|credentials present|no credentials stored/i],
     },
-    jsonContract: { objectRequiredFields: ["authenticated", "mode"] },
+    jsonContract: { objectRequiredFields: ["credentialsPresent", "mode"] },
   },
   // ── config ────────────────────────────────────────────────────────────────
   {

--- a/e2e/onboarding.test.ts
+++ b/e2e/onboarding.test.ts
@@ -32,9 +32,11 @@ describe("E2E: Onboarding — first-time user experience", () => {
   it("pax8 auth status shows auth info", async () => {
     // Subprocess stdout is non-TTY, so the agent-first contract auto-emits
     // JSON (#210). We assert on the structured shape rather than human copy.
+    // Field renamed from `authenticated` to `credentialsPresent` in #573 —
+    // `auth status` only checks files on disk, never hits /v1/token.
     const result = await runCliExpectSuccess(["auth", "status"]);
     const parsed = JSON.parse(result.stdout);
-    expect(parsed.authenticated).toBe(true);
+    expect(parsed.credentialsPresent).toBe(true);
     expect(parsed.mode).toBe("demo");
   });
 

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -156,17 +156,20 @@ describe("pax8 auth", () => {
     // Subprocess stdout is non-TTY, so per the agent-first contract (#210)
     // `auth status` auto-emits JSON. We assert on the structured shape and
     // separately verify the human path via the explicit format helpers.
+    // Field renamed from `authenticated` to `credentialsPresent` in #573 —
+    // the previous name implied an API-backed validity check the command
+    // doesn't actually perform.
     it("emits JSON in non-TTY (agent-first default)", async () => {
       const result = await runCliExpectSuccess(["auth", "status"]);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.authenticated).toBe(true);
+      expect(parsed.credentialsPresent).toBe(true);
       expect(parsed.mode).toBe("demo");
     });
 
     it("emits JSON when --json is passed explicitly", async () => {
       const result = await runCliExpectSuccess(["auth", "status", "--json"]);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed).toEqual({ authenticated: true, mode: "demo" });
+      expect(parsed).toEqual({ credentialsPresent: true, mode: "demo" });
     });
   });
 

--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -70,12 +70,12 @@ describe("auth status", () => {
     return stdoutWrite.mock.calls.map((c) => String(c[0])).join("");
   }
 
-  it("emits JSON with authenticated:true and mode:demo under --json + PAX8_DEMO=1", async () => {
+  it("emits JSON with credentialsPresent:true and mode:demo under --json + PAX8_DEMO=1", async () => {
     process.env.PAX8_DEMO = "1";
     await makeProgram().parseAsync(["node", "pax8", "auth", "status", "--json"]);
     const out = captured().trim();
     const parsed = JSON.parse(out);
-    expect(parsed).toEqual({ authenticated: true, mode: "demo" });
+    expect(parsed).toEqual({ credentialsPresent: true, mode: "demo" });
   });
 
   it("emits human-formatted text in TTY mode without --json (demo)", async () => {
@@ -84,7 +84,7 @@ describe("auth status", () => {
     const out = captured();
     // Human output uses the checkmark + "demo mode" copy; no JSON braces.
     expect(out).toContain("demo mode");
-    expect(out).not.toContain('"authenticated"');
+    expect(out).not.toContain('"credentialsPresent"');
   });
 
   it("auto-emits JSON when stdout is non-TTY (agent-first contract)", async () => {
@@ -96,11 +96,11 @@ describe("auth status", () => {
     await makeProgram().parseAsync(["node", "pax8", "auth", "status"]);
     const out = captured().trim();
     const parsed = JSON.parse(out);
-    expect(parsed.authenticated).toBe(true);
+    expect(parsed.credentialsPresent).toBe(true);
     expect(parsed.mode).toBe("demo");
   });
 
-  it("emits authenticated:true mode:live when creds are present (--json)", async () => {
+  it("emits credentialsPresent:true mode:live when creds are present (--json)", async () => {
     delete process.env.PAX8_DEMO;
     getCredentialsMock.mockResolvedValue({
       clientId: "abcdefghij1234567890",
@@ -109,19 +109,34 @@ describe("auth status", () => {
     await makeProgram().parseAsync(["node", "pax8", "auth", "status", "--json"]);
     const out = captured().trim();
     const parsed = JSON.parse(out);
-    expect(parsed.authenticated).toBe(true);
+    expect(parsed.credentialsPresent).toBe(true);
     expect(parsed.mode).toBe("live");
     // Mask should be present and must NOT include the full secret.
     expect(parsed.clientIdMasked).toBeDefined();
     expect(out).not.toContain("secret-value");
   });
 
-  it("emits authenticated:false mode:live when no creds are stored (--json)", async () => {
+  it("emits credentialsPresent:false mode:live when no creds are stored (--json)", async () => {
     delete process.env.PAX8_DEMO;
     getCredentialsMock.mockResolvedValue(null);
     await makeProgram().parseAsync(["node", "pax8", "auth", "status", "--json"]);
     const out = captured().trim();
     const parsed = JSON.parse(out);
-    expect(parsed).toEqual({ authenticated: false, mode: "live" });
+    expect(parsed).toEqual({ credentialsPresent: false, mode: "live" });
+  });
+
+  // #573: `auth status` only checks files on disk. The TTY human output for
+  // the credentials-present branch must point the user at `pax8 doctor` for
+  // an actual API-backed verification, so a user with rotated/revoked creds
+  // doesn't take "credentials present" as a green light.
+  it("hints at pax8 doctor when credentials are present (live, TTY)", async () => {
+    delete process.env.PAX8_DEMO;
+    getCredentialsMock.mockResolvedValue({
+      clientId: "abcdefghij1234567890",
+      clientSecret: "secret-value",
+    });
+    await makeProgram().parseAsync(["node", "pax8", "auth", "status"]);
+    const out = captured();
+    expect(out).toContain("pax8 doctor");
   });
 });

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -7,20 +7,30 @@ import { CredentialStore } from "@pax8/core";
 import { replCmd } from "../../lib/confirm.js";
 import { getOutputFormat } from "../../lib/context.js";
 
+// `auth status` reports whether credentials are present on disk — it does NOT
+// hit the API. A user with rotated or revoked credentials would see
+// `credentialsPresent: true` here until the next real call to `/token` fails.
+// For an actual authentication check, run `pax8 doctor`, which mints a token
+// against the Pax8 API. The field name is deliberately literal so the JSON
+// shape can't mislead an agent or script consumer (#573).
 interface AuthStatusJson {
-  authenticated: boolean;
+  credentialsPresent: boolean;
   mode: "demo" | "live";
   clientIdMasked?: string;
 }
 
 export const authStatusCommand = new Command("status")
-  .description("Show current authentication status")
+  .description("Check whether credentials are stored locally (does not validate against the API; run `pax8 doctor` for that)")
   .addHelpText(
     "after",
     `
 Examples:
   pax8 auth status
-  pax8 auth status --json`
+  pax8 auth status --json
+
+Notes:
+  This command only checks for credentials on disk. To verify they actually
+  authenticate against the Pax8 API, run \`pax8 doctor\`.`
   )
   .action(async (_options, command: Command) => {
     const allOpts = command.optsWithGlobals();
@@ -30,7 +40,7 @@ Examples:
     if (isDemo) {
       if (format === "json") {
         const payload: AuthStatusJson = {
-          authenticated: true,
+          credentialsPresent: true,
           mode: "demo",
         };
         process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
@@ -39,7 +49,7 @@ Examples:
 
       process.stdout.write("\n");
       process.stdout.write(
-        chalk.green("  ✓ Authenticated (demo mode)\n")
+        chalk.green("  ✓ Credentials present (demo mode)\n")
       );
       process.stdout.write(chalk.dim("  Mode: Demo\n"));
       process.stdout.write(
@@ -54,7 +64,7 @@ Examples:
 
     if (format === "json") {
       const payload: AuthStatusJson = {
-        authenticated: !!creds,
+        credentialsPresent: !!creds,
         mode: "live",
       };
       if (creds) {
@@ -75,13 +85,18 @@ Examples:
           ? creds.clientId.slice(0, 4) + "…" + creds.clientId.slice(-4)
           : "****";
 
-      process.stdout.write(chalk.green("  ✓ Authenticated\n"));
+      process.stdout.write(chalk.green("  ✓ Credentials present\n"));
       process.stdout.write(chalk.dim(`  Client ID: ${masked}\n`));
       process.stdout.write(
         chalk.dim("  Secret: ••••••••\n")
       );
+      process.stdout.write(
+        chalk.dim(
+          `\n  This only checks files on disk. Run ${replCmd("pax8 doctor")} to verify against the API.\n`
+        )
+      );
     } else {
-      process.stdout.write(chalk.red("  ✗ Not authenticated\n"));
+      process.stdout.write(chalk.red("  ✗ No credentials stored\n"));
       process.stdout.write(
         chalk.dim(
           `\n  Run: ${replCmd("pax8 auth login")} --client-id <id> --client-secret <secret>\n`


### PR DESCRIPTION
## Summary

`pax8 auth status` was reporting `authenticated: true` (and printing `✓ Authenticated`) based purely on whether credential files exist on disk — it never actually hits `/v1/token`. A user with rotated/revoked credentials saw the green checkmark until their next real API call failed.

## Changes

- **JSON shape:** field renamed `authenticated` → `credentialsPresent`. Literal about what the check actually does; an agent or script consumer can't misread it as an API-backed validity claim. Breaking shape change for `--json` callers — pre-publish per #370 so no deprecation owed.
- **Human output:** label renamed `✓ Authenticated` → `✓ Credentials present`. In the live-with-creds branch, a one-line dim hint now points at `pax8 doctor` (which does mint a token, per `doctor.ts:115` + the MCP token check at lines 247-281).
- **Command description + `--help` Notes block** updated to spell out the same distinction.
- **Tests** in `auth.test.ts` and `status.test.ts` updated to assert on `credentialsPresent`. New test pins the `pax8 doctor` hint so the redirect can't silently regress.

## Deliberately untouched

- `auth login`'s `status: "authenticated"` JSON envelope (#471) — that's a completion signal from a different command, not a credential-validity check.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test packages/cli/src/commands/auth/status.test.ts packages/cli/src/__tests__/auth.test.ts packages/cli/src/__tests__/json-contract.test.ts` — 32/32 pass
- [x] Targeted tests for the affected files pass in isolation
- [ ] Full CI suite — let CI run it (local machine hit a disk-space wall during the full run; the 2 reported failures both pass in isolation, suggesting environment, but CI is the source of truth)

Closes #573.