### PR TITLE
feat(preinstall): fail-fast Node 20+ check via npm preinstall hook

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "provenance": true
   },
   "scripts": {
+    "preinstall": "node ./scripts/check-prerequisites.js",
     "build": "tsup",
     "dev": "tsx src/index.ts"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
   },
   "main": "./dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "scripts/check-prerequisites.js"
   ],
   "publishConfig": {
     "access": "public",

--- a/packages/cli/scripts/check-prerequisites.js
+++ b/packages/cli/scripts/check-prerequisites.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Preinstall check for @pax8/cli
+ * Verifies Node.js and Git are available before installation proceeds
+ */
+
+import { execSync } from 'child_process';
+
+let hasErrors = false;
+
+function checkCommand(command, versionFlag = '--version') {
+  try {
+    execSync(`${command} ${versionFlag}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getVersion(command, versionFlag = '--version') {
+  try {
+    const output = execSync(`${command} ${versionFlag}`, { encoding: 'utf8' }).trim();
+    const match = output.match(/v?(\d+\.\d+\.\d+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function compareVersions(version, required) {
+  const v = version.split('.').map(Number);
+  const r = required.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (v[i] > r[i]) return true;
+    if (v[i] < r[i]) return false;
+  }
+  return true;
+}
+
+// Check Node.js
+const nodeVersion = process.versions.node;
+const requiredNodeVersion = '20.0.0';
+
+if (!compareVersions(nodeVersion, requiredNodeVersion)) {
+  console.error(
+    `\n❌ Node.js version ${requiredNodeVersion}+ required, but ${nodeVersion} is installed\n` +
+    `   Install Node.js from: https://nodejs.org/\n`
+  );
+  hasErrors = true;
+} else {
+  console.log(`✓ Node.js ${nodeVersion}`);
+}
+
+// Check Git
+if (!checkCommand('git')) {
+  console.error(
+    `\n❌ Git is not installed or not in PATH\n` +
+    `   Install Git from: https://git-scm.com/\n`
+  );
+  hasErrors = true;
+} else {
+  const gitVersion = getVersion('git');
+  console.log(`✓ Git ${gitVersion}`);
+}
+
+if (hasErrors) {
+  console.error(`Please install the missing prerequisites and try again.\n`);
+  process.exit(1);
+}
+
+console.log('\n✓ All prerequisites met\n');

--- a/packages/cli/scripts/check-prerequisites.js
+++ b/packages/cli/scripts/check-prerequisites.js
@@ -1,31 +1,19 @@
 #!/usr/bin/env node
 /**
- * Preinstall check for @pax8/cli
- * Verifies Node.js and Git are available before installation proceeds
+ * Preinstall check for @pax8/cli.
+ *
+ * Fails the install with a clear error if Node.js is older than the required
+ * floor. `package.json`'s `engines.node` will also nag, but a hard preinstall
+ * fail is the strongest signal — it stops the install before partial state
+ * lands under `node_modules`.
+ *
+ * Intentionally narrow scope: this checks Node only. An earlier draft also
+ * required git, but the CLI does not shell out to git at runtime (no
+ * `execSync("git …")` anywhere in `src/`), so requiring git would block npm
+ * installs on locked-down endpoints — managed Windows servers, minimal CI
+ * containers — for a dependency the runtime doesn't use. If a future feature
+ * does shell out to git, add the check then with a runtime-driven rationale.
  */
-
-import { execSync } from 'child_process';
-
-let hasErrors = false;
-
-function checkCommand(command, versionFlag = '--version') {
-  try {
-    execSync(`${command} ${versionFlag}`, { stdio: 'pipe' });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function getVersion(command, versionFlag = '--version') {
-  try {
-    const output = execSync(`${command} ${versionFlag}`, { encoding: 'utf8' }).trim();
-    const match = output.match(/v?(\d+\.\d+\.\d+)/);
-    return match ? match[1] : null;
-  } catch {
-    return null;
-  }
-}
 
 function compareVersions(version, required) {
   const v = version.split('.').map(Number);
@@ -37,35 +25,16 @@ function compareVersions(version, required) {
   return true;
 }
 
-// Check Node.js
 const nodeVersion = process.versions.node;
 const requiredNodeVersion = '20.0.0';
 
 if (!compareVersions(nodeVersion, requiredNodeVersion)) {
   console.error(
-    `\n❌ Node.js version ${requiredNodeVersion}+ required, but ${nodeVersion} is installed\n` +
-    `   Install Node.js from: https://nodejs.org/\n`
+    `\n❌ Node.js ${requiredNodeVersion}+ required, but ${nodeVersion} is installed.\n` +
+    `   Install Node.js from: https://nodejs.org/\n` +
+    `   See README "Prerequisites: Node.js" for OS-specific install shortcuts.\n`
   );
-  hasErrors = true;
-} else {
-  console.log(`✓ Node.js ${nodeVersion}`);
-}
-
-// Check Git
-if (!checkCommand('git')) {
-  console.error(
-    `\n❌ Git is not installed or not in PATH\n` +
-    `   Install Git from: https://git-scm.com/\n`
-  );
-  hasErrors = true;
-} else {
-  const gitVersion = getVersion('git');
-  console.log(`✓ Git ${gitVersion}`);
-}
-
-if (hasErrors) {
-  console.error(`Please install the missing prerequisites and try again.\n`);
   process.exit(1);
 }
 
-console.log('\n✓ All prerequisites met\n');
+console.log(`✓ Node.js ${nodeVersion}`);

--- a/packages/cli/src/__tests__/publish-artifacts.test.ts
+++ b/packages/cli/src/__tests__/publish-artifacts.test.ts
@@ -7,7 +7,18 @@ import { promisify } from "node:util";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const exec = promisify(execFile);
+const execFileAsync = promisify(execFile);
+
+// On Windows, `npm` is a `.cmd` shim that `execFile` cannot spawn
+// directly (only true binaries work without a shell). `shell: true`
+// routes through cmd.exe / sh on the respective platform so the
+// shim resolves. All args here are static — no shell-injection
+// surface. On macOS/Linux this is a slightly slower no-op (one
+// extra shell process); the cost is negligible for a single test.
+const NPM_OPTS = {
+  shell: true as const,
+  maxBuffer: 4 * 1024 * 1024,
+};
 
 // __dirname equivalent for ESM.
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -29,10 +40,10 @@ const CLI_PKG = path.resolve(HERE, "../..");
  */
 describe("publish artifacts", () => {
   it("npm pack tarball includes scripts/check-prerequisites.js (preinstall hook prereq) (#624)", async () => {
-    const { stdout, stderr } = await exec("npm", ["pack", "--dry-run", "--json"], {
+    const { stdout, stderr } = await execFileAsync("npm", ["pack", "--dry-run", "--json"], {
       cwd: CLI_PKG,
       env: process.env,
-      maxBuffer: 4 * 1024 * 1024,
+      ...NPM_OPTS,
     });
     // `npm pack --json` emits a JSON array on stdout with one entry per
     // package; each entry carries `files: [{ path, size, mode }, …]`.

--- a/packages/cli/src/__tests__/publish-artifacts.test.ts
+++ b/packages/cli/src/__tests__/publish-artifacts.test.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const exec = promisify(execFile);
+
+// __dirname equivalent for ESM.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PKG = path.resolve(HERE, "../..");
+
+/**
+ * Regression guard for #624: a `preinstall` lifecycle hook references
+ * `./scripts/check-prerequisites.js`, but the published tarball is
+ * limited by the `files` allowlist in `packages/cli/package.json`. If
+ * the script is in the hook but not in the allowlist, every
+ * `npm install -g @pax8/cli` fails with `Cannot find module …` —
+ * inverting the intent of the hook (block bad Node) into a universal
+ * install failure. Local `pnpm install` masks this because the
+ * workspace install runs against the working tree, not a tarball.
+ *
+ * `npm pack --dry-run` is the cheapest reliable check: it builds the
+ * tarball file list without actually packing or publishing, and we
+ * grep the output for the script path.
+ */
+describe("publish artifacts", () => {
+  it("npm pack tarball includes scripts/check-prerequisites.js (preinstall hook prereq) (#624)", async () => {
+    const { stdout, stderr } = await exec("npm", ["pack", "--dry-run", "--json"], {
+      cwd: CLI_PKG,
+      env: process.env,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    // `npm pack --json` emits a JSON array on stdout with one entry per
+    // package; each entry carries `files: [{ path, size, mode }, …]`.
+    const parsed = JSON.parse(stdout) as Array<{
+      files?: Array<{ path: string }>;
+    }>;
+    expect(parsed, `expected one package entry from npm pack --json; stderr=${stderr}`).toHaveLength(1);
+    const filePaths = (parsed[0].files ?? []).map((f) => f.path);
+    expect(
+      filePaths,
+      `tarball file list missing the preinstall script. Files: ${JSON.stringify(filePaths)}`,
+    ).toContain("scripts/check-prerequisites.js");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a \`preinstall\` hook to \`packages/cli/package.json\` that runs \`packages/cli/scripts/check-prerequisites.js\` before \`npm install -g @pax8/cli\` proceeds. If Node.js is older than 20, the install fails with a clear, OS-agnostic error message and a pointer to the README's Prerequisites section.

## Background

This PR consolidates the original prereq-checks work from commit \`2689c25\` (your in-flight branch at \`origin/wip/prereq-checks\`), with two intentional reductions versus that draft:

1. **Drop the README diff entirely.** The original draft added a small Prerequisites section to README. Since then #605, #617, #618, and #619 have built out a much better Prerequisites + Troubleshooting story in the README — installer-first framing, OS-appropriate package-manager shortcuts (winget / choco / brew), reopen-the-terminal guidance, EACCES recovery. The original draft's additions are now strictly redundant with what's already in the README.

2. **Drop the git prerequisite check.** The original script also hard-failed the install if git wasn't on PATH. Grepping \`packages/cli/src\` and \`packages/core/src\` shows zero \`execSync(\"git ...\")\` calls and no spawned git processes — git is a dev / contribute prereq (clone, push), not a runtime prereq for an npm-installed CLI. Requiring it would block partners on locked-down endpoints (managed Windows servers, minimal CI containers, sandboxed environments) from installing a CLI they could otherwise run cleanly. Same audience #606 targets with the standalone-binary path; we shouldn't be making their install story worse via a check that doesn't reflect a real runtime dependency.

## Behavior

```bash
$ node --version    # v20.0.0 or newer
$ npm install -g @pax8/cli
> @pax8/cli@0.1.4 preinstall
> node ./scripts/check-prerequisites.js
✓ Node.js 22.19.0
[rest of install proceeds normally]

$ node --version    # v18.x
$ npm install -g @pax8/cli
> @pax8/cli@0.1.4 preinstall
> node ./scripts/check-prerequisites.js

❌ Node.js 20.0.0+ required, but 18.20.0 is installed.
   Install Node.js from: https://nodejs.org/
   See README "Prerequisites: Node.js" for OS-specific install shortcuts.
[install fails before any state lands in node_modules]
```

\`engines.node: \">=20\"\` is already in \`package.json\` (added by #603) and gives npm itself a soft warning. The preinstall hook is the hard fail — it stops the install *before* a partial \`node_modules\` lands, which is the strongest signal we can give a user on an unsupported runtime.

## Compatibility

- Same behavior on every supported Node version (20+) — the script just prints \`✓ Node.js <version>\` and exits 0.
- No new npm dependencies. Plain Node, \`process.versions.node\` only.
- Workspace dev: \`pnpm install\` from a fresh clone now runs the script too — verified locally, sub-second overhead, just prints the green check.

## Test plan

- [x] Local: \`pnpm install\` runs the preinstall, prints \`✓ Node.js 22.19.0\`, install proceeds. Verified.
- [x] Local: \`node packages/cli/scripts/check-prerequisites.js\` directly — exits 0, prints version.
- [x] Existing license-consistency / smoke tests pass (no \`pax8\` lines in any new fenced block; only file added is a Node script, not docs).
- [ ] Reviewer: spot-check the error message on an actual Node-18-or-older host if available.

## Out of scope

- Standalone single-file binary for users without Node at all (#606 — parked on cert procurement).
- Tab-completion for \`pax8\` (\#112–#115).
- Repo-level setup-validation for contributors. This is install-time only.

Supersedes \`origin/wip/prereq-checks\` (the original draft branch). Once this merges, that branch can be deleted on origin.