### PR TITLE
docs(core): fix README quick-example to use list() not listAll()

### DIFF
--- a/.changeset/fix-core-readme-list-method.md
+++ b/.changeset/fix-core-readme-list-method.md
@@ -1,0 +1,5 @@
+---
+"@pax8/core": patch
+---
+
+Fix the `Pax8Client` quick-example in the README. The previous example used `client.subscriptions.listAll({...})` and `client.companies.listAll()` — methods that don't exist on the published sub-clients. The actual API is `client.subscriptions.list({...})` returning a `{ content, page }` envelope. Corrected the example, clarified the envelope shape, and listed the sub-clients that share the surface. Closes #591.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -24,11 +24,11 @@ const client = new Pax8Client({
   clientSecret: process.env.PAX8_CLIENT_SECRET!,
 });
 
-const subscriptions = await client.subscriptions.listAll({ status: "Active" });
-const companies = await client.companies.listAll();
-const companyNameById = new Map(companies.map((c) => [c.id, c.name]));
+const subsResult = await client.subscriptions.list({ status: "Active", size: 1000 });
+const companiesResult = await client.companies.list({ size: 1000 });
+const companyNameById = new Map(companiesResult.content.map((c) => [c.id, c.name]));
 
-const report = getUpcomingRenewals(subscriptions, companyNameById, {
+const report = getUpcomingRenewals(subsResult.content, companyNameById, {
   withinDays: 30,
 });
 
@@ -38,13 +38,15 @@ for (const item of report.items.slice(0, 5)) {
 }
 ```
 
+The sub-clients return a paginated envelope (`{ content, page }`); pass `size: 1000` (or walk pages explicitly) when you need every row in one shot. `Pax8Client` and `MockPax8Client` share the same surface: `subscriptions`, `companies`, `contacts`, `orders`, `invoices`, `products`, `usage`, `quotes`, and `webhooks` each expose `list` / `get` and the relevant CRUD subset.
+
 Demo mode (no credentials):
 
 ```ts
 import { MockPax8Client, getUpcomingRenewals } from "@pax8/core";
 
 const client = new MockPax8Client();
-const subscriptions = await client.subscriptions.listAll();
+const subsResult = await client.subscriptions.list({ status: "Active", size: 1000 });
 // ...same shape as above
 ```
 


### PR DESCRIPTION
## Summary

The published \`@pax8/core@0.1.0\` README documents \`client.subscriptions.listAll(...)\` and \`client.companies.listAll()\` as the canonical quick-example — methods that don't exist on the published sub-clients. Corrects the example to use the actual API: \`.list({...})\` returning a \`{ content, page }\` envelope.

Closes #591.

## Two-birds intent

Beyond closing the doc bug, this PR is the first **patch release** post-bootstrap. It deliberately exercises the changesets + trusted-publisher + OIDC pipeline end-to-end:

1. **This PR merges** → \`release.yml\` runs \`changesets/action\` → sees the changeset → opens a follow-up \"chore: release\" PR that bumps \`@pax8/core\` 0.1.0 → 0.1.1 and \`@pax8/cli\` 0.1.1 → 0.1.2 (via the \`linked\` config in \`.changeset/config.json\`).
2. **\"chore: release\" PR merges** → \`release.yml\` runs again → \`pnpm changeset publish\` → both packages publish to npm via OIDC trusted publisher, with provenance attestations.
3. If trusted publishers are wired correctly on both packages, both publishes succeed and provenance badges appear on the npm pages.
4. If anything is misconfigured, this surfaces it now (manageable: red CI, no new versions land, we fix the config).

## Changeset preview

\`pnpm changeset status\` confirms:

\`\`\`
🦋  info Packages to be bumped at patch:
🦋  - @pax8/core
🦋  - @pax8/cli
\`\`\`

(\`@pax8/cli\` gets pulled in automatically by the \`linked\` config + \`updateInternalDependencies: patch\` cascade.)

## Test plan

- [x] Verified the new example works against \`@pax8/core@0.1.0\` locally — returns 21 renewals / \$1,342.92 MRR in the demo fixture.
- [ ] CI green on this PR.
- [ ] After merge: \"chore: release\" PR auto-opens with correct version bumps + CHANGELOG entries.
- [ ] After \"chore: release\" merge: \`release.yml\` publishes both packages via OIDC. Provenance badges appear on https://www.npmjs.com/package/@pax8/cli and https://www.npmjs.com/package/@pax8/core.
- [ ] \`npm view @pax8/cli@0.1.2 dependencies\` confirms the workspace transform set \`@pax8/core\` to the new \`0.1.1\`.
- [ ] Clean-install e2e check against the new versions passes (golden-path command table from CLAUDE.md).