### PR TITLE
fix(release): pass bootstrap token via NPM_TOKEN, not NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,19 @@ jobs:
         # First-publish bootstrap: npm trusted-publisher OIDC requires the
         # target package to already exist on the registry, so it can't sign
         # the very first `npm publish`. We pass a short-lived granular token
-        # via `NODE_AUTH_TOKEN` for the 0.1.0 bootstrap publish only. Once
-        # `@pax8/cli` and `@pax8/core` exist on the registry, configure
-        # trusted publishers per-package (Settings → Trusted publishing),
-        # enable "Require 2FA and disallow tokens" in Settings → Publishing
-        # access, then open a follow-up PR that removes `NODE_AUTH_TOKEN`
-        # from this env block and revokes/deletes the `NPM_TOKEN` secret.
-        # Until that follow-up lands, OIDC and the token coexist — the npm
-        # CLI prefers OIDC when available and falls back to the token.
+        # via `NPM_TOKEN` for the 0.1.0 bootstrap publish only. `NPM_TOKEN`
+        # is the specific env var `changesets/action` checks to decide
+        # between token auth and OIDC — `NODE_AUTH_TOKEN` (the
+        # `actions/setup-node` convention) doesn't influence that branch,
+        # so the action would fall through to OIDC and fail without a
+        # trusted publisher. Once `@pax8/cli` and `@pax8/core` exist on
+        # the registry, configure trusted publishers per-package (Settings
+        # → Trusted publishing), enable "Require 2FA and disallow tokens"
+        # in Settings → Publishing access, then open a follow-up PR that
+        # removes `NPM_TOKEN` from this env block and revokes/deletes the
+        # `NPM_TOKEN` repo secret.
         # https://docs.npmjs.com/trusted-publishers
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The 0.1.0 publish from the merged #581 failed at the publish step. Diagnosis from the workflow log:

\`\`\`
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
...
🦋  info Publishing \"@pax8/cli\" at \"0.1.0\"
🦋  info Publishing \"@pax8/core\" at \"0.1.0\"
🦋  error EOTP This operation requires a one-time password from your authenticator.
\`\`\`

\`changesets/action\` keys its token-vs-OIDC branch specifically on the \`NPM_TOKEN\` env var. The previous \`NODE_AUTH_TOKEN\` name is the \`actions/setup-node\` convention — it gets written to \`.npmrc\` for any subsequent \`npm publish\` call, but it doesn't influence which auth path \`changesets/action\` selects. The action saw no \`NPM_TOKEN\`, chose OIDC, and OIDC publish failed because no trusted publisher is configured for net-new packages. The fallback path then hit account 2FA enforcement and surfaced as \`EOTP\`.

Renaming the env key forces the token-auth branch.

## Test plan

- [x] Repo secret \`NPM_TOKEN\` remains as-is (only the env-var name in the workflow changed).
- [x] npm account 2FA mode lowered off \"Authorization and writes\" so token-based publishes don't require an OTP code.
- [ ] After merge → \`release.yml\` re-fires on push to main → \`@pax8/cli@0.1.0\` and \`@pax8/core@0.1.0\` publish with provenance.
- [ ] Tags \`@pax8/cli@0.1.0\` and \`@pax8/core@0.1.0\` are pushed automatically by changesets/action.