### PR TITLE
fix(invoices): emit `audit --json` as a plain object, not a single-element array

### DIFF
--- a/e2e/billing-workflow.test.ts
+++ b/e2e/billing-workflow.test.ts
@@ -41,9 +41,7 @@ describe("E2E: Billing workflow — invoice and audit", () => {
 
   it("pax8 invoices audit --json produces valid JSON with discrepancies array", async () => {
     const result = await runCliExpectSuccess(["invoices", "audit", "--json"]);
-    const raw = JSON.parse(result.stdout);
-    // output() wraps in array; unwrap if needed
-    const data = Array.isArray(raw) ? raw[0] : raw;
+    const data = JSON.parse(result.stdout);
     expect(data).toHaveProperty("discrepancies");
     expect(Array.isArray(data.discrepancies)).toBe(true);
     expect(data).toHaveProperty("totalOvercharge");

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -198,12 +198,12 @@ describe("pax8 invoices", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      expect(data[0]).toHaveProperty("discrepancies");
-      expect(data[0]).toHaveProperty("totalOvercharge");
-      expect(data[0]).toHaveProperty("totalUndercharge");
-      expect(data[0]).toHaveProperty("netImpact");
-      expect(data[0]).toHaveProperty("itemsAudited");
-      expect(data[0].discrepancies.length).toBeGreaterThan(0);
+      expect(data).toHaveProperty("discrepancies");
+      expect(data).toHaveProperty("totalOvercharge");
+      expect(data).toHaveProperty("totalUndercharge");
+      expect(data).toHaveProperty("netImpact");
+      expect(data).toHaveProperty("itemsAudited");
+      expect(data.discrepancies.length).toBeGreaterThan(0);
     });
 
     it("each discrepancy has required fields", async () => {
@@ -213,7 +213,7 @@ describe("pax8 invoices", () => {
         "--json",
       ]);
       const data = JSON.parse(result.stdout);
-      const disc = data[0].discrepancies[0];
+      const disc = data.discrepancies[0];
       expect(disc).toHaveProperty("companyName");
       expect(disc).toHaveProperty("productName");
       expect(disc).toHaveProperty("invoicedQuantity");

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -34,9 +34,9 @@ the same as Pax8's internal vendor reconciliation, which compares
 vendor-billed amounts against Pax8's records (vendor-side).
 
 JSON output (--json):
-  Returns a single-element array (legacy shape) wrapping the audit report:
+  Returns the audit report as a plain object:
 
-  [{
+  {
     "discrepancies": [{
       "companyId": string,
       "companyName": string,
@@ -51,8 +51,9 @@ JSON output (--json):
     "totalOvercharge": number,
     "totalUndercharge": number,
     "netImpact": number,
+    "itemsAudited": number,
     "nextActions": [{ "command": string, "description": string }]
-  }]`
+  }`
   )
   .action(async (options, command) => {
     const globalOpts = command.optsWithGlobals();
@@ -94,7 +95,13 @@ JSON output (--json):
       // If no invoices/items, short circuit
       if (allItems.length === 0) {
         if (ctx.outputFormat === "json") {
-          output([{ discrepancies: [], totalOvercharge: 0, totalUndercharge: 0, netImpact: 0 }], { format: "json" });
+          process.stdout.write(
+            JSON.stringify(
+              { discrepancies: [], totalOvercharge: 0, totalUndercharge: 0, netImpact: 0, itemsAudited: 0 },
+              null,
+              2,
+            ) + "\n",
+          );
         } else if (ctx.outputFormat !== "quiet") {
           const monthLabel = options.month ? formatMonthLabel(options.month) : "current";
           process.stdout.write(`\n  ${chalk.green("✓")} No invoices found for ${monthLabel} period.\n\n`);
@@ -141,9 +148,12 @@ JSON output (--json):
             command: `pax8 invoices dispute --discrepancy ${d.discrepancyId}${options.month ? ` --month ${options.month}` : ""}`,
             description: `File a dispute for ${d.companyName} — ${d.productName} (${d.type}, Δ${d.delta > 0 ? "+" : ""}${d.delta})`,
           }));
-        output(
-          [{ ...report, discrepancies: stampedDiscrepancies, nextActions }],
-          { format: "json" },
+        process.stdout.write(
+          JSON.stringify(
+            { ...report, discrepancies: stampedDiscrepancies, nextActions },
+            null,
+            2,
+          ) + "\n",
         );
         return;
       }

--- a/packages/cli/src/commands/invoices/dispute.test.ts
+++ b/packages/cli/src/commands/invoices/dispute.test.ts
@@ -24,8 +24,7 @@ describe("invoices dispute (closed-loop counterpart to audit)", () => {
   it("happy path: files a dispute draft from a discrepancy ID in demo mode", async () => {
     // First run audit to grab a real discrepancy ID
     const auditResult = await runCliExpectSuccess(["invoices", "audit", "--json"]);
-    const audit = JSON.parse(auditResult.stdout);
-    const report = Array.isArray(audit) ? audit[0] : audit;
+    const report = JSON.parse(auditResult.stdout);
     expect(report.discrepancies.length).toBeGreaterThan(0);
     const discId = report.discrepancies[0].discrepancyId;
     expect(discId).toMatch(/^disc-[a-f0-9]{12}$/);
@@ -57,7 +56,7 @@ describe("invoices dispute (closed-loop counterpart to audit)", () => {
     // skipped (the test runner's 15s timeout would catch a regression).
     const auditResult = await runCliExpectSuccess(["invoices", "audit", "--json"]);
     const report = JSON.parse(auditResult.stdout);
-    const discId = (Array.isArray(report) ? report[0] : report).discrepancies[0].discrepancyId;
+    const discId = report.discrepancies[0].discrepancyId;
 
     const result = await runCliExpectSuccess(
       ["invoices", "dispute", "--discrepancy", discId, "--yes", "--json"],
@@ -71,7 +70,7 @@ describe("invoices dispute (closed-loop counterpart to audit)", () => {
   it("--idempotency-key replays a prior dispute byte-for-byte", async () => {
     const auditResult = await runCliExpectSuccess(["invoices", "audit", "--json"]);
     const report = JSON.parse(auditResult.stdout);
-    const discId = (Array.isArray(report) ? report[0] : report).discrepancies[0].discrepancyId;
+    const discId = report.discrepancies[0].discrepancyId;
 
     const key = "dispute-idem-1234-4abc-8def-0123456789ab";
 
@@ -132,8 +131,7 @@ describe("invoices dispute (closed-loop counterpart to audit)", () => {
 
   it("audit --json surfaces the dispute command in nextActions", async () => {
     const result = await runCliExpectSuccess(["invoices", "audit", "--json"]);
-    const audit = JSON.parse(result.stdout);
-    const report = Array.isArray(audit) ? audit[0] : audit;
+    const report = JSON.parse(result.stdout);
     expect(report.nextActions).toBeDefined();
     for (const action of report.nextActions) {
       expect(action.command).toMatch(/^pax8 invoices dispute --discrepancy disc-[a-f0-9]{12}/);


### PR DESCRIPTION
## Summary

`pax8 invoices audit --json` returned `[{...}]` — a JSON array of one element wrapping the audit summary — a relic of routing the response through `output([...], { format: "json" })`, which is designed for list-shape data. The in-help "JSON output" block documented this as `(legacy shape)` and every downstream consumer test had already shaped its parsing as `Array.isArray(x) ? x[0] : x` in anticipation of the unwrap.

This switches the success path and the empty-state short-circuit to write the summary as a plain object via `process.stdout.write(JSON.stringify(...))` — matching the pattern `pax8 dashboard --json` already uses for its single-object response. Drops the now-vestigial unwrap from the consumer tests.

### Before

```json
[
  {
    "discrepancies": [...],
    "totalOvercharge": 385,
    ...
  }
]
```

### After

```json
{
  "discrepancies": [...],
  "totalOvercharge": 385,
  ...
}
```

The empty-state branch (`allItems.length === 0`) now also includes `itemsAudited: 0` so its key set matches the populated path.

Surfaced during the pre-release e2e walkthrough of the golden-path command table from `CLAUDE.md`.

## Test plan

- [x] `pnpm test packages/cli/src/commands/invoices/dispute.test.ts e2e/billing-workflow.test.ts packages/cli/src/__tests__/invoices.test.ts` — 31/31 pass
- [x] `pnpm test` full suite — 2177 passing, 6 skipped, 6 todo (matches pre-change baseline)
- [x] `PAX8_DEMO=1 pax8 invoices audit --json | jq type` → `"object"`
- [x] `PAX8_DEMO=1 pax8 invoices audit --month 2030-01 --json` (empty-state) → plain object with `itemsAudited: 0`