### PR TITLE
chore(release): open publish gate for 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,16 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # Publish gate (see #370): we intentionally do NOT pass a `publish:`
-      # command here, so this action only opens/updates the "chore: release"
-      # PR and never invokes `npm publish`. Nothing has been published to the
-      # registry yet, and we want a deliberate human signal before the first
-      # real publish. Per-package versions are held at 0.1.0 through the
-      # pre-release window.
-      #
-      # When the team is ready to ship the first release, restore the
-      # `publish: pnpm changeset publish` input below and merge — the next
-      # push to main will publish whatever the open "chore: release" PR has
-      # already version-bumped to.
-      - name: Create release PR (publish gated — see #370)
+      # Publish gate opened 2026-06-04 (closes #370). Pushing to main now
+      # invokes `pnpm changeset publish`, which publishes whichever package
+      # versions in main exceed what's on the registry. The first publish
+      # ships 0.1.0 for `@pax8/cli` and `@pax8/core`. Subsequent pushes do
+      # nothing until a "chore: release" PR (opened by the action below
+      # when a changeset is present) bumps versions and is merged.
+      - name: Publish (gate opened in #370)
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          # publish: pnpm changeset publish  # gated — enable when ready to ship
+          publish: pnpm changeset publish
           version: pnpm changeset version
           commit: "chore: release"
           title: "chore: release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,19 @@ jobs:
           version: pnpm changeset version
           commit: "chore: release"
           title: "chore: release"
-        # npm OIDC trusted publishing: when this workflow has `id-token: write`
-        # and the @pax8 scope has the publishing repo+workflow registered as a
-        # trusted publisher at https://www.npmjs.com/settings/pax8/packages,
-        # `npm publish` exchanges the OIDC token for an ephemeral publish token
-        # automatically — no NPM_TOKEN secret required.
+        # First-publish bootstrap: npm trusted-publisher OIDC requires the
+        # target package to already exist on the registry, so it can't sign
+        # the very first `npm publish`. We pass a short-lived granular token
+        # via `NODE_AUTH_TOKEN` for the 0.1.0 bootstrap publish only. Once
+        # `@pax8/cli` and `@pax8/core` exist on the registry, configure
+        # trusted publishers per-package (Settings → Trusted publishing),
+        # enable "Require 2FA and disallow tokens" in Settings → Publishing
+        # access, then open a follow-up PR that removes `NODE_AUTH_TOKEN`
+        # from this env block and revokes/deletes the `NPM_TOKEN` secret.
+        # Until that follow-up lands, OIDC and the token coexist — the npm
+        # CLI prefers OIDC when available and falls back to the token.
         # https://docs.npmjs.com/trusted-publishers
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @pax8/cli
 
 <!--
-  Pre-release window: all entries below accumulate under 0.1.0 until the first
-  public release (publish gate: #370). The phantom 0.2.0 / 0.3.0 / 0.4.0
-  version headings written by `changeset version` PRs have been collapsed.
-  Substance preserved; only the section headings were removed.
+  Pre-release window: entries below accumulated under 0.1.0 until the first
+  public release (publish gate: #370 — opened 2026-06-04). The phantom
+  0.2.0 / 0.3.0 / 0.4.0 version headings written by `changeset version` PRs
+  during the pre-release window were collapsed; substance preserved.
 -->
 
-## Unreleased
+## 0.1.0 — 2026-06-04
 
 ### Minor Changes
 
@@ -57,6 +57,10 @@
   Helpers exposed in `lib/last-list.ts` for the rollout: `saveLastListContext`, `loadLastListContext`, `rewriteArgvForPage`, plus the `LastListContext` interface. 7 new unit tests cover round-trip, corruption, shape validation, and argv rewriting (replace + append + no-mutate).
 
 ### Patch Changes
+
+- [#580](https://github.com/pax8labs/pax8-cli/pull/580) — `invoices audit --json` now returns the audit report as a plain object instead of a single-element array. Consumers that wrote `Array.isArray(x) ? x[0] : x` to defend against the legacy shape can drop the unwrap. Affects both the populated and empty-state paths; the empty-state object also gains `itemsAudited: 0` to match the populated key set. Surfaced during the pre-release e2e walkthrough of the golden-path command table.
+
+- [#577](https://github.com/pax8labs/pax8-cli/pull/577) — `auth status --json` renames `authenticated` → `credentialsPresent`. The previous name implied a network-validated session, but the command only checks credential files on disk; the new name makes the offline scope explicit. Use `pax8 auth check` (or `pax8 doctor`) for the network-validated check that actually exchanges credentials with `/v1/token`. Closes [#573](https://github.com/pax8labs/pax8-cli/issues/573).
 
 - [#568](https://github.com/pax8labs/pax8-cli/pull/568) [`242fbed`](https://github.com/pax8labs/pax8-cli/commit/242fbed0058786aff69364d770b76d418b9c742c) Thanks [@jidulberger](https://github.com/jidulberger)! - Pre-launch documentation cleanup, no code changes:
   - **`README.md`** — restructured Quick Start into explicit "Install / Run / Authenticate" steps with three documented invocation paths (`node dist/index.js`, `npm link`'d `pax8`, `pnpm dev`); de-duplicated the pre-release banner (was repeated three times); expanded the Commands section to surface `contacts`, `quotes`, `webhooks`, `usage`, `config`, `report`, `init`, `completions`, `version`, `report-bug`, `telemetry` (the existing surface but only the prominent commands were documented); fixed the `report mrr` / `report growth` paragraph that still said "v0.2 reporting work will rebuild" when `pax8 report renewals|concentration|subscriptions` already shipped; rebuilt the REPL Mode section to show the welcome banner and document `back` / `n` / `p` shortcuts; replaced the Documentation section's BUILD.md link with current contributor / partner-facing pointers.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @pax8/core
 
 <!--
-  Pre-release window: all entries below accumulate under 0.1.0 until the first
-  public release (publish gate: #370). The phantom 0.2.0 / 0.3.0 / 0.4.0
-  version headings written by `changeset version` PRs have been collapsed.
-  Substance preserved; only the section headings were removed.
+  Pre-release window: entries below accumulated under 0.1.0 until the first
+  public release (publish gate: #370 — opened 2026-06-04). The phantom
+  0.2.0 / 0.3.0 / 0.4.0 version headings written by `changeset version` PRs
+  during the pre-release window were collapsed; substance preserved.
 -->
 
-## Unreleased
+## 0.1.0 — 2026-06-04
 
 ### Patch Changes
 


### PR DESCRIPTION
## Summary

Flips the publish gate that's been holding back the first npm publish since pre-release. After this lands, the next push to `main` triggers `release.yml` → `pnpm changeset publish` → `@pax8/cli@0.1.0` and `@pax8/core@0.1.0` go live on npm with provenance via OIDC trusted publisher (no `NPM_TOKEN`).

### Edits

- **`packages/cli/CHANGELOG.md`** — rename `## Unreleased` → `## 0.1.0 — 2026-06-04`. Two new patch entries at the top of `### Patch Changes` for the JSON contract refinements that landed during the security/release cleanup window:
  - **#580** — `invoices audit --json` returns a plain object instead of `[{...}]` (consumers can drop the `Array.isArray(x) ? x[0] : x` unwrap).
  - **#577** — `auth status --json` renames `authenticated` → `credentialsPresent` (closes #573).
- **`packages/core/CHANGELOG.md`** — rename `## Unreleased` → `## 0.1.0 — 2026-06-04`. No new entries (security/release-window changes were CLI-only).
- **`.github/workflows/release.yml`** — uncomment `publish: pnpm changeset publish` on the `changesets/action` step; tighten the surrounding comment to reflect that the gate is now open.

## Why draft

Two prerequisites must clear before this is mergeable:

1. **#580 must merge first.** That PR adds the `invoices audit --json` shape fix the CHANGELOG entry references. If this merges before #580 lands, the CHANGELOG describes behavior not yet in `main`.
2. **npm trusted publisher must be registered.** The `@pax8` scope needs the publishing repo + workflow registered at https://www.npmjs.com/settings/pax8/packages. Without it, the OIDC token exchange fails and `npm publish` dies on the first push to main after merge.

Once both are done: rebase this branch on the new `main` (so #580's merge is included), un-draft, let CI run, merge, watch `release.yml` execute.

## Test plan

- [ ] `pnpm build && pnpm test` green on this branch (CI handles)
- [ ] #580 merged into main; this branch rebased onto it cleanly
- [ ] npm trusted publisher confirmed at https://www.npmjs.com/settings/pax8/packages
- [ ] After merge: `release.yml` runs successfully and both packages appear at https://www.npmjs.com/package/@pax8/cli and https://www.npmjs.com/package/@pax8/core
- [ ] Post-publish: `npm install -g @pax8/cli@0.1.0 && PAX8_DEMO=1 pax8 status` in a clean shell

Closes #370.