### PR TITLE
docs: add stale-shell case to Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,14 @@ All business logic lives in [`@pax8/core`](packages/core) with zero CLI dependen
 
 **Solution:** Install [Node.js 20+](https://nodejs.org/) from nodejs.org.
 
+### `command not found: pax8` after installing Node.js
+
+**Cause:** Your terminal session started before Node.js was installed, so its `PATH` doesn't yet include npm's binary directory.
+
+**Solution:** Close the terminal and open a new one, then re-run the command. Most shells only read `PATH` at startup, so a freshly opened terminal will pick up the new installation. To reload in place without opening a new window, run `exec $SHELL`.
+
+**Still not found in a new shell?** Run `node --version`. If it prints `v20.x` or newer but `pax8` or `npx` still aren't found, this is a real `PATH` problem rather than a stale shell — your Node install put its binaries somewhere that isn't on `PATH` (common with version managers that need extra shell config). If `node --version` also fails, the install didn't complete; reinstall from [nodejs.org](https://nodejs.org/).
+
 ### `npm ERR! code EACCES` during `npm install -g`
 
 **Cause:** npm doesn't have permission to write to the global installation directory (usually because it's owned by root).


### PR DESCRIPTION
## Summary

Adds one entry to the existing Troubleshooting section in README.md covering the case where a user installed Node.js but their existing terminal session was opened before the install, so \`PATH\` doesn't yet include npm's bin directory and \`pax8\` / \`npx\` still appear "not found."

The new entry:
- Leads with the no-diagnosis fix (open a new terminal).
- Offers \`exec \$SHELL\` as an in-place alternative.
- Uses \`node --version\` as the diagnostic only when the new shell still can't find the command, with branches for "Node installed but PATH broken" vs "Node install never completed."

Intentionally prose-only with inline backticks; no new fenced \`\`\`bash blocks containing \`pax8\` / \`PAX8_DEMO=1 pax8\` lines, so the README snippet smoke test has nothing new to execute.

## Test plan

- [ ] CI green (build-and-test across Node 20/22 × Ubuntu/Windows)
- [ ] README snippet smoke test still passes (no new runnable snippets added)
- [ ] Diff is +8 lines, README.md only

🤖 Generated with [Claude Code](https://claude.com/claude-code)