### PR TITLE
chore(ci): guard claude-code-review against fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,18 @@
 name: Claude Code Review
 
+# Trigger model (defense-in-depth for fork PRs):
+#
+# We use `on: pull_request` (not `on: pull_request_target`). GitHub denies
+# secret exposure to workflows triggered by `pull_request` from forks by
+# default — `ANTHROPIC_API_KEY` is unavailable on fork PRs, so the workflow
+# already no-ops there even without a guard.
+#
+# The job-level `if` below is belt-and-suspenders: it skips cleanly on
+# fork PRs so the failure mode is "no review posted" rather than
+# "workflow ran, missing secret, errored out." It also makes the intent
+# explicit so a future contributor doesn't switch to
+# `pull_request_target` (which DOES expose secrets to fork PRs) without
+# thinking about the implications. See #572.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -10,7 +23,9 @@ concurrency:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Summary

Defense-in-depth around the `claude-code-review.yml` trigger model. Addresses the workflow-guard half of #572.

## Background

`claude-code-review.yml` already uses `on: pull_request` (not `pull_request_target`), so GitHub denies secret exposure to fork-PR runs by default — `ANTHROPIC_API_KEY` is unavailable on a fork PR and the action would fail cleanly without a posted review.

But "fails cleanly" depends on that trigger choice staying correct forever. A future contributor switching to `pull_request_target` without thinking through the secret-exposure implications would quietly turn the protection into a vulnerability — an arbitrary fork could then run code with our secrets in scope.

## Changes

- **Job-level `if` guard:** `github.event.pull_request.head.repo.full_name == github.repository` ANDed with the existing draft guard. Fork PRs now skip cleanly with no run rather than running and erroring on the missing secret.
- **Trigger-model comment block** at the top of the workflow file explaining the relationship between `pull_request`, `pull_request_target`, and the fork-secrets contract — so the next reviewer doesn't have to re-derive the reasoning.

## Test plan

- [x] No code or build changes; YAML-only edit
- [x] Existing draft-PR behavior preserved (still ANDed with the new repo-match condition)
- [ ] CI confirms the workflow parses and the `if` evaluates true on this same-repo PR (will run automatically)

Partially closes #572 (workflow-guard half). The branch-protection half (rules on `main`) is being applied separately via repo settings.