### PR TITLE
fix(test): disable time-quip in subprocess tests (#620 partial)

### DIFF
--- a/packages/cli/src/__tests__/test-utils.ts
+++ b/packages/cli/src/__tests__/test-utils.ts
@@ -56,7 +56,15 @@ export async function runCli(
   };
   try {
     const result = await exec("node", [CLI_PATH, ...args], {
-      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...finalEnv },
+      // PAX8_DISABLE_QUIP=1 suppresses the time-based easter-egg quip
+      // (`getTimeQuip` in `commands/easter-eggs/time-quip.ts`). Without
+      // this, CI matrix runs that happen to execute at 2-5 AM UTC
+      // (the late-night quip), Monday before 9 AM, Friday after 4:30
+      // PM, or the last two days of the month emit a stderr line that
+      // flakes any test grepping stderr (#620). A test that
+      // specifically wants to exercise the quip can override by passing
+      // `PAX8_DISABLE_QUIP: ""` in `env`.
+      env: { PAX8_DISABLE_QUIP: "1", ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...finalEnv },
       timeout: 15000,
       // Default execFile maxBuffer is 1 MB. The streaming-export tests
       // and any future scale-matrix test that exercises `subscriptions
@@ -89,7 +97,9 @@ export async function runCliWithInput(
 ): Promise<CliResult> {
   return new Promise((resolveResult) => {
     const child = spawn("node", [CLI_PATH, ...args], {
-      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...env },
+      // Same time-quip suppression as `runCli` — see #620 and the
+      // comment on the env block there.
+      env: { PAX8_DISABLE_QUIP: "1", ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...env },
     });
 
     let stdout = "";

--- a/packages/cli/src/__tests__/test-utils.ts
+++ b/packages/cli/src/__tests__/test-utils.ts
@@ -64,7 +64,7 @@ export async function runCli(
       // flakes any test grepping stderr (#620). A test that
       // specifically wants to exercise the quip can override by passing
       // `PAX8_DISABLE_QUIP: ""` in `env`.
-      env: { PAX8_DISABLE_QUIP: "1", ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...finalEnv },
+      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", PAX8_DISABLE_QUIP: "1", ...finalEnv },
       timeout: 15000,
       // Default execFile maxBuffer is 1 MB. The streaming-export tests
       // and any future scale-matrix test that exercises `subscriptions
@@ -99,7 +99,7 @@ export async function runCliWithInput(
     const child = spawn("node", [CLI_PATH, ...args], {
       // Same time-quip suppression as `runCli` — see #620 and the
       // comment on the env block there.
-      env: { PAX8_DISABLE_QUIP: "1", ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", ...env },
+      env: { ...process.env, PAX8_DEMO: "1", NO_COLOR: "1", PAX8_DISABLE_QUIP: "1", ...env },
     });
 
     let stdout = "";

--- a/packages/cli/src/commands/easter-eggs/time-quip.test.ts
+++ b/packages/cli/src/commands/easter-eggs/time-quip.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getTimeQuip } from "./time-quip.js";
+
+/**
+ * Coverage for `PAX8_DISABLE_QUIP` — the test-harness escape hatch
+ * added for #620. The quip itself is intentionally time-and-day
+ * dependent and we don't want to pin the exact text or schedule (that
+ * would make it unhelpful for the developer making changes); the
+ * contract this test pins is purely: when the env var is set, the
+ * function returns null regardless of time.
+ *
+ * `runCli` in `__tests__/test-utils.ts` sets this env var
+ * unconditionally so the rest of the suite never has to deal with
+ * time-of-day stderr leaks. A test that wants to exercise the quip
+ * itself can pass `PAX8_DISABLE_QUIP: ""` to override the harness.
+ */
+describe("getTimeQuip", () => {
+  const originalEnv = process.env.PAX8_DISABLE_QUIP;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PAX8_DISABLE_QUIP;
+    else process.env.PAX8_DISABLE_QUIP = originalEnv;
+    vi.useRealTimers();
+  });
+
+  describe("PAX8_DISABLE_QUIP bypass (#620)", () => {
+    it("returns null when PAX8_DISABLE_QUIP=1, even at the witching hour", () => {
+      // Force the wall clock to 3:10 AM local — the "go to bed" quip
+      // window the original #620 variant fired in. Without the bypass,
+      // getTimeQuip would return a non-null string here.
+      vi.useFakeTimers();
+      const witchingHour = new Date();
+      witchingHour.setHours(3, 10, 0, 0);
+      vi.setSystemTime(witchingHour);
+
+      process.env.PAX8_DISABLE_QUIP = "1";
+      expect(getTimeQuip()).toBeNull();
+    });
+
+    it("returns null when PAX8_DISABLE_QUIP=1, even on Friday evening", () => {
+      // Friday after 4:30 PM local — another quip window.
+      vi.useFakeTimers();
+      // Pick a known Friday: Oct 24, 2025 is a Friday (irrelevant to
+      // the test's correctness — only that getDay()===5).
+      const friday = new Date("2025-10-24T17:00:00");
+      vi.setSystemTime(friday);
+
+      process.env.PAX8_DISABLE_QUIP = "1";
+      expect(getTimeQuip()).toBeNull();
+    });
+
+    it("DOES return a quip when PAX8_DISABLE_QUIP is unset, in a quip window", () => {
+      // Sanity check the other direction — without the env var, the
+      // 3 AM window does emit a quip. If this ever fails, either the
+      // bypass is too aggressive (intercepting unrelated unset state)
+      // or the underlying time-window logic regressed.
+      vi.useFakeTimers();
+      const witchingHour = new Date();
+      witchingHour.setHours(3, 10, 0, 0);
+      vi.setSystemTime(witchingHour);
+
+      delete process.env.PAX8_DISABLE_QUIP;
+      expect(getTimeQuip()).not.toBeNull();
+    });
+
+    it("an explicit empty string does NOT trigger the bypass (only '1' counts)", () => {
+      // The test harness exposes the same env var with `""` as the
+      // documented opt-back-in shape (so a test that wants to
+      // exercise the quip can override the suite default). Make sure
+      // that path actually re-enables the quip — otherwise the test
+      // harness's override contract is broken.
+      vi.useFakeTimers();
+      const witchingHour = new Date();
+      witchingHour.setHours(3, 10, 0, 0);
+      vi.setSystemTime(witchingHour);
+
+      process.env.PAX8_DISABLE_QUIP = "";
+      expect(getTimeQuip()).not.toBeNull();
+    });
+  });
+});

--- a/packages/cli/src/commands/easter-eggs/time-quip.ts
+++ b/packages/cli/src/commands/easter-eggs/time-quip.ts
@@ -6,8 +6,18 @@ import chalk from "chalk";
 /**
  * Returns a snarky time-based quip, or null if the current time isn't notable.
  * Call this before command output to occasionally surprise the user.
+ *
+ * Subprocess tests set `PAX8_DISABLE_QUIP=1` (via `runCli` in
+ * `test-utils.ts`) so the time-of-day stderr line never lands in
+ * assertion targets. Without that bypass, CI matrix runs that happen to
+ * execute between 02:00–05:00 UTC (the "go to bed" quip), Monday before
+ * 9 AM local, Friday after 4:30 PM, or the last two days of the month
+ * flake any stderr-grep assertion in the suite. The flag is intentionally
+ * internal — not documented in the UX guide or README — and only the
+ * test harness should set it. See #620 for the original flake report.
  */
 export function getTimeQuip(): string | null {
+  if (process.env.PAX8_DISABLE_QUIP === "1") return null;
   const now = new Date();
   const hour = now.getHours();
   const day = now.getDay(); // 0 = Sunday


### PR DESCRIPTION
## Summary

Closes the **time-of-day variant** of #620. The orders-fixture-file mutation variant (the original #620 report under v8 coverage on Node 22 Ubuntu) has a different root cause and stays open — see the issue body update below.

## The bug class this PR closes

The CLI's `preAction` hook emits a snarky easter-egg quip at certain hours/days (3 AM, Monday before 9, Friday after 4:30 PM, last two days of the month). On its own that's a fine UX touch — but when CI matrix runs land in one of those windows, the quip text leaks onto stderr, which then breaks any test that greps stderr.

Two confirmed instances:
- The "go to bed" quip at 03:10 UTC on PR #627 broke `orders.test.ts` "table footer's next-page hint appears only when more pages exist" — the regex matched on something in the longer stderr the truncation hid in the failure output.
- The original #620 flake reports against PR #617 / #629 fall into the same class.

## Fix

| Change | Why |
|---|---|
| `getTimeQuip()` returns `null` when `PAX8_DISABLE_QUIP=1` | Bypass at the source — no behavioral conditional in the caller |
| `runCli` + `runCliWithInput` in `test-utils.ts` set the flag unconditionally | Whole suite is immune by default. Single line of env each |
| A test that explicitly wants to exercise the quip can pass `PAX8_DISABLE_QUIP: ""` | Preserves the opt-back-in shape so quip behavior remains testable |

The env var is **internal** — intentionally not documented in the UX guide or README. Only the test harness should set it.

## Tests

New `packages/cli/src/commands/easter-eggs/time-quip.test.ts` pins:

- Bypass returns `null` at 03:10 (the late-night quip is otherwise active)
- Bypass returns `null` at Fri 17:00 (another quip window)
- Without the bypass, the same windowed quip still fires (sanity — proves the bypass isn't masking a real regression)
- `""` is NOT a bypass — only `"1"` counts. Preserves the harness's documented override shape.

Plus the existing 2260 suite still passes (full local: 2264/2264).

## What's NOT closed by this PR

The **original** #620 — the `orders.test.ts:101 --with-actions omits the next-page entry on the last page (#478)` flake under v8 coverage on Node 22 Ubuntu — has a different root cause:

- `demoOrdersFile()` writes to a single shared `PAX8_CONFIG_DIR` set by `vitest.test-isolation-setup.ts` once per workers spawn.
- Concurrent test files that mutate orders (via `pax8 orders create`) write to that shared file mid-test, which can flip `totalElements` between the test's probe call and its last-page call.
- The fix requires per-test-file config-dir isolation, which is a bigger change than this PR's scope. Tracked as the remaining open scope on #620.

## Compatibility

- No production-behavior change. Outside the test harness, `PAX8_DISABLE_QUIP` is never set; quips fire as before.
- No new dependencies.

## Refs

Refs #620 (partial close — time-quip variant only).