### PR TITLE
feat(cli): add `pax8 demo on|off|status` for persistent demo-mode toggle

### DIFF
--- a/.changeset/demo-on-off-status.md
+++ b/.changeset/demo-on-off-status.md
@@ -1,0 +1,9 @@
+---
+"@pax8/cli": patch
+---
+
+Add `pax8 demo on|off|status` for persistent demo-mode toggle.
+
+Mirrors the `pax8-cta demo on` pattern so partners can use the same mental model across both Pax8 CLIs. Persists to `~/.pax8/config.yaml` (`demo: true|false`) so demo state survives across `npx` invocations.
+
+`PAX8_DEMO` env var still wins when set — `pax8 demo status` shows which source determined the current state and warns when env will override config. Closes #594.

--- a/packages/cli/src/__tests__/demo.test.ts
+++ b/packages/cli/src/__tests__/demo.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runCli, runCliExpectSuccess } from "./test-utils.js";
+
+describe("pax8 demo on|off|status", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-demo-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("`demo on` persists demo: true to config.yaml", async () => {
+    const result = await runCliExpectSuccess(["demo", "on"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "",
+    });
+    expect(result.stdout).toContain("Demo mode enabled");
+
+    const yaml = await fs.readFile(path.join(tmpDir, "config.yaml"), "utf-8");
+    expect(yaml).toMatch(/demo:\s*true/);
+  });
+
+  it("`demo off` persists demo: false to config.yaml", async () => {
+    await runCliExpectSuccess(["demo", "on"], { PAX8_CONFIG_DIR: tmpDir, PAX8_DEMO: "" });
+    const result = await runCliExpectSuccess(["demo", "off"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "",
+    });
+    expect(result.stdout).toContain("Demo mode disabled");
+
+    const yaml = await fs.readFile(path.join(tmpDir, "config.yaml"), "utf-8");
+    expect(yaml).toMatch(/demo:\s*false/);
+  });
+
+  it("`demo status --json` reports default (no env, no config)", async () => {
+    const result = await runCliExpectSuccess(["demo", "status", "--json"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "",
+    });
+    expect(JSON.parse(result.stdout)).toEqual({ enabled: false, source: "default" });
+  });
+
+  it("`demo status --json` reports config source after `demo on`", async () => {
+    await runCliExpectSuccess(["demo", "on"], { PAX8_CONFIG_DIR: tmpDir, PAX8_DEMO: "" });
+    const result = await runCliExpectSuccess(["demo", "status", "--json"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "",
+    });
+    expect(JSON.parse(result.stdout)).toEqual({ enabled: true, source: "config" });
+  });
+
+  it("PAX8_DEMO=1 env wins over `demo off` in config", async () => {
+    await runCliExpectSuccess(["demo", "off"], { PAX8_CONFIG_DIR: tmpDir, PAX8_DEMO: "" });
+    const result = await runCliExpectSuccess(["demo", "status", "--json"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "1",
+    });
+    expect(JSON.parse(result.stdout)).toEqual({ enabled: true, source: "env" });
+  });
+
+  it("PAX8_DEMO=0 env wins over `demo on` in config", async () => {
+    await runCliExpectSuccess(["demo", "on"], { PAX8_CONFIG_DIR: tmpDir, PAX8_DEMO: "" });
+    const result = await runCliExpectSuccess(["demo", "status", "--json"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "0",
+    });
+    expect(JSON.parse(result.stdout)).toEqual({ enabled: false, source: "env" });
+  });
+
+  it("`demo on` warns to stderr if PAX8_DEMO=0 env will override", async () => {
+    const result = await runCli(["demo", "on"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "0",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Demo mode enabled");
+    expect(result.stderr).toContain("PAX8_DEMO=0");
+    expect(result.stderr).toContain("overrides this config");
+  });
+
+  it("`demo on` is idempotent", async () => {
+    await runCliExpectSuccess(["demo", "on"], { PAX8_CONFIG_DIR: tmpDir, PAX8_DEMO: "" });
+    const second = await runCliExpectSuccess(["demo", "on"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "",
+    });
+    expect(second.stdout).toContain("Demo mode enabled");
+  });
+
+  it("after `demo on`, a subsequent demo command runs in demo mode without env var", async () => {
+    await runCliExpectSuccess(["demo", "on"], { PAX8_CONFIG_DIR: tmpDir, PAX8_DEMO: "" });
+    // `dashboard` uses MockPax8Client only in demo mode — if the config flag
+    // is honored, this runs without auth errors.
+    const result = await runCliExpectSuccess(["dashboard", "--json"], {
+      PAX8_CONFIG_DIR: tmpDir,
+      PAX8_DEMO: "",
+    });
+    const data = JSON.parse(result.stdout);
+    expect(data.totalCompanies).toBeGreaterThan(0);
+    expect(result.stderr).toContain("Demo mode");
+  });
+});

--- a/packages/cli/src/commands/demo/index.ts
+++ b/packages/cli/src/commands/demo/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import { demoOnCommand } from "./on.js";
+import { demoOffCommand } from "./off.js";
+import { demoStatusCommand } from "./status.js";
+
+export function registerDemoCommands(program: Command): void {
+  const demo = new Command("demo").description(
+    "Toggle persistent demo mode (in-memory sample data, no credentials)",
+  );
+
+  demo.addCommand(demoOnCommand);
+  demo.addCommand(demoOffCommand);
+  demo.addCommand(demoStatusCommand);
+
+  program.addCommand(demo);
+}

--- a/packages/cli/src/commands/demo/off.ts
+++ b/packages/cli/src/commands/demo/off.ts
@@ -19,9 +19,9 @@ This clears the persistent demo flag in ~/.pax8/config.yaml. The
 PAX8_DEMO env var still wins when set — see ${replCmd("pax8 demo status")}.`
   )
   .action(async () => {
-    const config = await loadConfig().catch(() => ({
-      version: "1.0" as const,
-    }));
+    // loadConfig() returns the full default Config when the file is absent
+    // (ENOENT branch in core's loader), so no catch is needed here.
+    const config = await loadConfig();
     // Setting to `false` rather than deleting keeps the field explicit
     // in the saved YAML — partners reading their config file should see
     // demo: false rather than an absent field they have to infer.

--- a/packages/cli/src/commands/demo/off.ts
+++ b/packages/cli/src/commands/demo/off.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, saveConfig } from "@pax8/core";
+import { replCmd } from "../../lib/confirm.js";
+
+export const demoOffCommand = new Command("off")
+  .description("Disable demo mode (return to live Pax8 API calls)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 demo off
+  pax8 demo off && pax8 dashboard
+
+This clears the persistent demo flag in ~/.pax8/config.yaml. The
+PAX8_DEMO env var still wins when set — see ${replCmd("pax8 demo status")}.`
+  )
+  .action(async () => {
+    const config = await loadConfig().catch(() => ({
+      version: "1.0" as const,
+    }));
+    // Setting to `false` rather than deleting keeps the field explicit
+    // in the saved YAML — partners reading their config file should see
+    // demo: false rather than an absent field they have to infer.
+    await saveConfig({ ...config, demo: false });
+
+    process.stdout.write(
+      chalk.green("\n  ✓ Demo mode disabled.\n") +
+        chalk.dim(
+          `  Next ${replCmd("pax8")} command runs against the live Pax8 API.\n` +
+            `  Run ${replCmd("pax8 auth login")} if you haven't authenticated yet.\n\n`,
+        ),
+    );
+
+    const envDemo = process.env.PAX8_DEMO;
+    if (envDemo === "1" || envDemo === "true") {
+      process.stderr.write(
+        chalk.yellow(
+          `  ⚠ PAX8_DEMO=${envDemo} is set in your environment — it overrides this config.\n` +
+            `    Demo mode WILL stay active until you unset the env var.\n\n`,
+        ),
+      );
+    }
+  });

