### PR TITLE
feat(telemetry): emit credentialed on command_executed (#621)

### DIFF
--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -217,6 +217,154 @@ describe("pax8 telemetry", () => {
       ).toBeDefined();
     });
 
+    // #621: `credentialed` flag — both success and failure paths.
+    //
+    // The contract: `credentialed = true` iff `CredentialStore.hasCredentials()`
+    // is true (env vars OR file). Independent of `demo_mode`. Tests run under
+    // `PAX8_DEMO=1` because the existing pattern in this file does — demo
+    // is independent of the credentialed signal, and using it keeps every
+    // test on the same fast in-memory path the rest of the suite uses.
+    //
+    // Important: `runCli` inherits `process.env`, so a developer running
+    // these locally with real `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` in
+    // their shell would see the "no creds" tests fail. We pass empty
+    // strings for those env vars in the no-creds cases — `getFromEnv()`
+    // in credential-store.ts requires both to be truthy, so the empty
+    // string disables the env-var path without unsetting (which
+    // execFile's env merge doesn't support).
+    describe("credentialed flag (#621)", () => {
+      const NO_CREDS_ENV = { PAX8_CLIENT_ID: "", PAX8_CLIENT_SECRET: "" };
+
+      it("success path emits credentialed: true when env vars are set", async () => {
+        await runCliExpectSuccess(["telemetry", "enable"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          ...NO_CREDS_ENV,
+        });
+
+        await runCliExpectSuccess(["clients", "list", "--json"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          PAX8_CLIENT_ID: "test-client-id",
+          PAX8_CLIENT_SECRET: "test-client-secret",
+        });
+
+        const events = await readEvents(tmpDir);
+        const success = events.find(
+          (e) => e.success === true && e.subcommand === "clients.list",
+        );
+        expect(
+          success,
+          `expected a clients.list success event in ${JSON.stringify(events)}`,
+        ).toBeDefined();
+        expect(success!.credentialed).toBe(true);
+      });
+
+      it("success path emits credentialed: true when a credentials file exists", async () => {
+        await runCliExpectSuccess(["telemetry", "enable"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          ...NO_CREDS_ENV,
+        });
+        // Write a credentials file directly into the temp config dir.
+        // hasCredentials() only stats the path — it doesn't read or parse,
+        // so any content is fine.
+        await fs.writeFile(
+          path.join(tmpDir, "credentials.json"),
+          JSON.stringify({ clientId: "x", clientSecret: "y" }),
+          { mode: 0o600 },
+        );
+
+        await runCliExpectSuccess(["clients", "list", "--json"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          ...NO_CREDS_ENV,
+        });
+
+        const events = await readEvents(tmpDir);
+        const success = events.find(
+          (e) => e.success === true && e.subcommand === "clients.list",
+        );
+        expect(
+          success,
+          `expected a clients.list success event in ${JSON.stringify(events)}`,
+        ).toBeDefined();
+        expect(success!.credentialed).toBe(true);
+      });
+
+      it("success path emits credentialed: false when no env vars and no file", async () => {
+        await runCliExpectSuccess(["telemetry", "enable"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          ...NO_CREDS_ENV,
+        });
+
+        await runCliExpectSuccess(["clients", "list", "--json"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          ...NO_CREDS_ENV,
+        });
+
+        const events = await readEvents(tmpDir);
+        const success = events.find(
+          (e) => e.success === true && e.subcommand === "clients.list",
+        );
+        expect(
+          success,
+          `expected a clients.list success event in ${JSON.stringify(events)}`,
+        ).toBeDefined();
+        expect(success!.credentialed).toBe(false);
+      });
+
+      it("failure path emits credentialed: true when env vars are set", async () => {
+        await runCliExpectSuccess(["telemetry", "enable"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          ...NO_CREDS_ENV,
+        });
+
+        // Same shape as the action-throw test above — invoices audit
+        // with a bad --month flag throws ERROR_INVALID_INPUT from the
+        // action, which routes through emitFailureEvent.
+        const result = await runCli(
+          ["invoices", "audit", "--month", "garbage", "--json"],
+          {
+            PAX8_CONFIG_DIR: tmpDir,
+            PAX8_DEMO: "1",
+            PAX8_CLIENT_ID: "test-client-id",
+            PAX8_CLIENT_SECRET: "test-client-secret",
+          },
+        );
+        expect(result.exitCode).not.toBe(0);
+
+        const events = await readEvents(tmpDir);
+        const failure = events.find(
+          (e) => e.success === false && e.subcommand === "invoices.audit",
+        );
+        expect(
+          failure,
+          `expected an invoices.audit failure event in ${JSON.stringify(events)}`,
+        ).toBeDefined();
+        expect(failure!.credentialed).toBe(true);
+      });
+
+      it("failure path emits credentialed: false when no env vars and no file", async () => {
+        await runCliExpectSuccess(["telemetry", "enable"], {
+          PAX8_CONFIG_DIR: tmpDir,
+          ...NO_CREDS_ENV,
+        });
+
+        const result = await runCli(
+          ["invoices", "audit", "--month", "garbage", "--json"],
+          { PAX8_CONFIG_DIR: tmpDir, PAX8_DEMO: "1", ...NO_CREDS_ENV },
+        );
+        expect(result.exitCode).not.toBe(0);
+
+        const events = await readEvents(tmpDir);
+        const failure = events.find(
+          (e) => e.success === false && e.subcommand === "invoices.audit",
+        );
+        expect(
+          failure,
+          `expected an invoices.audit failure event in ${JSON.stringify(events)}`,
+        ).toBeDefined();
+        expect(failure!.credentialed).toBe(false);
+      });
+    });
+
     it("Commander --help and --version do NOT emit failure events (#598)", async () => {
       // exitOverride makes Commander throw for --help / --version too,
       // but those are user-requested content (not errors). The

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ import {
   getTelemetry,
   getDefaultBaseUrl,
   getConfigDir,
+  CredentialStore,
 } from "@pax8/core";
 import { resolveDemoModeAsync } from "./lib/context.js";
 import type { Command as CommandType } from "commander";
@@ -220,6 +221,20 @@ export function createProgram(): Command {
       const subcommand = getFullCommandName(actionCommand);
       const flags = extractCommandFlags(actionCommand);
       const isDemo = await resolveDemoModeAsync();
+      // #621: emit credential-store state independently of demo_mode so we
+      // can answer "what share of partners transition from demo to real
+      // auth" and similar onboarding-funnel questions. Same primitive
+      // welcome.ts and `auth status` use; sub-millisecond stat + env-var
+      // read. Computed AFTER the action ran so a successful `auth login`
+      // emits `credentialed: true`.
+      let credentialed = false;
+      try {
+        credentialed = await new CredentialStore().hasCredentials();
+      } catch {
+        // Telemetry must never crash the CLI. hasCredentials() already
+        // swallows fs errors, but defense-in-depth in case PAX8_CONFIG_DIR
+        // validation throws synchronously.
+      }
 
       // Single canonical event for every command run (#146). Handlers
       // contribute aggregate counters via setTelemetryFields(); they no
@@ -235,6 +250,7 @@ export function createProgram(): Command {
         node_version: process.version,
         os: process.platform,
         demo_mode: isDemo,
+        credentialed,
         ...handlerProps,
       });
 

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -8,6 +8,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
   ApiError,
+  CredentialStore,
   ERROR_API_TIMEOUT,
   ERROR_API_VALIDATION,
   ERROR_AUTH_EXPIRED,
@@ -466,6 +467,19 @@ async function emitFailureEvent(error: unknown): Promise<void> {
       }
     }
     if (!telemetry.isEnabled()) return;
+    // #621: emit credential-store state on failure events too so we can
+    // measure auth-login failure rates and the broken `credentialed:
+    // false, demo_mode: false` cohort. Same primitive as the success
+    // path; bounded fs.access + env-var read. The parse-error branch
+    // above already pays one async tick for loadEnabled(); this is the
+    // same shape of bounded I/O. Wrapped in try so a config-dir issue
+    // can't break the failure-event emit.
+    let credentialed = false;
+    try {
+      credentialed = await new CredentialStore().hasCredentials();
+    } catch {
+      // Telemetry must never crash the CLI.
+    }
     telemetry.track({
       event: "command_executed",
       command: active?.command ?? "unknown",
@@ -478,6 +492,7 @@ async function emitFailureEvent(error: unknown): Promise<void> {
       node_version: process.version,
       os: process.platform,
       demo_mode: false,
+      credentialed,
     });
   } catch {
     // Telemetry must never crash the CLI.

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -46,6 +46,20 @@ export interface TelemetryEvent {
   node_version: string;
   os: string;
   demo_mode: boolean;
+  /**
+   * True when `CredentialStore.hasCredentials()` returned true at emit time
+   * — either `PAX8_CLIENT_ID` + `PAX8_CLIENT_SECRET` are set in env or a
+   * credentials.json file exists under the config dir. Independent of
+   * `demo_mode`: a partner can be `credentialed: true, demo_mode: true`
+   * (creds saved but explicitly running demo) or any other combination.
+   *
+   * Optional (rather than required) so other call sites that construct a
+   * `TelemetryEvent` directly aren't forced to compute it; the two
+   * canonical emit sites (success in `cli/src/index.ts` postAction and
+   * failure in `cli/src/lib/errors.ts` `emitFailureEvent`) both populate
+   * it. See #621.
+   */
+  credentialed?: boolean;
   /** Full subcommand path, e.g. "recommendations.list" */
   subcommand?: string;
   /** For order create, did the order actually succeed */


### PR DESCRIPTION
## Summary

- Adds a `credentialed: boolean` property to the `command_executed` telemetry event on both the success path (`packages/cli/src/index.ts` postAction hook) and the failure path (`packages/cli/src/lib/errors.ts` `emitFailureEvent`).
- Value reflects `CredentialStore.hasCredentials()` at emit time — true for either env-var or file presence. Independent of `demo_mode` so the four cohorts (`credentialed × demo`) become first-class in PostHog.
- Computed AFTER the action runs so a successful `pax8 auth login` correctly emits `credentialed: true`.

Closes #621

## Test plan

- [x] `pnpm build` green
- [x] `pnpm -r typecheck` green
- [x] `pnpm test` green (2230 passed; telemetry.test.ts now 17 tests, +5 new)
- [x] Subprocess test: env-var creds set → `credentialed: true` on success event
- [x] Subprocess test: credentials file present → `credentialed: true` on success event
- [x] Subprocess test: no env vars, no file → `credentialed: false` on success event
- [x] Subprocess test: env-var creds set → `credentialed: true` on failure event (`invoices audit --month garbage`)
- [x] Subprocess test: no env vars, no file → `credentialed: false` on failure event

## Notes

- Both call sites wrap `new CredentialStore().hasCredentials()` in try/catch as defense-in-depth — `hasCredentials()` already swallows fs errors, but `getConfigDir()` can throw synchronously on a misconfigured `PAX8_CONFIG_DIR`, and telemetry must never crash the CLI.
- Tests pass empty-string `PAX8_CLIENT_ID` / `PAX8_CLIENT_SECRET` for "no creds" cases so a developer with real creds in their shell env doesn't see flaky results (`runCli` inherits `process.env`, and `getFromEnv()` requires both to be truthy).