### PR TITLE
docs: add Prerequisites section, drop stray merge marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,20 @@ Every command supports `--json`, so humans and AI agents use the same tool.
 
 Pax8 publishes a hosted MCP server at `mcp.pax8.com` for AI assistants — see the [Pax8 MCP docs](https://devx.pax8.com/docs/mcp-server). Use this CLI when you want a richer command surface (recommendations, invoice audit, Pax8 cost analytics, demo mode) or when you're scripting against a stable, versioned interface. Use the Pax8 MCP when you want zero-install access via Claude, Cursor, Copilot, or VS Code and you don't need the CLI-specific capabilities.
 
+## Prerequisites: Node.js
+
+Run `node --version` in your terminal.
+
+- If it prints **v20** or newer, you're set — skip to [Quick Start](#quick-start).
+- If it prints an older version, or you see `command not found`, install Node.js first:
+  - **Easiest:** download the Node.js LTS installer from [nodejs.org](https://nodejs.org) and run it.
+  - **Or, if you use Homebrew:** `brew install node` (this installs current Node, which is fine — it's well past v20).
+
+Once installed, close this terminal, open a new one, and run `node --version` again to confirm it prints v20 or newer.
+
 ## Quick Start
 
-**Node.js 20+ is the only prerequisite.** No global install needed — use `npx` to run instantly.
+Don't have Node 20+? See [Prerequisites](#prerequisites-nodejs) first.
 
 ### Try with demo data (no credentials)
 
@@ -85,7 +96,6 @@ pax8 recommendations act
 
 ```bash
 pax8 dashboard                 # Quick snapshot: Pax8 monthly cost, renewals, recs, trials
->>>>>>> c6331ae (docs: fix install instructions and verify npm package is published)
 pax8 dashboard --all           # Full dashboard with top customers and details
 pax8 dashboard --renewals      # Focus on upcoming renewals
 pax8 dashboard --growth        # Focus on growth opportunities


### PR DESCRIPTION
## Summary

Quick Start currently assumes Node 20+ is already installed. For a first-time user without Node, that's a wall hidden behind an \`npx\` command. This PR adds a short Prerequisites section above Quick Start with a \`node --version\` diagnostic and the two simplest install paths.

Also removes a stray Git merge-conflict marker (\`>>>>>>> c6331ae ...\`) that leaked into the Commands/Dashboard fenced block during #603's rebase.

### Changes
1. **Delete** a leftover \`>>>>>>>\` marker line in the Dashboard examples block.
2. **Add** new "Prerequisites: Node.js" section above Quick Start with \`node --version\` diagnostic, nodejs.org installer link, and \`brew install node\` fallback. Closes the terminal-and-reopen loop. No version-manager nuance here — that stays in Troubleshooting.
3. **Trim** Quick Start's lead-in: replace the standalone "Node.js 20+ is the only prerequisite" sentence with a one-line cross-link to Prerequisites. The three subsections (npx demo, live use, optional permanent install) are unchanged.
4. **Untouched:** Troubleshooting still owns stale-shell, PATH nuance, and EACCES.

### Smoke test safety
No new lines start with \`pax8\` or \`PAX8_DEMO=1 pax8\`. The new section uses inline backticks only (\`node --version\`, \`brew install node\`) — \`e2e/ux-smoke.test.ts\` has nothing new to execute.

Resulting top-to-bottom order: Prerequisites: Node.js → Quick Start → (rest unchanged) → Troubleshooting.

## Test plan

- [ ] CI green across Node 20/22 × Ubuntu/Windows
- [ ] No \`<<<<<<<\` / \`=======\` / \`>>>>>>>\` markers anywhere in README.md
- [ ] README snippet smoke test passes (no new runnable snippets added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)