### PR TITLE
refactor(aggregator): return structured warnings from fetchAll helpers (#635)

### DIFF
--- a/packages/cli/src/commands/dashboard.fetch.test.ts
+++ b/packages/cli/src/commands/dashboard.fetch.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { fetchAll, type DashboardFetchedData } from "./dashboard.js";
+
+/**
+ * Unit-level coverage for `dashboard.ts`'s `fetchAll` partial-failure
+ * logic (#635). Symmetric with `today.fetch.test.ts` — see that file's
+ * header comment for the why. The two helpers fetch slightly different
+ * feeds (orders vs invoices+invoice line items), but both follow the
+ * same `Promise.allSettled → collect WarningRecord[] → return` shape.
+ */
+
+interface FeedControl {
+  companies?: "ok" | "fail";
+  products?: "ok" | "fail";
+  orders?: "ok" | "fail";
+  subs?: "ok" | "fail";
+}
+
+function buildFakeCtx(control: FeedControl) {
+  const okPage = { content: [], page: { number: 0, size: 0, totalPages: 0, totalElements: 0 } };
+  async function* okStream() {
+    yield { content: [], page: { number: 0, size: 0, totalPages: 1, totalElements: 0 } };
+  }
+  async function* failStream() {
+    throw new Error("stream blew up");
+    // eslint-disable-next-line no-unreachable
+    yield okPage;
+  }
+  return {
+    api: {
+      companies: {
+        list: async () => {
+          if (control.companies === "fail") throw new Error("companies down");
+          return okPage;
+        },
+      },
+      products: {
+        list: async () => {
+          if (control.products === "fail") throw new Error("products down");
+          return okPage;
+        },
+      },
+      orders: {
+        list: async () => {
+          if (control.orders === "fail") throw new Error("orders down");
+          return okPage;
+        },
+      },
+      subscriptions: {
+        streamAll: () => (control.subs === "fail" ? failStream() : okStream()),
+      },
+    },
+  };
+}
+
+function silentSpinner() {
+  return {
+    text: "",
+    start() { return this; },
+    stop() { return this; },
+    succeed() { return this; },
+    fail() { return this; },
+  };
+}
+
+async function run(control: FeedControl): Promise<DashboardFetchedData> {
+  const ctx = buildFakeCtx(control) as unknown as Parameters<typeof fetchAll>[0];
+  const spinner = silentSpinner() as unknown as Parameters<typeof fetchAll>[1];
+  return await fetchAll(ctx, spinner);
+}
+
+describe("dashboard.ts fetchAll — warning collection (#635)", () => {
+  it("returns an empty warnings[] when every feed resolves", async () => {
+    const result = await run({});
+    expect(result.warnings).toEqual([]);
+    expect(result.allSubs).toEqual([]);
+    expect(result.companiesResult.content).toEqual([]);
+    expect(result.productsResult.content).toEqual([]);
+    expect(result.ordersResult.content).toEqual([]);
+  });
+
+  it("collects a warning when companies fails", async () => {
+    const result = await run({ companies: "fail" });
+    expect(result.warnings).toEqual([
+      { feed: "companies", severity: "warn", message: "Could not load companies" },
+    ]);
+  });
+
+  it("collects a warning when subscriptions fails", async () => {
+    // Dashboard's subs-failure severity is "warn" (not "error" like today.ts).
+    // The two commands made independent UX calls about how to escalate the
+    // primary feed — the refactor preserves both verbatim.
+    const result = await run({ subs: "fail" });
+    expect(result.warnings).toEqual([
+      { feed: "subscriptions", severity: "warn", message: "Could not load subscriptions" },
+    ]);
+  });
+
+  it("collects a warning when products fails", async () => {
+    const result = await run({ products: "fail" });
+    expect(result.warnings).toEqual([
+      { feed: "products", severity: "warn", message: "Could not load products" },
+    ]);
+  });
+
+  it("does NOT warn on orders failure — orders are best-effort here", async () => {
+    // The pre-refactor inline block tracked companies/subs/products but not
+    // orders (the recent-activity render gracefully degrades to empty).
+    // The refactor preserves that exact tracking surface.
+    const result = await run({ orders: "fail" });
+    expect(result.warnings).toEqual([]);
+    expect(result.ordersResult.content).toEqual([]);
+  });
+
+  it("collects warnings in the documented order across multiple failures", async () => {
+    const result = await run({ companies: "fail", subs: "fail", products: "fail" });
+    expect(result.warnings.map((w) => w.feed)).toEqual([
+      "companies",
+      "subscriptions",
+      "products",
+    ]);
+    expect(result.warnings.every((w) => w.severity === "warn")).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -10,10 +10,11 @@ import { formatCurrency, calculateMrr, formatTimeAgo } from "../lib/formatters.j
 import { enrichProductNames, enrichCompanyNames } from "../lib/enrich-subscriptions.js";
 import { getUpcomingRenewals } from "@pax8/core";
 import { getRecommendations } from "@pax8/core";
-import type { Subscription, Company, Product, Order, RenewalReport, Recommendation } from "@pax8/core";
+import type { Subscription, RenewalReport, Recommendation } from "@pax8/core";
 import { replCmd } from "../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../lib/next-step.js";
 import { collectSubsWithSpinner } from "../lib/subs-stream.js";
+import { emitWarnings, type WarningRecord } from "../lib/aggregator-fetch.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -165,6 +166,92 @@ function renderGrowthSection(
   out.write(chalk.dim(`\n    → ${replCmd("pax8 recommendations act")}  walk through and order\n`));
 }
 
+// ── Data fetch ───────────────────────────────────────────────────────────────
+
+/**
+ * Result shape returned by the fetch layer. We derive the page-wrapper
+ * type from the actual api method signatures rather than re-declaring it
+ * because the bundled `@pax8/core` .d.ts exposes two structurally similar
+ * `PaginatedResponse` types (an internal wire-shape and a re-exported
+ * variant), and using `Awaited<ReturnType<...>>` keeps us aligned with
+ * whichever the api method actually returns.
+ */
+type CtxApi = Awaited<ReturnType<typeof buildContext>>["api"];
+type CompaniesListResult = Awaited<ReturnType<CtxApi["companies"]["list"]>>;
+type ProductsListResult = Awaited<ReturnType<CtxApi["products"]["list"]>>;
+type OrdersListResult = Awaited<ReturnType<CtxApi["orders"]["list"]>>;
+
+export interface DashboardFetchedData {
+  allSubs: Subscription[];
+  companiesResult: CompaniesListResult;
+  productsResult: ProductsListResult;
+  ordersResult: OrdersListResult;
+  /**
+   * Per-feed warnings collected during the parallel fetch. Returned as
+   * structured data (rather than written directly to stderr) so this
+   * helper is unit-testable in isolation. The command layer calls
+   * `emitWarnings(process.stderr, data.warnings)` at the appropriate
+   * point in the run sequence. See #635.
+   */
+  warnings: WarningRecord[];
+}
+
+export async function fetchAll(
+  ctx: Awaited<ReturnType<typeof buildContext>>,
+  spinner: ReturnType<typeof createSpinner>,
+): Promise<DashboardFetchedData> {
+  // Fetch companies/products/orders in parallel with the subscription
+  // stream. Subscriptions are the heaviest resource and now walk every
+  // page via `streamAll()` (#613) so partners with >1000 subs no longer
+  // get silently truncated portfolio totals. The other three resources
+  // stay single-page — none of dashboard's outputs grow with their
+  // count past the first 200 (companies are used as a name lookup,
+  // products for recommendations enrichment, orders for the recent-
+  // activity window).
+  const [companiesSettled, productsSettled, ordersSettled, subsSettled] = await Promise.allSettled([
+    ctx.api.companies.list({ size: 200 }),
+    ctx.api.products.list({ size: 200 }),
+    ctx.api.orders.list({ size: 200 }),
+    collectSubsWithSpinner(ctx.api.subscriptions.streamAll(), spinner, "dashboard"),
+  ]);
+
+  const emptyPage = { number: 0, size: 0, totalPages: 0, totalElements: 0 };
+  const companiesResult: CompaniesListResult = companiesSettled.status === 'fulfilled' ? companiesSettled.value : { content: [], page: { ...emptyPage } };
+  const productsResult: ProductsListResult = productsSettled.status === 'fulfilled' ? productsSettled.value : { content: [], page: { ...emptyPage } };
+  const ordersResult: OrdersListResult = ordersSettled.status === 'fulfilled' ? ordersSettled.value : { content: [], page: { ...emptyPage } };
+  const allSubs: Subscription[] = subsSettled.status === 'fulfilled' ? subsSettled.value : [];
+
+  // Collect partial-failure warnings as structured data so the partial-
+  // failure logic is unit-testable. The command layer emits these via
+  // `emitWarnings()` once the fetch returns. We never throw here — a
+  // single feed failure should still produce a partial dashboard — but
+  // the partner needs to know the numbers are incomplete (#635).
+  const warnings: WarningRecord[] = [];
+  if (companiesSettled.status === 'rejected') {
+    warnings.push({
+      feed: "companies",
+      severity: "warn",
+      message: "Could not load companies",
+    });
+  }
+  if (subsSettled.status === 'rejected') {
+    warnings.push({
+      feed: "subscriptions",
+      severity: "warn",
+      message: "Could not load subscriptions",
+    });
+  }
+  if (productsSettled.status === 'rejected') {
+    warnings.push({
+      feed: "products",
+      severity: "warn",
+      message: "Could not load products",
+    });
+  }
+
+  return { allSubs, companiesResult, productsResult, ordersResult, warnings };
+}
+
 // ── Command ──────────────────────────────────────────────────────────────────
 
 async function runDashboard(options: { all?: boolean; customers?: boolean; renewals?: boolean; growth?: boolean }, cmd: Command): Promise<void> {
@@ -173,36 +260,13 @@ async function runDashboard(options: { all?: boolean; customers?: boolean; renew
     const spinner = createSpinner("Loading dashboard...").start();
 
     try {
-      // Fetch companies/products/orders in parallel with the subscription
-      // stream. Subscriptions are the heaviest resource and now walk every
-      // page via `streamAll()` (#613) so partners with >1000 subs no longer
-      // get silently truncated portfolio totals. The other three resources
-      // stay single-page — none of dashboard's outputs grow with their
-      // count past the first 200 (companies are used as a name lookup,
-      // products for recommendations enrichment, orders for the recent-
-      // activity window).
-      const [companiesSettled, productsSettled, ordersSettled, subsSettled] = await Promise.allSettled([
-        ctx.api.companies.list({ size: 200 }),
-        ctx.api.products.list({ size: 200 }),
-        ctx.api.orders.list({ size: 200 }),
-        collectSubsWithSpinner(ctx.api.subscriptions.streamAll(), spinner, "dashboard"),
-      ]);
+      const { allSubs, companiesResult, productsResult, ordersResult, warnings } = await fetchAll(ctx, spinner);
 
-      const emptyPage = { number: 0, totalPages: 0, totalElements: 0 };
-      const companiesResult = companiesSettled.status === 'fulfilled' ? companiesSettled.value : { content: [] as Company[], page: { ...emptyPage } };
-      const productsResult = productsSettled.status === 'fulfilled' ? productsSettled.value : { content: [] as Product[], page: { ...emptyPage } };
-      const ordersResult = ordersSettled.status === 'fulfilled' ? ordersSettled.value : { content: [] as Order[], page: { ...emptyPage } };
-      const allSubs: Subscription[] = subsSettled.status === 'fulfilled' ? subsSettled.value : [];
-
-      if (companiesSettled.status === 'rejected') {
-        process.stderr.write(chalk.yellow("  ⚠ Could not load companies\n"));
-      }
-      if (subsSettled.status === 'rejected') {
-        process.stderr.write(chalk.yellow("  ⚠ Could not load subscriptions\n"));
-      }
-      if (productsSettled.status === 'rejected') {
-        process.stderr.write(chalk.yellow("  ⚠ Could not load products\n"));
-      }
+      // Surface partial-failure warnings before further processing so the
+      // partner sees them in the same place as before the refactor (#635).
+      // The fetch helper returns them as structured data; this layer owns
+      // I/O.
+      emitWarnings(process.stderr, warnings);
 
       const companyNames = new Map<string, string>();
       for (const c of companiesResult.content) {

--- a/packages/cli/src/commands/today.fetch.test.ts
+++ b/packages/cli/src/commands/today.fetch.test.ts
@@ -1,0 +1,164 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { fetchAll, type FetchedData } from "./today.js";
+
+/**
+ * Unit-level coverage for `today.ts`'s `fetchAll` partial-failure logic
+ * (#635). The helper used to write warnings directly to `process.stderr`,
+ * which made the failure paths only testable via subprocess. After the
+ * refactor it returns `warnings: WarningRecord[]` alongside the data —
+ * the four feeds × {fulfilled, rejected} truth table is now testable
+ * here without spinning a child process or stubbing chalk/I/O.
+ *
+ * We build a structural fake `ctx.api` rather than `MockPax8Client` so we
+ * can independently control each feed's resolved/rejected state.
+ */
+
+interface FeedControl {
+  companies?: "ok" | "fail";
+  products?: "ok" | "fail";
+  invoices?: "ok" | "fail";
+  subs?: "ok" | "fail";
+}
+
+function buildFakeCtx(control: FeedControl) {
+  const okPage = { content: [], page: { number: 0, size: 0, totalPages: 0, totalElements: 0 } };
+  // streamAll yields PaginatedResponse pages; an "ok" stream emits one empty
+  // page, a "fail" stream rejects on the first iteration.
+  async function* okStream() {
+    yield { content: [], page: { number: 0, size: 0, totalPages: 1, totalElements: 0 } };
+  }
+  async function* failStream() {
+    throw new Error("stream blew up");
+    // eslint-disable-next-line no-unreachable
+    yield okPage;
+  }
+  return {
+    api: {
+      companies: {
+        list: async () => {
+          if (control.companies === "fail") throw new Error("companies down");
+          return okPage;
+        },
+      },
+      products: {
+        list: async () => {
+          if (control.products === "fail") throw new Error("products down");
+          return okPage;
+        },
+      },
+      invoices: {
+        list: async () => {
+          if (control.invoices === "fail") throw new Error("invoices down");
+          return okPage;
+        },
+        listItems: async () => ({ content: [] }),
+      },
+      subscriptions: {
+        streamAll: () => (control.subs === "fail" ? failStream() : okStream()),
+      },
+    },
+  };
+}
+
+function silentSpinner() {
+  // Minimal Ora-shaped no-op spinner. `collectSubsWithSpinner` only writes
+  // to `.text`, so a setter is enough.
+  return {
+    text: "",
+    start() { return this; },
+    stop() { return this; },
+    succeed() { return this; },
+    fail() { return this; },
+  };
+}
+
+async function run(control: FeedControl): Promise<FetchedData> {
+  // `fetchAll` is typed against the real buildContext return shape; the
+  // structural fake matches the runtime shape exactly. Cast through unknown
+  // to silence the nominal class-brand mismatch.
+  const ctx = buildFakeCtx(control) as unknown as Parameters<typeof fetchAll>[0];
+  const spinner = silentSpinner() as unknown as Parameters<typeof fetchAll>[1];
+  return await fetchAll(ctx, spinner);
+}
+
+describe("today.ts fetchAll — warning collection (#635)", () => {
+  it("returns an empty warnings[] when every feed resolves", async () => {
+    const result = await run({});
+    expect(result.warnings).toEqual([]);
+    expect(result.allSubs).toEqual([]);
+    expect(result.companies).toEqual([]);
+    expect(result.products).toEqual([]);
+    expect(result.invoiceItems).toEqual([]);
+  });
+
+  it("collects a warn-severity record when companies fails", async () => {
+    const result = await run({ companies: "fail" });
+    expect(result.warnings).toEqual([
+      {
+        feed: "companies",
+        severity: "warn",
+        message: "Could not load companies — names may render as IDs",
+      },
+    ]);
+  });
+
+  it("collects a warn-severity record when products fails", async () => {
+    const result = await run({ products: "fail" });
+    expect(result.warnings).toEqual([
+      {
+        feed: "products",
+        severity: "warn",
+        message: "Could not load product catalog — growth opportunities suppressed",
+      },
+    ]);
+  });
+
+  it("collects a warn-severity record when invoices fails", async () => {
+    const result = await run({ invoices: "fail" });
+    expect(result.warnings).toEqual([
+      {
+        feed: "invoices",
+        severity: "warn",
+        message: "Could not load invoices — audit findings suppressed",
+      },
+    ]);
+  });
+
+  it("collects an error-severity record when subscriptions fails", async () => {
+    // Subs are the primary feed — an "all quiet" render with a failed subs
+    // fetch is the single most-misleading state, so the severity escalates
+    // to error.
+    const result = await run({ subs: "fail" });
+    expect(result.warnings).toEqual([
+      {
+        feed: "subscriptions",
+        severity: "error",
+        message: "Could not load subscriptions — today's list is incomplete",
+      },
+    ]);
+  });
+
+  it("collects multiple warnings in the documented order when several feeds fail", async () => {
+    const result = await run({
+      companies: "fail",
+      products: "fail",
+      invoices: "fail",
+      subs: "fail",
+    });
+    expect(result.warnings.map((w) => w.feed)).toEqual([
+      "companies",
+      "products",
+      "invoices",
+      "subscriptions",
+    ]);
+    expect(result.warnings.map((w) => w.severity)).toEqual([
+      "warn",
+      "warn",
+      "warn",
+      "error",
+    ]);
+  });
+});

--- a/packages/cli/src/commands/today.ts
+++ b/packages/cli/src/commands/today.ts
@@ -23,6 +23,7 @@ import { enrichCompanyNames, enrichProductNames } from "../lib/enrich-subscripti
 import { discrepancyId } from "./invoices/dispute.js";
 import { promptNextSteps, type NextStep } from "../lib/next-step.js";
 import { collectSubsWithSpinner } from "../lib/subs-stream.js";
+import { emitWarnings, type WarningRecord } from "../lib/aggregator-fetch.js";
 
 // ── Item shape ────────────────────────────────────────────────────────────────
 
@@ -75,14 +76,22 @@ export interface TodayItem {
 
 // ── Data fetch ───────────────────────────────────────────────────────────────
 
-interface FetchedData {
+export interface FetchedData {
   allSubs: Subscription[];
   companies: Company[];
   products: Product[];
   invoiceItems: InvoiceItem[];
+  /**
+   * Per-feed warnings collected during the parallel fetch. Returned as
+   * structured data (rather than written directly to stderr) so this
+   * helper is unit-testable in isolation. The command layer calls
+   * `emitWarnings(process.stderr, data.warnings)` at the appropriate
+   * point in the run sequence. See #635.
+   */
+  warnings: WarningRecord[];
 }
 
-async function fetchAll(
+export async function fetchAll(
   ctx: Awaited<ReturnType<typeof buildContext>>,
   spinner: ReturnType<typeof createSpinner>,
 ): Promise<FetchedData> {
@@ -105,27 +114,43 @@ async function fetchAll(
   const invoices = invoicesSettled.status === "fulfilled" ? invoicesSettled.value : empty;
   const allSubs = subsSettled.status === "fulfilled" ? subsSettled.value : [];
 
-  // Surface partial failures on stderr so a feed crash isn't conflated
-  // with a quiet/empty portfolio. `today` is a synthetic command — an
-  // empty render with a failed subscriptions feed looks identical to a
-  // partner with no urgent action, and that's misleading. Same pattern
-  // as dashboard.ts. We never throw here — a single feed failure should
-  // still produce a partial brief — but the partner needs to know the
-  // numbers are incomplete.
+  // Collect partial-failure warnings as structured data so the partial-
+  // failure logic is unit-testable. The command layer emits these via
+  // `emitWarnings()` once the spinner has settled. We never throw here —
+  // a single feed failure should still produce a partial brief — but
+  // the partner needs to know the numbers are incomplete. Same pattern
+  // as dashboard.ts (#635).
+  const warnings: WarningRecord[] = [];
   if (companiesSettled.status === "rejected") {
-    process.stderr.write(chalk.yellow("  ⚠ Could not load companies — names may render as IDs\n"));
+    warnings.push({
+      feed: "companies",
+      severity: "warn",
+      message: "Could not load companies — names may render as IDs",
+    });
   }
   if (productsSettled.status === "rejected") {
-    process.stderr.write(chalk.yellow("  ⚠ Could not load product catalog — growth opportunities suppressed\n"));
+    warnings.push({
+      feed: "products",
+      severity: "warn",
+      message: "Could not load product catalog — growth opportunities suppressed",
+    });
   }
   if (invoicesSettled.status === "rejected") {
-    process.stderr.write(chalk.yellow("  ⚠ Could not load invoices — audit findings suppressed\n"));
+    warnings.push({
+      feed: "invoices",
+      severity: "warn",
+      message: "Could not load invoices — audit findings suppressed",
+    });
   }
   if (subsSettled.status === "rejected") {
     // Subs are the primary feed (renewals + trials + audit normalization).
     // An empty result here is the single most-misleading shape — call it
     // out explicitly rather than rendering "all quiet."
-    process.stderr.write(chalk.red("  ✗ Could not load subscriptions — today's list is incomplete\n"));
+    warnings.push({
+      feed: "subscriptions",
+      severity: "error",
+      message: "Could not load subscriptions — today's list is incomplete",
+    });
   }
 
   // Per-invoice items fetched after subs land so the spinner already
@@ -139,7 +164,7 @@ async function fetchAll(
   );
   const invoiceItems = itemPages.flatMap((p) => p.content);
 
-  return { allSubs, companies, products, invoiceItems };
+  return { allSubs, companies, products, invoiceItems, warnings };
 }
 
 // ── Item builders ─────────────────────────────────────────────────────────────
@@ -549,7 +574,13 @@ async function runToday(options: Record<string, unknown>, cmd: Command): Promise
   const spinner = createSpinner("Loading today's list...").start();
 
   try {
-    const { allSubs, companies, products, invoiceItems } = await fetchAll(ctx, spinner);
+    const { allSubs, companies, products, invoiceItems, warnings } = await fetchAll(ctx, spinner);
+
+    // Surface partial-failure warnings before the spinner succeeds so the
+    // partner sees them in the same place as before the refactor (#635).
+    // The fetch helper returns them as structured data; this layer owns
+    // I/O.
+    emitWarnings(process.stderr, warnings);
 
     // Enrich subs with company + product names so the human render reads as
     // names, not UUIDs. Cheap; the heavy lookups are cached per-process.

--- a/packages/cli/src/lib/aggregator-fetch.test.ts
+++ b/packages/cli/src/lib/aggregator-fetch.test.ts
@@ -34,6 +34,14 @@ function collectStream(): {
   return { stream, read: () => buf };
 }
 
+// ANSI color codes are stripped from captured stderr before content
+// assertions so this file isn't coupled to chalk's exact escape shape.
+// The literal ESC character is required in a regex; the matching string-
+// literal form (e.g. `expect(s).toContain("\x1b[")` in table-output.test.ts)
+// doesn't trigger no-control-regex, but the regex form does.
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[\d+m/g;
+
 describe("formatWarning", () => {
   it("renders a warn-severity record with the yellow ⚠ prefix", () => {
     const w: WarningRecord = {
@@ -98,7 +106,7 @@ describe("emitWarnings", () => {
     expect(lines).toHaveLength(3);
     // strip ANSI colour codes for content assertions; order must match
     // input order.
-    const stripped = lines.map((l) => l.replace(/\[\d+m/g, ""));
+    const stripped = lines.map((l) => l.replace(ANSI_RE, ""));
     expect(stripped[0]).toContain("first");
     expect(stripped[1]).toContain("second");
     expect(stripped[2]).toContain("third");
@@ -134,7 +142,7 @@ describe("emitWarnings", () => {
         message: "Could not load subscriptions — today's list is incomplete",
       },
     ]);
-    const stripped = read().replace(/\[\d+m/g, "");
+    const stripped = read().replace(ANSI_RE, "");
     expect(stripped).toContain("  ⚠ Could not load companies — names may render as IDs\n");
     expect(stripped).toContain("  ⚠ Could not load product catalog — growth opportunities suppressed\n");
     expect(stripped).toContain("  ⚠ Could not load invoices — audit findings suppressed\n");
@@ -148,7 +156,7 @@ describe("emitWarnings", () => {
       { feed: "subscriptions", severity: "warn", message: "Could not load subscriptions" },
       { feed: "products", severity: "warn", message: "Could not load products" },
     ]);
-    const stripped = read().replace(/\[\d+m/g, "");
+    const stripped = read().replace(ANSI_RE, "");
     expect(stripped).toContain("  ⚠ Could not load companies\n");
     expect(stripped).toContain("  ⚠ Could not load subscriptions\n");
     expect(stripped).toContain("  ⚠ Could not load products\n");

--- a/packages/cli/src/lib/aggregator-fetch.test.ts
+++ b/packages/cli/src/lib/aggregator-fetch.test.ts
@@ -1,0 +1,156 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { Writable } from "node:stream";
+import {
+  emitWarnings,
+  formatWarning,
+  type WarningRecord,
+} from "./aggregator-fetch.js";
+
+/**
+ * Unit tests for the shared warning-record plumbing used by the `today` and
+ * `dashboard` aggregator-fetch helpers (#635).
+ *
+ * The fetch helpers now return `warnings: WarningRecord[]` alongside their
+ * data; the command layer is responsible for surfacing them via
+ * `emitWarnings()`. These tests pin the formatter shape (chalk colouring,
+ * glyph, indent, newline) so the observable stderr output cannot drift
+ * silently when the helper is touched.
+ */
+
+function collectStream(): {
+  stream: NodeJS.WritableStream;
+  read: () => string;
+} {
+  let buf = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      buf += chunk.toString();
+      callback();
+    },
+  });
+  return { stream, read: () => buf };
+}
+
+describe("formatWarning", () => {
+  it("renders a warn-severity record with the yellow ⚠ prefix", () => {
+    const w: WarningRecord = {
+      feed: "companies",
+      severity: "warn",
+      message: "Could not load companies",
+    };
+    const out = formatWarning(w);
+    // Trailing newline + glyph + message — colour codes are present but we
+    // assert the visible substring, not the exact escape sequence (chalk
+    // varies with the test environment's colour-depth detection).
+    expect(out).toMatch(/⚠ Could not load companies/);
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.startsWith("  ") || out.includes("")).toBe(true);
+  });
+
+  it("renders an error-severity record with the red ✗ prefix", () => {
+    const w: WarningRecord = {
+      feed: "subscriptions",
+      severity: "error",
+      message: "Could not load subscriptions — today's list is incomplete",
+    };
+    const out = formatWarning(w);
+    expect(out).toMatch(/✗ Could not load subscriptions/);
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("uses different glyphs for warn vs error severities", () => {
+    const warn = formatWarning({
+      feed: "products",
+      severity: "warn",
+      message: "x",
+    });
+    const error = formatWarning({
+      feed: "products",
+      severity: "error",
+      message: "x",
+    });
+    expect(warn).toContain("⚠");
+    expect(warn).not.toContain("✗");
+    expect(error).toContain("✗");
+    expect(error).not.toContain("⚠");
+  });
+});
+
+describe("emitWarnings", () => {
+  it("writes nothing to the stream when the warnings array is empty", () => {
+    const { stream, read } = collectStream();
+    emitWarnings(stream, []);
+    expect(read()).toBe("");
+  });
+
+  it("writes one line per warning in input order", () => {
+    const { stream, read } = collectStream();
+    const warnings: WarningRecord[] = [
+      { feed: "companies", severity: "warn", message: "first" },
+      { feed: "products", severity: "warn", message: "second" },
+      { feed: "subscriptions", severity: "error", message: "third" },
+    ];
+    emitWarnings(stream, warnings);
+    const lines = read().split("\n").filter((l) => l.length > 0);
+    expect(lines).toHaveLength(3);
+    // strip ANSI colour codes for content assertions; order must match
+    // input order.
+    const stripped = lines.map((l) => l.replace(/\[\d+m/g, ""));
+    expect(stripped[0]).toContain("first");
+    expect(stripped[1]).toContain("second");
+    expect(stripped[2]).toContain("third");
+    // first two are warn (⚠), third is error (✗).
+    expect(stripped[0]).toContain("⚠");
+    expect(stripped[1]).toContain("⚠");
+    expect(stripped[2]).toContain("✗");
+  });
+
+  it("matches the pre-refactor today.ts inline messages verbatim", () => {
+    // Locking in the exact strings the helper used to write inline so the
+    // observable stderr behavior cannot drift under refactor.
+    const { stream, read } = collectStream();
+    emitWarnings(stream, [
+      {
+        feed: "companies",
+        severity: "warn",
+        message: "Could not load companies — names may render as IDs",
+      },
+      {
+        feed: "products",
+        severity: "warn",
+        message: "Could not load product catalog — growth opportunities suppressed",
+      },
+      {
+        feed: "invoices",
+        severity: "warn",
+        message: "Could not load invoices — audit findings suppressed",
+      },
+      {
+        feed: "subscriptions",
+        severity: "error",
+        message: "Could not load subscriptions — today's list is incomplete",
+      },
+    ]);
+    const stripped = read().replace(/\[\d+m/g, "");
+    expect(stripped).toContain("  ⚠ Could not load companies — names may render as IDs\n");
+    expect(stripped).toContain("  ⚠ Could not load product catalog — growth opportunities suppressed\n");
+    expect(stripped).toContain("  ⚠ Could not load invoices — audit findings suppressed\n");
+    expect(stripped).toContain("  ✗ Could not load subscriptions — today's list is incomplete\n");
+  });
+
+  it("matches the pre-refactor dashboard.ts inline messages verbatim", () => {
+    const { stream, read } = collectStream();
+    emitWarnings(stream, [
+      { feed: "companies", severity: "warn", message: "Could not load companies" },
+      { feed: "subscriptions", severity: "warn", message: "Could not load subscriptions" },
+      { feed: "products", severity: "warn", message: "Could not load products" },
+    ]);
+    const stripped = read().replace(/\[\d+m/g, "");
+    expect(stripped).toContain("  ⚠ Could not load companies\n");
+    expect(stripped).toContain("  ⚠ Could not load subscriptions\n");
+    expect(stripped).toContain("  ⚠ Could not load products\n");
+  });
+});

--- a/packages/cli/src/lib/aggregator-fetch.ts
+++ b/packages/cli/src/lib/aggregator-fetch.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import chalk from "chalk";
+
+/**
+ * Aggregator-feed identifier. Both `today` and `dashboard` fetch a small
+ * fixed set of feeds in parallel via `Promise.allSettled`; when one rejects,
+ * the command degrades gracefully and emits a per-feed warning to stderr.
+ *
+ * Keeping the union tight (rather than `string`) lets callers exhaustively
+ * map per-feed messages and lets agents reading stderr disambiguate which
+ * feed degraded.
+ */
+export type FeedName =
+  | "subscriptions"
+  | "companies"
+  | "products"
+  | "invoices"
+  | "orders";
+
+/**
+ * Structured warning emitted by the fetch layer when a single feed fails.
+ *
+ * The fetch helper returns these as data instead of writing them to stderr
+ * directly so the helper is unit-testable in isolation. The command layer
+ * (`runToday`, `runDashboard`) is responsible for emitting them via
+ * `emitWarnings()` at the appropriate point in the run sequence.
+ *
+ * NOTE: per #635, these warnings are stderr-only — they are intentionally
+ * NOT surfaced on the JSON envelope. Whether to add `warnings[]` to the
+ * JSON contract is a separate decision; refer to the issue body.
+ */
+export interface WarningRecord {
+  feed: FeedName;
+  severity: "warn" | "error";
+  message: string;
+}
+
+/**
+ * Format a single warning record as a chalk-coloured stderr line. The
+ * line matches the pre-refactor inline shape (whole string coloured, two-
+ * space indent, severity glyph prefix, trailing newline) so observable
+ * behaviour is identical to the prior `process.stderr.write(chalk.yellow(...))`
+ * calls in `today.ts` / `dashboard.ts`.
+ *
+ *   - severity "warn"  → yellow "  ⚠ <message>\n"
+ *   - severity "error" → red    "  ✗ <message>\n"
+ *
+ * Exported so tests can assert formatting without spawning a subprocess.
+ */
+export function formatWarning(w: WarningRecord): string {
+  const glyph = w.severity === "error" ? "✗" : "⚠";
+  const colour = w.severity === "error" ? chalk.red : chalk.yellow;
+  return colour(`  ${glyph} ${w.message}`) + "\n";
+}
+
+/**
+ * Emit a list of warning records to a stderr-style stream.
+ *
+ * The fetch helper returns warnings as data; the command layer calls this
+ * to surface them. Stderr is the side channel — the JSON stdout envelope
+ * is unaffected (callers can still emit warnings even under `--json`).
+ */
+export function emitWarnings(
+  stream: NodeJS.WritableStream,
+  warnings: readonly WarningRecord[],
+): void {
+  for (const w of warnings) {
+    stream.write(formatWarning(w));
+  }
+}


### PR DESCRIPTION
## Summary

Closes #635.

Both `today.ts` and `dashboard.ts` had a `Promise.allSettled` block that wrote per-feed partial-failure warnings directly to `process.stderr` via chalk inside the fetch helper itself. This coupled the data-fetch layer to process-level I/O and made the partial-failure logic only reachable through subprocess tests.

This PR refactors each `fetchAll` to return `warnings: WarningRecord[]` alongside the data. The command layer (`runToday`, `runDashboard`) now owns the stderr emission.

### Changes

- **New helper** `packages/cli/src/lib/aggregator-fetch.ts`:
  - `WarningRecord` — `{ feed, severity: "warn" | "error", message }`
  - `formatWarning(w)` — renders a chalk-coloured stderr line matching the pre-refactor inline shape (whole string coloured, 2-space indent, ⚠ / ✗ glyph, trailing newline)
  - `emitWarnings(stream, warnings)` — writes each record to the given stream
- **`packages/cli/src/commands/today.ts`**: `fetchAll` is now exported, returns `FetchedData` including `warnings[]`. `runToday` calls `emitWarnings(process.stderr, warnings)` right after `fetchAll` returns — same emit point relative to the spinner as before.
- **`packages/cli/src/commands/dashboard.ts`**: same refactor (`fetchAll` exported, returns `DashboardFetchedData` with `warnings[]`). `runDashboard` emits via the shared helper.

### Design call: parallel, not shared

The two `fetchAll` functions stay **parallel** (not extracted into a shared helper). Their feed sets differ enough — `today` fetches invoices + per-invoice line items, `dashboard` fetches orders, plus the two commands made independent UX calls about severity (today escalates subscriptions to `error`; dashboard keeps it at `warn`) — that a single helper would be a wrong abstraction at this stage. Only the `WarningRecord` plumbing is shared. Sanity-check welcome.

### Observable behaviour

Unchanged. Same messages, same colours, same emit point relative to the spinner. Subprocess tests in `__tests__/today.test.ts` and `__tests__/dashboard.test.ts` pass unchanged — the proof that stderr behaviour didn't drift.

### Tests added

- `packages/cli/src/lib/aggregator-fetch.test.ts` — 7 cases for `formatWarning` / `emitWarnings`, including verbatim-message assertions for both commands' pre-refactor stderr lines.
- `packages/cli/src/commands/today.fetch.test.ts` — 6 cases covering the full 4-feed truth table for `today.ts` `fetchAll` (each feed individually + all-failing).
- `packages/cli/src/commands/dashboard.fetch.test.ts` — 6 symmetric cases for `dashboard.ts`, including the negative assertion that an orders-feed failure does NOT warn (matches the pre-refactor tracking surface).

### Out of scope (per the issue body)

- Surfacing `warnings[]` on the JSON envelope (separate contract decision).
- Adding new warnings — this is a pure refactor.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test` — 138 test files, 2304 tests pass (was 138 / 2285 pre-PR; +19 new tests)
- [x] `pnpm lint` clean (one pre-existing unrelated warning in `resolve-company.ts`)
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` clean
- [x] Manual smoke: `PAX8_DEMO=1 pax8 today` and `PAX8_DEMO=1 pax8 dashboard` both render normal output
- [x] Subprocess tests in `today.test.ts` / `dashboard.test.ts` pass unchanged