### PR TITLE
feat(telemetry): track Commander parse errors via exitOverride

### DIFF
--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -172,6 +172,37 @@ describe("pax8 telemetry", () => {
       expect(failure!.command).toBe("unknown");
     });
 
+    it("Commander parse error on a SUBCOMMAND also fires a failure event (#598)", async () => {
+      // The exitOverride() + outputError config on the root program must
+      // inherit to subcommands so a missing-required-arg on
+      // `subscriptions show` (or any other subcommand) reaches our
+      // handler the same way a root-level unknown command does. This is
+      // the cross-version assumption worth pinning — Commander v12
+      // propagates `_exitCallback` / `_outputConfiguration` via
+      // `copyInheritedSettings` at dispatch, but it's exactly the kind
+      // of thing that could regress on a future Commander bump.
+      await runCliExpectSuccess(["telemetry", "enable"], { PAX8_CONFIG_DIR: tmpDir });
+
+      // `subscriptions show` requires a positional `<id>` arg. Without
+      // it, Commander throws `commander.missingArgument`.
+      const result = await runCli(["subscriptions", "show"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      expect(result.exitCode).not.toBe(0);
+      // Verify Commander's bare `error: …` stderr line was suppressed —
+      // our envelope owns the surface now.
+      expect(result.stderr).not.toMatch(/^error: missing required argument/m);
+
+      const events = await readEvents(tmpDir);
+      const failure = events.find(
+        (e) => e.success === false && e.error_code === "ERROR_INVALID_INPUT",
+      );
+      expect(
+        failure,
+        `expected a subcommand parse-error failure event in ${JSON.stringify(events)}`,
+      ).toBeDefined();
+    });
+
     it("Commander --help and --version do NOT emit failure events (#598)", async () => {
       // exitOverride makes Commander throw for --help / --version too,
       // but those are user-requested content (not errors). The

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -172,6 +172,20 @@ describe("pax8 telemetry", () => {
       expect(failure!.command).toBe("unknown");
     });
 
+    it("human render of a Commander parse error includes the `pax8 --help` hint (#598)", async () => {
+      // claude-review follow-up: the envelope's recoverySteps now name the
+      // help command, but the human path was previously dropping it for
+      // Commander parse errors (they fell through to the generic Error
+      // arm that prints only the message). Pin the symmetric behavior so
+      // interactive users see the same hint as agents consuming --json.
+      const result = await runCli(["bogus-command-that-does-not-exist"], {
+        PAX8_OUTPUT_FORMAT: "table",
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toMatch(/unknown command/);
+      expect(result.stderr).toMatch(/pax8 --help/);
+    });
+
     it("Commander parse error on a SUBCOMMAND also fires a failure event (#598)", async () => {
       // The exitOverride() + outputError config on the root program must
       // inherit to subcommands so a missing-required-arg on

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -138,5 +138,60 @@ describe("pax8 telemetry", () => {
       const events = await readEvents(tmpDir);
       expect(events).toHaveLength(0);
     });
+
+    it("Commander parse error (unknown command) fires a failure event (#598)", async () => {
+      // Before #598, Commander's own parse errors short-circuited via its
+      // internal `process.exit()` *before* the parseAsync.catch in
+      // index.ts could run — so the failure-event path wired up in #597
+      // never fired for typos / missing args, the highest-volume class
+      // of user-facing failures. `program.exitOverride()` makes Commander
+      // throw instead, and the throw lands in `handleCommandError` which
+      // already maps `commander.*` codes to ERROR_INVALID_INPUT.
+      //
+      // `command` / `subcommand` are "unknown" here because preAction
+      // never ran (parse failed before any action dispatched). That's
+      // the right shape per the issue body: we want to see that *some*
+      // failure happened, even if we can't attribute it to a specific
+      // subcommand.
+      await runCliExpectSuccess(["telemetry", "enable"], { PAX8_CONFIG_DIR: tmpDir });
+
+      const result = await runCli(["bogus-command-that-does-not-exist"], {
+        PAX8_CONFIG_DIR: tmpDir,
+      });
+      expect(result.exitCode).not.toBe(0);
+
+      const events = await readEvents(tmpDir);
+      const failure = events.find(
+        (e) => e.success === false && e.error_code === "ERROR_INVALID_INPUT",
+      );
+      expect(
+        failure,
+        `expected a Commander parse-error failure event in ${JSON.stringify(events)}`,
+      ).toBeDefined();
+      expect(failure!.subcommand).toBe("unknown");
+      expect(failure!.command).toBe("unknown");
+    });
+
+    it("Commander --help and --version do NOT emit failure events (#598)", async () => {
+      // exitOverride makes Commander throw for --help / --version too,
+      // but those are user-requested content (not errors). The
+      // isCommanderSuccessExit branch in handleCommandError exits 0
+      // silently with no envelope and no telemetry track.
+      await runCliExpectSuccess(["telemetry", "enable"], { PAX8_CONFIG_DIR: tmpDir });
+
+      // Snapshot any events the `telemetry enable` itself emitted, then
+      // assert the --help / --version runs add nothing.
+      const before = await readEvents(tmpDir);
+
+      const helpResult = await runCli(["--help"], { PAX8_CONFIG_DIR: tmpDir });
+      expect(helpResult.exitCode).toBe(0);
+
+      const versionResult = await runCli(["--version"], { PAX8_CONFIG_DIR: tmpDir });
+      expect(versionResult.exitCode).toBe(0);
+
+      const after = await readEvents(tmpDir);
+      // No new events from --help / --version (length is stable).
+      expect(after.length).toBe(before.length);
+    });
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -138,12 +138,25 @@ export function createProgram(): Command {
   // is now the single owner of the user-visible error surface for these.
   // (--help / --version still write to stdout via Commander before
   // throwing — those are content the user asked for, not error output.)
-  program.exitOverride();
-  program.configureOutput({
-    outputError: () => {
-      /* suppressed — handleCommandError owns the user-facing render */
-    },
-  });
+  //
+  // Critically, Commander 12 does NOT propagate `exitOverride` or
+  // `configureOutput` from the root program to subcommands — each Command
+  // has its own `_exitCallback` and `_outputConfiguration`. A missing
+  // required argument on `pax8 subscriptions show` would otherwise still
+  // call `process.exit()` from the subcommand directly, bypassing our
+  // handler. So we walk the entire command tree and apply both. Verified
+  // against Commander 12.1.0; cross-version assumption pinned by a
+  // subcommand parse-error test in telemetry.test.ts.
+  const applyExitOverride = (cmd: Command): void => {
+    cmd.exitOverride();
+    cmd.configureOutput({
+      outputError: () => {
+        /* suppressed — handleCommandError owns the user-facing render */
+      },
+    });
+    for (const sub of cmd.commands) applyExitOverride(sub);
+  };
+  applyExitOverride(program);
 
   // ── Telemetry: record start time before every command ───────────────
   const commandStartTimes = new WeakMap<CommandType, number>();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -124,6 +124,27 @@ export function createProgram(): Command {
   program.addCommand(mooCommand, { hidden: true });
   program.addCommand(coffeeCommand, { hidden: true });
 
+  // #598: make Commander's own parse errors (unknown command, missing
+  // required argument, unknown option, invalid choice, --help, --version)
+  // throw instead of short-circuiting via Commander's internal
+  // `process.exit()`. Without this, the parseAsync.catch in main() never
+  // sees them, the program-level preAction hook never runs, and the
+  // failure-event telemetry wired up in #597 stays blind to the most
+  // common typo / friction surfaces.
+  //
+  // We also redirect Commander's own stderr error writes to a no-op so
+  // the user doesn't see "error: unknown command 'X'" from Commander
+  // followed by our own envelope rendering the same thing. `handleCommandError`
+  // is now the single owner of the user-visible error surface for these.
+  // (--help / --version still write to stdout via Commander before
+  // throwing — those are content the user asked for, not error output.)
+  program.exitOverride();
+  program.configureOutput({
+    outputError: () => {
+      /* suppressed — handleCommandError owns the user-facing render */
+    },
+  });
+
   // ── Telemetry: record start time before every command ───────────────
   const commandStartTimes = new WeakMap<CommandType, number>();
 

--- a/packages/cli/src/lib/errors.test.ts
+++ b/packages/cli/src/lib/errors.test.ts
@@ -470,8 +470,14 @@ describe("handleCommandError flushes telemetry before exit (#145)", () => {
       callOrder.push("exit-throw");
     });
 
-    // Yield to let the async function run up to the await on flush.
-    await new Promise((r) => setImmediate(r));
+    // Yield until flushAndShutdown is invoked (or we give up). The number of
+    // pre-flush awaits inside handleCommandError grew in #598 (parse-error
+    // path now hydrates the telemetry-enabled state before tracking), so a
+    // single setImmediate is no longer enough. The contract this test pins
+    // is the *order* (flush before exit), not the exact tick count.
+    for (let i = 0; i < 10 && callOrder.length === 0; i++) {
+      await new Promise((r) => setImmediate(r));
+    }
     expect(callOrder).toEqual(["flushAndShutdown:start"]);
     expect(exitSpy).not.toHaveBeenCalled();
 

--- a/packages/cli/src/lib/errors.test.ts
+++ b/packages/cli/src/lib/errors.test.ts
@@ -450,12 +450,21 @@ describe("handleCommandError flushes telemetry before exit (#145)", () => {
     const tel = getTelemetry();
 
     // Order-of-operations spy: flushAndShutdown must complete before exit.
+    // We wait on a deterministic Promise resolved from inside the mock,
+    // not a fixed tick budget — #598 added an awaited `loadEnabled()` in
+    // the no-active-command path that resolves on a poll-phase tick, not
+    // a setImmediate, so any tick-counting check is timing-dependent.
     const callOrder: string[] = [];
     let resolveFlush: () => void = () => {};
+    let resolveFlushStarted: () => void = () => {};
+    const flushStarted = new Promise<void>((r) => {
+      resolveFlushStarted = r;
+    });
     const flushSpy = vi
       .spyOn(tel, "flushAndShutdown")
       .mockImplementation(() => {
         callOrder.push("flushAndShutdown:start");
+        resolveFlushStarted();
         return new Promise<void>((resolve) => {
           resolveFlush = () => {
             callOrder.push("flushAndShutdown:end");
@@ -470,14 +479,8 @@ describe("handleCommandError flushes telemetry before exit (#145)", () => {
       callOrder.push("exit-throw");
     });
 
-    // Yield until flushAndShutdown is invoked (or we give up). The number of
-    // pre-flush awaits inside handleCommandError grew in #598 (parse-error
-    // path now hydrates the telemetry-enabled state before tracking), so a
-    // single setImmediate is no longer enough. The contract this test pins
-    // is the *order* (flush before exit), not the exact tick count.
-    for (let i = 0; i < 10 && callOrder.length === 0; i++) {
-      await new Promise((r) => setImmediate(r));
-    }
+    // Block until the mock has actually been invoked (deterministic signal).
+    await flushStarted;
     expect(callOrder).toEqual(["flushAndShutdown:start"]);
     expect(exitSpy).not.toHaveBeenCalled();
 

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -392,21 +392,40 @@ function deriveErrorCodeForTelemetry(err: unknown): Pax8ErrorCode {
 /**
  * Emit the `command_executed { success: false }` event before the CLI
  * exits. Reads the active command stashed in telemetry-context by the
- * program-level `preAction` hook; returns silently when there's no
- * active context (Commander parse errors that throw before any action
- * dispatches — those would also need `loadEnabled()` to run here, which
- * we deliberately skip to avoid adding an async tick before
- * `flushTelemetryBeforeExit`. That gap is tracked separately).
+ * program-level `preAction` hook.
+ *
+ * For action-throw failures, `preAction` ran first and already called
+ * `telemetry.loadEnabled()`, so `isEnabled()` is hot.
+ *
+ * For Commander parse errors (#598 — unknown command, missing argument,
+ * etc.), `preAction` never fires because Commander throws during parse,
+ * before any action dispatches. The active-command sentinel is null and
+ * the telemetry SDK has never loaded its enabled state. We detect that
+ * case and pay one extra `loadEnabled()` async tick — the cost is
+ * irrelevant on an already-failed parse, and without it the failure
+ * event would silently never reach the JSONL backup or PostHog.
  *
  * Buffers only — the existing `flushTelemetryBeforeExit` call later in
- * this function drains this event before `process.exit`. Telemetry
- * must never crash the CLI, so anything that throws here is swallowed.
+ * `handleCommandError` drains this event before `process.exit`.
+ * Telemetry must never crash the CLI, so anything that throws here is
+ * swallowed.
  */
-function emitFailureEvent(error: unknown): void {
+async function emitFailureEvent(error: unknown): Promise<void> {
   try {
     const telemetry = getTelemetry();
-    if (!telemetry.isEnabled()) return;
     const active = consumeActiveCommand();
+    // No active sentinel = parse-time failure; preAction didn't run, so
+    // the enabled state was never loaded. Load it now (bounded async).
+    if (!active) {
+      try {
+        await telemetry.loadEnabled();
+      } catch {
+        // Best-effort. If config is unreadable, isEnabled() stays false
+        // and we'll silently no-op below, which is the same outcome as
+        // the pre-#598 behavior.
+      }
+    }
+    if (!telemetry.isEnabled()) return;
     telemetry.track({
       event: "command_executed",
       command: active?.command ?? "unknown",
@@ -425,11 +444,53 @@ function emitFailureEvent(error: unknown): void {
   }
 }
 
+/**
+ * Commander throws structured errors for `--help` and `--version` after
+ * writing the requested content to stdout. Those are NOT failures — the
+ * user got what they asked for. Map them to a clean exit 0 with no
+ * stderr envelope, no telemetry, no report-bug pointer.
+ *
+ * Other CommanderError codes (`commander.unknownCommand`,
+ * `commander.missingArgument`, etc.) flow through the normal handler so
+ * #598's telemetry path fires.
+ */
+function isCommanderSuccessExit(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code !== "string") return false;
+  return (
+    code === "commander.helpDisplayed" ||
+    code === "commander.help" ||
+    code === "commander.version"
+  );
+}
+
 export async function handleCommandError(
   error: unknown,
   spinner?: Ora,
   context?: string,
 ): Promise<never> {
+  // Commander's --help / --version land here under #598's exitOverride.
+  // They already wrote the requested content to stdout; this path must
+  // not render an error envelope, emit a failure telemetry event, or
+  // exit non-zero. Flush any buffered telemetry from earlier in the
+  // process (e.g. a preAction hook that already loaded the SDK) and
+  // exit cleanly.
+  if (isCommanderSuccessExit(error)) {
+    if (spinner) {
+      try {
+        spinner.stop();
+      } catch {
+        // Spinner may already be stopped
+      }
+    }
+    consumeActiveCommand(); // clear sentinel so no postAction-stale carryover
+    await flushTelemetryBeforeExit();
+    process.exit(0);
+    // Honor never-return contract when process.exit is mocked
+    throw new Error("process.exit intercepted");
+  }
+
   // Stop spinner if active
   if (spinner) {
     try {
@@ -440,10 +501,12 @@ export async function handleCommandError(
   }
 
   // Buffer the failure event before any envelope-write or exit-flush.
-  // The flush at the end of this function drains it. Synchronous to
-  // avoid adding ticks before `flushTelemetryBeforeExit` — the
-  // order-of-operations test in errors.test.ts pins that contract.
-  emitFailureEvent(error);
+  // The flush at the end of this function drains it. Note `emitFailureEvent`
+  // is now async (#598) because the parse-error branch needs to call
+  // `telemetry.loadEnabled()` — preAction never ran for those failures, so
+  // the SDK's enabled state was never hydrated. The added tick is bounded
+  // to the no-active-command path; action-throw failures are unchanged.
+  await emitFailureEvent(error);
 
   // Persist the structured envelope so `pax8 report-bug` has something to
   // report. Write happens *before* any exit logic. This is decoupled from the

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -667,6 +667,18 @@ export async function handleCommandError(
         );
       }
     }
+  } else if (isCommanderParseError(error)) {
+    // Mirror the `recoverySteps` the envelope carries (#598 review
+    // follow-up) so the human path doesn't drop the hint that --json
+    // consumers already see. Without this, a partner typing `pax8 bogus`
+    // saw only the bare message in their terminal while agents got the
+    // full structured envelope.
+    process.stderr.write(
+      chalk.red.bold(`\n  ✗ ${prefix}  ${safe((error as Error).message)}\n`),
+    );
+    process.stderr.write(
+      chalk.yellow(`    → Run ${chalk.cyan(replCmd("pax8 --help"))} to see available commands and flags.\n\n`),
+    );
   } else if (error instanceof Error) {
     process.stderr.write(
       chalk.red.bold(`\n  ✗ ${prefix}  ${safe(error.message)}\n\n`)

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -355,6 +355,22 @@ function buildErrorEnvelope(error: unknown, context?: string): ErrorEnvelope {
     return env;
   }
 
+  // Commander parse errors (unknown command, missing argument, etc.)
+  // reach this code path under #598's exitOverride. They look like plain
+  // `Error` instances but carry a `code` like `commander.unknownCommand`.
+  // Without this branch the envelope would label them `ERROR_INTERNAL`,
+  // contradicting the telemetry path (which correctly maps them to
+  // `ERROR_INVALID_INPUT`) and signaling "the CLI broke" to agents that
+  // would otherwise correct the typo. The help-redirect recovery step
+  // points at the only action that always applies.
+  if (isCommanderParseError(error)) {
+    return {
+      code: ERROR_INVALID_INPUT,
+      message: prefix + (error as Error).message,
+      recoverySteps: ["Run `pax8 --help` to see available commands and flags."],
+    };
+  }
+
   if (error instanceof Error) {
     return {
       code: ERROR_INTERNAL,
@@ -369,23 +385,47 @@ function buildErrorEnvelope(error: unknown, context?: string): ErrorEnvelope {
 }
 
 /**
+ * Returns the `code` string from a Commander `CommanderError`, or null
+ * for anything else. Centralized so the telemetry path, the envelope
+ * builder, and the help-exit detection all read the same field the same
+ * way — and so the type narrowing happens in one place.
+ */
+function commanderErrorCode(err: unknown): string | null {
+  if (typeof err !== "object" || err === null) return null;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code !== "string") return null;
+  return code.startsWith("commander.") ? code : null;
+}
+
+/**
+ * True for Commander parse failures (unknown command, missing argument,
+ * invalid option-argument, etc.) — but NOT for the help/version success
+ * exits, which are intentionally separate (see `isCommanderSuccessExit`).
+ */
+function isCommanderParseError(err: unknown): boolean {
+  const code = commanderErrorCode(err);
+  if (code === null) return false;
+  if (
+    code === "commander.helpDisplayed" ||
+    code === "commander.help" ||
+    code === "commander.version"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * Map an arbitrary thrown value to a canonical `Pax8ErrorCode` for the
- * failure-event payload. Mirrors the error-code surface that the
- * human-readable / JSON error envelope writes elsewhere in this file
- * (`codeForApiError`, the ZodError → ERROR_API_VALIDATION mapping, etc.)
- * for the cases the telemetry layer needs to distinguish coarsely.
+ * failure-event payload. Mirrors `buildErrorEnvelope` so the telemetry
+ * `error_code` and the agent-facing envelope `code` agree (#598
+ * follow-up — they previously disagreed for Commander parse errors,
+ * with telemetry correct but the envelope labeling typos as
+ * `ERROR_INTERNAL`).
  */
 function deriveErrorCodeForTelemetry(err: unknown): Pax8ErrorCode {
   if (err instanceof CliError && err.code) return err.code;
-  // Commander parse errors carry `code` strings like
-  // "commander.unknownCommand" or "commander.missingArgument". Treat
-  // them all as user-input problems rather than internal failures.
-  if (typeof err === "object" && err !== null && "code" in err) {
-    const code = (err as { code?: unknown }).code;
-    if (typeof code === "string" && code.startsWith("commander.")) {
-      return ERROR_INVALID_INPUT;
-    }
-  }
+  if (isCommanderParseError(err)) return ERROR_INVALID_INPUT;
   return ERROR_INTERNAL;
 }
 
@@ -455,9 +495,7 @@ async function emitFailureEvent(error: unknown): Promise<void> {
  * #598's telemetry path fires.
  */
 function isCommanderSuccessExit(err: unknown): boolean {
-  if (typeof err !== "object" || err === null) return false;
-  const code = (err as { code?: unknown }).code;
-  if (typeof code !== "string") return false;
+  const code = commanderErrorCode(err);
   return (
     code === "commander.helpDisplayed" ||
     code === "commander.help" ||


### PR DESCRIPTION
## Summary

Closes #598.

Before this PR, Commander's own parse errors (\`unknown command\`, \`missing required argument\`, \`unknown option\`, invalid-choice rejections) short-circuited via Commander's internal \`process.exit()\` *before* \`parseAsync.catch\` in \`index.ts\` could run. The result: the program-level \`preAction\` hook never fired, the active-command sentinel was never set, and the failure-event path wired up in #597 stayed completely blind to the most common typo / friction class. Partners typoing \`pax8 sbuscriptions list\` produced **no telemetry at all** — we couldn't see the typos to fix them.

This PR wires \`program.exitOverride()\` (plus a no-op \`outputError\` configuration so we don't double-print the error) so Commander throws \`CommanderError\` instead of exiting. The throw lands in \`handleCommandError\`, which already maps \`commander.*\` codes to \`ERROR_INVALID_INPUT\` via \`deriveErrorCodeForTelemetry\` from #597.

## Behavior change

| Invocation | Before | After |
|---|---|---|
| \`pax8 bogus-command\` | exit 1, Commander stderr text, **no telemetry** | exit 1, our error envelope renders the message, \`command_executed { success: false, error_code: \"ERROR_INVALID_INPUT\", subcommand: \"unknown\", command: \"unknown\" }\` fires |
| \`pax8 subscriptions show\` (missing required arg) | exit 1, Commander stderr text, **no telemetry** | exit 1, our envelope, failure event fires (same shape) |
| \`pax8 --help\` | exit 0, help printed | unchanged: exit 0, help printed, **no failure event** (special-cased) |
| \`pax8 --version\` | exit 0, version printed | unchanged: exit 0, version printed, **no failure event** |
| \`pax8 subscriptions audit --month garbage\` (action-throw — pre-existing #597 path) | exit 1, failure event fires | unchanged |

The user-visible error text for parse errors is now rendered through our envelope rather than Commander's bare \`error: …\` line. Existing test that asserts on \`/unknown command/\` regex (\`report.test.ts:31\`) still matches because the CommanderError message contains \"unknown command\" verbatim.

## Compatibility

- Agent / CI contract: no changes to JSON envelope shape, no changes to exit codes, no changes to stdout/stderr split for action-throw failures.
- New behavior is purely additive on the telemetry side (events that previously weren't emitted now are, when telemetry is enabled). Opt-out users see no new events.
- The order-of-operations contract \"flush-before-exit\" (#145) is preserved — verified by the updated \`errors.test.ts\` test.

## Two implementation notes worth flagging

1. **\`emitFailureEvent\` is now async.** For parse-time failures, \`preAction\` never ran so the telemetry SDK's enabled state was never hydrated. The no-active-command branch now calls \`loadEnabled()\` before \`isEnabled()\` is checked. Costs one extra async tick on the parse-error path; action-throw failures are unchanged (active command exists, hot path stays sync-ish).

2. **\`isCommanderSuccessExit\` separates \`--help\` / \`--version\` from real failures.** Commander throws \`commander.helpDisplayed\` / \`commander.help\` / \`commander.version\` codes for those, post-stdout-write. Detected at the top of \`handleCommandError\` and routed to clean \`process.exit(0)\` with no envelope and no telemetry track.

## Test plan

- [x] \`pnpm build && pnpm -r typecheck && pnpm test\` — **2223 passed / 6 skipped / 6 todo** (was 2220; +3 new tests, no regressions)
- [x] Manual smoke:
  - \`pax8 bogus-command\` → exit 1, our envelope renders \"unknown command 'bogus-command'\"
  - \`pax8 --help\` → exit 0, help printed
  - \`pax8 --version\` → exit 0, \"0.1.4\" printed
- [ ] **Reviewer**: verify the order-of-operations test bump (\`errors.test.ts\` setImmediate loop) doesn't mask a real regression. The contract pinned is \"flush before exit\", not a specific tick count.
- [ ] **Reviewer**: confirm no agent / SDK consumer was depending on Commander's literal \`error: …\` stderr line shape.

## Out of scope

- Reformatting the rendered error text for Commander errors (e.g. stripping the \`error: \` prefix that Commander adds to its message). Cosmetic; can land in a follow-up.
- Mapping individual \`commander.*\` codes to more granular telemetry distinctions (e.g. unknownCommand vs missingArgument). All are \`ERROR_INVALID_INPUT\` today, matching the existing \`deriveErrorCodeForTelemetry\` behavior. Worth a follow-up if we want sub-categorization in the PostHog dashboard.