### PR TITLE
feat(auth): add --browser flag to auth login (#610)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ export PAX8_CLIENT_SECRET=your-client-secret
 
 Generate API credentials in the [Pax8 Integrations Hub](https://app.pax8.com). For detailed setup instructions, see the [Credential Setup Guide](docs/credential-setup.md). A copy-pasteable starter is in [`.env.example`](.env.example).
 
+Pass `--browser` to `pax8 auth login` to open the [credentials page](https://app.pax8.com/integrations/credentials) in your default browser before the prompt — you still paste the Client ID and Secret into the terminal (the flag doesn't eliminate the secret, just the click-through to find the page). Falls back to printing the URL on headless / SSH boxes.
+
 ### Pointing at a non-prod environment
 
 By default, the CLI talks to `https://api.pax8.com/v1`. Partners testing against a sandbox or staging environment can override the base URL without code changes:

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -247,6 +247,136 @@ describe("pax8 auth", () => {
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr + result.stdout).toMatch(/Missing credentials|client-id/);
     });
+
+    // --- #610: `--browser` flag --------------------------------------------
+
+    it("advertises --browser in help with a one-line description (#610)", async () => {
+      const result = await runCliExpectSuccess(["auth", "login", "--help"]);
+      expect(result.stdout).toContain("--browser");
+      // Affirmatively name what gets opened so the help line is actionable.
+      expect(result.stdout.toLowerCase()).toMatch(/browser/);
+    });
+
+    it("with --browser, invokes the opener with the credentials URL (#610)", async () => {
+      // Stub the opener via PAX8_OPEN_URL_LOG: openUrl() appends the URL to
+      // the file path instead of spawning a real `open` / `xdg-open`. Lets
+      // us assert the opener was called with the right URL from a subprocess
+      // test without launching a browser on the CI box.
+      const logPath = path.join(os.tmpdir(), `pax8-open-url-${Date.now()}.log`);
+      try {
+        await runCli(["auth", "login", "--browser"], {
+          PAX8_DEMO: "",
+          PAX8_CLIENT_ID: "",
+          PAX8_CLIENT_SECRET: "",
+          PAX8_OPEN_URL_LOG: logPath,
+        });
+        const logged = await fs.readFile(logPath, "utf-8");
+        expect(logged.trim()).toBe(
+          "https://app.pax8.com/integrations/credentials",
+        );
+      } finally {
+        await fs.rm(logPath, { force: true });
+      }
+    });
+
+    it("with --browser, prints a 'what to do there' hint pointing at the credentials page (#610)", async () => {
+      const logPath = path.join(os.tmpdir(), `pax8-open-url-${Date.now()}.log`);
+      try {
+        const result = await runCli(["auth", "login", "--browser"], {
+          PAX8_DEMO: "",
+          PAX8_CLIENT_ID: "",
+          PAX8_CLIENT_SECRET: "",
+          PAX8_OPEN_URL_LOG: logPath,
+        });
+        // One-line "what we're opening / what to do" message lands on
+        // stderr per the stdout-is-data contract.
+        expect(result.stderr).toContain(
+          "https://app.pax8.com/integrations/credentials",
+        );
+        expect(result.stderr.toLowerCase()).toMatch(/paste|client id/);
+      } finally {
+        await fs.rm(logPath, { force: true });
+      }
+    });
+
+    it("with --browser, the prompt flow continues after the opener returns (#610)", async () => {
+      // Subprocess stdin is non-TTY, so the interactive prompt block is
+      // skipped — but the post-open code still runs and falls through to
+      // the missing-creds error path. Asserting that we get the normal
+      // missing-creds error (not a hang, not a crash) proves the flow
+      // continued past the browser-open step rather than blocking on it.
+      const logPath = path.join(os.tmpdir(), `pax8-open-url-${Date.now()}.log`);
+      try {
+        const result = await runCli(["auth", "login", "--browser"], {
+          PAX8_DEMO: "",
+          PAX8_CLIENT_ID: "",
+          PAX8_CLIENT_SECRET: "",
+          PAX8_OPEN_URL_LOG: logPath,
+        });
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stderr + result.stdout).toMatch(
+          /Missing credentials|client-id/,
+        );
+      } finally {
+        await fs.rm(logPath, { force: true });
+      }
+    });
+
+    it("with --browser and a no-opener fallback, prints the URL plainly and continues (#610)", async () => {
+      // PAX8_OPEN_URL_SUCCESS=0 makes the stubbed opener report failure
+      // (headless / SSH / missing-binary simulation). The CLI must print
+      // the URL plainly on stderr and proceed — never block, never crash.
+      const logPath = path.join(os.tmpdir(), `pax8-open-url-${Date.now()}.log`);
+      try {
+        const result = await runCli(["auth", "login", "--browser"], {
+          PAX8_DEMO: "",
+          PAX8_CLIENT_ID: "",
+          PAX8_CLIENT_SECRET: "",
+          PAX8_OPEN_URL_LOG: logPath,
+          PAX8_OPEN_URL_SUCCESS: "0",
+        });
+        // URL is printed (twice — once in the intro line, once in the
+        // fallback hint — both fine).
+        expect(result.stderr).toContain(
+          "https://app.pax8.com/integrations/credentials",
+        );
+        expect(result.stderr.toLowerCase()).toMatch(
+          /could not launch|open this url manually/,
+        );
+        // Flow proceeds to the normal missing-creds error (no hang).
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stderr + result.stdout).toMatch(
+          /Missing credentials|client-id/,
+        );
+      } finally {
+        await fs.rm(logPath, { force: true });
+      }
+    });
+
+    it("--browser is a no-op short-circuit under demo mode (no opener call) (#610)", async () => {
+      // Demo mode short-circuits the whole login flow before the
+      // browser-open block, so the opener must not be called even with
+      // --browser. Matches the demo contract — every flag is a no-op
+      // short-circuit under PAX8_DEMO=1.
+      const logPath = path.join(os.tmpdir(), `pax8-open-url-${Date.now()}.log`);
+      try {
+        await runCliExpectSuccess(["auth", "login", "--browser"], {
+          PAX8_OPEN_URL_LOG: logPath,
+        });
+        // Either the file doesn't exist (preferred) or it's empty — both
+        // prove the opener was not called.
+        const exists = await fs
+          .stat(logPath)
+          .then(() => true)
+          .catch(() => false);
+        if (exists) {
+          const logged = await fs.readFile(logPath, "utf-8");
+          expect(logged).toBe("");
+        }
+      } finally {
+        await fs.rm(logPath, { force: true });
+      }
+    });
   });
 
   describe("auth status", () => {

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -262,6 +262,11 @@ describe("pax8 auth", () => {
       // the file path instead of spawning a real `open` / `xdg-open`. Lets
       // us assert the opener was called with the right URL from a subprocess
       // test without launching a browser on the CI box.
+      //
+      // PAX8_OUTPUT_FORMAT=table forces the human/table path: subprocess
+      // stdout is non-TTY, so `getOutputFormat()` would otherwise resolve
+      // to `json`, and the `--browser` block is gated on `!jsonMode` so an
+      // agent passing `--json` never gets a stray GUI browser.
       const logPath = path.join(os.tmpdir(), `pax8-open-url-${Date.now()}.log`);
       try {
         await runCli(["auth", "login", "--browser"], {
@@ -269,6 +274,7 @@ describe("pax8 auth", () => {
           PAX8_CLIENT_ID: "",
           PAX8_CLIENT_SECRET: "",
           PAX8_OPEN_URL_LOG: logPath,
+          PAX8_OUTPUT_FORMAT: "table",
         });
         const logged = await fs.readFile(logPath, "utf-8");
         expect(logged.trim()).toBe(
@@ -287,6 +293,7 @@ describe("pax8 auth", () => {
           PAX8_CLIENT_ID: "",
           PAX8_CLIENT_SECRET: "",
           PAX8_OPEN_URL_LOG: logPath,
+          PAX8_OUTPUT_FORMAT: "table",
         });
         // One-line "what we're opening / what to do" message lands on
         // stderr per the stdout-is-data contract.
@@ -312,6 +319,7 @@ describe("pax8 auth", () => {
           PAX8_CLIENT_ID: "",
           PAX8_CLIENT_SECRET: "",
           PAX8_OPEN_URL_LOG: logPath,
+          PAX8_OUTPUT_FORMAT: "table",
         });
         expect(result.exitCode).not.toBe(0);
         expect(result.stderr + result.stdout).toMatch(
@@ -334,6 +342,7 @@ describe("pax8 auth", () => {
           PAX8_CLIENT_SECRET: "",
           PAX8_OPEN_URL_LOG: logPath,
           PAX8_OPEN_URL_SUCCESS: "0",
+          PAX8_OUTPUT_FORMAT: "table",
         });
         // URL is printed (twice — once in the intro line, once in the
         // fallback hint — both fine).
@@ -373,6 +382,38 @@ describe("pax8 auth", () => {
           const logged = await fs.readFile(logPath, "utf-8");
           expect(logged).toBe("");
         }
+      } finally {
+        await fs.rm(logPath, { force: true });
+      }
+    });
+
+    it("--browser + --json does NOT open a browser (no GUI from agent invocations) (#610)", async () => {
+      // Agents and CI scripts pass `--json` for machine-readable output.
+      // Spawning a GUI browser during a machine-driven invocation is
+      // surprising and useless — there's no human to paste into the prompt.
+      // The flow should fall straight through to the structured
+      // missing-creds error without ever calling the opener.
+      const logPath = path.join(os.tmpdir(), `pax8-open-url-${Date.now()}.log`);
+      try {
+        const result = await runCli(["auth", "login", "--browser", "--json"], {
+          PAX8_DEMO: "",
+          PAX8_CLIENT_ID: "",
+          PAX8_CLIENT_SECRET: "",
+          PAX8_OPEN_URL_LOG: logPath,
+        });
+        // Opener was not invoked.
+        const exists = await fs
+          .stat(logPath)
+          .then(() => true)
+          .catch(() => false);
+        if (exists) {
+          const logged = await fs.readFile(logPath, "utf-8");
+          expect(logged).toBe("");
+        }
+        // And the flow proceeded to the normal missing-creds error path.
+        expect(result.exitCode).not.toBe(0);
+        const haystack = result.stderr + result.stdout;
+        expect(haystack).toMatch(/Missing credentials|ERROR_AUTH_MISSING/);
       } finally {
         await fs.rm(logPath, { force: true });
       }

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -19,6 +19,15 @@ import {
   resolveDemoModeWithSourceAsync,
   disableDemoHint,
 } from "../../lib/context.js";
+import { openUrl } from "../../lib/open-url.js";
+
+/**
+ * Pax8 Integrations Hub credentials page. `--browser` opens this URL so the
+ * user can create / copy an API credential without having to find the link
+ * themselves. The page is documented in the Authentication section of the
+ * README and the Credential Setup Guide.
+ */
+const CREDENTIALS_URL = "https://app.pax8.com/integrations/credentials";
 
 function authMissingError(): CliError {
   return new CliError(
@@ -60,6 +69,10 @@ export const authLoginCommand = new Command("login")
   .description("Authenticate with Pax8 API credentials")
   .option("--client-id <id>", "Pax8 client ID")
   .option("--client-secret <secret>", "Pax8 client secret")
+  .option(
+    "--browser",
+    "open the Pax8 credentials page in your default browser before prompting",
+  )
   .addHelpText(
     "after",
     `
@@ -67,6 +80,11 @@ Examples:
   # Interactive (recommended — prompts for the secret without echoing it
   # to shell history)
   pax8 auth login
+
+  # Opens the Pax8 credentials page in your default browser, then prompts
+  # for the values you just copied. Falls back to printing the URL if no
+  # browser is available (headless / SSH).
+  pax8 auth login --browser
 
   pax8 auth login --json
 
@@ -179,6 +197,35 @@ PAX8_CLIENT_SECRET environment variable.`
       options.clientId ?? process.env.PAX8_CLIENT_ID;
     let clientSecret: string | undefined =
       options.clientSecret ?? process.env.PAX8_CLIENT_SECRET;
+
+    // `--browser` opens the credentials page so the user doesn't have to find
+    // the link themselves, then falls through to the normal interactive
+    // prompt below. Only meaningful when we still need credentials — if
+    // flags / env vars already supplied them, there's nothing to paste so
+    // opening a browser would be confusing. Scope is deliberately small:
+    // open URL, fall back to printing it on failure, continue the existing
+    // paste flow (#610). Not OAuth — that's #609.
+    if (options.browser && (!clientId || !clientSecret)) {
+      process.stderr.write(
+        chalk.cyan(
+          `\n  Opening the Pax8 Integrations Hub credentials page in your default browser.\n` +
+            `  Create or copy an API credential there, then paste the Client ID and Secret below.\n` +
+            `  Page: ${CREDENTIALS_URL}\n\n`,
+        ),
+      );
+      const opened = await openUrl(CREDENTIALS_URL);
+      if (!opened) {
+        // Headless / SSH / no opener installed — never block on the browser.
+        // Print the URL plainly so the user can open it themselves, then
+        // continue straight into the interactive prompt.
+        process.stderr.write(
+          chalk.yellow(
+            `  Could not launch a browser automatically. Open this URL manually:\n` +
+              `    ${CREDENTIALS_URL}\n\n`,
+          ),
+        );
+      }
+    }
 
     // Interactive fallback: prompt only when stdin is a TTY and credentials
     // weren't supplied via flags or env vars. Non-TTY without credentials

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -205,7 +205,13 @@ PAX8_CLIENT_SECRET environment variable.`
     // opening a browser would be confusing. Scope is deliberately small:
     // open URL, fall back to printing it on failure, continue the existing
     // paste flow (#610). Not OAuth — that's #609.
-    if (options.browser && (!clientId || !clientSecret)) {
+    //
+    // Skip in `--json` mode: launching a GUI browser during a machine-driven
+    // invocation (agent, CI) is surprising, and the paste prompt that follows
+    // would just error with `Missing credentials` anyway since `--json` mode
+    // implies non-interactive use. The agent caller gets the structured
+    // missing-creds error without a stray browser window.
+    if (options.browser && (!clientId || !clientSecret) && !jsonMode) {
       process.stderr.write(
         chalk.cyan(
           `\n  Opening the Pax8 Integrations Hub credentials page in your default browser.\n` +

--- a/packages/cli/src/commands/report-bug.ts
+++ b/packages/cli/src/commands/report-bug.ts
@@ -5,10 +5,11 @@ import { Command } from "commander";
 import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { execFile, spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { getConfigDir } from "@pax8/core";
 import { confirm } from "../lib/confirm.js";
+import { openUrl } from "../lib/open-url.js";
 import { redactEnvelope, type BugReportEnvelope } from "../lib/redactor.js";
 
 const execFileP = promisify(execFile);
@@ -89,40 +90,6 @@ export function buildIssueTitle(env: BugReportEnvelope): string {
   const msg = (env.message ?? "").trim().split("\n")[0] ?? "";
   const truncated = msg.length > 60 ? msg.slice(0, 60).trimEnd() + "…" : msg;
   return `[${code}] ${truncated}`.trim();
-}
-
-/**
- * Cross-platform "open this URL in the user's default browser" using only
- * Node's built-in `child_process` — deliberately avoids the `open` npm
- * package since this is the only call site and the platform commands are
- * stable.
- */
-async function openUrl(url: string): Promise<void> {
-  const platform = process.platform;
-  let cmd: string;
-  let args: string[];
-  if (platform === "darwin") {
-    cmd = "open";
-    args = [url];
-  } else if (platform === "win32") {
-    // `start` is a cmd.exe builtin; `""` is the empty title arg required when
-    // the URL contains characters cmd would otherwise treat as a title.
-    cmd = "cmd";
-    args = ["/c", "start", "", url];
-  } else {
-    cmd = "xdg-open";
-    args = [url];
-  }
-  await new Promise<void>((resolve) => {
-    const child = spawn(cmd, args, {
-      detached: true,
-      stdio: "ignore",
-    });
-    child.on("error", () => resolve());
-    child.unref();
-    // Don't await — detached. Resolve next tick so the caller can return.
-    setImmediate(resolve);
-  });
 }
 
 /**

--- a/packages/cli/src/lib/open-url.test.ts
+++ b/packages/cli/src/lib/open-url.test.ts
@@ -1,0 +1,94 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { openUrl, resolveOpener, type Spawner } from "./open-url.js";
+
+/**
+ * Build a fake child-process emitter that satisfies the subset of
+ * ChildProcess our `Spawner` shape requires. Optionally fires `error` on
+ * next tick so we can exercise the failure branch.
+ */
+function fakeChild(opts: { failWith?: Error } = {}) {
+  const ee = new EventEmitter() as EventEmitter & { unref: () => void };
+  ee.unref = () => {};
+  if (opts.failWith) {
+    process.nextTick(() => ee.emit("error", opts.failWith));
+  }
+  return ee;
+}
+
+describe("resolveOpener", () => {
+  it("returns `open` + [url] on darwin", () => {
+    const r = resolveOpener("darwin");
+    expect(r.cmd).toBe("open");
+    expect(r.args("https://example.com")).toEqual(["https://example.com"]);
+  });
+
+  it("returns `cmd /c start \"\" <url>` on win32 (handles URL-special chars)", () => {
+    const r = resolveOpener("win32");
+    expect(r.cmd).toBe("cmd");
+    expect(r.args("https://example.com?a=1&b=2")).toEqual([
+      "/c",
+      "start",
+      "",
+      "https://example.com?a=1&b=2",
+    ]);
+  });
+
+  it("returns `xdg-open` + [url] on linux / other", () => {
+    const r = resolveOpener("linux");
+    expect(r.cmd).toBe("xdg-open");
+    expect(r.args("https://example.com")).toEqual(["https://example.com"]);
+  });
+});
+
+describe("openUrl", () => {
+  it("invokes the platform opener with the URL and resolves true", async () => {
+    const spawner = vi.fn<Spawner>().mockReturnValue(fakeChild());
+    const ok = await openUrl("https://example.com/x", {
+      spawner,
+      platform: "darwin",
+      logPath: null,
+    });
+    expect(ok).toBe(true);
+    expect(spawner).toHaveBeenCalledTimes(1);
+    const [cmd, args] = spawner.mock.calls[0];
+    expect(cmd).toBe("open");
+    expect(args).toEqual(["https://example.com/x"]);
+  });
+
+  it("resolves false when the spawner emits an error (no opener / headless)", async () => {
+    const spawner = vi
+      .fn<Spawner>()
+      .mockReturnValue(fakeChild({ failWith: new Error("ENOENT") }));
+    const ok = await openUrl("https://example.com/y", {
+      spawner,
+      platform: "linux",
+      logPath: null,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("resolves false when the spawner throws synchronously", async () => {
+    const spawner = vi.fn<Spawner>().mockImplementation(() => {
+      throw new Error("spawn EACCES");
+    });
+    const ok = await openUrl("https://example.com/z", {
+      spawner,
+      platform: "linux",
+      logPath: null,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("never throws even when the spawner is broken", async () => {
+    const spawner = vi.fn<Spawner>().mockImplementation(() => {
+      throw new Error("boom");
+    });
+    await expect(
+      openUrl("https://example.com", { spawner, platform: "linux", logPath: null }),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/cli/src/lib/open-url.ts
+++ b/packages/cli/src/lib/open-url.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawn, type SpawnOptions } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+/**
+ * Spawner shape used by `openUrl`. Carved out as a type so tests can inject a
+ * stub without monkey-patching `node:child_process`.
+ */
+export type Spawner = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: SpawnOptions,
+) => { on: (event: "error", listener: (err: Error) => void) => void; unref: () => void };
+
+/**
+ * Resolve the OS-native opener for a URL. Exposed so tests can assert the
+ * argv shape per platform without spawning a real process.
+ */
+export function resolveOpener(
+  platform: NodeJS.Platform = process.platform,
+): { cmd: string; args: (url: string) => string[] } {
+  if (platform === "darwin") {
+    return { cmd: "open", args: (url) => [url] };
+  }
+  if (platform === "win32") {
+    // `start` is a cmd.exe builtin; `""` is the empty title arg required when
+    // the URL contains characters cmd would otherwise treat as a title.
+    return { cmd: "cmd", args: (url) => ["/c", "start", "", url] };
+  }
+  return { cmd: "xdg-open", args: (url) => [url] };
+}
+
+/**
+ * Cross-platform "open this URL in the user's default browser" using only
+ * Node built-ins — deliberately avoids the `open` npm package since the
+ * platform commands are stable and the call sites are few.
+ *
+ * Resolves to `true` if the opener spawned without error, `false` otherwise.
+ * Headless environments (no `xdg-open`, no DISPLAY, SSH-only shells) report
+ * `false` so callers can print the URL plainly and continue rather than
+ * blocking on a browser that will never appear.
+ *
+ * Never throws — callers can `await` without try/catch.
+ */
+export async function openUrl(
+  url: string,
+  opts: {
+    spawner?: Spawner;
+    platform?: NodeJS.Platform;
+    /**
+     * Test hook: when truthy (default reads `PAX8_OPEN_URL_LOG`), the URL
+     * that would have been opened is appended to that file path instead of
+     * spawning a process. Returns the value of `PAX8_OPEN_URL_SUCCESS`
+     * (`"0"` simulates a failed opener, anything else simulates success).
+     * Internal — not part of the public CLI contract.
+     */
+     logPath?: string | null;
+  } = {},
+): Promise<boolean> {
+  const logPath = opts.logPath ?? process.env.PAX8_OPEN_URL_LOG ?? null;
+  if (logPath) {
+    try {
+      appendFileSync(logPath, url + "\n");
+    } catch {
+      // Don't let a logging-side failure cascade.
+    }
+    return process.env.PAX8_OPEN_URL_SUCCESS === "0" ? false : true;
+  }
+  const { cmd, args } = resolveOpener(opts.platform);
+  const spawner = opts.spawner ?? ((c, a, o) => spawn(c, a, o));
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    try {
+      const child = spawner(cmd, args(url), {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.on("error", () => finish(false));
+      child.unref();
+      // The opener is detached; we don't wait for it to exit. Resolve next
+      // tick so the caller can return — if `error` fires synchronously
+      // (missing binary), the `false` branch above wins.
+      setImmediate(() => finish(true));
+    } catch {
+      finish(false);
+    }
+  });
+}

--- a/packages/cli/src/lib/open-url.ts
+++ b/packages/cli/src/lib/open-url.ts
@@ -50,13 +50,20 @@ export async function openUrl(
     spawner?: Spawner;
     platform?: NodeJS.Platform;
     /**
-     * Test hook: when truthy (default reads `PAX8_OPEN_URL_LOG`), the URL
+     * Test-only hook: when set (default reads `PAX8_OPEN_URL_LOG`), the URL
      * that would have been opened is appended to that file path instead of
      * spawning a process. Returns the value of `PAX8_OPEN_URL_SUCCESS`
      * (`"0"` simulates a failed opener, anything else simulates success).
-     * Internal — not part of the public CLI contract.
+     *
+     * INTERNAL — not part of the public CLI contract. The `PAX8_OPEN_URL_LOG`
+     * / `PAX8_OPEN_URL_SUCCESS` env vars exist solely so subprocess tests
+     * can stub the opener across the process boundary (where `opts.spawner`
+     * injection isn't reachable). Unit tests inside this package should use
+     * `opts.spawner` / `opts.platform` / `opts.logPath` directly. These
+     * env vars MUST NOT be documented in the UX guide or README, and code
+     * outside this file should never read or set them.
      */
-     logPath?: string | null;
+    logPath?: string | null;
   } = {},
 ): Promise<boolean> {
   const logPath = opts.logPath ?? process.env.PAX8_OPEN_URL_LOG ?? null;
@@ -66,7 +73,7 @@ export async function openUrl(
     } catch {
       // Don't let a logging-side failure cascade.
     }
-    return process.env.PAX8_OPEN_URL_SUCCESS === "0" ? false : true;
+    return process.env.PAX8_OPEN_URL_SUCCESS !== "0";
   }
   const { cmd, args } = resolveOpener(opts.platform);
   const spawner = opts.spawner ?? ((c, a, o) => spawn(c, a, o));


### PR DESCRIPTION
## Summary

`pax8 auth login --browser` opens the Pax8 Integrations Hub credentials page in the user's default browser, then continues the existing interactive paste prompt for Client ID and Client Secret. Storage, validation, and token exchange are unchanged.

This collapses the "find and open the credentials page" half of first-run setup. Deliberately small UX shim — not OAuth (that's #609); the user still pastes the two values back.

## Changes

- **`packages/cli/src/lib/open-url.ts`** (new): cross-platform URL opener carved out of `report-bug.ts` into a shared helper. Returns `boolean` so callers can fall back when the opener fails (headless / SSH / no `xdg-open`). Uses only Node built-ins — no new npm deps.
- **`packages/cli/src/commands/auth/login.ts`**: new `--browser` flag. When passed (and credentials weren't already supplied via flags / env vars), prints a one-line "what's opening / what to do" message to stderr, opens `https://app.pax8.com/integrations/credentials`, and falls through to the existing interactive prompt. If the opener fails, prints the URL plainly and continues — never blocks.
- **`packages/cli/src/commands/report-bug.ts`**: refactored to use the shared `openUrl` helper. Behavior unchanged.
- **`README.md`**: one-line note in the Authentication section about `--browser` (inline backticks only, no fenced commands — the smoke test extracts and runs those and `auth login` is interactive).
- **Tests**: new unit tests for `open-url.ts` (per-platform argv shape, success / failure / throw paths). New subprocess tests in `auth.test.ts` covering:
  - opener is invoked with the credentials URL
  - the "what to do there" hint lands on stderr
  - the flow continues past the open (proven by reaching the normal missing-creds error in a non-TTY subprocess)
  - the no-opener fallback prints the URL plainly and proceeds
  - `--browser` is a no-op short-circuit under demo mode

`PAX8_OPEN_URL_LOG` / `PAX8_OPEN_URL_SUCCESS` are internal test hooks (not part of the public CLI contract) that let the subprocess tests assert opener invocation without launching a real browser on CI.

Closes #610

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm -r typecheck` + per-package `tsc --noEmit` clean
- [x] `pnpm test` — 2220 passed, 6 skipped, 6 todo (all green)
- [x] `pnpm lint` clean (no new findings)
- [ ] Manual: `pax8 auth login --browser` on macOS opens the credentials page and falls through to the prompt
- [ ] Manual: `pax8 auth login --browser` on a headless box prints the URL and falls through to the prompt
- [ ] Manual: `pax8 auth login --help` lists `--browser` with a clear description