### PR TITLE
feat(dashboard): paginate the full portfolio — drop silent truncation

### DIFF
--- a/packages/cli/src/__tests__/dashboard.test.ts
+++ b/packages/cli/src/__tests__/dashboard.test.ts
@@ -41,6 +41,30 @@ describe("pax8 dashboard (canonical)", () => {
     const result = await runCliExpectSuccess(["--help"]);
     expect(result.stdout).toContain("dashboard");
   });
+
+  // #613: pre-fix, dashboard fetched a single page of subscriptions and
+  // silently truncated portfolio totals for partners with >1000 subs. The
+  // large-scale fixture (5000 subs across 5 pages) is the smallest realistic
+  // exercise of the bug: pre-fix this returned `activeSubscriptions: 770`
+  // and `monthlyCost ≈ £6M` (the active subset of the first 1000); post-fix
+  // it walks all 5 pages via `streamAll()` and returns the full-portfolio
+  // count + cost. Tests pin the post-fix shape against the pre-fix
+  // ceiling so a regression that re-introduces the truncation would fail
+  // here loudly.
+  it("at large scale walks every page — no silent truncation (#613)", async () => {
+    const result = await runCliExpectSuccess(["dashboard", "--json"], {
+      PAX8_DEMO_SCALE: "large",
+    });
+    const data = JSON.parse(result.stdout);
+    // The 5000-sub fixture has way more active subs than would fit in a
+    // single 1000-page response. Pre-fix this number was ~770; post-fix it
+    // must be > 1000 (the page size) — anything in that range indicates
+    // streamAll didn't walk to the end.
+    expect(data.activeSubscriptions).toBeGreaterThan(1000);
+    // And the truncation warning must NOT be in stderr — pre-fix it was the
+    // only signal a user got that their numbers were wrong.
+    expect(result.stderr).not.toMatch(/page limit|results may be incomplete/);
+  });
 });
 
 describe("pax8 dashboard (removed)", () => {

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -3,18 +3,48 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
-import { buildContext, warnIfTruncated } from "../lib/context.js";
+import { buildContext } from "../lib/context.js";
 import { createSpinner } from "../lib/spinner.js";
 import { handleCommandError } from "../lib/errors.js";
 import { formatCurrency, calculateMrr, formatTimeAgo } from "../lib/formatters.js";
 import { enrichProductNames, enrichCompanyNames } from "../lib/enrich-subscriptions.js";
-import { ALL_SUBS_PAGE_SIZE, getUpcomingRenewals } from "@pax8/core";
+import { getUpcomingRenewals } from "@pax8/core";
 import { getRecommendations } from "@pax8/core";
-import type { Subscription, Company, Product, Order, RenewalReport, Recommendation } from "@pax8/core";
+import type { Subscription, Company, Product, Order, RenewalReport, Recommendation, PaginatedResponse } from "@pax8/core";
 import { replCmd } from "../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../lib/next-step.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Materialize every page of subscriptions from a `streamAll()` iterator
+ * into a single array. Used by dashboard (and Phase 2 — the other three
+ * aggregator commands) to get the full portfolio without the silent
+ * page-limit truncation #613 was tracking.
+ *
+ * Calls `onProgress(loaded, total)` after each page so the caller can
+ * keep its spinner honest on large portfolios. `total` is read from the
+ * first page's `page.totalElements` and held stable across the iteration
+ * (the server reports the same value on every page).
+ *
+ * The future `pax8 subscriptions export` command will consume the same
+ * `streamAll()` iterator directly — writing each page to stdout/file as
+ * it arrives without materializing. This helper exists because dashboard
+ * needs the full array for its multi-pass computations
+ * (`computePortfolioStats`, `getUpcomingRenewals`, `getRecommendations`,
+ * trial/active filters); export does not.
+ */
+async function collectAllSubscriptions(
+  stream: AsyncIterableIterator<PaginatedResponse<Subscription>>,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<Subscription[]> {
+  const all: Subscription[] = [];
+  for await (const result of stream) {
+    all.push(...result.content);
+    onProgress?.(all.length, result.page.totalElements);
+  }
+  return all;
+}
 
 // Internal name `cost` reflects what these numbers actually are: the
 // partner's monthly cost to Pax8 (price × quantity, amortized monthly).
@@ -172,18 +202,33 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
     const spinner = createSpinner("Loading dashboard...").start();
 
     try {
-      const [companiesSettled, subsSettled, productsSettled, ordersSettled] = await Promise.allSettled([
+      // Fetch companies/products/orders in parallel with the subscription
+      // stream. Subscriptions are the heaviest resource and now walk every
+      // page via `streamAll()` (#613) so partners with >1000 subs no longer
+      // get silently truncated portfolio totals. The other three resources
+      // stay single-page — none of dashboard's outputs grow with their
+      // count past the first 200 (companies are used as a name lookup,
+      // products for recommendations enrichment, orders for the recent-
+      // activity window).
+      const [companiesSettled, productsSettled, ordersSettled, subsSettled] = await Promise.allSettled([
         ctx.api.companies.list({ size: 200 }),
-        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE }),
         ctx.api.products.list({ size: 200 }),
         ctx.api.orders.list({ size: 200 }),
+        collectAllSubscriptions(ctx.api.subscriptions.streamAll(), (loaded, total) => {
+          if (total > 1000) {
+            // Only update the spinner when there's a real portfolio to
+            // count down — small portfolios load fast enough that the
+            // running-tally text just flickers.
+            spinner.text = `Loading dashboard... (${loaded.toLocaleString()} of ${total.toLocaleString()} subscriptions)`;
+          }
+        }),
       ]);
 
       const emptyPage = { number: 0, totalPages: 0, totalElements: 0 };
       const companiesResult = companiesSettled.status === 'fulfilled' ? companiesSettled.value : { content: [] as Company[], page: { ...emptyPage } };
-      const subsResult = subsSettled.status === 'fulfilled' ? subsSettled.value : { content: [] as Subscription[], page: { ...emptyPage } };
       const productsResult = productsSettled.status === 'fulfilled' ? productsSettled.value : { content: [] as Product[], page: { ...emptyPage } };
       const ordersResult = ordersSettled.status === 'fulfilled' ? ordersSettled.value : { content: [] as Order[], page: { ...emptyPage } };
+      const allSubs: Subscription[] = subsSettled.status === 'fulfilled' ? subsSettled.value : [];
 
       if (companiesSettled.status === 'rejected') {
         process.stderr.write(chalk.yellow("  ⚠ Could not load companies\n"));
@@ -200,9 +245,6 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
         companyNames.set(c.id, c.name);
       }
 
-      warnIfTruncated(subsResult, ALL_SUBS_PAGE_SIZE);
-
-      const allSubs = subsResult.content;
       enrichCompanyNames(companyNames, allSubs);
       await enrichProductNames(ctx, allSubs);
 

--- a/packages/core/src/api/subscriptions.test.ts
+++ b/packages/core/src/api/subscriptions.test.ts
@@ -57,6 +57,116 @@ describe("SubscriptionsApi", () => {
     expect(result.content[0].quantity).toBe(45);
   });
 
+  describe("streamAll (#613)", () => {
+    function makePage(opts: {
+      number: number;
+      totalPages: number;
+      totalElements: number;
+      contentSize: number;
+    }) {
+      const content = Array.from({ length: opts.contentSize }, (_, i) => ({
+        ...sampleSubscription,
+        // Distinct IDs per row so the test can assert ordering / count.
+        id: `${SUB_ID.slice(0, -4)}${(opts.number * 1000 + i).toString().padStart(4, "0")}`,
+      }));
+      return {
+        page: {
+          size: 1000,
+          totalElements: opts.totalElements,
+          totalPages: opts.totalPages,
+          number: opts.number,
+        },
+        content,
+      };
+    }
+
+    it("walks every page until totalPages is reached", async () => {
+      // 3-page portfolio: pages 0, 1, 2 with 1000+1000+250 = 2250 subs.
+      const page0 = makePage({ number: 0, totalPages: 3, totalElements: 2250, contentSize: 1000 });
+      const page1 = makePage({ number: 1, totalPages: 3, totalElements: 2250, contentSize: 1000 });
+      const page2 = makePage({ number: 2, totalPages: 3, totalElements: 2250, contentSize: 250 });
+      const getMock = client.get as ReturnType<typeof vi.fn>;
+      getMock
+        .mockResolvedValueOnce(page0)
+        .mockResolvedValueOnce(page1)
+        .mockResolvedValueOnce(page2);
+
+      const pages = [];
+      for await (const p of api.streamAll()) {
+        pages.push(p);
+      }
+
+      expect(pages).toHaveLength(3);
+      expect(pages.flatMap((p) => p.content)).toHaveLength(2250);
+      // Page 0 must be fetched first, then 1, then 2 — verifies the
+      // sequential page-walker hasn't been mis-wired to e.g. always fetch
+      // page 0.
+      expect(getMock).toHaveBeenNthCalledWith(1, "/subscriptions", { page: 0, size: 1000 });
+      expect(getMock).toHaveBeenNthCalledWith(2, "/subscriptions", { page: 1, size: 1000 });
+      expect(getMock).toHaveBeenNthCalledWith(3, "/subscriptions", { page: 2, size: 1000 });
+    });
+
+    it("stops after a single request when totalPages is 1", async () => {
+      const onePage = makePage({ number: 0, totalPages: 1, totalElements: 42, contentSize: 42 });
+      const getMock = client.get as ReturnType<typeof vi.fn>;
+      getMock.mockResolvedValueOnce(onePage);
+
+      const pages = [];
+      for await (const p of api.streamAll()) {
+        pages.push(p);
+      }
+
+      expect(pages).toHaveLength(1);
+      expect(getMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("yields zero pages when totalPages is 0 (empty portfolio)", async () => {
+      const empty = {
+        page: { size: 1000, totalElements: 0, totalPages: 0, number: 0 },
+        content: [],
+      };
+      (client.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(empty);
+
+      const pages = [];
+      for await (const p of api.streamAll()) {
+        pages.push(p);
+      }
+
+      // totalPages=0 means the while-loop exits after page 0 fires once.
+      // The empty page still gets yielded so callers see a definite
+      // "yes I checked, the answer is zero" rather than no yield at all.
+      expect(pages).toHaveLength(1);
+      expect(pages[0].content).toEqual([]);
+    });
+
+    it("propagates filter params verbatim on every page", async () => {
+      const page0 = makePage({ number: 0, totalPages: 2, totalElements: 1100, contentSize: 1000 });
+      const page1 = makePage({ number: 1, totalPages: 2, totalElements: 1100, contentSize: 100 });
+      const getMock = client.get as ReturnType<typeof vi.fn>;
+      getMock.mockResolvedValueOnce(page0).mockResolvedValueOnce(page1);
+
+      const pages = [];
+      for await (const p of api.streamAll({ status: "Active", companyId: COMPANY_ID })) {
+        pages.push(p);
+      }
+
+      // Both page calls carry the filter — agents pushing a server-side
+      // filter to reduce wire bytes depend on this.
+      expect(getMock).toHaveBeenNthCalledWith(1, "/subscriptions", {
+        status: "Active",
+        companyId: COMPANY_ID,
+        page: 0,
+        size: 1000,
+      });
+      expect(getMock).toHaveBeenNthCalledWith(2, "/subscriptions", {
+        status: "Active",
+        companyId: COMPANY_ID,
+        page: 1,
+        size: 1000,
+      });
+    });
+  });
+
   it("get returns a single subscription", async () => {
     (client.get as ReturnType<typeof vi.fn>).mockResolvedValue(sampleSubscription);
 

--- a/packages/core/src/api/subscriptions.ts
+++ b/packages/core/src/api/subscriptions.ts
@@ -3,6 +3,7 @@
 
 import type { Pax8Client } from "./client.js";
 import { z } from "zod";
+import { ALL_SUBS_PAGE_SIZE } from "./constants.js";
 import {
   SubscriptionSchema,
   SubscriptionHistorySchema,
@@ -56,12 +57,12 @@ export class SubscriptionsApi {
    * render `Loaded 1,000 of 5,000 …`. Matches the shape `list()` returns,
    * so the swap is mechanical.
    *
-   * Page size is fixed at 1000 — the API's documented max via
-   * `LIST_SIZE_CAP`. Smaller sizes are pointless: the goal is to minimize
-   * round-trips, and fewer items per page just means more sequential HTTP
-   * calls. The first page request takes the usual round-trip; subsequent
-   * pages benefit from the same auth-token reuse the singleton client
-   * already provides.
+   * Page size is fixed at `ALL_SUBS_PAGE_SIZE` (1000) — the API's
+   * documented max per page. Smaller sizes are pointless: the goal is to
+   * minimize round-trips, and fewer items per page just means more
+   * sequential HTTP calls. The first page request takes the usual round-
+   * trip; subsequent pages benefit from the same auth-token reuse the
+   * singleton client already provides.
    *
    * No safety cap: today's aggregator callers materialize the full set
    * anyway (10s of MB for the largest realistic MSP portfolio), and the
@@ -79,7 +80,7 @@ export class SubscriptionsApi {
     let page = 0;
     let totalPages = 1;
     while (page < totalPages) {
-      const result = await this.list({ ...filter, page, size: 1000 });
+      const result = await this.list({ ...filter, page, size: ALL_SUBS_PAGE_SIZE });
       yield result;
       totalPages = result.page.totalPages;
       page = result.page.number + 1;

--- a/packages/core/src/api/subscriptions.ts
+++ b/packages/core/src/api/subscriptions.ts
@@ -40,6 +40,52 @@ export class SubscriptionsApi {
     return PaginatedSubscriptionSchema.parse(raw);
   }
 
+  /**
+   * Iterate every page of subscriptions matching `filter`, yielding each
+   * page's full envelope (content + page metadata) until the server says
+   * `totalPages` is reached.
+   *
+   * Use this when the caller needs the full portfolio — `dashboard`,
+   * `invoices audit`, `recommendations list`, `report subscriptions`, and
+   * the future `subscriptions export`. Anything that previously did
+   * `list({ size: ALL_SUBS_PAGE_SIZE })` and silently truncated at the
+   * page limit (#613) should switch to this.
+   *
+   * Yields `PaginatedResponse<Subscription>` (not just `content`) so a
+   * progress consumer can read `page.totalElements` on the first page and
+   * render `Loaded 1,000 of 5,000 …`. Matches the shape `list()` returns,
+   * so the swap is mechanical.
+   *
+   * Page size is fixed at 1000 — the API's documented max via
+   * `LIST_SIZE_CAP`. Smaller sizes are pointless: the goal is to minimize
+   * round-trips, and fewer items per page just means more sequential HTTP
+   * calls. The first page request takes the usual round-trip; subsequent
+   * pages benefit from the same auth-token reuse the singleton client
+   * already provides.
+   *
+   * No safety cap: today's aggregator callers materialize the full set
+   * anyway (10s of MB for the largest realistic MSP portfolio), and the
+   * future streaming consumer (`subscriptions export`) will write each
+   * page to stdout/file as it arrives without materializing. If a future
+   * caller wants a ceiling, they can break out of the `for await`.
+   */
+  async *streamAll(filter?: {
+    companyId?: string;
+    status?: string;
+    billingTerm?: string;
+    productId?: string;
+    sort?: string;
+  }): AsyncIterableIterator<PaginatedResponse<Subscription>> {
+    let page = 0;
+    let totalPages = 1;
+    while (page < totalPages) {
+      const result = await this.list({ ...filter, page, size: 1000 });
+      yield result;
+      totalPages = result.page.totalPages;
+      page = result.page.number + 1;
+    }
+  }
+
   async get(id: string): Promise<Subscription> {
     const raw = await this.client.get<unknown>(`/subscriptions/${id}`);
     return SubscriptionSchema.parse(raw);

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -280,6 +280,30 @@ class SubscriptionsResource {
     return page;
   }
 
+  /**
+   * Mock counterpart to `SubscriptionsApi.streamAll` — walks pages of the
+   * in-memory fixture and yields them as `PaginatedResponse<Subscription>`
+   * envelopes. Same precedence and shape as the real API path so demo-mode
+   * exercises the same caller logic. See `api/subscriptions.ts` for the
+   * full contract.
+   */
+  async *streamAll(filter?: {
+    companyId?: string;
+    status?: string;
+    billingTerm?: string;
+    productId?: string;
+    sort?: string;
+  }): AsyncIterableIterator<PaginatedResponse<Subscription>> {
+    let page = 0;
+    let totalPages = 1;
+    while (page < totalPages) {
+      const result = await this.list({ ...filter, page, size: 1000 });
+      yield result;
+      totalPages = result.page.totalPages;
+      page = result.page.number + 1;
+    }
+  }
+
   async get(id: string): Promise<Subscription> {
     await randomDelay();
     const sub = subscriptions.find((s) => s.id === id);

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -43,6 +43,7 @@ import type {
   WebhookTopicDefinition,
 } from "./demo-data.js";
 import { ApiError, NotFoundError } from "../api/errors.js";
+import { ALL_SUBS_PAGE_SIZE } from "../api/constants.js";
 import {
   QuoteSchema,
   type CreateOrderInput,
@@ -297,7 +298,7 @@ class SubscriptionsResource {
     let page = 0;
     let totalPages = 1;
     while (page < totalPages) {
-      const result = await this.list({ ...filter, page, size: 1000 });
+      const result = await this.list({ ...filter, page, size: ALL_SUBS_PAGE_SIZE });
       yield result;
       totalPages = result.page.totalPages;
       page = result.page.number + 1;


### PR DESCRIPTION
## Summary

Phase 1 of **#613**. Closes the headline symptom — silently wrong portfolio numbers from \`pax8 dashboard\` when a partner has >1000 subscriptions.

Pre-fix at \`PAX8_DEMO_SCALE=large\` (5,000-sub fixture across 5 pages):
\`\`\`json
{ \"activeSubscriptions\": 770, \"monthlyCost\": { \"amount\": 6061601.88, \"currency\": \"GBP\" } }
\`\`\`
Post-fix:
\`\`\`json
{ \"activeSubscriptions\": 3752, \"monthlyCost\": { \"amount\": 27929701.79, \"currency\": \"GBP\" } }
\`\`\`
Almost 5× larger — the full portfolio, not the active subset of an arbitrary 1000-row sample.

## What changed

- **\`@pax8/core\`**: \`SubscriptionsApi.streamAll(filter?)\` (async iterable, yields \`PaginatedResponse<Subscription>\` envelopes — content + page metadata for progress reporting). Page size pinned to 1000 (the API's documented max). No safety cap. Real-client wraps \`getPaginated\`; mock-client mirrors the shape.
- **\`packages/cli/src/commands/dashboard.ts\`**: \`subscriptions.list({ size: 1000 })\` → \`collectAllSubscriptions(streamAll())\`. New helper materializes the iterator into an array because dashboard's downstream computations (\`computePortfolioStats\`, \`getUpcomingRenewals\`, \`getRecommendations\`, trial/active filters) all do multi-pass work and aren't streamable without a substantial refactor. Materialization is fine at realistic MSP scale (5000 subs ≈ 10 MB).
- **Progress spinner** updates to \`Loading dashboard... (1,000 of 5,000 subscriptions)\` on portfolios > 1000. Below that threshold, no flicker.
- **\`warnIfTruncated\` call dropped from dashboard.** It was the only signal users got that their numbers were wrong; now the numbers aren't wrong. The helper stays in \`lib/context.ts\` because Phase 2 still needs it for \`invoices audit\`, \`recommendations list\`, and \`recommendations upsell\` until those convert too.

## Compatibility

- **JSON envelope shape unchanged.** Same fields, same types — just accurate now. Agents and \`--json | jq\` consumers don't reshape anything.
- **No change to \`subscriptions list\` command** — that's the paginated browse command and stays single-page with \`--page\`/\`--size\`.
- **Wire impact**: dashboard now makes N + 3 requests instead of 4 (where N = number of subscription pages). For the default ~20-sub case, N = 1 and total round-trips are unchanged. For a 5000-sub case, N = 5 — sub-second extra wall-time, well under the 1000 req/min rate limit.
- **\`SubscriptionsApi.streamAll\`** is the primitive the planned \`pax8 subscriptions export\` command (Phase 3) will consume directly without materializing. Phase 1 doesn't ship that command; it just makes the iterator available so phases 2 and 3 are mechanical.

## Why phase this

Three of the four aggregator commands (\`dashboard\`, \`invoices audit\`, \`recommendations list/upsell\`) silently truncate. This PR fixes the headline one — the most-run command and the one in the README. The other three repeat the same fix shape in Phase 2 (mechanical, separate PR). Phase 3 ships \`pax8 subscriptions export\` for the partners who want raw data, not aggregates.

Design notes lived in the issue/PR discussion: eager materialization (this PR) over true streaming because three of the four consumers do multi-pass work; streaming-only memory bounds aren't the constraint at realistic MSP scale. \`streamAll\` is shaped to support both consumers — dashboard materializes, export will stream.

## Test plan

- [x] **New unit tests** for \`SubscriptionsApi.streamAll\`: 3-page walk, single-page short-circuit, empty-portfolio (\`totalPages = 0\`), filter-param propagation (4 tests).
- [x] **New dashboard subprocess test** asserts \`activeSubscriptions > 1000\` and no truncation warning at \`PAX8_DEMO_SCALE=large\`. Pre-fix this would fail loudly (770 < 1000).
- [x] **Full suite 2236/2236** locally (\`pnpm build && pnpm -r typecheck && pnpm test\`).
- [x] **Manual smoke** at both scales:
  - Default (~20 subs): \`activeSubscriptions: 25\`, \`monthlyCost: $1,760.41\`. Unchanged.
  - Large (5,000 subs): \`activeSubscriptions: 3,752\`, \`monthlyCost: £27,929,701.79\`. Full-portfolio totals.
- [ ] **Reviewer**: spot-check the spinner-progress UX in a real terminal (subprocess tests can't observe the redraw).

## Out of scope

- Phase 2: \`invoices audit\`, \`recommendations list\`, \`recommendations upsell\` switch to \`streamAll\`. Will reuse \`collectAllSubscriptions\` or its sibling.
- Phase 3: \`pax8 subscriptions export\` command — streams \`streamAll\` directly to stdout/file as CSV/JSON/JSONL.
- Other resources (\`companies\`, \`orders\`, \`products\`) keep their \`size: 200\` single-page fetches. None of dashboard's outputs grow with their count past the first 200 (companies as a name lookup, products for rec enrichment, orders for the today-window).
- A safety cap on \`streamAll\`. The realistic MSP portfolio fits in memory; if a future caller needs one, they can break out of the \`for await\`.

Refs #613.