### PR TITLE
fix(auth): surface demo-mode source on login/status/doctor

### DIFF
--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -2,7 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
 import { runCli, runCliExpectFailure, runCliExpectSuccess } from "./test-utils.js";
+
+/**
+ * Builds an isolated config dir with `demo: true` written into config.yaml.
+ * Returns the dir path; callers must pass it as `PAX8_CONFIG_DIR` and also
+ * unset `PAX8_DEMO` (the test harness sets it to "1" by default) so the
+ * config-source branch is exercised rather than the env-source branch.
+ */
+async function makeConfigPinnedDemoDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-demo-config-"));
+  await fs.writeFile(
+    path.join(dir, "config.yaml"),
+    "version: '1.0'\ndemo: true\n",
+    "utf-8",
+  );
+  return dir;
+}
 
 describe("pax8 auth", () => {
   describe("auth login", () => {
@@ -23,19 +42,97 @@ describe("pax8 auth", () => {
       expect(result.stdout).toContain("Examples:");
     });
 
-    it("accepts credentials via flags (non-interactive path)", async () => {
+    it("accepts credentials via flags (non-interactive path) — under demo mode, surfaces conflict", async () => {
       // Demo mode short-circuits before validation, but the flag-parsing
       // path still runs — proves the non-interactive contract is intact.
+      // Regression for the silent-no-op trap: when credentials are supplied
+      // but demo mode is active, the user previously saw a green-check
+      // "authenticated" with no signal that creds weren't saved. Now we
+      // emit a stderr warning and embed a `notice` in the JSON envelope.
       const result = await runCliExpectSuccess([
         "auth",
         "login",
         "--client-id",
-        "test-id",
+        "test-id-with-valid-chars",
         "--client-secret",
-        "test-secret",
+        "test-secret-with-valid-chars",
       ]);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.status).toBe("authenticated");
+      expect(parsed.mode).toBe("demo");
+      expect(parsed.demoSource).toBe("env");
+      expect(parsed.notice).toMatch(/demo mode/i);
+      expect(parsed.notice).toMatch(/not saved/i);
+      // Loud stderr warning so interactive users notice the conflict.
+      expect(result.stderr).toMatch(/Demo mode is active/);
+      expect(result.stderr).toMatch(/credentials were NOT saved/);
+    });
+
+    it("emits a `disable demo` nextAction when creds are supplied under demo mode", async () => {
+      const result = await runCliExpectSuccess([
+        "auth",
+        "login",
+        "--client-id",
+        "test-id-with-valid-chars",
+        "--client-secret",
+        "test-secret-with-valid-chars",
+      ]);
+      const parsed = JSON.parse(result.stdout);
+      const actions = parsed.nextActions as Array<{ command: string }>;
+      expect(actions.some((a) => /unset PAX8_DEMO/.test(a.command))).toBe(true);
+    });
+
+    it("bare `auth login` in demo mode adds a dim source hint to the human banner", async () => {
+      const result = await runCliExpectSuccess(["auth", "login"], {
+        PAX8_OUTPUT_FORMAT: "table",
+      });
+      // The dim chalk styling drops the actual codes in non-TTY, but the
+      // literal text is preserved.
+      expect(result.stderr).toContain("Authenticated");
+      expect(result.stderr).toContain("demo source: env");
+    });
+
+    it("bare `auth login` in demo mode (no creds) does NOT emit a notice", async () => {
+      const result = await runCliExpectSuccess(["auth", "login"]);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.status).toBe("authenticated");
+      expect(parsed.notice).toBeUndefined();
+    });
+
+    it("detects `source: config` when PAX8_DEMO is unset but config.demo is true", async () => {
+      // Reproduces Dori's likely entry path: `pax8 init --demo` (or
+      // `pax8 demo on`) pinned `demo: true` in config.yaml. Without the
+      // config-source branch, `auth login` would attempt real cred entry
+      // — but every downstream command still hits the mock client because
+      // `buildContext()` honors config.demo. The fix is to detect this
+      // here too so the user sees the conflict at login time.
+      const dir = await makeConfigPinnedDemoDir();
+      try {
+        const result = await runCliExpectSuccess(
+          [
+            "auth",
+            "login",
+            "--client-id",
+            "real-id-1234",
+            "--client-secret",
+            "real-secret-5678",
+          ],
+          {
+            PAX8_DEMO: "",
+            PAX8_CONFIG_DIR: dir,
+            PAX8_CLIENT_ID: "",
+            PAX8_CLIENT_SECRET: "",
+          },
+        );
+        const parsed = JSON.parse(result.stdout);
+        expect(parsed.mode).toBe("demo");
+        expect(parsed.demoSource).toBe("config");
+        expect(parsed.notice).toMatch(/source: config/);
+        expect(result.stderr).toMatch(/source: config/);
+        expect(result.stderr).toMatch(/pax8 demo off/);
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
     });
 
     // Regression for #471: human banner ("✓ Authenticated (demo mode)") must
@@ -169,7 +266,39 @@ describe("pax8 auth", () => {
     it("emits JSON when --json is passed explicitly", async () => {
       const result = await runCliExpectSuccess(["auth", "status", "--json"]);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed).toEqual({ credentialsPresent: true, mode: "demo" });
+      expect(parsed.credentialsPresent).toBe(true);
+      expect(parsed.mode).toBe("demo");
+      expect(parsed.demoSource).toBe("env");
+    });
+
+    it("surfaces demoSource:config + disable hint when config.demo:true", async () => {
+      const dir = await makeConfigPinnedDemoDir();
+      try {
+        const result = await runCliExpectSuccess(["auth", "status", "--json"], {
+          PAX8_DEMO: "",
+          PAX8_CONFIG_DIR: dir,
+        });
+        const parsed = JSON.parse(result.stdout);
+        expect(parsed.mode).toBe("demo");
+        expect(parsed.demoSource).toBe("config");
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("includes a disable hint in human output (config source)", async () => {
+      const dir = await makeConfigPinnedDemoDir();
+      try {
+        const result = await runCliExpectSuccess(["auth", "status"], {
+          PAX8_DEMO: "",
+          PAX8_CONFIG_DIR: dir,
+          PAX8_OUTPUT_FORMAT: "table",
+        });
+        expect(result.stdout).toContain("Demo source: config");
+        expect(result.stdout).toContain("pax8 demo off");
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -33,6 +33,35 @@ describe("pax8 doctor", () => {
     expect(result.stdout).toContain("Demo mode");
   });
 
+  it("names the demo source + disable hint in the auth check (env)", async () => {
+    // Without this, a partner who pinned demo via `pax8 init --demo` (or
+    // `PAX8_DEMO=1` in a shell rc) sees "Demo mode" and has no idea how
+    // to exit it. The hint names the exact disable command.
+    const result = await runCliExpectSuccess(["doctor"], TABLE);
+    expect(result.stdout).toContain("source: env");
+    expect(result.stdout).toContain("unset PAX8_DEMO");
+  });
+
+  it("names the demo source as `config` when config.demo:true (no env)", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-doctor-cfg-"));
+    try {
+      await fs.writeFile(
+        path.join(dir, "config.yaml"),
+        "version: '1.0'\ndemo: true\n",
+        "utf-8",
+      );
+      const result = await runCliExpectSuccess(["doctor"], {
+        ...TABLE,
+        PAX8_DEMO: "",
+        PAX8_CONFIG_DIR: dir,
+      });
+      expect(result.stdout).toContain("source: config");
+      expect(result.stdout).toContain("pax8 demo off");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reports token fetch skipped in demo mode", async () => {
     const result = await runCliExpectSuccess(["doctor"], TABLE);
     expect(result.stdout).toMatch(/✓.*Token fetch/);

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -14,7 +14,11 @@ import { ask } from "../../lib/prompts.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
 import { replCmd } from "../../lib/confirm.js";
-import { getOutputFormat } from "../../lib/context.js";
+import {
+  getOutputFormat,
+  resolveDemoModeWithSourceAsync,
+  disableDemoHint,
+} from "../../lib/context.js";
 
 function authMissingError(): CliError {
   return new CliError(
@@ -80,7 +84,7 @@ PAX8_CLIENT_SECRET environment variable.`
     const allOpts = command.optsWithGlobals();
     const outputFormat = getOutputFormat(allOpts);
     const jsonMode = outputFormat === "json";
-    const isDemo = process.env.PAX8_DEMO === "1";
+    const { isDemo, source: demoSource } = await resolveDemoModeWithSourceAsync();
 
     // Warn (don't reject) when --client-secret is passed as a flag: the value
     // lands in shell history and process listings. We still honor the flag —
@@ -97,6 +101,27 @@ PAX8_CLIENT_SECRET environment variable.`
     }
 
     if (isDemo) {
+      // Detect the silent-no-op trap (#TBD): user supplied credentials, but
+      // demo mode is active so we'd save nothing and every subsequent command
+      // would hit the mock client. Previously this exited 0 with no signal,
+      // leaving users convinced they'd authenticated. Now we surface the
+      // conflict loudly on stderr and embed a `notice` in the JSON envelope.
+      const credsAttempted =
+        options.clientId !== undefined ||
+        options.clientSecret !== undefined ||
+        !!process.env.PAX8_CLIENT_ID ||
+        !!process.env.PAX8_CLIENT_SECRET;
+
+      if (credsAttempted && demoSource) {
+        process.stderr.write(
+          chalk.yellow(
+            `\n  ⚠ Demo mode is active (source: ${demoSource}) — credentials were NOT saved.\n` +
+              `    Every command will continue to return sample data.\n` +
+              `    To log in with real credentials, ${disableDemoHint(demoSource)} and re-run \`pax8 auth login\`.\n\n`,
+          ),
+        );
+      }
+
       // #471: success banner must not pollute stdout — `pax8 auth login --json | jq`
       // previously got ANSI text and parsing failed. Human banner goes to stderr;
       // `--json` mode emits a structured envelope on stdout.
@@ -106,11 +131,30 @@ PAX8_CLIENT_SECRET environment variable.`
             {
               status: "authenticated",
               mode: "demo",
+              demoSource,
+              ...(credsAttempted && demoSource
+                ? {
+                    notice:
+                      `Demo mode is active (source: ${demoSource}); credentials were NOT saved. ` +
+                      `Disable demo mode and re-run \`pax8 auth login\` to log in for real.`,
+                  }
+                : {}),
               nextActions: [
                 {
                   command: "pax8 dashboard --json",
                   description: "Run a portfolio summary against the demo data set",
                 },
+                ...(credsAttempted && demoSource
+                  ? [
+                      {
+                        command:
+                          demoSource === "env"
+                            ? "unset PAX8_DEMO && pax8 auth login"
+                            : "pax8 demo off && pax8 auth login",
+                        description: "Disable demo mode and log in for real",
+                      },
+                    ]
+                  : []),
               ],
             },
             null,
@@ -121,7 +165,12 @@ PAX8_CLIENT_SECRET environment variable.`
       }
 
       process.stderr.write(
-        chalk.green("\n  ✓ Authenticated (demo mode)\n\n")
+        chalk.green("\n  ✓ Authenticated (demo mode)\n") +
+          (demoSource
+            ? chalk.dim(
+                `    (demo source: ${demoSource} — disable with: ${disableDemoHint(demoSource)})\n\n`,
+              )
+            : "\n"),
       );
       return;
     }

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -101,7 +101,7 @@ PAX8_CLIENT_SECRET environment variable.`
     }
 
     if (isDemo) {
-      // Detect the silent-no-op trap (#TBD): user supplied credentials, but
+      // Detect the silent-no-op trap (#607): user supplied credentials, but
       // demo mode is active so we'd save nothing and every subsequent command
       // would hit the mock client. Previously this exited 0 with no signal,
       // leaving users convinced they'd authenticated. Now we surface the

--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -75,7 +75,13 @@ describe("auth status", () => {
     await makeProgram().parseAsync(["node", "pax8", "auth", "status", "--json"]);
     const out = captured().trim();
     const parsed = JSON.parse(out);
-    expect(parsed).toEqual({ credentialsPresent: true, mode: "demo" });
+    // `demoSource` was added so users can see *where* demo mode came from
+    // and how to disable it. For PAX8_DEMO=1, the source is `env`.
+    expect(parsed).toEqual({
+      credentialsPresent: true,
+      mode: "demo",
+      demoSource: "env",
+    });
   });
 
   it("emits human-formatted text in TTY mode without --json (demo)", async () => {

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -5,7 +5,12 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { CredentialStore } from "@pax8/core";
 import { replCmd } from "../../lib/confirm.js";
-import { getOutputFormat } from "../../lib/context.js";
+import {
+  getOutputFormat,
+  resolveDemoModeWithSourceAsync,
+  disableDemoHint,
+  type DemoSource,
+} from "../../lib/context.js";
 
 // `auth status` reports whether credentials are present on disk — it does NOT
 // hit the API. A user with rotated or revoked credentials would see
@@ -13,9 +18,15 @@ import { getOutputFormat } from "../../lib/context.js";
 // For an actual authentication check, run `pax8 doctor`, which mints a token
 // against the Pax8 API. The field name is deliberately literal so the JSON
 // shape can't mislead an agent or script consumer (#573).
+//
+// `demoSource` is populated only when `mode === "demo"`. It tells consumers
+// (and the human view) *where* demo mode was configured so they can disable
+// it without guessing — same root cause as the silent-no-op trap fixed in
+// `auth login`.
 interface AuthStatusJson {
   credentialsPresent: boolean;
   mode: "demo" | "live";
+  demoSource?: DemoSource;
   clientIdMasked?: string;
 }
 
@@ -35,13 +46,14 @@ Notes:
   .action(async (_options, command: Command) => {
     const allOpts = command.optsWithGlobals();
     const format = getOutputFormat(allOpts);
-    const isDemo = process.env.PAX8_DEMO === "1";
+    const { isDemo, source: demoSource } = await resolveDemoModeWithSourceAsync();
 
     if (isDemo) {
       if (format === "json") {
         const payload: AuthStatusJson = {
           credentialsPresent: true,
           mode: "demo",
+          demoSource,
         };
         process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
         return;
@@ -55,6 +67,13 @@ Notes:
       process.stdout.write(
         chalk.dim("  All commands return mock data\n")
       );
+      if (demoSource) {
+        process.stdout.write(
+          chalk.dim(
+            `  Demo source: ${demoSource} — disable with: ${disableDemoHint(demoSource)}\n`,
+          ),
+        );
+      }
       process.stdout.write("\n");
       return;
     }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -7,7 +7,12 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { replCmd } from "../lib/confirm.js";
 import { CredentialStore, getConfigDir, getDefaultBaseUrl } from "@pax8/core";
-import { getOutputFormat, resolveDemoModeAsync } from "../lib/context.js";
+import {
+  getOutputFormat,
+  resolveDemoModeAsync,
+  resolveDemoModeWithSourceAsync,
+  disableDemoHint,
+} from "../lib/context.js";
 
 // Build-time injected by tsup (see packages/cli/tsup.config.ts). At runtime
 // inside `pax8 doctor --json` we surface this in the structured envelope so
@@ -85,9 +90,20 @@ async function checkConfigFile(): Promise<CheckResult> {
 }
 
 async function checkAuth(): Promise<CheckResult> {
-  const isDemo = await isDemoMode();
+  const { isDemo, source: demoSource } = await resolveDemoModeWithSourceAsync();
   if (isDemo) {
-    return { name: "Authentication configured", passed: true, detail: "Demo mode" };
+    // Tell the user *where* demo mode came from. Without this, a partner
+    // who pinned demo via `pax8 init --demo` (or `pax8 demo on`) sees
+    // "Demo mode" on doctor, runs `auth login`, gets a green checkmark,
+    // and then can't figure out why every command still returns sample
+    // data. The hint names the right disable command for the source.
+    const sourceTag = demoSource ? ` (source: ${demoSource})` : "";
+    const disableTag = demoSource ? ` — disable with: ${disableDemoHint(demoSource)}` : "";
+    return {
+      name: "Authentication configured",
+      passed: true,
+      detail: `Demo mode${sourceTag}${disableTag}`,
+    };
   }
 
   const store = new CredentialStore();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -22,7 +22,11 @@ Examples:
   pax8 init                Create default config at <config-dir>/config.yaml
   pax8 init --force        Overwrite an existing config with defaults
   pax8 init --demo         Enable demo mode persistently (no credentials needed)
-  pax8 init --demo off     Disable demo mode and return to live API`
+  pax8 demo off            Disable demo mode and return to live API
+
+For one-shot demo runs (no persistence), prefer:
+  PAX8_DEMO=1 pax8 dashboard       (macOS/Linux)
+  $env:PAX8_DEMO="1"; pax8 dashboard   (PowerShell)`
   )
   .action(async (options) => {
     try {
@@ -50,10 +54,15 @@ Examples:
           config.demo = true;
           await saveConfig(config);
           process.stdout.write(
-            chalk.green(`\n  ✓ Demo mode enabled. Try: ${replCmd("pax8 clients list")}\n`)
+            chalk.green(`\n  ✓ Demo mode enabled (persistent). Try: ${replCmd("pax8 clients list")}\n`)
           );
+          // Wording matches `auth status`, `auth login`, and `doctor` — all
+          // four point at `pax8 demo off`. Previously this one said
+          // `pax8 init --demo off`, which works but creates two ways to say
+          // the same thing and made the "where's demo coming from?" debug
+          // path harder to follow.
           process.stdout.write(
-            chalk.dim(`  Disable with: ${replCmd("pax8 init --demo off")}\n\n`)
+            chalk.dim(`  Disable with: ${replCmd("pax8 demo off")}\n\n`)
           );
         }
         return;

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -161,6 +161,43 @@ export async function resolveDemoModeAsync(): Promise<boolean> {
   }
 }
 
+/**
+ * Like `resolveDemoModeAsync` but also returns *where* demo mode came from
+ * (`env` | `config` | `null`). Callers that need to tell users how to turn
+ * demo off — `auth login`, `auth status`, `doctor` — use this so the hint
+ * names the right thing (`unset PAX8_DEMO` vs `pax8 demo off`).
+ *
+ * Same precedence as `resolveDemoMode`: env literal wins (`1`/`true`/`0`/
+ * `false`), then `config.demo`. Returns `source: null` when demo is off.
+ */
+export type DemoSource = "env" | "config" | null;
+export async function resolveDemoModeWithSourceAsync(): Promise<{
+  isDemo: boolean;
+  source: DemoSource;
+}> {
+  const envDemo = process.env.PAX8_DEMO;
+  if (envDemo === "1" || envDemo === "true") return { isDemo: true, source: "env" };
+  if (envDemo === "0" || envDemo === "false") return { isDemo: false, source: null };
+  try {
+    const cfg = await loadConfig();
+    if ("demo" in cfg && cfg.demo === true) return { isDemo: true, source: "config" };
+  } catch {
+    // Config unreadable — fall through; treat as demo off.
+  }
+  return { isDemo: false, source: null };
+}
+
+/**
+ * The shell-friendly instruction for turning off demo mode, given its
+ * source. Surfaced verbatim in user-facing copy from `auth login`,
+ * `auth status`, and `doctor`. Centralized so the wording stays consistent.
+ */
+export function disableDemoHint(source: Exclude<DemoSource, null>): string {
+  return source === "env"
+    ? "unset PAX8_DEMO (or run with `PAX8_DEMO=0`)"
+    : `run \`${replCmd("pax8 demo off")}\``;
+}
+
 export async function buildContext(
   options: GlobalOptions,
 ): Promise<CommandContext> {

--- a/packages/cli/src/lib/welcome.test.ts
+++ b/packages/cli/src/lib/welcome.test.ts
@@ -58,8 +58,19 @@ describe("showWelcomeScreen", () => {
     expect(captured).toContain("auth login");
     expect(captured).toContain("Stuck?");
     expect(captured).toContain("doctor");
-    expect(captured).toContain("Sample data, no auth required");
+    expect(captured).toContain("Sample data, one-shot");
     expect(captured).toContain("Connect your Pax8 partner account");
+
+    // Regression guard: the persistent-demo option must be visibly
+    // annotated as persistent + name the disable command. Without this,
+    // first-run users pinned demo mode via `init --demo`, ran `auth login`,
+    // and couldn't figure out why every command still returned sample data.
+    expect(captured).toContain("Pin demo mode (persistent");
+    expect(captured).toContain("demo off");
+
+    // The safer one-shot entry-point (env-var, no persistence) is also
+    // surfaced as a first-class option alongside `init --demo`.
+    expect(captured).toContain("PAX8_DEMO=1 pax8 dashboard");
 
     // The authenticated-only command headings/items must NOT appear.
     // Note: "recommendations" appears in the value-prop blurb ("upsell
@@ -93,8 +104,9 @@ describe("showWelcomeScreen", () => {
     // The unauthenticated-only sections must NOT appear.
     expect(captured).not.toContain("Try it:");
     expect(captured).not.toContain("Stuck?");
-    expect(captured).not.toContain("Sample data, no auth required");
+    expect(captured).not.toContain("Sample data, one-shot");
     expect(captured).not.toContain("Connect your Pax8 partner account");
+    expect(captured).not.toContain("Pin demo mode");
 
     expect(captured).toContain("Pax8 CLI turns the marketplace API");
   });

--- a/packages/cli/src/lib/welcome.ts
+++ b/packages/cli/src/lib/welcome.ts
@@ -54,9 +54,9 @@ export async function showWelcomeScreen(): Promise<void> {
   const authed = await isAuthenticated();
 
   // Column width is sized to the longest command across both branches
-  // (`subscriptions renewals` = 22 chars). +2 for trailing padding so the
+  // (`PAX8_DEMO=1 pax8 dash…` = 26 chars). +2 for trailing padding so the
   // descriptions line up cleanly under either layout.
-  const COL = 24;
+  const COL = 28;
   const cmd = (name: string): string => chalk.cyan(name.padEnd(COL));
 
   const commandBlock = authed
@@ -70,9 +70,15 @@ export async function showWelcomeScreen(): Promise<void> {
         `    ${cmd("help")}${chalk.dim("All commands · doctor for setup checks")}`,
       ]
     : [
+        // First-run options. Order matters: the ephemeral one-shot demo is
+        // listed first because it's the safer entry-point — it doesn't pin
+        // demo mode in config and so it can't silently override a later
+        // `auth login`. `init --demo` stays available but is annotated as
+        // persistent so first-run users understand what they're enabling.
         `  ${chalk.dim("Try it:")}`,
-        `    ${cmd("init --demo")}${chalk.dim("Sample data, no auth required")}`,
+        `    ${cmd("PAX8_DEMO=1 pax8 dashboard")}${chalk.dim("Sample data, one-shot (no setup)")}`,
         `    ${cmd("auth login")}${chalk.dim("Connect your Pax8 partner account")}`,
+        `    ${cmd("init --demo")}${chalk.dim("Pin demo mode (persistent — disable with `demo off`)")}`,
         "",
         `  ${chalk.dim("Stuck?")}`,
         `    ${cmd("doctor")}${chalk.dim("Check your setup")}`,


### PR DESCRIPTION
## Summary

- Closes #607 — `pax8 auth login` silently no-op'd under demo mode (env or config-pinned), leaving users convinced they'd authenticated while every command kept returning sample data.
- Centralizes demo-mode resolution with source attribution in `lib/context.ts` and propagates it through `auth login`, `auth status`, and `doctor` so users always see *where* demo mode came from and *how* to disable it.
- Reframes the welcome screen so the ephemeral `PAX8_DEMO=1 pax8 <cmd>` pattern is the first first-run suggestion; `init --demo` stays available but is annotated as persistent.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Bare `pax8 auth login` with `PAX8_DEMO=1` | `✓ Authenticated (demo mode)` | Same + dim hint: `(demo source: env — disable with: unset PAX8_DEMO)` |
| `pax8 auth login --client-id … --client-secret …` with `PAX8_DEMO=1` | Silent success — creds discarded, no signal | Loud yellow stderr warning: `⚠ Demo mode is active (source: env) — credentials were NOT saved`. JSON envelope gains `notice` and a `disable demo` `nextAction`. |
| Same with `config.demo: true` (pinned by `pax8 init --demo`) | Silently saved real creds — but every downstream command still hit `MockPax8Client` | Now also detected; warning names `source: config`, hint says `run pax8 demo off` |
| `pax8 auth status --json` in demo | `{ credentialsPresent: true, mode: \"demo\" }` | Adds `demoSource: \"env\" \| \"config\"` |
| `pax8 doctor` "Authentication configured" line in demo | `Demo mode` | `Demo mode (source: <env\|config>) — disable with: …` |
| Welcome screen ("Try it") | `init --demo  Sample data, no auth required` | `PAX8_DEMO=1 pax8 dashboard  Sample data, one-shot (no setup)` listed first; `init --demo` annotated `Pin demo mode (persistent — disable with \`demo off\`)` |
| `init --demo` success message | `Disable with: pax8 init --demo off` | `Disable with: pax8 demo off` |

## Compatibility

Agent / CI contract: every JSON change is additive. Existing required fields (`status`, `mode`, `credentialsPresent`) are unchanged; new optional fields (`demoSource`, `notice`) are nullable / omitted when irrelevant. Existing tests that strict-equal'd the demo-mode envelopes were updated to include the new `demoSource: \"env\"` field.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` — **2203 passed / 6 skipped / 6 todo** (was 2198; +5 new test cases, no regressions)
- [x] Manual repro of both env-source and config-source paths for `auth login`, `auth status`, and `doctor` — all three surface the source and the disable command correctly
- [x] Welcome screen rendered manually — one-shot pattern is listed first; `init --demo` annotated as persistent
- [ ] **Reviewer**: verify the `init --demo` flow you previously relied on still works (`pax8 init --demo` → writes `demo: true`; `pax8 demo off` reverses it)
- [ ] **Reviewer**: confirm no agent / SDK consumers depend on `auth status --json` being a strict-equal `{credentialsPresent, mode}` two-field object

## Out of scope

- Renaming or removing `pax8 init --demo off` (still works; we just stopped recommending it).
- Browser-based / device-code auth flow for live login — separate concern.
- README + getting-started docs updates — track separately.