### PR TITLE
chore(release): prep @pax8/cli@0.1.1 with README and version bump

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,7 +7,22 @@
   during the pre-release window were collapsed; substance preserved.
 -->
 
+## 0.1.1 — 2026-06-05
+
+Bootstrap-cycle fixes; no functional changes. `0.1.1` is the de-facto initial public release of `@pax8/cli` on npm — see the note at the end of this entry for why `0.1.0` doesn't exist on the registry.
+
+### Fixed
+
+- **`dependencies['@pax8/core']` correctly references the concrete version.** The first publish attempt for `@pax8/cli@0.1.0` used `npm publish` instead of `pnpm publish` and shipped `"@pax8/core": "workspace:*"` literally — a pnpm workspace protocol that no consumer can resolve. `pnpm publish` rewrites `workspace:*` to the concrete version at pack time; that's what `0.1.1` ships.
+- **`README.md` included in the published tarball.** The first publish attempt lacked a package-level README. `packages/cli/README.md` now exists and is automatically included alongside `LICENSE` and `dist/`.
+
+### Note about `@pax8/cli@0.1.0`
+
+`@pax8/cli@0.1.0` was published and unpublished within minutes on 2026-06-04 due to the two issues above. Per npm policy, the `0.1.0` version slot is permanently retired and cannot be republished. `0.1.1` is the de-facto initial public release. `@pax8/core@0.1.0` is unaffected and remains the canonical version of the SDK package — `@pax8/cli@0.1.1` depends on `@pax8/core@0.1.0`.
+
 ## 0.1.0 — 2026-06-04
