### PR TITLE
fix(auth): drop shell-syntax nextActions; dedupe demo-mode resolver

### DIFF
--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -68,7 +68,14 @@ describe("pax8 auth", () => {
       expect(result.stderr).toMatch(/credentials were NOT saved/);
     });
 
-    it("emits a `disable demo` nextAction when creds are supplied under demo mode", async () => {
+    it("`nextActions` entries are spawnable argv — no shell metacharacters (#612)", async () => {
+      // Pinned by #612 after claude-review on #608 flagged that the
+      // two-step "unset PAX8_DEMO && pax8 auth login" entries violated
+      // the #562 argv contract — agents consume `args` directly and
+      // never tokenize `command` or pipe it to a shell. Every entry's
+      // `command` must be a single `pax8 …` invocation; the `notice`
+      // field above (asserted by the earlier test in this block) is
+      // where the disable-demo guidance lives now.
       const result = await runCliExpectSuccess([
         "auth",
         "login",
@@ -79,7 +86,19 @@ describe("pax8 auth", () => {
       ]);
       const parsed = JSON.parse(result.stdout);
       const actions = parsed.nextActions as Array<{ command: string }>;
-      expect(actions.some((a) => /unset PAX8_DEMO/.test(a.command))).toBe(true);
+      // Every command starts with `pax8 ` — no leading `unset`, `cd`, etc.
+      for (const a of actions) {
+        expect(a.command, `nextAction ${JSON.stringify(a)} must start with "pax8 "`).toMatch(/^pax8 /);
+      }
+      // No shell metacharacters anywhere in any command — &&, ||, ;,
+      // pipe, redirect, command substitution, backticks.
+      const shellMetaRe = /(&&|\|\||;|[|<>$`])/;
+      for (const a of actions) {
+        expect(
+          shellMetaRe.test(a.command),
+          `nextAction ${JSON.stringify(a)} contains shell metacharacters; agents cannot spawn this safely`,
+        ).toBe(false);
+      }
     });
 
     it("bare `auth login` in demo mode adds a dim source hint to the human banner", async () => {

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -157,22 +157,18 @@ PAX8_CLIENT_SECRET environment variable.`
                       `Disable demo mode and re-run \`pax8 auth login\` to log in for real.`,
                   }
                 : {}),
+              // Every `nextActions[].command` MUST be a spawnable single
+              // `pax8 …` invocation per the #562 agent contract — never
+              // shell syntax. The earlier two-step disable-demo entries
+              // ("unset PAX8_DEMO && pax8 auth login") were strings an
+              // agent could not execute; the `notice` field above already
+              // conveys the same instruction in human-readable form
+              // (#612).
               nextActions: [
                 {
                   command: "pax8 dashboard --json",
                   description: "Run a portfolio summary against the demo data set",
                 },
-                ...(credsAttempted && demoSource
-                  ? [
-                      {
-                        command:
-                          demoSource === "env"
-                            ? "unset PAX8_DEMO && pax8 auth login"
-                            : "pax8 demo off && pax8 auth login",
-                        description: "Disable demo mode and log in for real",
-                      },
-                    ]
-                  : []),
               ],
             },
             null,

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -149,18 +149,6 @@ export function resolveDemoMode(config: { demo?: boolean }): boolean {
   return config.demo === true;
 }
 
-export async function resolveDemoModeAsync(): Promise<boolean> {
-  const envDemo = process.env.PAX8_DEMO;
-  if (envDemo === "1" || envDemo === "true") return true;
-  if (envDemo === "0" || envDemo === "false") return false;
-  try {
-    const config = await loadConfig();
-    return config.demo === true;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Like `resolveDemoModeAsync` but also returns *where* demo mode came from
  * (`env` | `config` | `null`). Callers that need to tell users how to turn
@@ -169,6 +157,11 @@ export async function resolveDemoModeAsync(): Promise<boolean> {
  *
  * Same precedence as `resolveDemoMode`: env literal wins (`1`/`true`/`0`/
  * `false`), then `config.demo`. Returns `source: null` when demo is off.
+ *
+ * The canonical single source of the env-then-config ladder for async call
+ * sites. `resolveDemoModeAsync` delegates here so the precedence logic
+ * lives in exactly one place — drift across inline copies of this ladder
+ * was the original bug the comment on `resolveDemoMode` warns about (#614).
  */
 export type DemoSource = "env" | "config" | null;
 export async function resolveDemoModeWithSourceAsync(): Promise<{
@@ -180,11 +173,15 @@ export async function resolveDemoModeWithSourceAsync(): Promise<{
   if (envDemo === "0" || envDemo === "false") return { isDemo: false, source: null };
   try {
     const cfg = await loadConfig();
-    if ("demo" in cfg && cfg.demo === true) return { isDemo: true, source: "config" };
+    if (cfg.demo === true) return { isDemo: true, source: "config" };
   } catch {
     // Config unreadable — fall through; treat as demo off.
   }
   return { isDemo: false, source: null };
+}
+
+export async function resolveDemoModeAsync(): Promise<boolean> {
+  return (await resolveDemoModeWithSourceAsync()).isDemo;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #612, closes #614.

Two follow-ups from claude-review on #608, bundled because they share a theme (centralizing / tightening contracts the previous PR introduced) and neither warrants a PR on its own.

### #612 — \`auth login\` nextActions violated the #562 argv contract

The demo-conflict path in \`auth login --json\` emitted entries like:
\`\`\`json
{ \"command\": \"unset PAX8_DEMO && pax8 auth login\", \"description\": \"Disable demo mode and log in for real\" }
\`\`\`

Per the repo's \`packages/claude-skill/skill.md\` agent contract, every \`nextActions[].command\` must be a spawnable single \`pax8 …\` invocation. Agents consume \`args\` directly and never tokenize \`command\` or pipe it to a shell. The strings above are shell syntax (\`unset\`, \`&&\`) — not argv tokens at all — and they carry no \`args\` array, so an agent cannot execute them safely.

**Fix:** drop both entries entirely. The \`notice\` field already conveys the same instruction in human-readable form (asserted by a sibling test), and the cyan stderr warning is the discoverability surface for interactive users. Only the spawnable \`pax8 dashboard --json\` entry remains.

**Regression guard:** replaced the brittle \"this string contains \`unset PAX8_DEMO\`\" assertion with a contract test that:
1. Every \`nextActions[].command\` starts with \`pax8 \`.
2. No \`command\` contains shell metacharacters (\`&&\`, \`||\`, \`;\`, \`|\`, \`<\`, \`>\`, \`$\`, backticks).

This catches future attempts to sneak shell-syntax commands into the array.

### #614 — Demo-mode resolver ladder duplicated

\`packages/cli/src/lib/context.ts\` had two parallel implementations of the env-then-config precedence ladder: \`resolveDemoModeAsync()\` and \`resolveDemoModeWithSourceAsync()\`. The comment on \`resolveDemoMode\` explicitly warns that drift across inline copies of this ladder was the original bug that motivated the centralization in the first place — and #608 added a third copy when it added the source-aware variant.

**Fix:** make \`resolveDemoModeAsync\` a one-liner that delegates to the source-aware variant. The precedence logic now lives in exactly one place.

Also a small consistency fix in the same file: \`\"demo\" in cfg && cfg.demo === true\` → \`cfg.demo === true\`, matching the simpler form used in \`resolveDemoMode\` (sync variant). The \`in\` check was defensive but redundant — \`cfg.demo === true\` short-circuits on \`undefined\` or missing-property either way.

## Compatibility

- **Agent contract:** the JSON envelope shape is structurally unchanged. The \`nextActions\` array still exists with the same \`{command, description}\` entry shape; only the count of entries shrinks (1 always, instead of 1 or 2). No required field removed.
- **Telemetry:** no change.
- **Behavior:** the only user-observable change is that \`auth login --json | jq .nextActions\` returns one entry instead of two when demo mode + creds-attempted. The disable-demo guidance is in \`notice\` (unchanged) and the stderr warning (unchanged).
- \`resolveDemoModeAsync\` behavior is unchanged — same precedence, same outputs. The implementation just gets shorter.

## Test plan

- [x] \`pnpm build && pnpm -r typecheck && pnpm test\` — **2225 passed / 6 skipped / 6 todo**. No regressions.
- [x] Manual: \`PAX8_DEMO=1 pax8 auth login --client-id X --client-secret Y --json | jq .nextActions\` returns exactly one entry (\`pax8 dashboard --json\`). Verified.
- [x] New contract test for \`nextActions\` shape catches shell-syntax entries.

## Out of scope

- Renaming \`nextActions\` or evolving its shape (separate concern — \`packages/claude-skill/skill.md\` documents the current contract).
- Adding \`args\` arrays to \`nextActions\` entries (already done elsewhere via #562; this PR doesn't add or remove any).