### PR TITLE
chore(repo): add CODEOWNERS and Issue Forms templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Auto-assigned reviewers for every PR. GitHub's CODEOWNERS file.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-policies/customizing-your-repository/about-code-owners
+
+# Default owners — every PR opens with these two as required reviewers.
+* @jidulberger @cbrownpax8

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Something `pax8` does that it shouldn't, or doesn't do that it should.
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A few minutes filling this in saves an hour of back-and-forth.
+
+        **Security vulnerability?** Stop here and use the private disclosure flow in [SECURITY.md](https://github.com/pax8labs/pax8-cli/blob/main/SECURITY.md) instead — public issues are the wrong place.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: One or two sentences. What did you run, and what went wrong?
+      placeholder: "Ran `pax8 invoices audit --month 2026-03`, got a TypeError instead of a discrepancy report."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: |
+        Exact commands you ran. If possible, **reproduce in demo mode** (`PAX8_DEMO=1`) so we can confirm without your credentials.
+      placeholder: |
+        1. `PAX8_DEMO=1 pax8 invoices audit --month 2026-03`
+        2. Observe the error
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: "`pax8 --version` output"
+      placeholder: "0.1.4"
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: "`node --version` output"
+      placeholder: "v22.x.y"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - WSL
+        - Other (specify in additional context)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: demo-or-real
+    attributes:
+      label: Does this reproduce in `PAX8_DEMO=1`?
+      description: If yes, we can debug without your credentials and the issue is much higher-priority for us.
+      options:
+        - "Yes — reproduces in demo mode"
+        - "No — only against the real Pax8 API"
+        - "Haven't checked"
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error output
+      description: |
+        Paste relevant stderr / stdout. If the CLI generated an error envelope (`pax8 report-bug` will have captured it), include the redacted JSON. **Redact any partner names, customer IDs, or credentials before pasting.**
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Context, hypotheses, related issues, screenshots, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/pax8labs/pax8-cli/blob/main/SECURITY.md
+    about: Use the private disclosure flow described in SECURITY.md — don't open a public issue for a security report.
+  - name: Question or general discussion
+    url: https://github.com/pax8labs/pax8-cli/blob/main/SUPPORT.md
+    about: Read SUPPORT.md for the right channel — many questions are answered there or in the README.
+  - name: Documentation pointer
+    url: https://github.com/pax8labs/pax8-cli#readme
+    about: Quick start, full command surface, agent-first contracts.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,60 @@
+name: Feature request
+description: A new command, flag, output mode, or behavior you wish `pax8` had.
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. Feature requests grounded in a concrete workflow problem ship faster than abstract "wouldn't it be nice if…" ones.
+
+        Before writing, **scan [open issues](https://github.com/pax8labs/pax8-cli/issues?q=is%3Aissue+label%3Aenhancement)** — your idea may already be tracked.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What workflow problem does this solve?
+      description: |
+        What are you trying to do with the CLI right now that's harder than it should be?
+      placeholder: |
+        "I want to find all subscriptions renewing in the next 90 days *grouped by vendor*, but `pax8 subscriptions renewals` only lists them flat."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed surface
+      description: |
+        What would the command/flag/output look like? Don't worry about getting the exact syntax right — the shape is what matters.
+
+        Patterns we already use: [docs/UX_GUIDE.md §2 flag vocabulary](https://github.com/pax8labs/pax8-cli/blob/main/docs/UX_GUIDE.md).
+      placeholder: |
+        ```
+        pax8 subscriptions renewals --within 90d --by vendor --json
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds exist today? Why aren't they enough?
+
+  - type: dropdown
+    id: who-uses
+    attributes:
+      label: Who's the primary user?
+      options:
+        - Human at a terminal
+        - AI agent (Claude Code, Cursor, Copilot, etc.) consuming `--json` output
+        - Both
+        - Other (specify)
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Mockups, expected output shape, related Pax8 API endpoints, etc.


### PR DESCRIPTION
## Summary

Repo-hygiene pass ahead of broader external exposure next week. Closes the only gap on the community-profile audit (\`issue_template: present: false\`).

### CODEOWNERS

\`.github/CODEOWNERS\` — auto-assigns @jidulberger + @cbrownpax8 as required reviewers on every PR. With branch protection's 1-approving-review gate already in place, this means Dependabot bumps now route to us automatically. No more manual reviewer-assignment work.

### Issue templates (GitHub Issue Forms)

- **\`bug.yml\`** — structured form that forces version, OS, Node, demo-mode reproduction, and exact repro steps. Surfaces ~80% of the back-and-forth bug triage previously needed.
- **\`feature.yml\`** — leads with the workflow problem, then the proposed surface. Filters out abstract \"wouldn't it be nice if…\" requests in favor of grounded ones.
- **\`config.yml\`** — disables the blank-issue option and routes three common mis-categorizations:
  - Security vulnerabilities → \`SECURITY.md\` private disclosure flow (not public issues)
  - General questions → \`SUPPORT.md\`
  - Documentation lookups → README

### Test plan

- [x] CI green on this branch (will validate)
- [ ] After merge: open a fake test issue from the GitHub UI — confirm the two forms render and the blank-issue option is gone
- [ ] Confirm Dependabot's next PR auto-assigns reviewers per CODEOWNERS

No code changes; pure config.