+
+> **Note:** `@pax8/cli@0.1.0` was published and unpublished within minutes on 2026-06-04 due to packaging issues (see `0.1.1` above). The version slot is permanently retired on npm. The entries below describe the substance of the initial public release; the actual artifact shipped is `0.1.1`.
 
 ### Minor Changes
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,76 @@
+# @pax8/cli
+
+An open-source CLI for Pax8 partners that turns the raw marketplace API into computed answers — renewals, invoice audits, Pax8-cost analytics, upsell recommendations, and closed-loop order placement. Built for MSPs who want to manage subscriptions, billing, customers, and growth opportunities from the terminal. Designed so humans and AI agents (Claude Code, Cursor, Copilot, scripted pipelines) use the same surface.
+
+## Install
+
+```bash
+npm install -g @pax8/cli
+# or: pnpm add -g @pax8/cli
+# or: yarn global add @pax8/cli
+```
+
+Requires Node.js 20+. ESM only.
+
+## Try it without credentials
+
+Demo mode runs every command against an in-memory fixture — no Pax8 account, no API access required:
+
+```bash
+PAX8_DEMO=1 pax8 dashboard
+PAX8_DEMO=1 pax8 subscriptions renewals --within 30d
+PAX8_DEMO=1 pax8 recommendations list
+PAX8_DEMO=1 pax8 invoices audit
+```
+
+## Authenticate
+
+```bash
+pax8 auth login
+# prompts for PAX8_CLIENT_ID and PAX8_CLIENT_SECRET (OAuth client credentials)
+# stored at ~/.pax8/credentials.json (mode 0600)
+```
+
+Or set `PAX8_CLIENT_ID` and `PAX8_CLIENT_SECRET` in your environment.
+
+## What the CLI computes
+
+The Pax8 API is a CRUD layer; this CLI is what turns raw subscriptions, invoices, and products into the questions MSPs actually ask:
+
+- **`pax8 dashboard`** — portfolio overview: monthly Pax8 cost, active subscriptions, top customers, high-priority recommendations.
+- **`pax8 subscriptions renewals --within 30d`** — which subscriptions renew in the window, total MRR renewing, days until each renewal. The Pax8 API has no renewals endpoint; the CLI computes from commitment dates.
+- **`pax8 invoices audit`** — cross-references invoice line items against active subscriptions to flag overcharges, undercharges, and orphan items with dollar impact. Each discrepancy gets a stable ID for filing via `pax8 invoices dispute --discrepancy <id>`.
+- **`pax8 recommendations list`** — gap analysis across each customer's stack against backup / security / identity / productivity categories; estimates additional Pax8 monthly cost if acted on; emits ready-to-execute order parameters (the `orderArgs` argv array is shell-injection-safe).
+- **`pax8 recommendations act`** — interactive flow that walks portfolio gaps and places the orders. Closes the loop between insight and action in the same tool.
+- **`pax8 cost sim`** — model SKU swaps, quantity changes, and add-product scenarios with monthly/annual MRR delta, *before* placing the order.
+- **`pax8 report subscriptions --by vendor`** / **`pax8 report mrr`** / **`pax8 report growth`** — aggregations and trends with annual-to-monthly amortization; emits the partner's cost to Pax8 (not partner-side resale revenue).
+- **`pax8 doctor`** — diagnostic health check (Node version, config, API connectivity, credentials).
+
+Every command supports `--json`, `--csv`, and `--quiet`. List commands have `--with-actions` to ride a `{ data, nextActions }` envelope. Write commands take `--idempotency-key <uuid>` for safe retry.
+
+## Agent-first contracts
+
+If you're using this CLI as a tool inside an agent (Claude Code, Cursor, Copilot, etc.):
+
+- **`--json` is non-TTY-aware**: subprocess invocations auto-emit JSON even without the flag. Pipelines like `pax8 dashboard | jq` work cleanly — stdout is data only, spinners and banners stay on stderr.
+- **Machine-readable error codes**: every `CliError` carries a stable `code` (`ERROR_API_VALIDATION`, `ERROR_COMPANY_NOT_FOUND`, etc.) so agents can branch on outcome without parsing strings.
+- **`nextActions[]` argv-safe contract**: each entry has both a `command` (display string) and `args` (argv array starting with `"pax8"`). Agents should spawn `args.slice(1)` directly via their tool's argv form — never tokenize the display string.
+- **Read/write safety contract**: see [`packages/claude-skill/skill.md`](https://github.com/pax8labs/pax8-cli/blob/main/packages/claude-skill/skill.md). Every write command requires explicit user approval unless `-y` / `--yes` / `PAX8_YES=1` is set.
+- **`@pax8/claude-skill`** ships the agent-facing skill manifest as an installable package; the contracts apply whether the skill is loaded or not.
+
+## Versioning
+
+**Experimental.** `@pax8/cli` is currently `0.x` and the public surface (commands, flags, JSON envelope shapes) may change between minor versions. Pin a specific version (`"@pax8/cli": "0.1.1"`, not `"^0.1.0"`) until the CLI reaches `1.0`. Breaking changes will be called out in release notes.
+
+## Source
+
+- **Repository:** [pax8labs/pax8-cli](https://github.com/pax8labs/pax8-cli)
+- **Full feature tour and demo flow:** see the [repo README](https://github.com/pax8labs/pax8-cli#readme)
+- **Per-package changelogs:** [CLI](https://github.com/pax8labs/pax8-cli/blob/main/packages/cli/CHANGELOG.md) · [Core SDK](https://github.com/pax8labs/pax8-cli/blob/main/packages/core/CHANGELOG.md)
+- **Issues and feature requests:** [GitHub issues](https://github.com/pax8labs/pax8-cli/issues)
+
+The `@pax8/core` package (the durable, interface-agnostic business logic) is published separately at [`@pax8/core`](https://www.npmjs.com/package/@pax8/core) and is suitable for embedding in portals, Lambdas, or partner tooling.
+
+## License
+
+Apache-2.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pax8/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pax8 open source CLI for MSPs to manage cloud marketplace operations",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Tomorrow's publish target moves from \`@pax8/cli@0.1.0\` to \`@pax8/cli@0.1.1\` because npm policy permanently retires the \`0.1.0\` version slot after our unpublish on 2026-06-04 (initial bootstrap had two issues: \`workspace:*\` protocol leak from using \`npm publish\` instead of \`pnpm publish\`, and a missing package-level README).

This PR prepares the 0.1.1 publish artifact.

### Changes

- **\`packages/cli/package.json\`** — version 0.1.0 → 0.1.1.
- **\`packages/cli/README.md\`** — new file. The CLI lacked a package-level README; the root \`README.md\` is monorepo-wide and doesn't land in the published tarball. This is what partners see at https://www.npmjs.com/package/@pax8/cli. Matches the structure of the existing \`packages/core/README.md\`.
- **\`packages/cli/CHANGELOG.md\`** — 0.1.1 entry explaining the bootstrap regression honestly; the existing 0.1.0 entry gets a note explaining the npm registry state.

### Tarball verification

\`pnpm pack\` confirms the would-be 0.1.1 tarball:
- ✅ \`package/README.md\` included
- ✅ \`version: 0.1.1\`
- ✅ \`dependencies['@pax8/core']\` correctly transforms \`workspace:*\` → \`0.1.0\`
- Files: \`README.md\`, \`LICENSE\`, \`package.json\`, \`dist/*\` (8 total)

## @pax8/core scope

\`@pax8/core@0.1.0\` is **unaffected** and remains the canonical SDK version. \`@pax8/cli@0.1.1\` declares \`@pax8/core\` at \`0.1.0\` in its dependencies. Partners already pinning to \`@pax8/core@0.1.0\` shouldn't have to bump.

## Test plan

- [x] \`pnpm build && pnpm test\` green on this branch (CI will validate)
- [x] \`pnpm pack\` includes README, transforms workspace:* correctly, version is 0.1.1
- [ ] Merge after CI green (no urgency — won't trigger anything since the publish workflow is gated on the \`NPM_TOKEN\` env that's still in place)
- [ ] Tomorrow (after npm's 24h package-name cooldown lifts ~18:05 UTC): \`cd packages/cli && pnpm publish --access public --no-git-checks --provenance=false --otp <code>\`

## What still needs to happen on top of this

Tomorrow's runbook (in order):

1. Publish 0.1.1 manually (above).
2. Tag \`@pax8/cli@0.1.1\` and push tag.
3. Run the clean-install e2e check against the published artifact.
4. Configure trusted publisher for \`@pax8/cli\` on npm (Settings → Trusted publishing — \`pax8labs/pax8-cli\`, workflow \`release.yml\`, env blank, action \`npm publish\`).
5. Same for \`@pax8/core\` if not done today.
6. Mark PR #583 (NPM_TOKEN bootstrap removal) ready and merge.
7. Delete the \`NPM_TOKEN\` repo secret.
8. Update the draft GitHub Release to target \`@pax8/cli@0.1.1\` and publish it.
9. Delete the orphaned \`@pax8/cli@0.1.0\` git tag.