--- a/packages/cli/src/commands/demo/on.ts
+++ b/packages/cli/src/commands/demo/on.ts
@@ -19,9 +19,11 @@ Persistent across CLI invocations. The PAX8_DEMO env var always wins
 when set — see ${replCmd("pax8 demo status")} to inspect precedence.`
   )
   .action(async () => {
-    const config = await loadConfig().catch(() => ({
-      version: "1.0" as const,
-    }));
+    // loadConfig() returns the full default Config when the file is absent
+    // (ENOENT branch in core's loader), so no catch is needed here. Other
+    // errors (permission denied, malformed YAML, etc.) bubble up as real
+    // failures — they're not "use default" cases.
+    const config = await loadConfig();
     await saveConfig({ ...config, demo: true });
 
     process.stdout.write(

--- a/packages/cli/src/commands/demo/on.ts
+++ b/packages/cli/src/commands/demo/on.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, saveConfig } from "@pax8/core";
+import { replCmd } from "../../lib/confirm.js";
+
+export const demoOnCommand = new Command("on")
+  .description("Enable demo mode persistently in ~/.pax8/config.yaml")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 demo on
+  pax8 demo on && pax8 dashboard
+
+Persistent across CLI invocations. The PAX8_DEMO env var always wins
+when set — see ${replCmd("pax8 demo status")} to inspect precedence.`
+  )
+  .action(async () => {
+    const config = await loadConfig().catch(() => ({
+      version: "1.0" as const,
+    }));
+    await saveConfig({ ...config, demo: true });
+
+    process.stdout.write(
+      chalk.green("\n  ✓ Demo mode enabled.\n") +
+        chalk.dim(
+          `  Next ${replCmd("pax8")} command runs against in-memory sample data.\n` +
+            `  Run ${replCmd("pax8 demo off")} to return to live API calls.\n\n`,
+        ),
+    );
+
+    const envDemo = process.env.PAX8_DEMO;
+    if (envDemo === "0" || envDemo === "false") {
+      process.stderr.write(
+        chalk.yellow(
+          `  ⚠ PAX8_DEMO=${envDemo} is set in your environment — it overrides this config.\n` +
+            `    Demo mode will NOT activate until you unset the env var.\n\n`,
+        ),
+      );
+    }
+  });

