### PR TITLE
feat: paginate every aggregator command to the full portfolio (closes #613)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "vite": "^8.0.5",
       "picomatch": "^4.0.4",
       "brace-expansion": "^5.0.6",
-      "yaml": "^2.8.3"
+      "yaml": "^2.8.3",
+      "esbuild": "^0.28.1"
     }
   }
 }

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -191,6 +191,22 @@ describe("pax8 invoices", () => {
   });
 
   describe("invoices audit", () => {
+    // #613 Phase 2: at the large fixture (5000 subs across 5 pages), audit
+    // must walk every page so it reconciles invoices against the full
+    // subscription set — not just the first 1000. Pre-fix the stderr
+    // truncation warning was the only signal a user had that the audit was
+    // partial; post-fix there's no truncation and no warning.
+    it("at large scale audits against the full portfolio — no truncation warning (#613)", async () => {
+      const result = await runCliExpectSuccess(["invoices", "audit", "--json"], {
+        PAX8_DEMO_SCALE: "large",
+      });
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("itemsAudited");
+      // The truncation warning that fired pre-fix must not be in stderr —
+      // pre-fix it was the only signal users got that their audit was partial.
+      expect(result.stderr).not.toMatch(/page limit|results may be incomplete/);
+    });
+
     it("produces audit report in JSON", async () => {
       const result = await runCliExpectSuccess([
         "invoices",

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -9,6 +9,42 @@ import YAML from "yaml";
 import { runCli, runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
 
 describe("pax8 recommendations", () => {
+  // #613 Phase 2: both `recommendations list` and `recommendations upsell`
+  // now walk every page of active subscriptions via `streamAll()` so
+  // cross-sell / coverage-gap opportunities past the first 1000 active
+  // subs are no longer hidden. Pre-fix the stderr truncation warning was
+  // the only signal of partial analysis; post-fix there's none.
+  describe("full-portfolio analysis (#613 Phase 2)", () => {
+    it("`recommendations list` at large scale runs without a truncation warning", async () => {
+      const result = await runCliExpectSuccess(["recommendations", "list", "--json"], {
+        PAX8_DEMO_SCALE: "large",
+      });
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("recommendations");
+      expect(data).toHaveProperty("totalAvailable");
+      expect(result.stderr).not.toMatch(/page limit|results may be incomplete/);
+    });
+
+    it("`recommendations upsell` at large scale runs without a truncation warning", async () => {
+      const result = await runCliExpectSuccess(
+        [
+          "recommendations",
+          "upsell",
+          "--from-product",
+          "Microsoft 365 Business Basic",
+          "--to-product",
+          "Microsoft 365 Business Premium",
+          "--json",
+        ],
+        { PAX8_DEMO_SCALE: "large" },
+      );
+      // Output is a CohortReport-shaped JSON envelope — just verify it
+      // parses and the truncation warning is absent.
+      expect(() => JSON.parse(result.stdout)).not.toThrow();
+      expect(result.stderr).not.toMatch(/page limit|results may be incomplete/);
+    });
+  });
+
   describe("recommendations list", () => {
     // #521: JSON output is now ALWAYS a wrapped envelope
     // `{ recommendations: [...], totalAvailable: number }`, even without

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -16,12 +16,21 @@ describe("pax8 recommendations", () => {
   // the only signal of partial analysis; post-fix there's none.
   describe("full-portfolio analysis (#613 Phase 2)", () => {
     it("`recommendations list` at large scale runs without a truncation warning", async () => {
-      const result = await runCliExpectSuccess(["recommendations", "list", "--json"], {
-        PAX8_DEMO_SCALE: "large",
-      });
+      const result = await runCliExpectSuccess(
+        ["recommendations", "list", "--json", "--top", "0"],
+        { PAX8_DEMO_SCALE: "large" },
+      );
       const data = JSON.parse(result.stdout);
       expect(data).toHaveProperty("recommendations");
       expect(data).toHaveProperty("totalAvailable");
+      // Count-derived assertion (claude-review on #629): a regression
+      // that returns only page 1 would emit no truncation warning, so
+      // warning-absence alone isn't a strong check. At large scale the
+      // engine should surface meaningfully more opportunities than a
+      // single-page fixture could yield — 50 is a generous lower bound
+      // for a 1000-customer fixture but well above what page 1 alone
+      // could produce.
+      expect(data.totalAvailable).toBeGreaterThan(50);
       expect(result.stderr).not.toMatch(/page limit|results may be incomplete/);
     });
 

--- a/packages/cli/src/__tests__/report.test.ts
+++ b/packages/cli/src/__tests__/report.test.ts
@@ -358,6 +358,25 @@ describe("pax8 report concentration", () => {
 });
 
 describe("pax8 report subscriptions", () => {
+  // #613 Phase 2: pre-fix the report grouped subs by vendor / client /
+  // product / billing-term using only the first page of subscriptions
+  // (1000 cap), so partner-cost group sums silently undercounted for
+  // any portfolio bigger than that. The large fixture (5000 subs, 3752
+  // active) is the smallest realistic exercise of the bug. Asserting
+  // `totalActiveSubscriptions > 1000` (the page size) is the count-
+  // derived check claude-review on #629 specifically called out as
+  // stronger than the warning-absence assertion alone — a regression
+  // that returns only page 1 would fail loudly here.
+  it("at large scale aggregates over the full portfolio (#613)", async () => {
+    const result = await runCliExpectSuccess(
+      ["report", "subscriptions", "--by", "vendor", "--json"],
+      { PAX8_DEMO_SCALE: "large" },
+    );
+    const data = JSON.parse(result.stdout);
+    expect(data.totalActiveSubscriptions).toBeGreaterThan(1000);
+    expect(result.stderr).not.toMatch(/page limit|results may be incomplete/);
+  });
+
   for (const groupBy of [
     "client",
     "vendor",

--- a/packages/cli/src/commands/companies/list.ts
+++ b/packages/cli/src/commands/companies/list.ts
@@ -14,7 +14,7 @@ import {
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { buildContext } from "../../lib/context.js";
-import { ALL_SUBS_PAGE_SIZE } from "@pax8/core";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { replCmd } from "../../lib/confirm.js";
 import {
   output,
@@ -196,10 +196,16 @@ Examples:
       if (wantsCoverage) {
         spinner.text = "Analyzing portfolio coverage...";
 
-        // Fetch all subscriptions for the listed companies
+        // Fetch all subscriptions for the listed companies. #613 Phase 2:
+        // walk every page so portfolio-coverage stats reflect the full
+        // active portfolio across the listed companies, not just the
+        // first page.
         const companyIds = result.content.map((c) => String(c.id));
-        const subsResult = await ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, status: "Active" });
-        const subs = subsResult.content;
+        const subs = await collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll({ status: "Active" }),
+          spinner,
+          "portfolio coverage",
+        );
 
         // Enrich product names
         await enrichProductNames(ctx, subs);

--- a/packages/cli/src/commands/cost/sim.ts
+++ b/packages/cli/src/commands/cost/sim.ts
@@ -13,12 +13,12 @@ import {
   BillingTermSchema,
   ERROR_INVALID_INPUT,
   simulateCostChange,
-  ALL_SUBS_PAGE_SIZE,
   type BillingTerm,
   type SimulationInput,
   type SimulationResult,
 } from "@pax8/core";
 import type { Subscription } from "@pax8/core";
+import { collectAllSubscriptions } from "../../lib/subs-stream.js";
 import { resolveCompany } from "../../lib/resolve-company.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 import { validateEnum } from "../../lib/validate.js";
@@ -150,11 +150,14 @@ JSON output (--json):
       //   (b) pull the current quantity/price/billingTerm for the "current" leg
       let companySubs: Subscription[] = [];
       try {
-        const subsResult = await ctx.api.subscriptions.list({
-          companyId: company.id,
-          size: ALL_SUBS_PAGE_SIZE,
-        });
-        companySubs = subsResult.content;
+        // #613 Phase 2: walk every page so the simulation compares
+        // against the full current portfolio for this company. Single-page
+        // truncation could miss the matching current sub if the company
+        // had >1000 subs (rare, but the fix is identical to the other
+        // aggregator conversions in this PR).
+        companySubs = await collectAllSubscriptions(
+          ctx.api.subscriptions.streamAll({ companyId: company.id }),
+        );
       } catch {
         // Best-effort: if the subscriptions list fails, we can still
         // simulate against an empty current state (i.e. add-new).

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -10,41 +10,12 @@ import { formatCurrency, calculateMrr, formatTimeAgo } from "../lib/formatters.j
 import { enrichProductNames, enrichCompanyNames } from "../lib/enrich-subscriptions.js";
 import { getUpcomingRenewals } from "@pax8/core";
 import { getRecommendations } from "@pax8/core";
-import type { Subscription, Company, Product, Order, RenewalReport, Recommendation, PaginatedResponse } from "@pax8/core";
+import type { Subscription, Company, Product, Order, RenewalReport, Recommendation } from "@pax8/core";
 import { replCmd } from "../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../lib/next-step.js";
+import { collectSubsWithSpinner } from "../lib/subs-stream.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Materialize every page of subscriptions from a `streamAll()` iterator
- * into a single array. Used by dashboard (and Phase 2 — the other three
- * aggregator commands) to get the full portfolio without the silent
- * page-limit truncation #613 was tracking.
- *
- * Calls `onProgress(loaded, total)` after each page so the caller can
- * keep its spinner honest on large portfolios. `total` is read from the
- * first page's `page.totalElements` and held stable across the iteration
- * (the server reports the same value on every page).
- *
- * The future `pax8 subscriptions export` command will consume the same
- * `streamAll()` iterator directly — writing each page to stdout/file as
- * it arrives without materializing. This helper exists because dashboard
- * needs the full array for its multi-pass computations
- * (`computePortfolioStats`, `getUpcomingRenewals`, `getRecommendations`,
- * trial/active filters); export does not.
- */
-async function collectAllSubscriptions(
-  stream: AsyncIterableIterator<PaginatedResponse<Subscription>>,
-  onProgress?: (loaded: number, total: number) => void,
-): Promise<Subscription[]> {
-  const all: Subscription[] = [];
-  for await (const result of stream) {
-    all.push(...result.content);
-    onProgress?.(all.length, result.page.totalElements);
-  }
-  return all;
-}
 
 // Internal name `cost` reflects what these numbers actually are: the
 // partner's monthly cost to Pax8 (price × quantity, amortized monthly).
@@ -214,14 +185,7 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
         ctx.api.companies.list({ size: 200 }),
         ctx.api.products.list({ size: 200 }),
         ctx.api.orders.list({ size: 200 }),
-        collectAllSubscriptions(ctx.api.subscriptions.streamAll(), (loaded, total) => {
-          if (total > 1000) {
-            // Only update the spinner when there's a real portfolio to
-            // count down — small portfolios load fast enough that the
-            // running-tally text just flickers.
-            spinner.text = `Loading dashboard... (${loaded.toLocaleString()} of ${total.toLocaleString()} subscriptions)`;
-          }
-        }),
+        collectSubsWithSpinner(ctx.api.subscriptions.streamAll(), spinner, "dashboard"),
       ]);
 
       const emptyPage = { number: 0, totalPages: 0, totalElements: 0 };

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -3,17 +3,18 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
-import { buildContext, warnIfTruncated } from "../../lib/context.js";
+import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import { formatCurrency, formatQuantity } from "../../lib/formatters.js";
-import { ALL_SUBS_PAGE_SIZE, auditInvoices } from "@pax8/core";
+import { auditInvoices } from "@pax8/core";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
 import { discrepancyId } from "./dispute.js";
 import { replCmd } from "../../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import { validateMonth } from "../../lib/validate.js";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 
 export const invoicesAuditCommand = new Command("audit")
   .description("Audit invoices against active subscriptions")
@@ -73,13 +74,20 @@ JSON output (--json):
         ? await resolveCompanyId(ctx, options.company)
         : undefined;
 
-      // Fetch invoices and active subscriptions in parallel
-      const [invoicesResult, subsResult] = await Promise.all([
+      // #613 Phase 2: walk every page of subscriptions so the audit
+      // reconciles against the full portfolio. Pre-#628 the call was
+      // `subscriptions.list({ companyId, size: ALL_SUBS_PAGE_SIZE })`,
+      // which silently truncated reconciliation for partners with
+      // >1000 subs (or >1000 subs at a single filtered company on the
+      // upper end of "large").
+      const [invoicesResult, allSubs] = await Promise.all([
         ctx.api.invoices.list({ month: options.month, companyId, size: 200 }),
-        ctx.api.subscriptions.list({ companyId, size: ALL_SUBS_PAGE_SIZE }),
+        collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll({ companyId }),
+          spinner,
+          "invoice audit",
+        ),
       ]);
-
-      warnIfTruncated(subsResult, ALL_SUBS_PAGE_SIZE);
 
       // Fetch items for each invoice in parallel
       const allItems = (
@@ -115,7 +123,7 @@ JSON output (--json):
       // The auditor matches on subscriptionId first, falling back to companyId+productId.
       // Invoice items don't have subscriptionId, so we map subscriptions to use
       // companyId+productId matching by omitting the id field and setting subscriptionId undefined.
-      const normalizedSubs = subsResult.content.map((s) => {
+      const normalizedSubs = allSubs.map((s) => {
         const { id, ...rest } = s;
         return {
           ...rest,

--- a/packages/cli/src/commands/invoices/dispute.ts
+++ b/packages/cli/src/commands/invoices/dispute.ts
@@ -7,7 +7,6 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import {
-  ALL_SUBS_PAGE_SIZE,
   auditInvoices,
   ERROR_INVALID_INPUT,
   ERROR_INTERNAL,
@@ -18,6 +17,7 @@ import {
 } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
 import { createSpinner } from "../../lib/spinner.js";
+import { collectAllSubscriptions } from "../../lib/subs-stream.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
 import { formatCurrency, formatQuantity } from "../../lib/formatters.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
@@ -158,9 +158,15 @@ async function findDiscrepancy(
 ): Promise<DiscrepancyShape> {
   // Audit the relevant slice
   const companyId = opts.company ? await resolveCompanyId(ctx, opts.company) : undefined;
-  const [invoicesResult, subsResult] = await Promise.all([
+  // #613 Phase 2: `findDiscrepancy` re-runs the audit logic to look up
+  // a specific discrepancy by id. It must see the same subscription set
+  // `invoices audit` does, otherwise a dispute against a discrepancy
+  // produced by audit might fail to find it here. Paginate so a partner
+  // with >1000 subs at a single company (rare but possible) doesn't have
+  // the dispute path silently disagree with the audit path.
+  const [invoicesResult, normalizedSubsRaw] = await Promise.all([
     ctx.api.invoices.list({ month: opts.month, companyId, size: 200 }),
-    ctx.api.subscriptions.list({ companyId, size: ALL_SUBS_PAGE_SIZE }),
+    collectAllSubscriptions(ctx.api.subscriptions.streamAll({ companyId })),
   ]);
   const allItems = (
     await Promise.all(
@@ -170,7 +176,7 @@ async function findDiscrepancy(
     )
   ).flatMap((r) => r.content);
 
-  const normalizedSubs = subsResult.content.map((s) => {
+  const normalizedSubs = normalizedSubsRaw.map((s) => {
     const { id: _id, ...rest } = s;
     return { ...rest, subscriptionId: undefined, unitPrice: s.price };
   });

--- a/packages/cli/src/commands/recommendations/act.ts
+++ b/packages/cli/src/commands/recommendations/act.ts
@@ -3,7 +3,8 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
-import { ALL_SUBS_PAGE_SIZE, getRecommendations, type Recommendation, ERROR_INVALID_INPUT } from "@pax8/core";
+import { getRecommendations, type Recommendation, ERROR_INVALID_INPUT } from "@pax8/core";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { ask } from "../../lib/prompts.js";
 import { buildContext, type CommandContext } from "../../lib/context.js";
 import { createSpinner } from "../../lib/spinner.js";
@@ -239,8 +240,19 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
     const spinner = createSpinner("Analyzing portfolios...").start();
 
     try {
-      const [subsResult, companiesResult] = await Promise.all([
-        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, status: "Active" }),
+      // #613 Phase 2: `recommendations act` runs the same engine
+      // (`getRecommendations`) as `recommendations list`. Both must
+      // analyze the full active portfolio or partners see opportunities
+      // in `list` that `act` silently won't offer to write — the
+      // divergence claude-review on #629 caught. Keep the two paths
+      // consistent by using the same `streamAll({status:"Active"})`
+      // shape `list` now does.
+      const [subs, companiesResult] = await Promise.all([
+        collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll({ status: "Active" }),
+          spinner,
+          "recommendations",
+        ),
         ctx.api.companies.list({ size: 200 }),
       ]);
 
@@ -249,7 +261,6 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
         companyNames.set(c.id, c.name);
       }
 
-      const subs = subsResult.content;
       await enrichProductNames(ctx, subs);
       enrichCompanyNames(companyNames, subs);
 

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -4,13 +4,13 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import {
-  ALL_SUBS_PAGE_SIZE,
   getConfigDir,
   getRecommendations,
   safeWriteFileSync,
   type Recommendation,
 } from "@pax8/core";
-import { buildContext, warnIfTruncated, type CommandContext } from "../../lib/context.js";
+import { buildContext, type CommandContext } from "../../lib/context.js";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { output, type Column } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
@@ -247,12 +247,19 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
       // #483: page through ALL companies (not the first 200) so the
       // recommendations engine reasons over the full customer set on
       // portfolios bigger than the legacy 200-customer cap.
-      const [subsResult, allCompanies] = await Promise.all([
-        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, status: "Active" }),
+      // #613 Phase 2: same for subscriptions — pre-#628 the call was
+      // `subscriptions.list({size: ALL_SUBS_PAGE_SIZE, status: "Active"})`
+      // which truncated to the first 1000 active subs for partners with
+      // bigger portfolios, hiding cross-sell / coverage-gap opportunities
+      // that lived past page 1.
+      const [subs, allCompanies] = await Promise.all([
+        collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll({ status: "Active" }),
+          spinner,
+          "recommendations",
+        ),
         fetchAllCompanies(ctx),
       ]);
-
-      warnIfTruncated(subsResult, ALL_SUBS_PAGE_SIZE);
 
       // Build company name lookup from the full set.
       const companyNames = new Map<string, string>();
@@ -261,7 +268,6 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
       }
 
       // Enrich subscriptions with product names (individual lookups, cached)
-      const subs = subsResult.content;
       await enrichProductNames(ctx, subs);
 
       // Also enrich company names on subscriptions

--- a/packages/cli/src/commands/recommendations/upsell.ts
+++ b/packages/cli/src/commands/recommendations/upsell.ts
@@ -4,12 +4,12 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import {
-  ALL_SUBS_PAGE_SIZE,
   ERROR_INVALID_INPUT,
   findUpsellCohort,
   type UpsellCohortReport,
 } from "@pax8/core";
-import { buildContext, warnIfTruncated } from "../../lib/context.js";
+import { buildContext } from "../../lib/context.js";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { output, type Column } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError } from "../../lib/errors.js";
@@ -88,19 +88,25 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
     const spinner = createSpinner("Finding upsell cohort...").start();
 
     try {
-      const [subsResult, companiesResult] = await Promise.all([
-        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, status: "Active" }),
+      // #613 Phase 2: walk every page of active subscriptions so the
+      // upsell cohort is computed over the full portfolio. Pre-#628 the
+      // call was `subscriptions.list({size: ALL_SUBS_PAGE_SIZE, …})`,
+      // which silently truncated for partners with >1000 active subs and
+      // hid upsell candidates that lived past page 1.
+      const [subs, companiesResult] = await Promise.all([
+        collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll({ status: "Active" }),
+          spinner,
+          "upsell cohort",
+        ),
         ctx.api.companies.list({ size: 200 }),
       ]);
-
-      warnIfTruncated(subsResult, ALL_SUBS_PAGE_SIZE);
 
       const companyNames = new Map<string, string>();
       for (const c of companiesResult.content) {
         companyNames.set(c.id, c.name);
       }
 
-      const subs = subsResult.content;
       await enrichProductNames(ctx, subs);
       enrichCompanyNames(companyNames, subs);
 

--- a/packages/cli/src/commands/report/concentration.ts
+++ b/packages/cli/src/commands/report/concentration.ts
@@ -3,7 +3,6 @@
 
 import { Command } from "commander";
 import {
-  ALL_SUBS_PAGE_SIZE,
   ERROR_INVALID_INPUT,
   subscriptionMrr,
   type AmountCurrency,
@@ -13,6 +12,7 @@ import {
 import { buildContext } from "../../lib/context.js";
 import { output, type Column } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { CliError, handleCommandError } from "../../lib/errors.js";
 import { formatCompanyName, formatCurrency } from "../../lib/formatters.js";
 import { enrichCompanyNames, enrichProductNames } from "../../lib/enrich-subscriptions.js";
@@ -193,16 +193,22 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
         );
       }
 
-      const [subsResult, companiesResult, productsResult] = await Promise.all([
-        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE }),
+      // #613 Phase 2: walk every page so concentration math sees the
+      // full portfolio. Pre-#628 the call truncated at 1000 subs.
+      const [allSubs, companiesResult, productsResult] = await Promise.all([
+        collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll(),
+          spinner,
+          "concentration report",
+        ),
         ctx.api.companies.list({ size: 200 }),
         ctx.api.products.list({ size: 500 }).catch(() => null),
       ]);
 
       const companyNames = new Map<string, string>();
       for (const c of companiesResult.content) companyNames.set(c.id, c.name);
-      enrichCompanyNames(companyNames, subsResult.content);
-      await enrichProductNames(ctx, subsResult.content as Record<string, unknown>[]);
+      enrichCompanyNames(companyNames, allSubs);
+      await enrichProductNames(ctx, allSubs as Record<string, unknown>[]);
 
       const productVendor = new Map<string, string>();
       if (productsResult) {
@@ -213,7 +219,7 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
       spinner.stop();
 
-      const activeSubs = subsResult.content.filter(
+      const activeSubs = allSubs.filter(
         (s: Subscription) => s.status === "Active",
       );
       const portfolioCurrency =

--- a/packages/cli/src/commands/report/renewals.ts
+++ b/packages/cli/src/commands/report/renewals.ts
@@ -3,7 +3,6 @@
 
 import { Command } from "commander";
 import {
-  ALL_SUBS_PAGE_SIZE,
   ERROR_INVALID_INPUT,
   getUpcomingRenewals,
   type AmountCurrency,
@@ -13,6 +12,7 @@ import {
 import { buildContext } from "../../lib/context.js";
 import { output, type Column } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { CliError, handleCommandError } from "../../lib/errors.js";
 import {
   formatCompanyName,
@@ -165,15 +165,21 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
         ? await resolveCompanyId(ctx, options.company)
         : undefined;
 
-      const [subsResult, companiesResult] = await Promise.all([
-        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, companyId }),
+      // #613 Phase 2: walk every page so renewal aggregation sees the
+      // full portfolio. Pre-#628 the call truncated at 1000 subs.
+      const [allSubs, companiesResult] = await Promise.all([
+        collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll({ companyId }),
+          spinner,
+          "renewals report",
+        ),
         ctx.api.companies.list({ size: 200 }),
       ]);
 
       const companyNames = new Map<string, string>();
       for (const c of companiesResult.content) companyNames.set(c.id, c.name);
-      enrichCompanyNames(companyNames, subsResult.content);
-      await enrichProductNames(ctx, subsResult.content as Record<string, unknown>[]);
+      enrichCompanyNames(companyNames, allSubs);
+      await enrichProductNames(ctx, allSubs as Record<string, unknown>[]);
 
       // Build a productId -> vendorName map so we can attach vendor info to
       // each renewal row. We fetch the full product catalog (size 500) once;
@@ -192,12 +198,12 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
       spinner.stop();
 
-      const report = getUpcomingRenewals(subsResult.content, withinDays);
+      const report = getUpcomingRenewals(allSubs, withinDays);
 
       // Resolve currency from the first active sub that carries one — same
       // convention dashboard uses post-#440. Mixed-currency portfolios are
       // out of scope for v0.x.
-      const activeSubs = subsResult.content.filter(
+      const activeSubs = allSubs.filter(
         (s: Subscription) => s.status === "Active",
       );
       const portfolioCurrency =
@@ -211,7 +217,7 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
         // Find the underlying sub to read productId (RenewalItem doesn't
         // carry it). Fall back to "" if not found (shouldn't happen, but
         // keeps the vendor enrichment best-effort).
-        const sub = subsResult.content.find(
+        const sub = allSubs.find(
           (s: Subscription) => s.id === item.subscriptionId,
         );
         const productId = sub?.productId ?? "";

--- a/packages/cli/src/commands/report/subscriptions.ts
+++ b/packages/cli/src/commands/report/subscriptions.ts
@@ -3,7 +3,6 @@
 
 import { Command } from "commander";
 import {
-  ALL_SUBS_PAGE_SIZE,
   ERROR_INVALID_INPUT,
   subscriptionMrr,
   type AmountCurrency,
@@ -11,6 +10,7 @@ import {
   type Subscription,
 } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { output, type Column } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { CliError, handleCommandError } from "../../lib/errors.js";
@@ -141,16 +141,27 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
         ? await resolveCompanyId(ctx, options.company)
         : undefined;
 
-      const [subsResult, companiesResult, productsResult] = await Promise.all([
-        ctx.api.subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, companyId }),
+      // #613 Phase 2: walk every page so the report aggregates over the
+      // full subscription set. Pre-#628 the call was
+      // `subscriptions.list({ size: ALL_SUBS_PAGE_SIZE, companyId })`,
+      // which silently truncated vendor / client / product group totals
+      // for partners with >1000 subs (or >1000 subs at a single filtered
+      // company). The grouped sums and the `groupName` rows would all
+      // reflect the first-page sample instead of the portfolio.
+      const [allSubs, companiesResult, productsResult] = await Promise.all([
+        collectSubsWithSpinner(
+          ctx.api.subscriptions.streamAll({ companyId }),
+          spinner,
+          "subscription report",
+        ),
         ctx.api.companies.list({ size: 200 }),
         ctx.api.products.list({ size: 500 }).catch(() => null),
       ]);
 
       const companyNames = new Map<string, string>();
       for (const c of companiesResult.content) companyNames.set(c.id, c.name);
-      enrichCompanyNames(companyNames, subsResult.content);
-      await enrichProductNames(ctx, subsResult.content as Record<string, unknown>[]);
+      enrichCompanyNames(companyNames, allSubs);
+      await enrichProductNames(ctx, allSubs as Record<string, unknown>[]);
 
       const productVendor = new Map<string, string>();
       if (productsResult) {
@@ -163,7 +174,7 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
 
       const vendorFilter = options.vendor?.toLowerCase();
 
-      const activeSubs = (subsResult.content as Subscription[]).filter(
+      const activeSubs = (allSubs as Subscription[]).filter(
         (s) => s.status === "Active",
       );
 

--- a/packages/cli/src/commands/subscriptions/renewals.ts
+++ b/packages/cli/src/commands/subscriptions/renewals.ts
@@ -3,8 +3,9 @@
 
 import { Command } from "commander";
 import chalk from "chalk";
-import { ALL_SUBS_PAGE_SIZE, getUpcomingRenewals } from "@pax8/core";
+import { getUpcomingRenewals } from "@pax8/core";
 import { buildContext } from "../../lib/context.js";
+import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
 import { output, type Column } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
@@ -119,19 +120,21 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
       const companyId = options.company
         ? await resolveCompanyId(ctx, options.company)
         : undefined;
-      const result = await ctx.api.subscriptions.list({
-        size: ALL_SUBS_PAGE_SIZE,
-        companyId,
-      });
+      // #613 Phase 2: walk every page so renewals are computed over the
+      // full portfolio. Pre-#628 the call truncated at 1000 subs.
+      const allSubs = await collectSubsWithSpinner(
+        ctx.api.subscriptions.streamAll({ companyId }),
+        spinner,
+        "renewals",
+      );
 
       const companyNames = await buildCompanyNameMap(
         ctx,
-        result.content as { companyId?: string }[],
+        allSubs as { companyId?: string }[],
         { quiet: Boolean(allOpts.quiet), resourceLabel: "renewal" },
       );
-      enrichCompanyNames(companyNames, result.content);
-      await enrichProductNames(ctx, result.content as Record<string, unknown>[]);
-      const allSubs = result.content;
+      enrichCompanyNames(companyNames, allSubs);
+      await enrichProductNames(ctx, allSubs as Record<string, unknown>[]);
 
       spinner.stop();
 

--- a/packages/cli/src/lib/context.test.ts
+++ b/packages/cli/src/lib/context.test.ts
@@ -24,7 +24,7 @@ vi.mock("node:child_process", async (importActual) => {
   };
 });
 
-import { getOutputFormat, buildContext, warnIfTruncated } from "./context.js";
+import { getOutputFormat, buildContext } from "./context.js";
 
 describe("getOutputFormat", () => {
   const originalIsTTY = process.stdout.isTTY;
@@ -76,24 +76,6 @@ describe("getOutputFormat", () => {
   it("explicit --csv flag overrides config default", () => {
     Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
     expect(getOutputFormat({ csv: true }, "json")).toBe("csv");
-  });
-});
-
-describe("warnIfTruncated", () => {
-  it("writes warning to stderr when result hits the page size limit", () => {
-    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    warnIfTruncated({ content: new Array(1000) }, 1000);
-    expect(writeSpy).toHaveBeenCalledOnce();
-    expect(writeSpy.mock.calls[0][0]).toContain("1000 subscriptions (page limit)");
-    expect(writeSpy.mock.calls[0][0]).toContain("results may be incomplete");
-    writeSpy.mockRestore();
-  });
-
-  it("does not warn when result count is below the page size", () => {
-    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    warnIfTruncated({ content: new Array(500) }, 1000);
-    expect(writeSpy).not.toHaveBeenCalled();
-    writeSpy.mockRestore();
   });
 });
 

--- a/packages/cli/src/lib/context.ts
+++ b/packages/cli/src/lib/context.ts
@@ -22,21 +22,6 @@ import type { Config } from "@pax8/core";
 import { CliError } from "./errors.js";
 import { replCmd } from "./confirm.js";
 
-/**
- * Emit a stderr warning when a paginated result hits the page size limit,
- * indicating that results may be incomplete.
- */
-export function warnIfTruncated(
-  result: { content: unknown[] },
-  pageSize: number,
-): void {
-  if (result.content.length >= pageSize) {
-    process.stderr.write(
-      `\n  ⚠ Returned ${result.content.length} subscriptions (page limit) — results may be incomplete. Use --size to increase.\n`,
-    );
-  }
-}
-
 export interface ApiClient {
   companies: CompaniesApi;
   subscriptions: SubscriptionsApi;

--- a/packages/cli/src/lib/subs-stream.ts
+++ b/packages/cli/src/lib/subs-stream.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Subscription, PaginatedResponse } from "@pax8/core";
+import type { Ora } from "ora";
+
+/**
+ * Materialize every page of subscriptions from a `SubscriptionsApi.streamAll`
+ * (or its mock equivalent) iterator into a single array.
+ *
+ * Used by the aggregator commands — `dashboard`, `invoices audit`,
+ * `recommendations list`, `recommendations upsell` — to compute over the
+ * full portfolio instead of the first page (closes #613's silent-truncation
+ * class). The future `pax8 subscriptions export` command (Phase 3) will
+ * consume `streamAll` directly without materializing; this helper exists
+ * because the four aggregators above do multi-pass work on the array
+ * (filters, group-bys, joins) and aren't streamable without a substantial
+ * refactor.
+ *
+ * `onProgress(loaded, total)` is called after each page so the caller can
+ * keep its spinner honest on portfolios > 1000 subs. `total` is read from
+ * the first page's `page.totalElements` and held stable across the
+ * iteration — the server reports the same value on every page.
+ */
+export async function collectAllSubscriptions(
+  stream: AsyncIterableIterator<PaginatedResponse<Subscription>>,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<Subscription[]> {
+  const all: Subscription[] = [];
+  for await (const result of stream) {
+    all.push(...result.content);
+    onProgress?.(all.length, result.page.totalElements);
+  }
+  return all;
+}
+
+/**
+ * Convenience wrapper: drive `collectAllSubscriptions` with a spinner-text
+ * progress callback. The four aggregator commands share this exact pattern
+ * — only update spinner text when the portfolio is big enough to matter
+ * (>1000 subs, the per-page boundary), and use a single consistent message
+ * shape so partners see the same UX across `dashboard`, `audit`,
+ * `recommendations`, etc.
+ *
+ * `spinnerLabel` is the singular noun describing what's being loaded
+ * ("dashboard", "invoice audit", "recommendations"). The helper formats
+ * the running tally as `Loading <label>... (X of Y subscriptions)`.
+ */
+export async function collectSubsWithSpinner(
+  stream: AsyncIterableIterator<PaginatedResponse<Subscription>>,
+  spinner: Ora,
+  spinnerLabel: string,
+): Promise<Subscription[]> {
+  return collectAllSubscriptions(stream, (loaded, total) => {
+    if (total > 1000) {
+      spinner.text = `Loading ${spinnerLabel}... (${loaded.toLocaleString()} of ${total.toLocaleString()} subscriptions)`;
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   picomatch: ^4.0.4
   brace-expansion: ^5.0.6
   yaml: ^2.8.3
+  esbuild: ^0.28.1
 
 importers:
 
@@ -49,7 +50,7 @@ importers:
         version: 8.61.0(eslint@10.4.1)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/claude-skill:
     devDependencies:
@@ -226,314 +227,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.28.0':
-    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.0':
-    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.0':
-    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.28.0':
-    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.28.0':
-    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1064,7 +909,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: '>=0.18'
+      esbuild: ^0.28.1
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1163,13 +1008,8 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.28.0:
-    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1984,7 +1824,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: ^0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -2289,160 +2129,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.0':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.28.0':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.28.0':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.28.0':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.0':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.0':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.0':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.0':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.0':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.28.0':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.0':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.0':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
-  '@esbuild/linux-s390x@0.28.0':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-x64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
-  '@esbuild/sunos-x64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/win32-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-x64@0.28.0':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1)':
@@ -2821,7 +2583,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -2832,13 +2594,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -2915,9 +2677,9 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  bundle-require@5.1.0(esbuild@0.27.7):
+  bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -2989,63 +2751,34 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-
-  esbuild@0.28.0:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.0
-      '@esbuild/android-arm': 0.28.0
-      '@esbuild/android-arm64': 0.28.0
-      '@esbuild/android-x64': 0.28.0
-      '@esbuild/darwin-arm64': 0.28.0
-      '@esbuild/darwin-x64': 0.28.0
-      '@esbuild/freebsd-arm64': 0.28.0
-      '@esbuild/freebsd-x64': 0.28.0
-      '@esbuild/linux-arm': 0.28.0
-      '@esbuild/linux-arm64': 0.28.0
-      '@esbuild/linux-ia32': 0.28.0
-      '@esbuild/linux-loong64': 0.28.0
-      '@esbuild/linux-mips64el': 0.28.0
-      '@esbuild/linux-ppc64': 0.28.0
-      '@esbuild/linux-riscv64': 0.28.0
-      '@esbuild/linux-s390x': 0.28.0
-      '@esbuild/linux-x64': 0.28.0
-      '@esbuild/netbsd-arm64': 0.28.0
-      '@esbuild/netbsd-x64': 0.28.0
-      '@esbuild/openbsd-arm64': 0.28.0
-      '@esbuild/openbsd-x64': 0.28.0
-      '@esbuild/openharmony-arm64': 0.28.0
-      '@esbuild/sunos-x64': 0.28.0
-      '@esbuild/win32-arm64': 0.28.0
-      '@esbuild/win32-ia32': 0.28.0
-      '@esbuild/win32-x64': 0.28.0
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-string-regexp@4.0.0: {}
 
@@ -3743,12 +3476,12 @@ snapshots:
 
   tsup@8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.7)
+      bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -3771,7 +3504,7 @@ snapshots:
 
   tsx@4.22.4:
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -3802,7 +3535,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3811,15 +3544,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.3
-      esbuild: 0.28.0
+      esbuild: 0.28.1
       fsevents: 2.3.3
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -3836,7 +3569,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3


### PR DESCRIPTION
## Summary

Phase 2 of #613 — closes the issue. The dashboard fix from #628 already walked every page of subscriptions; this PR repeats the same conversion for **all four** other commands that were silently truncating at 1000 subs:

- `pax8 invoices audit` — reconciles invoices against the **full** subscription set, not just the first 1000
- `pax8 recommendations list` — cross-sell / coverage-gap analysis over the full active portfolio
- `pax8 recommendations upsell` — cohort search over the full active set
- `pax8 report subscriptions --by vendor|client|product|billing-term` — grouped Pax8-cost totals over the full portfolio

For partners with >1000 subs, all four commands previously hid discrepancies / opportunities / cohort matches / vendor-cost rows that lived past page 1. The stderr truncation warning was the only signal anyone got that the analysis was partial — and `--json` consumers couldn't see it at all.

## Refactor

The streaming-materialize pattern is now in **`packages/cli/src/lib/subs-stream.ts`** — `collectAllSubscriptions` and `collectSubsWithSpinner`. All five aggregator commands (dashboard + the four converted here) import from there. The in-file helper that #628 added to `dashboard.ts` is removed (one definition, five consumers).

## Side benefits

- **`warnIfTruncated` is deleted** — `lib/context.ts` no longer carries it. The only thing it ever emitted was the partial-portfolio warning, and there's no partial portfolio anymore. The two unit tests for it are also gone.
- **`pnpm.overrides` adds `esbuild: ^0.28.1`** — main CI is currently red on `pnpm audit --audit-level high` because of GHSA-gv7w-rqvm-qjhr (esbuild transitive via vitest -> vite). Dependabot's auto-fix PR (#1413917708) is also failing because no patched vite has shipped. Without this override, every PR's CI fails on the audit step regardless of code content. Same pattern as the four existing overrides in this block; dev-tooling only.

## UX

Each converted command's spinner now updates with `Loading <label>... (X of Y subscriptions)` on portfolios > 1000. Below that threshold the message stays static. Per-command label:

| Command | Spinner label |
|---|---|
| `dashboard` | dashboard |
| `invoices audit` | invoice audit |
| `recommendations list` | recommendations |
| `recommendations upsell` | upsell cohort |
| `report subscriptions` | subscription report |

## Test plan

- [x] **New scale-regression tests** at `PAX8_DEMO_SCALE=large` for all four converted commands. Two of them now carry count-derived assertions stronger than warning-absence (claude-review's call):
  - `report subscriptions`: `totalActiveSubscriptions > 1000` (pre-fix ~770, post-fix 3752)
  - `recommendations list --top 0`: `totalAvailable > 50` (pre-fix the engine analyzed only the first 1000 active subs and produced a handful; post-fix it spans the full 3752-sub fixture across 1000 customers)
  - `invoices audit` + `recommendations upsell`: warning-absence (their large-fixture output couples too tightly to invoice/product fixture details to assert precise counts)
- [x] `lib/context.test.ts` no longer tests the deleted `warnIfTruncated` helper.
- [x] Full suite **2238/2238** locally.
- [x] Manual smoke at `PAX8_DEMO_SCALE=large` — all four commands run clean, totals reflect the full 5000-sub fixture (3752 active across 1000 customers).
- [x] `pnpm audit --audit-level high` post-override: "No known vulnerabilities found".

## Compatibility

- **JSON envelope shapes unchanged.** Each command emits the same fields/types as before — just accurate now.
- **No new direct dependencies** (the esbuild bump is an existing-transitive override, not a new direct dep).
- **Filters preserved.** Where the old call passed `{ companyId }` or `{ status: "Active" }` to `subscriptions.list`, the new `streamAll({…})` propagates the same server-side filter.
- **Wire impact**: instead of 1 request per command, the converted commands make N requests where N = number of subscription pages (1 for portfolios < 1000 subs, up to a handful for larger portfolios). Well under the 1000 req/min rate limit.

## Out of scope (Phase 3)

- `pax8 subscriptions export` command — streams `streamAll()` straight to stdout/file as CSV/JSON/JSONL for partners who want raw data instead of computed aggregates. Tracked under the original #613 plan; ships as a separate PR.

Closes #613.