### PR TITLE
chore(release): remove NPM_TOKEN bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,22 +53,16 @@ jobs:
           version: pnpm changeset version
           commit: "chore: release"
           title: "chore: release"
-        # First-publish bootstrap: npm trusted-publisher OIDC requires the
-        # target package to already exist on the registry, so it can't sign
-        # the very first `npm publish`. We pass a short-lived granular token
-        # via `NPM_TOKEN` for the 0.1.0 bootstrap publish only. `NPM_TOKEN`
-        # is the specific env var `changesets/action` checks to decide
-        # between token auth and OIDC — `NODE_AUTH_TOKEN` (the
-        # `actions/setup-node` convention) doesn't influence that branch,
-        # so the action would fall through to OIDC and fail without a
-        # trusted publisher. Once `@pax8/cli` and `@pax8/core` exist on
-        # the registry, configure trusted publishers per-package (Settings
-        # → Trusted publishing), enable "Require 2FA and disallow tokens"
-        # in Settings → Publishing access, then open a follow-up PR that
-        # removes `NPM_TOKEN` from this env block and revokes/deletes the
-        # `NPM_TOKEN` repo secret.
+        # npm OIDC trusted publishing: when this workflow has `id-token: write`
+        # and each `@pax8` package has the publishing repo+workflow registered
+        # as a trusted publisher (Settings → Trusted publishing on each
+        # package's npm page), `npm publish` exchanges the OIDC token for
+        # an ephemeral publish token automatically — no NPM_TOKEN secret
+        # required. Both packages must have trusted publisher configured
+        # before this workflow can publish; the 0.1.0 bootstrap was done
+        # manually with `pnpm publish --otp` since trusted publishers
+        # require the target package to already exist on the registry.
         # https://docs.npmjs.com/trusted-publishers
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Now that \`@pax8/cli@0.1.1\` and \`@pax8/core@0.1.0\` are live on the registry (publish details below), trusted-publisher OIDC is configurable per-package and signs all subsequent publishes — the bootstrap token is no longer needed.

This PR:
- Strips \`NPM_TOKEN: \${{ secrets.NPM_TOKEN }}\` from the \`changesets/action\` env block in \`release.yml\`.
- Restores the prior trusted-publisher comment.

## Pre-merge checklist (operational, outside this PR)

- [ ] \`@pax8/cli@0.1.1\` published from a clean \`pnpm publish\` (the 0.1.0 slot was retired during the bootstrap — see #584 for details)
- [ ] Trusted publisher configured on \`@pax8/cli\` (Settings → Trusted publishing → GitHub Actions, \`pax8labs/pax8-cli\`, workflow \`release.yml\`, env blank, action \`npm publish\`)
- [ ] Trusted publisher configured on \`@pax8/core\` (same form)
- [ ] (Recommended) \"Require 2FA and disallow tokens\" enabled on each package (Settings → Publishing access)

## Post-merge cleanup

- [ ] Delete the \`NPM_TOKEN\` repo secret at https://github.com/pax8labs/pax8-cli/settings/secrets/actions
- [ ] Revoke the granular token on npm (it auto-expires in 7 days regardless)
- [ ] Delete the orphan \`@pax8/cli@0.1.0\` git tag (\`git tag -d @pax8/cli@0.1.0 && git push origin :refs/tags/@pax8/cli@0.1.0\`) — points at a version that doesn't exist on npm

## Why draft

This PR sits in draft until trusted publishers are configured on both packages. Merging before that would leave \`release.yml\` unable to publish on the next changeset. Once both checkboxes above are ticked, mark ready for review and merge.

## Test plan

- [ ] CI green on this branch
- [ ] After merge + next changeset, \`release.yml\` publishes via OIDC and provenance attestations appear on both package pages