--- a/packages/cli/src/commands/demo/status.ts
+++ b/packages/cli/src/commands/demo/status.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig } from "@pax8/core";
+import { replCmd } from "../../lib/confirm.js";
+
+type Source = "env" | "config" | "default";
+
+interface DemoStatus {
+  enabled: boolean;
+  source: Source;
+}
+
+function resolveStatus(envValue: string | undefined, configDemo: boolean | undefined): DemoStatus {
+  if (envValue === "1" || envValue === "true") return { enabled: true, source: "env" };
+  if (envValue === "0" || envValue === "false") return { enabled: false, source: "env" };
+  if (configDemo === true) return { enabled: true, source: "config" };
+  if (configDemo === false) return { enabled: false, source: "config" };
+  return { enabled: false, source: "default" };
+}
+
+export const demoStatusCommand = new Command("status")
+  .description("Show whether demo mode is on, off, and which source determined it")
+  .option("--json", "Output as JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 demo status
+  pax8 demo status --json
+
+Reports the resolved demo state and which source set it:
+  - env       PAX8_DEMO env var was set (1/true/0/false) — always wins
+  - config    ~/.pax8/config.yaml has demo: true|false
+  - default   Neither set; demo mode is off`
+  )
+  .action(async (options: { json?: boolean }, command) => {
+    const envValue = process.env.PAX8_DEMO;
+    const config = await loadConfig().catch(() => ({}) as { demo?: boolean });
+    const status = resolveStatus(envValue, config.demo);
+
+    // Honor the parent program's `--json` global flag in addition to
+    // local `--json` so `pax8 --json demo status` works the same way
+    // it does for every other read command.
+    const wantsJson = options.json || command.optsWithGlobals?.()?.json === true;
+
+    if (wantsJson) {
+      process.stdout.write(JSON.stringify(status, null, 2) + "\n");
+      return;
+    }
+
+    const onOff = status.enabled ? chalk.green("ON") : chalk.dim("OFF");
+    process.stdout.write(`\n  Demo mode: ${onOff}\n`);
+
+    if (status.source === "env") {
+      process.stdout.write(
+        chalk.dim(
+          `  Source:    PAX8_DEMO=${envValue} (env var overrides config)\n\n`,
+        ),
+      );
+    } else if (status.source === "config") {
+      process.stdout.write(
+        chalk.dim(`  Source:    ~/.pax8/config.yaml — demo: ${config.demo}\n\n`),
+      );
+    } else {
+      process.stdout.write(
+        chalk.dim(
+          `  Source:    default (no env var, no config setting)\n` +
+            `  Enable:    ${replCmd("pax8 demo on")}\n\n`,
+        ),
+      );
+    }
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import chalk from "chalk";
 declare const __CLI_VERSION__: string;
 import { registerAuthCommands } from "./commands/auth/index.js";
 import { registerConfigCommands } from "./commands/config/index.js";
+import { registerDemoCommands } from "./commands/demo/index.js";
 import { registerCompaniesCommands } from "./commands/companies/index.js";
 import { registerSubscriptionsCommands } from "./commands/subscriptions/index.js";
 import { registerProductsCommands } from "./commands/products/index.js";
@@ -97,6 +98,7 @@ export function createProgram(): Command {
   // Register command groups
   registerAuthCommands(program);
   registerConfigCommands(program);
+  registerDemoCommands(program);
   registerCompaniesCommands(program);
   registerSubscriptionsCommands(program);
   registerProductsCommands(program);


### PR DESCRIPTION
## Summary

Mirrors the `pax8-cta demo on` pattern so partners can use the same mental model across both Pax8 CLIs. Persists to `~/.pax8/config.yaml` (`demo: true|false`) so demo state survives across `npx` invocations.

Closes #594.

## What changed

- **New command surface**: `pax8 demo on`, `pax8 demo off`, `pax8 demo status` (with `--json`)
- **No schema or resolver changes needed** — `Config.demo` was already an optional field on the Zod schema, and `resolveDemoMode()` already implemented the env-var-wins-over-config precedence. This PR adds only the write surface.
- **`on`/`off` warn to stderr** when `PAX8_DEMO` env var would override the persistent setting they just wrote.
- **`status --json`** returns `{ enabled: boolean, source: "env" | "config" | "default" }` for agent consumers.

## Before vs after

**Before** (env var must repeat per `npx` process):
```bash
PAX8_DEMO=1 npx -y -p @pax8/cli pax8 dashboard
PAX8_DEMO=1 npx -y -p @pax8/cli pax8 recommendations list
```

**After** (matches `pax8-cta`'s pattern):
```bash
npx -y -p @pax8/cli pax8 demo on \
  && npx -y -p @pax8/cli pax8 dashboard \
  && npx -y -p @pax8/cli pax8 recommendations list
```

## Tests

9 new subprocess tests in `packages/cli/src/__tests__/demo.test.ts` covering the full precedence matrix:

- [x] `demo on` writes `demo: true` to config
- [x] `demo off` writes `demo: false` to config
- [x] `demo status --json` reports `{enabled: false, source: "default"}` on a fresh config
- [x] After `demo on`, status reports `{enabled: true, source: "config"}`
- [x] `PAX8_DEMO=1` overrides `demo off` → status reports `{enabled: true, source: "env"}`
- [x] `PAX8_DEMO=0` overrides `demo on` → status reports `{enabled: false, source: "env"}`
- [x] `demo on` warns to stderr when `PAX8_DEMO=0` will override
- [x] `demo on` is idempotent (running twice is fine)
- [x] After `demo on`, a subsequent `dashboard` invocation runs in demo mode without any env var

Full suite: 2186 passing (+9 from this PR), 6 skipped, 6 todo. No regressions.

## Test plan post-merge

- [ ] CI green
- [ ] Merge → \`release.yml\` opens \"chore: release\" PR bumping \`@pax8/cli\` 0.1.2 → 0.1.3 (and \`@pax8/core\` synced via \`linked\` config)
- [ ] Merge \"chore: release\" PR → OIDC publish via trusted publishers (second test of the pipeline; if it works this time, we know the publisher config is stable)
- [ ] Verify on the published artifact:
  ```bash
  npx -y -p @pax8/cli@0.1.3 pax8 demo on \
    && npx -y -p @pax8/cli pax8 dashboard
  ```
  works in a clean shell.