### PR TITLE
fix(test): per-test PAX8_CONFIG_DIR isolation (closes #620)

### DIFF
--- a/packages/cli/src/__tests__/per-test-config-isolation.test.ts
+++ b/packages/cli/src/__tests__/per-test-config-isolation.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+
+/**
+ * Regression test for #620 Variant B — the orders-fixture file shared
+ * state. The fix is `vitest.per-test-config-dir-setup.ts`, which
+ * registers global beforeEach/afterEach hooks that give each `it` block
+ * its own `PAX8_CONFIG_DIR` mkdtemp. Without this isolation, concurrent
+ * tests that call `pax8 orders create` write to the same
+ * `${PAX8_CONFIG_DIR}/demo-orders.json` and shift `totalElements` under
+ * each other, producing the original #620 flake on coverage-Node22-Ubuntu.
+ *
+ * This test pins the contract from the test-side: every test gets a
+ * different `PAX8_CONFIG_DIR` value. If the setupFile is removed or
+ * regresses (e.g. the override-respect check breaks), the assertion
+ * below fails loudly.
+ *
+ * We can't easily test the subprocess-spawn path here without exercising
+ * the mock client; that's covered by the existing scale-regression tests
+ * in `orders.test.ts` which rely on the dir being clean. The contract
+ * we pin here is the building block.
+ */
+describe("per-test PAX8_CONFIG_DIR isolation (#620 Variant B)", () => {
+  let firstTestConfigDir: string | undefined;
+
+  it("test A captures the per-test PAX8_CONFIG_DIR", () => {
+    firstTestConfigDir = process.env.PAX8_CONFIG_DIR;
+    // It exists (globalSetup + setupFile both populate it).
+    expect(firstTestConfigDir).toBeTruthy();
+    // And it lives under the OS tmpdir — the setupFile's mkdtemp shape.
+    expect(firstTestConfigDir).toMatch(/pax8-test-/);
+  });
+
+  it("test B sees a DIFFERENT PAX8_CONFIG_DIR from test A", () => {
+    const secondTestConfigDir = process.env.PAX8_CONFIG_DIR;
+    expect(secondTestConfigDir).toBeTruthy();
+    expect(secondTestConfigDir).toMatch(/pax8-test-/);
+    // The core contract: two tests in the same file see distinct dirs.
+    // Pre-fix this would have been `expect(...).toBe(firstTestConfigDir)`
+    // because PAX8_CONFIG_DIR was set once per workers spawn.
+    expect(secondTestConfigDir).not.toBe(firstTestConfigDir);
+  });
+
+  describe("a nested describe block also gets fresh dirs per test", () => {
+    let nestedDir: string | undefined;
+
+    it("nested test 1", () => {
+      nestedDir = process.env.PAX8_CONFIG_DIR;
+      expect(nestedDir).toBeTruthy();
+    });
+
+    it("nested test 2 is also different", () => {
+      const otherNestedDir = process.env.PAX8_CONFIG_DIR;
+      expect(otherNestedDir).not.toBe(nestedDir);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,12 @@ export default defineConfig({
       "./vitest.test-isolation-setup.ts",
       "./vitest.coverage-setup.ts",
     ],
+    // #620 Variant B: per-test mkdtemp PAX8_CONFIG_DIR so concurrent
+    // tests can't collide on the orders-fixture file (or any other
+    // demo-mode persisted state under PAX8_CONFIG_DIR). Runs in each
+    // worker and registers global beforeEach/afterEach hooks; see the
+    // file header for the design rationale.
+    setupFiles: ["./vitest.per-test-config-dir-setup.ts"],
     coverage: {
       // Custom provider wraps the standard v8 provider and additionally
       // ingests subprocess coverage profiles. See vitest.coverage-provider.ts.

--- a/vitest.per-test-config-dir-setup.ts
+++ b/vitest.per-test-config-dir-setup.ts
@@ -1,0 +1,96 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Vitest setupFile: gives **each test** its own `PAX8_CONFIG_DIR` mkdtemp.
+ *
+ * Closes Variant B of #620 — the orders-fixture-file shared-state flake.
+ *
+ * Why this is per-test, not per-file or per-run:
+ *
+ * - The globalSetup in `vitest.test-isolation-setup.ts` already provides a
+ *   single mkdtemp for the whole vitest run. That covers "the developer's
+ *   local `~/.pax8/` shouldn't leak in" but DOESN'T cover the case where
+ *   two test files (or two parallel workers) mutate the same shared file.
+ *   `MockPax8Client.OrdersResource` persists created orders to
+ *   `${PAX8_CONFIG_DIR}/demo-orders.json`. Test A's `orders create` can
+ *   shift Test B's `orders list` totals mid-call. That's exactly the
+ *   pattern that produced #620's pagination flake.
+ *
+ * - Per-FILE isolation (one mkdtemp per test file) would still let
+ *   concurrent `it()` blocks in the same file race — vitest's default
+ *   pool runs files serially per worker but tests within a file can
+ *   interleave at I/O boundaries when async.
+ *
+ * - Per-TEST isolation gives every `it()` block its own clean slate.
+ *   Multiple `runCli()` calls inside ONE test still share state (the
+ *   legitimate "create then list" pattern) because they happen within
+ *   the same beforeEach/afterEach scope.
+ *
+ * Implementation: registers global beforeEach + afterEach hooks. These
+ * apply to every test in every file in this worker. The mutated
+ * `process.env.PAX8_CONFIG_DIR` is inherited by every subprocess
+ * spawned via `execFile`/`spawn` in `runCli` (`__tests__/test-utils.ts`)
+ * since that helper passes `{ ...process.env, ... }`.
+ *
+ * Tests that explicitly set `PAX8_CONFIG_DIR` via `runCli({ PAX8_CONFIG_DIR: ... })`
+ * still take precedence — the `finalEnv` spread in `runCli` runs last.
+ * Likewise, tests that mutate `process.env.PAX8_CONFIG_DIR` in their own
+ * beforeAll/beforeEach take precedence within their scope and we restore
+ * the previous value afterward so an earlier-set ad-hoc dir survives
+ * untouched after this hook's afterEach fires.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, afterEach } from "vitest";
+
+// Module-load-time snapshot of the globalSetup-provided baseline. This
+// runs once per worker, after `vitest.test-isolation-setup.ts` has run
+// in the parent and the worker has inherited the env, but before any
+// test's beforeAll / beforeEach has executed. If a later test mutates
+// `process.env.PAX8_CONFIG_DIR` to point at its own tmpdir (the
+// existing pattern in errors.test.ts, report-bug.test.ts, etc.), our
+// beforeEach detects that — the current value no longer matches the
+// baseline — and stands aside. Those tests get the dir they set; we
+// don't clobber it.
+const BASELINE_CONFIG_DIR = process.env.PAX8_CONFIG_DIR;
+
+let savedConfigDir: string | undefined;
+let currentTestDir: string | undefined;
+
+beforeEach(() => {
+  savedConfigDir = process.env.PAX8_CONFIG_DIR;
+  // Only mint a fresh per-test dir when no test-level override is
+  // currently active. The "active override" signal is "current value
+  // differs from the globalSetup baseline" — i.e. some beforeAll or
+  // outer hook set it explicitly. Respecting that preserves the
+  // beforeAll/beforeEach-based isolation patterns existing tests
+  // already use, while still giving the (much larger) population of
+  // tests that DON'T set PAX8_CONFIG_DIR per-test isolation for free.
+  if (process.env.PAX8_CONFIG_DIR === BASELINE_CONFIG_DIR) {
+    currentTestDir = mkdtempSync(join(tmpdir(), "pax8-test-"));
+    process.env.PAX8_CONFIG_DIR = currentTestDir;
+  } else {
+    currentTestDir = undefined;
+  }
+});
+
+afterEach(() => {
+  if (currentTestDir) {
+    try {
+      rmSync(currentTestDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup; tmpdir gets reaped by the OS anyway.
+    }
+    currentTestDir = undefined;
+  }
+  // Restore the prior value rather than clobbering — preserves
+  // whatever the globalSetup or a per-test override had set.
+  if (savedConfigDir === undefined) {
+    delete process.env.PAX8_CONFIG_DIR;
+  } else {
+    process.env.PAX8_CONFIG_DIR = savedConfigDir;
+  }
+  savedConfigDir = undefined;
+});


### PR DESCRIPTION
## Summary

Closes Variant B of #620 — the orders-fixture-file shared-state flake that produced the original CI report under v8 coverage on Node 22 Ubuntu. Variant A (the time-quip stderr leak) was already closed by #632.

## Root cause

| Layer | Behavior |
|---|---|
| `MockPax8Client.OrdersResource` | Persists created orders to `${PAX8_CONFIG_DIR}/demo-orders.json`. Legitimate — it lets `pax8 orders create` followed by `pax8 orders list` in separate subprocesses see the new order, mirroring real-API behavior under demo mode. |
| `vitest.test-isolation-setup.ts` (globalSetup) | Sets `PAX8_CONFIG_DIR` to **one** mkdtemp shared across every test in the workers spawn. |
| Cross-test collision | Test A calls `pax8 orders create` → writes to the shared file. Test B (different file, possibly different worker) calls `pax8 orders list` → reads the same file, sees Test A's mutation, `totalPages` shifts mid-test, the pagination assertion flips. |
| Why coverage-Node22-Ubuntu was the visible failure mode | v8 coverage instrumentation slowed tests down enough to widen the race window. The bug existed everywhere; only that matrix variant was slow enough to surface it consistently. |

## Fix

New `vitest.per-test-config-dir-setup.ts` runs in each worker and registers global `beforeEach`/`afterEach` hooks that mkdtemp a fresh `PAX8_CONFIG_DIR` for **every `it` block**.

**Multiple `runCli` calls within ONE test still share state** — the legitimate "create then list" pattern — because they happen inside one beforeEach/afterEach scope.

**Across tests — same file or different file or different worker — the dirs are distinct.** No mutual file access, no orders.json races, no shifted totalElements mid-test.

### Override discipline

Tests with their own `beforeAll`-based `PAX8_CONFIG_DIR` (`errors.test.ts`, `report-bug.test.ts`, several others) continue to work unmodified. The setupFile snapshots the globalSetup-provided baseline at module-load and **only mints a new dir when the current value matches the baseline**. If a test-level `beforeAll` has already pointed `PAX8_CONFIG_DIR` somewhere else, the hook stands aside.

This was the breakage I hit on the first pass: my hook stomped on `errors.test.ts`'s `beforeAll`-set dir. The override-respect check is the surgical fix that preserves existing patterns.

## Regression test

`packages/cli/src/__tests__/per-test-config-isolation.test.ts` pins the contract: two `it` blocks in the same file see **different** `PAX8_CONFIG_DIR` values, and a nested `describe` is no different.

A future refactor that removes the setupFile or breaks the override-respect check fails this test loudly.

## Verified

- [x] `pnpm build && pnpm -r typecheck && pnpm test` — **2264/2264 full suite** (was 2260; +4 new tests including the regression test, no regressions).
- [x] No existing test broke despite ~130 test files now seeing per-test mkdtemp dirs.
- [x] `errors.test.ts` and `report-bug.test.ts` (the two test files that already use `beforeAll`-based PAX8_CONFIG_DIR) continue to pass — confirms the override-respect check works.

## Out of scope

Doesn't touch `OrdersResource`'s disk-persistence behavior — that's legitimate demo-mode UX that real partners depend on. The fix is purely test-side: isolate the test environment so concurrent tests don't see each other's writes.

## Closes

Closes #620 fully (Variant A: #632, Variant B: this PR).