### PR TITLE
docs(readme): add OS-appropriate Node install shortcuts to Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Pax8 publishes a hosted MCP server at `mcp.pax8.com` for AI assistants — see t
 Run `node --version` in your terminal.
 
 - If it prints **v20** or newer, you're set — skip to [Quick Start](#quick-start).
-- If it prints an older version, or you see `command not found`, install Node.js first:
-  - **Easiest:** download the Node.js LTS installer from [nodejs.org](https://nodejs.org) and run it.
-  - **Or, if you use Homebrew:** `brew install node` (this installs current Node, which is fine — it's well past v20).
+- If it prints an older version, or you see `command not found`, install Node.js. Use the GUI installer by default; the package-manager one-liners below are just shortcuts if you already use one.
+  - **Default, every OS, assumes nothing:** download the Node.js LTS installer from [nodejs.org](https://nodejs.org) and run it.
+  - **Windows, if you already use winget** (built into Windows 10/11): `winget install OpenJS.NodeJS.LTS`.
+  - **Windows, if you already use Chocolatey:** `choco install nodejs-lts`.
+  - **macOS or Linux, if you already use Homebrew:** `brew install node` (installs current Node — fine, well past the v20 floor).
 
-Once installed, close this terminal, open a new one, and run `node --version` again to confirm it prints v20 or newer.
+Once installed — whichever path you took — close this terminal, open a new one, and run `node --version` again. All of these paths leave your existing shell with a stale `PATH`; a fresh shell is what picks up the new `node` binary.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Closes #616.

#605 added the Prerequisites section with the GUI installer + \`brew install node\`. That's solid for macOS / Linux but understates Windows — most Windows 10/11 users have \`winget\` built in and would prefer one command over an installer wizard. Add three one-liners alongside the GUI installer, framed as \"if you already use X\" so the GUI path remains the unconditional default for anyone who doesn't.

Also rewrite the post-install reopen-terminal guidance so it clearly applies to **every** install path, not just the GUI installer — \`winget\` and the installer both leave the existing shell with a stale \`PATH\` until restart.

## Verification

- **Chocolatey package ID** (\`nodejs-lts\`) confirmed current at merge time via the community feed:
  - \`IsLatestVersion=true\`, \`IsApproved=true\`, \`PackageStatus=Approved\`
  - Owner: OpenJS Foundation
  - Latest published version: 24.16.0, which is Node Active LTS today (\"Krypton\") per \`nodejs.org/dist/index.json\`
- winget ID (\`OpenJS.NodeJS.LTS\`) and brew formula (\`node\`) were pre-confirmed before this PR.
- No new lines start with \`pax8\` or \`PAX8_DEMO=1 pax8\` inside the Prerequisites section.

## Test plan

- [x] \`pnpm test e2e/ux-smoke.test.ts\` — **65/65 pass** (README snippet smoke test happy, no new fenced \`\`\`bash blocks with executable \`pax8\` commands added to Prerequisites).
- [ ] Reviewer: eyeball the rendered Prerequisites section on GitHub.

## Diff

One file, six lines:

\`\`\`
README.md | 10 +++++-----
1 file changed, 6 insertions(+), 4 deletions(-)
\`\`\`

## Out of scope

- \`nvm\` / \`fnm\` / \`volta\` / \`asdf\` version-manager paths. Those stay in Troubleshooting (see #603) where the EACCES nuance lives.
- Standalone signed CLI binary (tracked separately in #606 — for the genuinely-no-Node audience).