### PR TITLE
docs(security): route vulnerability disclosure through Pax8's VDP webform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ The release workflow publishes via [npm OIDC trusted publishing](https://docs.np
 
 ## Security Reports
 
-Do **not** open a GitHub Issue for security vulnerabilities. Report them via the process in [SECURITY.md](SECURITY.md) (email to `security@pax8.com`).
+Do **not** open a GitHub Issue for security vulnerabilities. Report them via the process in [SECURITY.md](SECURITY.md) (Pax8's Vulnerability Disclosure Program webform).
 
 ### Static analysis (CodeQL)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,18 +8,20 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in pax8-cli, please report it responsibly.
+If you discover a security vulnerability in pax8-cli, please report it responsibly through Pax8's Vulnerability Disclosure Program:
+
+**<https://www.pax8.com/en-us/about/vulnerability-disclosure-program/>**
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email **security@pax8.com** with:
+When submitting, please include:
 
 - A description of the vulnerability
 - Steps to reproduce
 - Potential impact
 - Suggested fix (if any)
 
-You should receive a response within 48 hours. We will work with you to understand the issue and coordinate a fix before any public disclosure.
+We will work with you to understand the issue and coordinate a fix before any public disclosure.
 
 ## Scope
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -24,7 +24,7 @@ This redacts UUIDs, emails, paths, and tokens before opening the issue draft.
 
 ## Security issues
 
-Don't file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the disclosure path (security@pax8.com, 48-hour acknowledgment).
+Don't file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the disclosure path (Pax8's Vulnerability Disclosure Program webform).
 
 ## Questions, ideas, troubleshooting
 


### PR DESCRIPTION
## Summary

Replaces the `security@pax8.com` email path with Pax8's Vulnerability Disclosure Program webform as the canonical vulnerability-reporting channel for `pax8-cli`:

<https://www.pax8.com/en-us/about/vulnerability-disclosure-program/>

Now that the repo is going public, the VDP is the right intake — same channel Pax8 documents publicly for the marketplace API, defined triage process, routes reports through a single workflow instead of an email inbox.

## Changes

- **`SECURITY.md`** — "Reporting a Vulnerability" section rewritten. Webform is the sole intake. The 48-hour-acknowledgment SLA promise is removed (the VDP defines its own response timeline; a SECURITY.md in this repo shouldn't pre-commit to a number the upstream process doesn't control).
- **`SUPPORT.md`**, **`CONTRIBUTING.md`** — in-prose mentions of the email address are rewritten to reference the VDP via SECURITY.md as single source of truth, so future changes to the disclosure path only need one edit here.

## Test plan

- [x] No remaining `security@pax8.com` references in tracked files (verified via `grep -rn`)
- [x] Both in-prose references in SUPPORT.md and CONTRIBUTING.md now point at SECURITY.md, not at the email directly — single source of truth
- [x] Docs-only PR; no code or build changes