### PR TITLE
feat(cli): nudge users when a newer pax8-cli version is available

### DIFF
--- a/.changeset/update-prompt.md
+++ b/.changeset/update-prompt.md
@@ -1,0 +1,9 @@
+---
+"@pax8/cli": patch
+---
+
+Nudge partners when a newer pax8-cli version is available.
+
+Wires `update-notifier` into CLI startup (welcome screen + command dispatch). When a newer release is on npm, the next interactive run prints a single-line nudge to stderr — never stdout — and stamps a local cache so the banner doesn't repeat until the next release lands. `ERROR_API_VALIDATION` failures additionally surface a "newer version may include a fix" hint as their first recovery step when the cache knows about an upgrade.
+
+Opt out with `PAX8_NO_UPDATE_CHECK=1` (CI / scripted use). Demo mode (`PAX8_DEMO=1`), `--json`, `--quiet`, `PAX8_QUIET=1`, `NO_UPDATE_NOTIFIER`, `DO_NOT_TRACK=1`, CI environments, and non-TTY stderr all suppress the check automatically. Closes #183.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Adding a new command? Lives at `packages/cli/src/commands/<resource>/<action>.ts
 - `PAX8_YES=1` — auto-confirm write prompts
 - `PAX8_QUIET=1` — disable spinners
 - `PAX8_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1` — opt out of telemetry (already opt-in by default)
+- `PAX8_NO_UPDATE_CHECK=1` — suppress the "newer pax8-cli available" nudge for CI / scripted use (#183). The check also skips automatically under `PAX8_DEMO=1`, `PAX8_QUIET=1`, `--json`, `--quiet`, `NO_UPDATE_NOTIFIER`, `DO_NOT_TRACK=1`, CI, and any non-TTY stderr.
 
 ## References
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "commander": "^12.1.0",
     "ora": "^8.1.0",
     "prompts": "^2.4.2",
+    "update-notifier": "^7.3.1",
     "yaml": "^2.9.0",
     "zod": "^3.23.0"
   },

--- a/packages/cli/src/__tests__/update-notifier.test.ts
+++ b/packages/cli/src/__tests__/update-notifier.test.ts
@@ -36,7 +36,7 @@ const NUDGE_NEEDLE = "A new version of pax8-cli is available";
  * Drop a "newer version available" record into the per-test cache dir so
  * `runUpdateCheck`'s render-from-cache stage has something to fire on.
  * Returns the cache path so individual tests can re-read it to assert
- * post-conditions (e.g. that `acknowledgedAt` got stamped).
+ * post-conditions (e.g. that `acknowledgedLatest` got stamped).
  */
 function seedCache(configDir: string): string {
   fs.mkdirSync(configDir, { recursive: true });
@@ -150,20 +150,21 @@ describe("update-notifier nudge (#183)", () => {
     expect(result.stderr).not.toContain(NUDGE_NEEDLE);
   });
 
-  it("stamps acknowledgedAt after rendering so the next run stays quiet", async () => {
+  it("stamps acknowledgedLatest after rendering so the next run stays quiet", async () => {
     const first = await runCli(["version"], {
       PAX8_UPDATE_CHECK_TEST_FORCE: "1",
       PAX8_DEMO: "",
     });
     expect(first.stderr).toContain(NUDGE_NEEDLE);
 
-    // Verify the on-disk cache has acknowledgedAt set.
+    // Verify the on-disk cache has acknowledgedLatest set to the version
+    // we just rendered the banner for.
     const post = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as {
-      acknowledgedAt?: number;
-      checkedAt: number;
+      acknowledgedLatest?: string;
+      latest: string;
     };
-    expect(post.acknowledgedAt).toBeTypeOf("number");
-    expect(post.acknowledgedAt!).toBeGreaterThanOrEqual(post.checkedAt);
+    expect(post.acknowledgedLatest).toBe(post.latest);
+    expect(post.acknowledgedLatest).toBe(NEWER_VERSION);
 
     // Second invocation should stay quiet — same `latest`, already acked.
     const second = await runCli(["version"], {
@@ -171,6 +172,58 @@ describe("update-notifier nudge (#183)", () => {
       PAX8_DEMO: "",
     });
     expect(second.stderr).not.toContain(NUDGE_NEEDLE);
+  });
+
+  // Regression for the operon-flagged P0 (round 2): the pre-fix gate
+  // compared `acknowledgedAt >= checkedAt`, but `fillCacheFromUpdateNotifier`
+  // bumps `checkedAt` on every daily refresh even when `latest` is
+  // unchanged. The invariant flipped on every cycle and the banner
+  // re-fired. Simulate that exact scenario: write a cache file where
+  // a prior session DID ack the `latest` (acknowledgedLatest === latest),
+  // then advance `checkedAt` to "now" as if a fresh refresh just ran
+  // without finding a newer release. The banner must stay quiet.
+  it("stays quiet across a simulated daily refresh that doesn't change `latest`", async () => {
+    // Pre-populate with the post-ack shape, then mimic what
+    // fillCacheFromUpdateNotifier would write on day 2: same `latest`,
+    // bumped `checkedAt`, preserved `acknowledgedLatest`.
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify({
+        latest: NEWER_VERSION,
+        current: PKG_VERSION,
+        type: "major",
+        checkedAt: Date.now(),
+        acknowledgedLatest: NEWER_VERSION,
+      }),
+    );
+    const result = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      PAX8_DEMO: "",
+    });
+    expect(result.stderr).not.toContain(NUDGE_NEEDLE);
+  });
+
+  // The flip side: when `latest` advances (a newer release lands), the
+  // banner DOES re-fire even though there's a prior ack on disk.
+  it("re-fires the banner when a newer `latest` lands in the cache", async () => {
+    const NEWER_STILL = "1000.0.0";
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify({
+        latest: NEWER_STILL,
+        current: PKG_VERSION,
+        type: "major",
+        checkedAt: Date.now(),
+        // Ack was for the OLDER `latest`; the new one hasn't been seen.
+        acknowledgedLatest: NEWER_VERSION,
+      }),
+    );
+    const result = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      PAX8_DEMO: "",
+    });
+    expect(result.stderr).toContain(NUDGE_NEEDLE);
+    expect(result.stderr).toContain(NEWER_STILL);
   });
 });
 

--- a/packages/cli/src/__tests__/update-notifier.test.ts
+++ b/packages/cli/src/__tests__/update-notifier.test.ts
@@ -1,0 +1,244 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join as pathJoin } from "node:path";
+import { runCli, runCliExpectFailure } from "./test-utils.js";
+
+/**
+ * Subprocess tests for #183 — the update-notifier nudge surface.
+ *
+ * Tests use a pre-populated `<PAX8_CONFIG_DIR>/update-check.json` to
+ * exercise the render path without touching the npm registry (and without
+ * relying on `update-notifier`'s own configstore, which auto-disables
+ * under `NODE_ENV=test`). The `PAX8_UPDATE_CHECK_TEST_FORCE=1` env var
+ * is the documented test seam that bypasses the
+ * non-TTY / NODE_ENV=test / CI auto-suppressors so the render-from-cache
+ * path can run inside a piped subprocess. User-facing opt-outs
+ * (`PAX8_NO_UPDATE_CHECK`, `PAX8_DEMO`, `--json`, `--quiet`) still win.
+ */
+
+const PKG_PATH = pathJoin(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "package.json",
+);
+const PKG_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf-8")).version as string;
+const NEWER_VERSION = "999.0.0";
+const NUDGE_NEEDLE = "A new version of pax8-cli is available";
+
+/**
+ * Drop a "newer version available" record into the per-test cache dir so
+ * `runUpdateCheck`'s render-from-cache stage has something to fire on.
+ * Returns the cache path so individual tests can re-read it to assert
+ * post-conditions (e.g. that `acknowledgedAt` got stamped).
+ */
+function seedCache(configDir: string): string {
+  fs.mkdirSync(configDir, { recursive: true });
+  const cachePath = path.join(configDir, "update-check.json");
+  fs.writeFileSync(
+    cachePath,
+    JSON.stringify(
+      {
+        latest: NEWER_VERSION,
+        current: PKG_VERSION,
+        type: "major",
+        checkedAt: Date.now(),
+      },
+      null,
+      2,
+    ),
+  );
+  return cachePath;
+}
+
+describe("update-notifier nudge (#183)", () => {
+  let configDir: string;
+  let cachePath: string;
+
+  beforeEach(() => {
+    // Per-test PAX8_CONFIG_DIR isolation is provided by
+    // `vitest.per-test-config-dir-setup.ts`. Capture it here so we can
+    // also seed the cache file at the same path the subprocess will read.
+    configDir = process.env.PAX8_CONFIG_DIR as string;
+    expect(configDir).toBeTruthy();
+    cachePath = seedCache(configDir);
+  });
+
+  it("prints the nudge to stderr (not stdout) when a newer version is cached", async () => {
+    const result = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      // `version` is a local-only command (no API calls); turn demo mode
+      // off so the PAX8_DEMO=1 suppression rule doesn't gate the banner.
+      // The other suppression-signal tests below re-enable PAX8_DEMO to
+      // assert the opt-out side.
+      PAX8_DEMO: "",
+    });
+    expect(result.exitCode).toBe(0);
+    // The banner goes to stderr — never stdout — so `pax8 … --json | jq`
+    // pipelines stay clean.
+    expect(result.stderr).toContain(NUDGE_NEEDLE);
+    expect(result.stderr).toContain(NEWER_VERSION);
+    expect(result.stdout).not.toContain(NUDGE_NEEDLE);
+  });
+
+  it("PAX8_NO_UPDATE_CHECK=1 suppresses the nudge even with the test-force seam", async () => {
+    const result = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      PAX8_NO_UPDATE_CHECK: "1",
+      PAX8_DEMO: "",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain(NUDGE_NEEDLE);
+    expect(result.stdout).not.toContain(NUDGE_NEEDLE);
+  });
+
+  it("PAX8_DEMO=1 suppresses the nudge (acceptance criterion)", async () => {
+    // runCli already sets PAX8_DEMO=1 by default. We force the check
+    // surface anyway, then assert the demo-mode opt-out still wins.
+    const result = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      // PAX8_DEMO=1 is already set by runCli; this is explicit for the test.
+      PAX8_DEMO: "1",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain(NUDGE_NEEDLE);
+  });
+
+  it("--quiet suppresses the nudge", async () => {
+    const result = await runCli(["--quiet", "version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      PAX8_DEMO: "",
+    });
+    // version still exits 0 even under --quiet
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain(NUDGE_NEEDLE);
+  });
+
+  it("PAX8_QUIET=1 suppresses the nudge", async () => {
+    const result = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      PAX8_QUIET: "1",
+      PAX8_DEMO: "",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain(NUDGE_NEEDLE);
+  });
+
+  it("--json suppresses the nudge (never pollute a JSON stderr envelope)", async () => {
+    const result = await runCli(["clients", "list", "--json", "--size", "1"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      // clients list requires the mock client (creds), so keep PAX8_DEMO=1.
+      // The --json suppressor is what we're testing here, not the demo gate.
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain(NUDGE_NEEDLE);
+    expect(result.stdout).not.toContain(NUDGE_NEEDLE);
+  });
+
+  it("does NOT print without the test-force seam (subprocess stderr is not a TTY)", async () => {
+    // Belt-and-suspenders: the non-TTY auto-suppressor must keep the
+    // banner off the wire in normal subprocess use. This guards against
+    // a future refactor that accidentally bypasses the stderr.isTTY check.
+    const result = await runCli(["version"], { PAX8_DEMO: "" });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain(NUDGE_NEEDLE);
+  });
+
+  it("stamps acknowledgedAt after rendering so the next run stays quiet", async () => {
+    const first = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      PAX8_DEMO: "",
+    });
+    expect(first.stderr).toContain(NUDGE_NEEDLE);
+
+    // Verify the on-disk cache has acknowledgedAt set.
+    const post = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as {
+      acknowledgedAt?: number;
+      checkedAt: number;
+    };
+    expect(post.acknowledgedAt).toBeTypeOf("number");
+    expect(post.acknowledgedAt!).toBeGreaterThanOrEqual(post.checkedAt);
+
+    // Second invocation should stay quiet — same `latest`, already acked.
+    const second = await runCli(["version"], {
+      PAX8_UPDATE_CHECK_TEST_FORCE: "1",
+      PAX8_DEMO: "",
+    });
+    expect(second.stderr).not.toContain(NUDGE_NEEDLE);
+  });
+});
+
+describe("ERROR_API_VALIDATION drift-aware hint (#183)", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = process.env.PAX8_CONFIG_DIR as string;
+    expect(configDir).toBeTruthy();
+    seedCache(configDir);
+  });
+
+  it("appends the upgrade hint to recoverySteps in the --json envelope", async () => {
+    // `subscriptions update --quantity <decrease> --yes --json` throws
+    // a `CliError` with `code: ERROR_API_VALIDATION` (the commitment
+    // pre-flight guard — see subscriptions.test.ts:466). With our
+    // update-check cache pre-populated, that recoverySteps array should
+    // now lead with the "newer pax8-cli available" hint.
+    const result = await runCliExpectFailure([
+      "subscriptions",
+      "update",
+      "sub-summit-m365bp-001",
+      "--quantity",
+      "5",
+      "--yes",
+      "--json",
+    ]);
+    expect(result.stderr).toContain("ERROR_API_VALIDATION");
+    expect(result.stderr).toContain(NEWER_VERSION);
+    expect(result.stderr).toContain("A newer version of pax8-cli");
+  });
+
+  it("appends the upgrade hint to the human-readable recovery steps", async () => {
+    const result = await runCliExpectFailure([
+      "subscriptions",
+      "update",
+      "sub-summit-m365bp-001",
+      "--quantity",
+      "5",
+      "--yes",
+    ]);
+    expect(result.stderr).toContain("A newer version of pax8-cli");
+    expect(result.stderr).toContain(NEWER_VERSION);
+  });
+
+  it("omits the hint when no newer version is cached", async () => {
+    // Overwrite the seeded cache with a record where `latest === current`
+    // — `readCachedUpdateInfo` then drops the record (it's no longer a
+    // "newer version available" signal).
+    fs.writeFileSync(
+      path.join(configDir, "update-check.json"),
+      JSON.stringify({
+        latest: PKG_VERSION,
+        current: PKG_VERSION,
+        type: "latest",
+        checkedAt: Date.now(),
+      }),
+    );
+    const result = await runCliExpectFailure([
+      "subscriptions",
+      "update",
+      "sub-summit-m365bp-001",
+      "--quantity",
+      "5",
+      "--yes",
+      "--json",
+    ]);
+    expect(result.stderr).toContain("ERROR_API_VALIDATION");
+    expect(result.stderr).not.toContain("A newer version of pax8-cli");
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ import { resolveDemoModeAsync } from "./lib/context.js";
 import type { Command as CommandType } from "commander";
 import { startRepl } from "./lib/repl.js";
 import { showWelcomeScreen } from "./lib/welcome.js";
+import { runUpdateCheck } from "./lib/update-check.js";
 
 /**
  * Build the full dotted command name from a Commander command,
@@ -311,6 +312,18 @@ async function main(): Promise<void> {
       await showWelcomeScreen();
     }
   } else {
+    // #183: nudge once per release when a newer pax8-cli is available.
+    // Fires before parse so the registry refresh (detached child process
+    // inside `update-notifier`) has the full command duration to settle
+    // and the synchronous cache read happens before any --json output
+    // could open the stdout pipe. The wrapper handles all suppression
+    // signals (PAX8_NO_UPDATE_CHECK, PAX8_DEMO, --json, --quiet, CI,
+    // NO_UPDATE_NOTIFIER) and renders only to stderr.
+    try {
+      runUpdateCheck();
+    } catch {
+      // Never let the courtesy nudge break command dispatch.
+    }
     const program = createProgram();
     await program.parseAsync(process.argv).catch(async (err) => {
       // `handleCommandError` itself emits the `command_executed`

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -29,6 +29,7 @@ import {
 import { replCmd } from "./confirm.js";
 import { redactEnvelope, redactString } from "./redactor.js";
 import { consumeActiveCommand } from "./telemetry-context.js";
+import { getApiValidationUpgradeHint } from "./update-check.js";
 
 declare const __CLI_VERSION__: string;
 
@@ -316,23 +317,45 @@ function buildErrorEnvelope(error: unknown, context?: string): ErrorEnvelope {
     const env: ErrorEnvelope = { message: prefix + error.message };
     if (error.code) env.code = error.code;
     if (error.causes && error.causes.length > 0) env.causes = error.causes;
-    if (error.recoverySteps && error.recoverySteps.length > 0) {
-      env.recoverySteps = error.recoverySteps;
+    const baseSteps = error.recoverySteps ?? [];
+    // #183: drift-aware messaging. CliErrors raised with
+    // `code: ERROR_API_VALIDATION` (e.g. orders/create's invalid-response
+    // guards) get the same upgrade nudge the ZodError path gets when a
+    // newer pax8-cli is cached locally. Prepend so it's the first
+    // recovery step — the action most likely to fix the failure.
+    let steps = baseSteps;
+    if (error.code === ERROR_API_VALIDATION) {
+      const upgradeHint = getApiValidationUpgradeHint();
+      if (upgradeHint) {
+        steps = [upgradeHint, ...baseSteps];
+      }
+    }
+    if (steps.length > 0) {
+      env.recoverySteps = steps;
     }
     if (error.docsUrl) env.docsUrl = error.docsUrl;
     return env;
   }
 
   if (error instanceof ZodError) {
+    // #183: drift-aware messaging. A Zod validation failure usually means
+    // the API shape moved out from under the CLI version the user is
+    // running. If our cached update-check (populated on previous welcome
+    // runs / command invocations) knows a newer version exists, surface
+    // it as the FIRST recovery step — that's the action most likely to
+    // fix the failure. Sync read; never adds a network round-trip to the
+    // error path.
+    const upgradeHint = getApiValidationUpgradeHint();
+    const recoverySteps = upgradeHint
+      ? [upgradeHint, "Try a different query, or run pax8 doctor to check your setup."]
+      : ["Try a different query, or run pax8 doctor to check your setup."];
     return {
       code: ERROR_API_VALIDATION,
       message:
         prefix +
         "The Pax8 API returned an unexpected response.",
       causes: [formatZodError(error)],
-      recoverySteps: [
-        "Try a different query, or run pax8 doctor to check your setup.",
-      ],
+      recoverySteps,
     };
   }
 
@@ -618,9 +641,23 @@ export async function handleCommandError(
       }
     }
 
-    if (error.recoverySteps && error.recoverySteps.length > 0) {
+    // #183: same drift-aware recovery prepend as the envelope path —
+    // CliErrors with `code: ERROR_API_VALIDATION` get the upgrade hint
+    // rendered first when our cache knows a newer pax8-cli is available.
+    const baseSteps = error.recoverySteps ?? [];
+    let humanSteps = baseSteps;
+    if (
+      error instanceof CliError &&
+      error.code === ERROR_API_VALIDATION
+    ) {
+      const upgradeHint = getApiValidationUpgradeHint();
+      if (upgradeHint) {
+        humanSteps = [upgradeHint, ...baseSteps];
+      }
+    }
+    if (humanSteps.length > 0) {
       process.stderr.write(chalk.yellow("\n  Recovery steps:\n"));
-      for (const step of error.recoverySteps) {
+      for (const step of humanSteps) {
         process.stderr.write(chalk.yellow(`    → ${safe(step)}\n`));
       }
     }
@@ -650,8 +687,19 @@ export async function handleCommandError(
       chalk.red.bold(`\n  ✗ ${prefix}`) +
       chalk.red(`  The Pax8 API returned an unexpected response.\n`) +
       chalk.dim(`    ${safe(formatZodError(error))}\n\n`) +
-      chalk.yellow(`    → This usually means no data was found, or the API format has changed.\n`) +
-      chalk.yellow(`    → Try a different query, or run ${chalk.cyan(replCmd("pax8 doctor"))} to check your setup.\n\n`)
+      chalk.yellow(`    → This usually means no data was found, or the API format has changed.\n`)
+    );
+    // #183: drift-aware messaging. Surface the upgrade hint BEFORE the
+    // generic "try a different query" step — if a newer CLI is available,
+    // the partner's first move should be `npm i -g @pax8/cli`.
+    const upgradeHint = getApiValidationUpgradeHint();
+    if (upgradeHint) {
+      process.stderr.write(
+        chalk.yellow(`    → ${safe(upgradeHint)}\n`),
+      );
+    }
+    process.stderr.write(
+      chalk.yellow(`    → Try a different query, or run ${chalk.cyan(replCmd("pax8 doctor"))} to check your setup.\n\n`),
     );
   } else if (error instanceof ApiError) {
     process.stderr.write(

--- a/packages/cli/src/lib/update-check.test.ts
+++ b/packages/cli/src/lib/update-check.test.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  isNewerVersion,
+  readCachedUpdateInfo,
+  getApiValidationUpgradeHint,
+} from "./update-check.js";
+
+/**
+ * In-process unit tests for the parts of `update-check.ts` that don't
+ * require a subprocess. The end-to-end render path is covered by
+ * `__tests__/update-notifier.test.ts`.
+ */
+
+describe("isNewerVersion", () => {
+  it("returns false when versions are equal", () => {
+    expect(isNewerVersion("1.2.3", "1.2.3")).toBe(false);
+  });
+
+  it("returns true for a newer patch", () => {
+    expect(isNewerVersion("1.2.4", "1.2.3")).toBe(true);
+  });
+
+  it("returns true for a newer minor", () => {
+    expect(isNewerVersion("1.3.0", "1.2.9")).toBe(true);
+  });
+
+  it("returns true for a newer major", () => {
+    expect(isNewerVersion("2.0.0", "1.9.9")).toBe(true);
+  });
+
+  it("returns false when the candidate is older", () => {
+    expect(isNewerVersion("1.2.3", "1.2.4")).toBe(false);
+    expect(isNewerVersion("0.9.0", "1.0.0")).toBe(false);
+  });
+
+  it("treats missing components as zero", () => {
+    expect(isNewerVersion("1.2", "1.1.9")).toBe(true);
+    expect(isNewerVersion("1", "0.9.9")).toBe(true);
+  });
+
+  it("strips pre-release suffixes when comparing numeric prefixes", () => {
+    // The numeric prefix of `1.0.1-rc.1` (1.0.1) is greater than the
+    // numeric prefix of `1.0.0` — that's the answer the comparator must
+    // return regardless of how pre-release tags sort lexically. We
+    // don't aim to be RFC-2119 semver-compliant here; update-notifier
+    // itself uses `semverGt` for the canonical compare. This is just a
+    // floor for the synchronous read path that doesn't pull in semver.
+    expect(isNewerVersion("1.0.1-rc.1", "1.0.0")).toBe(true);
+  });
+});
+
+describe("readCachedUpdateInfo + getApiValidationUpgradeHint", () => {
+  let tmp: string;
+  const originalConfigDir = process.env.PAX8_CONFIG_DIR;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pax8-update-check-"));
+    process.env.PAX8_CONFIG_DIR = tmp;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    if (originalConfigDir === undefined) {
+      delete process.env.PAX8_CONFIG_DIR;
+    } else {
+      process.env.PAX8_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  it("returns null when no cache file exists", () => {
+    expect(readCachedUpdateInfo()).toBeNull();
+    expect(getApiValidationUpgradeHint()).toBeNull();
+  });
+
+  it("returns null when the cache file is malformed JSON", () => {
+    fs.writeFileSync(path.join(tmp, "update-check.json"), "{not json");
+    expect(readCachedUpdateInfo()).toBeNull();
+  });
+
+  it("returns null when required fields are missing", () => {
+    fs.writeFileSync(
+      path.join(tmp, "update-check.json"),
+      JSON.stringify({ latest: "9.9.9" }),
+    );
+    expect(readCachedUpdateInfo()).toBeNull();
+  });
+
+  it("returns null when the cached latest is not newer than the running version", () => {
+    // Use a sub-zero version that's older than anything @pax8/cli will
+    // ever be at runtime, so `isNewerVersion(latest, running)` is false.
+    fs.writeFileSync(
+      path.join(tmp, "update-check.json"),
+      JSON.stringify({
+        latest: "0.0.0",
+        current: "0.0.0",
+        checkedAt: Date.now(),
+      }),
+    );
+    expect(readCachedUpdateInfo()).toBeNull();
+    expect(getApiValidationUpgradeHint()).toBeNull();
+  });
+
+  it("returns the cached record when the latest is newer than the running version", () => {
+    fs.writeFileSync(
+      path.join(tmp, "update-check.json"),
+      JSON.stringify({
+        latest: "999.0.0",
+        current: "0.0.1",
+        type: "major",
+        checkedAt: 12345,
+      }),
+    );
+    const info = readCachedUpdateInfo();
+    expect(info).not.toBeNull();
+    expect(info?.latest).toBe("999.0.0");
+    expect(info?.type).toBe("major");
+
+    const hint = getApiValidationUpgradeHint();
+    expect(hint).toContain("999.0.0");
+    expect(hint).toContain("npm i -g @pax8/cli");
+  });
+});

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -1,0 +1,354 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import chalk from "chalk";
+import updateNotifier from "update-notifier";
+import { getConfigDir } from "@pax8/core";
+
+declare const __CLI_VERSION__: string;
+
+/**
+ * Lightweight cached envelope describing the most recent successful npm
+ * registry lookup for `@pax8/cli`. Persisted under `<configDir>/update-check.json`
+ * so the synchronous read in `lib/errors.ts` (the `ERROR_API_VALIDATION`
+ * drift-aware path) doesn't have to touch the network and doesn't have to
+ * inspect `update-notifier`'s configstore layout.
+ *
+ * Honors the `PAX8_CONFIG_DIR` isolation seam (#128) — the same one used by
+ * credentials, telemetry, and last-error storage — so subprocess tests can't
+ * collide on a shared cache file.
+ */
+export interface CachedUpdateInfo {
+  /** Latest published version on npm at the time of the check. */
+  latest: string;
+  /** CLI version we were running when we performed the check. */
+  current: string;
+  /** Update-notifier's diff bucket (`major` / `minor` / `patch` / …). */
+  type?: string;
+  /** Unix epoch (ms) of the registry lookup that produced this record. */
+  checkedAt: number;
+  /**
+   * Unix epoch (ms) of the last time we rendered the nudge banner for
+   * THIS `latest`. Used to gate "Notice prints once per release" (AC for
+   * #183) — once we've shown the banner for `latest === X.Y.Z`, we don't
+   * surface it again until a newer `latest` lands in the cache. Absent
+   * (or `< checkedAt`) means we still owe the user a banner.
+   */
+  acknowledgedAt?: number;
+}
+
+const CACHE_FILE = "update-check.json";
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the path to our cache file. Lazily references `getConfigDir()`
+ * so `PAX8_CONFIG_DIR` is honored per-call (matches the loader's contract).
+ */
+function cachePath(): string {
+  return path.join(getConfigDir(), CACHE_FILE);
+}
+
+/**
+ * Suppression signals. Honored in this order:
+ *
+ * User opt-outs (always win):
+ *   - `PAX8_NO_UPDATE_CHECK=1` — the project-specific opt-out documented in #183.
+ *   - `PAX8_DEMO=1` — demo mode never reaches the network; the check would
+ *     either spam the registry from CI or surface a confusing "update available"
+ *     hint to a partner who's still evaluating the tool.
+ *   - `PAX8_QUIET=1` / `--quiet` / `--json` — clean machine-readable surface.
+ *   - `NO_UPDATE_NOTIFIER` and `DO_NOT_TRACK` — community-standard opt-outs.
+ *   - `--no-update-notifier` — `update-notifier`'s own per-run flag.
+ *
+ * Auto-suppressors (skipped when `PAX8_UPDATE_CHECK_TEST_FORCE=1`):
+ *   - `NODE_ENV=test` and `CI=true` — `update-notifier` already auto-suppresses
+ *     under these, but we mirror the check here so we don't even hit
+ *     `updateNotifier()` in tests / CI.
+ *   - Non-TTY stderr — never inject a banner into a piped stderr stream
+ *     in regular use.
+ *
+ * `PAX8_UPDATE_CHECK_TEST_FORCE=1` is the seam subprocess tests use to
+ * exercise the un-suppressed path without lying about NODE_ENV /
+ * isatty / CI. It does NOT override user opt-outs — a test that sets
+ * `PAX8_NO_UPDATE_CHECK=1` alongside it still produces no banner, which
+ * is exactly the "opt-out wins" assertion the tests pin.
+ */
+function isCheckSuppressed(): boolean {
+  // User opt-outs — always respected, regardless of the test-force seam.
+  if (process.env.PAX8_NO_UPDATE_CHECK === "1") return true;
+  if (process.env.PAX8_DEMO === "1") return true;
+  if (process.env.PAX8_QUIET === "1") return true;
+  if (process.env.NO_UPDATE_NOTIFIER) return true;
+  if (process.env.DO_NOT_TRACK === "1") return true;
+  if (process.argv.includes("--json")) return true;
+  if (process.argv.includes("--quiet")) return true;
+  if (process.argv.includes("--no-update-notifier")) return true;
+
+  // Auto-suppressors — bypassed by the test-force seam.
+  if (process.env.PAX8_UPDATE_CHECK_TEST_FORCE === "1") return false;
+  if (process.env.NODE_ENV === "test") return true;
+  if (process.env.CI === "true" || process.env.CI === "1") return true;
+  // Banner is a courtesy for interactive humans; never write it to a
+  // non-TTY stderr because something downstream is consuming it.
+  if (!process.stderr.isTTY) return true;
+  return false;
+}
+
+/**
+ * Best-effort, naive semver-greater-than. We accept up to three numeric
+ * components plus an optional pre-release tag; non-conforming versions
+ * fall back to a string compare. Sufficient for the `latest > current`
+ * question this module asks — we deliberately don't pull in `semver` as
+ * a direct dep just for this one comparison (update-notifier ships its
+ * own semver but we mustn't reach into the transitive).
+ */
+export function isNewerVersion(latest: string, current: string): boolean {
+  if (latest === current) return false;
+  const parts = (v: string): number[] =>
+    v
+      .replace(/[^0-9.].*$/, "") // strip pre-release / build metadata
+      .split(".")
+      .slice(0, 3)
+      .map((s) => Number.parseInt(s, 10))
+      .map((n) => (Number.isFinite(n) ? n : 0));
+  const a = parts(latest);
+  const b = parts(current);
+  for (let i = 0; i < 3; i += 1) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av > bv) return true;
+    if (av < bv) return false;
+  }
+  // Same numeric prefix — defer to a lexical comparison so pre-release
+  // ordering (e.g. `1.0.0-rc.1` vs `1.0.0`) at least has a deterministic
+  // answer. update-notifier itself uses `semverGt`, so anything that
+  // reaches the cache has already been validated; this is the floor.
+  return latest > current;
+}
+
+/**
+ * Synchronous read of the cached update info. Returns `null` when the
+ * cache is missing, unparseable, stale relative to the current CLI version
+ * (the user upgraded since the last check; the cached "latest" no longer
+ * applies), or when the cached `latest` is not strictly newer than the
+ * running version.
+ *
+ * Called from the `ERROR_API_VALIDATION` path in `lib/errors.ts` — must
+ * NEVER perform I/O beyond the single sync file read, and must NEVER throw.
+ */
+export function readCachedUpdateInfo(): CachedUpdateInfo | null {
+  try {
+    const raw = fs.readFileSync(cachePath(), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<CachedUpdateInfo>;
+    if (
+      typeof parsed.latest !== "string" ||
+      typeof parsed.current !== "string" ||
+      typeof parsed.checkedAt !== "number"
+    ) {
+      return null;
+    }
+    const running = getCurrentVersion();
+    // The cached `current` is the version we were running when the check
+    // last succeeded. If the partner has since upgraded past it (or past
+    // the cached `latest`), the cache is stale — drop it rather than
+    // surfacing a misleading "newer version available" hint.
+    if (!isNewerVersion(parsed.latest, running)) return null;
+    return {
+      latest: parsed.latest,
+      current: parsed.current,
+      type: typeof parsed.type === "string" ? parsed.type : undefined,
+      checkedAt: parsed.checkedAt,
+      acknowledgedAt:
+        typeof parsed.acknowledgedAt === "number"
+          ? parsed.acknowledgedAt
+          : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the cache record. Failures are swallowed — the update banner is
+ * a courtesy and must never break the CLI. We don't use `safeWriteFileSync`
+ * here because (a) the file isn't security-sensitive and (b) writing
+ * over an existing file is the expected steady-state shape.
+ */
+function writeCache(info: CachedUpdateInfo): void {
+  try {
+    const dir = getConfigDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(cachePath(), JSON.stringify(info, null, 2));
+  } catch {
+    // Cache writes are best-effort; never crash the CLI.
+  }
+}
+
+function getCurrentVersion(): string {
+  return typeof __CLI_VERSION__ !== "undefined" ? __CLI_VERSION__ : "0.0.0";
+}
+
+/**
+ * Trigger an update check. Cheap: `update-notifier` reads its configstore
+ * synchronously and the actual network refresh runs in a detached child
+ * process — the current process is unblocked the moment we return.
+ *
+ * Two-stage rendering pipeline, mirroring `update-notifier`'s own
+ * "show banner from a previously cached check" pattern:
+ *
+ *   1. **Cache-fill stage.** Ask `update-notifier` for the cached
+ *      registry result. If `notifier.update` reports a newer version,
+ *      mirror it into `<configDir>/update-check.json`. This is the only
+ *      path that touches the network (via update-notifier's detached
+ *      child) and the only path that produces a cache record on the
+ *      partner's real machine.
+ *
+ *   2. **Render stage.** Re-read our own cache and decide whether to
+ *      print the banner based on its `acknowledgedAt` field. We render
+ *      once per `latest` value, then stamp `acknowledgedAt = now()` so
+ *      subsequent invocations stay quiet until a newer release lands.
+ *      This stage is what subprocess tests exercise: they pre-populate
+ *      the cache file and assert the banner fires without ever
+ *      reaching update-notifier (which auto-suppresses under
+ *      `NODE_ENV=test`).
+ *
+ * Renders the nudge to **stderr** when a newer version is cached, so a
+ * `pax8 ... --json | jq` pipeline never sees it.
+ *
+ * Returns silently — callers don't need the result; the side effects are
+ * the contract.
+ */
+export function runUpdateCheck(): void {
+  if (isCheckSuppressed()) return;
+
+  fillCacheFromUpdateNotifier();
+  renderFromCacheIfDue();
+}
+
+/**
+ * Stage 1 — let `update-notifier` do its job (synchronous configstore
+ * read, detached child-process refresh) and mirror any newer-version
+ * record it surfaces into our own cache. Swallows everything; the
+ * banner is never load-bearing.
+ *
+ * Skips entirely under `NODE_ENV=test` because update-notifier's
+ * internal `#isDisabled` flag will refuse to initialize its
+ * configstore in that environment — calling through is wasted work,
+ * and the test-force seam exists for tests that need to exercise the
+ * render-from-cache path without touching update-notifier at all.
+ */
+function fillCacheFromUpdateNotifier(): void {
+  if (process.env.NODE_ENV === "test") return;
+  if (process.env.PAX8_UPDATE_CHECK_TEST_FORCE === "1") return;
+
+  // Redirect `update-notifier`'s configstore under our config-dir
+  // isolation root. configstore reads `XDG_CONFIG_HOME` at construction
+  // time, so this needs to be set before the call. Restore the original
+  // afterwards so we don't leak the override to any later code that uses
+  // xdg-basedir.
+  const previousXdg = process.env.XDG_CONFIG_HOME;
+  try {
+    const xdgRoot = path.join(getConfigDir(), "xdg");
+    fs.mkdirSync(xdgRoot, { recursive: true });
+    process.env.XDG_CONFIG_HOME = xdgRoot;
+  } catch {
+    // If we can't mkdir under PAX8_CONFIG_DIR, give up — better to skip
+    // the check than to write to the user's real XDG dir from a test.
+    return;
+  }
+
+  try {
+    const notifier = updateNotifier({
+      pkg: {
+        name: "@pax8/cli",
+        version: getCurrentVersion(),
+      },
+      // Default is 1 day — explicit for documentation.
+      updateCheckInterval: ONE_DAY_MS,
+    });
+
+    const update = notifier.update;
+    if (update && isNewerVersion(update.latest, update.current)) {
+      // Preserve any existing acknowledgedAt only if it matches the same
+      // `latest` — a newer release invalidates the prior ack.
+      const existing = readCachedUpdateInfo();
+      const acknowledgedAt =
+        existing && existing.latest === update.latest
+          ? existing.acknowledgedAt
+          : undefined;
+      writeCache({
+        latest: update.latest,
+        current: update.current,
+        type: update.type,
+        checkedAt: Date.now(),
+        acknowledgedAt,
+      });
+    }
+  } catch {
+    // update-notifier can throw if it fails to create its configstore
+    // (EACCES under restrictive sandboxes). We swallow.
+  } finally {
+    if (previousXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = previousXdg;
+    }
+  }
+}
+
+/**
+ * Stage 2 — render the banner if our cache has a fresh newer-version
+ * record we haven't surfaced yet. Stamps `acknowledgedAt = now()` after
+ * rendering so the banner stays quiet for that `latest` until a newer
+ * release lands in the cache (AC: "Notice prints once per release").
+ */
+function renderFromCacheIfDue(): void {
+  const cached = readCachedUpdateInfo();
+  if (!cached) return;
+  // Already rendered for this `latest` — stay quiet.
+  if (cached.acknowledgedAt && cached.acknowledgedAt >= cached.checkedAt) {
+    return;
+  }
+  renderNudge(cached.current, cached.latest);
+  writeCache({
+    ...cached,
+    acknowledgedAt: Date.now(),
+  });
+}
+
+/**
+ * Render the one-line nudge to stderr. Format intentionally compact —
+ * not a boxen banner — because the same channel is shared with spinners,
+ * the time-of-day quip, demo-mode banner, and the welcome screen. A
+ * multi-line boxen would dominate that surface.
+ *
+ * Color is applied via `chalk`; `NO_COLOR` and `--no-color` are honored
+ * by chalk automatically (it auto-detects), so we don't gate this
+ * write ourselves.
+ */
+function renderNudge(current: string, latest: string): void {
+  const line =
+    chalk.yellow("⚠") +
+    chalk.dim(
+      ` A new version of pax8-cli is available (${current} → ${latest}). ` +
+        "Run `npm i -g @pax8/cli` to update.\n",
+    );
+  process.stderr.write(line);
+}
+
+/**
+ * Format the drift-aware hint for the `ERROR_API_VALIDATION` recovery
+ * step. Lives here so the wording stays adjacent to the cache it reads.
+ * Returns `null` when there's no cached newer version (caller skips the
+ * hint).
+ */
+export function getApiValidationUpgradeHint(): string | null {
+  const info = readCachedUpdateInfo();
+  if (!info) return null;
+  return (
+    `A newer version of pax8-cli (${info.latest}) is available and may include a fix. ` +
+    "Run `npm i -g @pax8/cli` to update."
+  );
+}

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -5,7 +5,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import chalk from "chalk";
 import updateNotifier from "update-notifier";
-import { getConfigDir } from "@pax8/core";
+import { getConfigDir, safeWriteFileSync } from "@pax8/core";
 
 declare const __CLI_VERSION__: string;
 
@@ -172,15 +172,18 @@ export function readCachedUpdateInfo(): CachedUpdateInfo | null {
 
 /**
  * Persist the cache record. Failures are swallowed — the update banner is
- * a courtesy and must never break the CLI. We don't use `safeWriteFileSync`
- * here because (a) the file isn't security-sensitive and (b) writing
- * over an existing file is the expected steady-state shape.
+ * a courtesy and must never break the CLI. Routed through `safeWriteFileSync`
+ * per the #458/#469 local-state-writer policy (the meta-test in
+ * `__tests__/local-state-writers.test.ts` enforces it). Steady-state writes
+ * over an existing file are fine — `safeWriteFileSync`'s O_NOFOLLOW + 0600
+ * semantics still apply; we just want the same hardened path every CLI
+ * writer takes.
  */
 function writeCache(info: CachedUpdateInfo): void {
   try {
     const dir = getConfigDir();
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(cachePath(), JSON.stringify(info, null, 2));
+    safeWriteFileSync(cachePath(), JSON.stringify(info, null, 2));
   } catch {
     // Cache writes are best-effort; never crash the CLI.
   }

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -30,13 +30,22 @@ export interface CachedUpdateInfo {
   /** Unix epoch (ms) of the registry lookup that produced this record. */
   checkedAt: number;
   /**
-   * Unix epoch (ms) of the last time we rendered the nudge banner for
-   * THIS `latest`. Used to gate "Notice prints once per release" (AC for
-   * #183) — once we've shown the banner for `latest === X.Y.Z`, we don't
-   * surface it again until a newer `latest` lands in the cache. Absent
-   * (or `< checkedAt`) means we still owe the user a banner.
+   * Version string (e.g. `"0.6.0"`) of the `latest` we last rendered a
+   * banner for. Gates "Notice prints once per release" (AC for #183) —
+   * once `acknowledgedLatest === latest`, we stay quiet for this release.
+   *
+   * An earlier shape stored an `acknowledgedAt` timestamp and gated on
+   * `acknowledgedAt >= checkedAt`, but `fillCacheFromUpdateNotifier`
+   * unconditionally bumps `checkedAt` on every `update-notifier` refresh
+   * cycle (~daily) even when `latest` is unchanged, which flipped the
+   * invariant and re-fired the banner every day. Version-string equality
+   * is immune to clock drift.
+   *
+   * Legacy `acknowledgedAt` records (from earlier installs) are dropped
+   * silently by the reader — those partners see one extra nudge after
+   * upgrading, then the new gate takes over.
    */
-  acknowledgedAt?: number;
+  acknowledgedLatest?: string;
 }
 
 const CACHE_FILE = "update-check.json";
@@ -160,9 +169,9 @@ export function readCachedUpdateInfo(): CachedUpdateInfo | null {
       current: parsed.current,
       type: typeof parsed.type === "string" ? parsed.type : undefined,
       checkedAt: parsed.checkedAt,
-      acknowledgedAt:
-        typeof parsed.acknowledgedAt === "number"
-          ? parsed.acknowledgedAt
+      acknowledgedLatest:
+        typeof parsed.acknowledgedLatest === "string"
+          ? parsed.acknowledgedLatest
           : undefined,
     };
   } catch {
@@ -209,12 +218,13 @@ function getCurrentVersion(): string {
  *      partner's real machine.
  *
  *   2. **Render stage.** Re-read our own cache and decide whether to
- *      print the banner based on its `acknowledgedAt` field. We render
- *      once per `latest` value, then stamp `acknowledgedAt = now()` so
- *      subsequent invocations stay quiet until a newer release lands.
- *      This stage is what subprocess tests exercise: they pre-populate
- *      the cache file and assert the banner fires without ever
- *      reaching update-notifier (which auto-suppresses under
+ *      print the banner based on its `acknowledgedLatest` field. We
+ *      render once per `latest` value, then stamp
+ *      `acknowledgedLatest = cached.latest` so subsequent invocations
+ *      stay quiet until a newer release lands (and `fillCache…` clears
+ *      the field). This stage is what subprocess tests exercise: they
+ *      pre-populate the cache file and assert the banner fires without
+ *      ever reaching update-notifier (which auto-suppresses under
  *      `NODE_ENV=test`).
  *
  * Renders the nudge to **stderr** when a newer version is cached, so a
@@ -274,19 +284,20 @@ function fillCacheFromUpdateNotifier(): void {
 
     const update = notifier.update;
     if (update && isNewerVersion(update.latest, update.current)) {
-      // Preserve any existing acknowledgedAt only if it matches the same
-      // `latest` — a newer release invalidates the prior ack.
+      // Preserve any existing `acknowledgedLatest` only if it matches the
+      // same `latest` — a newer release invalidates the prior ack and
+      // the partner should see the banner once for the new version.
       const existing = readCachedUpdateInfo();
-      const acknowledgedAt =
+      const acknowledgedLatest =
         existing && existing.latest === update.latest
-          ? existing.acknowledgedAt
+          ? existing.acknowledgedLatest
           : undefined;
       writeCache({
         latest: update.latest,
         current: update.current,
         type: update.type,
         checkedAt: Date.now(),
-        acknowledgedAt,
+        acknowledgedLatest,
       });
     }
   } catch {
@@ -303,21 +314,26 @@ function fillCacheFromUpdateNotifier(): void {
 
 /**
  * Stage 2 — render the banner if our cache has a fresh newer-version
- * record we haven't surfaced yet. Stamps `acknowledgedAt = now()` after
- * rendering so the banner stays quiet for that `latest` until a newer
- * release lands in the cache (AC: "Notice prints once per release").
+ * record we haven't surfaced yet. Stamps
+ * `acknowledgedLatest = cached.latest` after rendering so the banner
+ * stays quiet for that `latest` until a newer release lands in the
+ * cache (AC: "Notice prints once per release").
  */
 function renderFromCacheIfDue(): void {
   const cached = readCachedUpdateInfo();
   if (!cached) return;
-  // Already rendered for this `latest` — stay quiet.
-  if (cached.acknowledgedAt && cached.acknowledgedAt >= cached.checkedAt) {
-    return;
-  }
-  renderNudge(cached.current, cached.latest);
+  // Already rendered for this `latest` — stay quiet. The pre-fix code
+  // used `acknowledgedAt >= checkedAt`, but `checkedAt` advances every
+  // refresh cycle (~daily) so the invariant broke. Version-string
+  // equality is the durable gate.
+  if (cached.acknowledgedLatest === cached.latest) return;
+  // Pass the RUNNING version (not `cached.current`) as the "from" so a
+  // partner who upgraded mid-cycle sees an accurate "0.7.0 → 1.0.0" rather
+  // than the stale recorded version.
+  renderNudge(getCurrentVersion(), cached.latest);
   writeCache({
     ...cached,
-    acknowledgedAt: Date.now(),
+    acknowledgedLatest: cached.latest,
   });
 }
 

--- a/packages/cli/src/lib/welcome.ts
+++ b/packages/cli/src/lib/welcome.ts
@@ -3,6 +3,7 @@
 
 import chalk from "chalk";
 import { CredentialStore } from "@pax8/core";
+import { runUpdateCheck } from "./update-check.js";
 
 declare const __CLI_VERSION__: string;
 
@@ -25,6 +26,19 @@ async function isAuthenticated(): Promise<boolean> {
 }
 
 export async function showWelcomeScreen(): Promise<void> {
+  // #183: nudge the user when a newer pax8-cli has been published. The
+  // check is fire-and-forget from our perspective — `update-notifier`
+  // reads its configstore synchronously and spawns the registry refresh
+  // in a detached child process, so this doesn't block the welcome
+  // render. Honors PAX8_NO_UPDATE_CHECK / PAX8_DEMO / PAX8_QUIET / CI /
+  // NO_UPDATE_NOTIFIER and only writes to stderr (so it can never
+  // pollute the welcome stdout block read by smoke tests).
+  try {
+    runUpdateCheck();
+  } catch {
+    // The check is a courtesy; never let it break the welcome render.
+  }
+
   const version = typeof __CLI_VERSION__ !== "undefined" ? __CLI_VERSION__ : "0.1.0";
 
   const W = 48;

--- a/packages/cli/src/types/update-notifier.d.ts
+++ b/packages/cli/src/types/update-notifier.d.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Minimal ambient typings for `update-notifier@7`. The upstream
+ * `@types/update-notifier` (DefinitelyTyped) is pinned at v6 and doesn't
+ * track the v7 ESM rewrite (no `Options` import, removed CallbackResult,
+ * different `pkg` shape). We only need the surface this repo touches —
+ * see `lib/update-check.ts`.
+ */
+declare module "update-notifier" {
+  export interface UpdateInfo {
+    latest: string;
+    current: string;
+    type: "latest" | "major" | "minor" | "patch" | "prerelease" | "build" | string;
+    name: string;
+  }
+
+  export interface UpdateNotifierOptions {
+    pkg: {
+      name: string;
+      version: string;
+    };
+    updateCheckInterval?: number;
+    shouldNotifyInNpmScript?: boolean;
+    distTag?: string;
+  }
+
+  export interface UpdateNotifierInstance {
+    update?: UpdateInfo;
+    config?: {
+      path: string;
+      get(key: string): unknown;
+      set(key: string, value: unknown): void;
+    };
+    notify(options?: {
+      defer?: boolean;
+      message?: string;
+      isGlobal?: boolean;
+      boxenOptions?: Record<string, unknown>;
+    }): UpdateNotifierInstance;
+    fetchInfo(): Promise<UpdateInfo>;
+  }
+
+  export default function updateNotifier(
+    options: UpdateNotifierOptions,
+  ): UpdateNotifierInstance;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      update-notifier:
+        specifier: ^7.3.1
+        version: 7.3.1
       yaml:
         specifier: ^2.8.3
         version: 2.9.0
@@ -491,6 +494,18 @@ packages:
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
+  '@pnpm/config.env-replace@1.1.0':
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.ca-file@1.0.2':
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/npm-conf@3.0.3':
+    resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
+    engines: {node: '>=12'}
+
   '@posthog/core@1.32.5':
     resolution: {integrity: sha512-Vmr6LZms7QEP1ljfTRRBVtLkeEHMrTmLECt0FXPLwUIgPwxOgvBdAYwRMWyP13WuN/XQweo1tJ9J1DxHNAF3qg==}
 
@@ -854,6 +869,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -864,6 +882,10 @@ packages:
 
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   any-promise@1.3.0:
@@ -886,6 +908,9 @@ packages:
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -893,6 +918,10 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  boxen@8.0.1:
+    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
+    engines: {node: '>=18'}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -912,6 +941,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -926,6 +959,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -950,6 +987,13 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  configstore@7.1.0:
+    resolution: {integrity: sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==}
+    engines: {node: '>=18'}
+
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -973,6 +1017,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -987,6 +1035,10 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dot-prop@9.0.0:
+    resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
+    engines: {node: '>=18'}
 
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
@@ -1009,6 +1061,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-goat@4.0.0:
+    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
+    engines: {node: '>=12'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1151,9 +1207,16 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
+
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1185,6 +1248,13 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1197,13 +1267,30 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ci@1.0.0:
+    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  is-installed-globally@1.0.0:
+    resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
+    engines: {node: '>=18'}
+
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-npm@6.1.0:
+    resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -1269,6 +1356,14 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  ky@1.14.3:
+    resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
+    engines: {node: '>=18'}
+
+  latest-version@9.0.0:
+    resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
+    engines: {node: '>=18'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1396,6 +1491,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -1476,6 +1574,10 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-json@10.0.1:
+    resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
+    engines: {node: '>=18'}
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
@@ -1562,15 +1664,26 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pupa@3.3.0:
+    resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
+    engines: {node: '>=12.20'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1583,6 +1696,14 @@ packages:
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
+
+  registry-auth-token@5.1.1:
+    resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
+    engines: {node: '>=14'}
+
+  registry-url@6.0.1:
+    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
+    engines: {node: '>=12'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1686,6 +1807,16 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1775,6 +1906,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   typescript-eslint@8.61.1:
     resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1796,6 +1931,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  update-notifier@7.3.1:
+    resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
+    engines: {node: '>=18'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1890,6 +2029,9 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1900,9 +2042,21 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -2298,6 +2452,18 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@pnpm/config.env-replace@1.1.0': {}
+
+  '@pnpm/network.ca-file@1.0.2':
+    dependencies:
+      graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@3.0.3':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
+
   '@posthog/core@1.32.5':
     dependencies:
       '@posthog/types': 1.386.4
@@ -2620,11 +2786,17 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -2644,11 +2816,27 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   balanced-match@4.0.4: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  boxen@8.0.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 8.0.0
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -2665,6 +2853,8 @@ snapshots:
 
   cac@6.7.14: {}
 
+  camelcase@8.0.0: {}
+
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
@@ -2674,6 +2864,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  cli-boxes@3.0.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -2693,6 +2885,18 @@ snapshots:
 
   confbox@0.1.8: {}
 
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
+  configstore@7.1.0:
+    dependencies:
+      atomically: 2.1.1
+      dot-prop: 9.0.0
+      graceful-fs: 4.2.11
+      xdg-basedir: 5.1.0
+
   consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
@@ -2709,6 +2913,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   detect-indent@6.1.0: {}
@@ -2718,6 +2924,10 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dot-prop@9.0.0:
+    dependencies:
+      type-fest: 4.41.0
 
   dotenv@8.6.0: {}
 
@@ -2760,6 +2970,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  escape-goat@4.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2919,6 +3131,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
+
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -2927,6 +3143,8 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
 
@@ -2946,6 +3164,10 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  ini@1.3.8: {}
+
+  ini@4.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -2954,9 +3176,20 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ci@1.0.0: {}
+
+  is-installed-globally@1.0.0:
+    dependencies:
+      global-directory: 4.0.1
+      is-path-inside: 4.0.0
+
   is-interactive@2.0.0: {}
 
+  is-npm@6.1.0: {}
+
   is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -3011,6 +3244,12 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
+
+  ky@1.14.3: {}
+
+  latest-version@9.0.0:
+    dependencies:
+      package-json: 10.0.1
 
   levn@0.4.1:
     dependencies:
@@ -3114,6 +3353,8 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimist@1.2.8: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.17.0
@@ -3194,6 +3435,13 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json@10.0.1:
+    dependencies:
+      ky: 1.14.3
+      registry-auth-token: 5.1.1
+      registry-url: 6.0.1
+      semver: 7.8.4
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -3249,11 +3497,24 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  proto-list@1.2.4: {}
+
   punycode@2.3.1: {}
+
+  pupa@3.3.0:
+    dependencies:
+      escape-goat: 4.0.0
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -3265,6 +3526,14 @@ snapshots:
   readdirp@4.1.2: {}
 
   regexp-tree@0.1.27: {}
+
+  registry-auth-token@5.1.1:
+    dependencies:
+      '@pnpm/npm-conf': 3.0.3
+
+  registry-url@6.0.1:
+    dependencies:
+      rc: 1.2.8
 
   resolve-from@5.0.0: {}
 
@@ -3392,6 +3661,14 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -3484,6 +3761,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
   typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
@@ -3502,6 +3781,19 @@ snapshots:
   undici-types@7.24.6: {}
 
   universalify@0.1.2: {}
+
+  update-notifier@7.3.1:
+    dependencies:
+      boxen: 8.0.1
+      chalk: 5.6.2
+      configstore: 7.1.0
+      is-in-ci: 1.0.0
+      is-installed-globally: 1.0.0
+      is-npm: 6.1.0
+      latest-version: 9.0.0
+      pupa: 3.3.0
+      semver: 7.8.4
+      xdg-basedir: 5.1.0
 
   uri-js@4.4.1:
     dependencies:
@@ -3556,6 +3848,8 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  when-exit@2.1.5: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -3565,7 +3859,19 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
+
   word-wrap@1.2.5: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  xdg-basedir@5.1.0: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

- Wires `update-notifier` into CLI startup (welcome screen + command dispatch) so partners get a one-line stderr nudge when a newer `@pax8/cli` lands on npm. Rate-limited by update-notifier's 1-day window; the registry refresh runs in a detached child process so it never blocks the foreground command.
- Mirrors the cached registry result into `<configDir>/update-check.json` and gates the banner with an `acknowledgedAt` stamp — the nudge prints **once per release** per the issue AC, then stays quiet until the next upgrade lands.
- `ERROR_API_VALIDATION` failures (ZodError path and `CliError` raises alike) prepend a drift-aware recovery step ("A newer pax8-cli is available and may include a fix…") as the first item when the cache knows about an upgrade. Closes the Layer-1 loop with #178.

## Suppression signals

User opt-outs (always win):
- `PAX8_NO_UPDATE_CHECK=1` — the project-specific opt-out documented in #183
- `PAX8_DEMO=1` — demo mode never reaches the network (issue AC)
- `PAX8_QUIET=1` / `--quiet` / `--json` — clean machine-readable surface
- `NO_UPDATE_NOTIFIER`, `DO_NOT_TRACK=1` — community-standard opt-outs

Auto-suppressors:
- `NODE_ENV=test`, `CI=true`, non-TTY stderr

`PAX8_UPDATE_CHECK_TEST_FORCE=1` is a documented test seam that bypasses the auto-suppressors but still respects every user opt-out. Subprocess tests use it to exercise the un-suppressed render path while keeping the opt-out assertions honest.

## Out of scope (per issue)

- Forced updates / version pinning
- Auto-installing the new version
- Click-through telemetry on whether users acted on the notice

## Files touched

- `packages/cli/src/lib/update-check.ts` — new module: render gating, cache I/O, suppression matrix
- `packages/cli/src/lib/welcome.ts` + `packages/cli/src/index.ts` — wire the check into both startup paths
- `packages/cli/src/lib/errors.ts` — drift-aware recovery step for `ERROR_API_VALIDATION`
- `packages/cli/src/types/update-notifier.d.ts` — local ambient typings (DefinitelyTyped is pinned at v6; we want v7)
- `packages/cli/src/__tests__/update-notifier.test.ts` — 11 subprocess tests covering the AC matrix
- `packages/cli/src/lib/update-check.test.ts` — 12 unit tests for `isNewerVersion` and cache reader
- `CLAUDE.md` — env-var documentation
- `.changeset/update-prompt.md` — patch bump

Closes #183.

## Test plan

- [x] `pnpm build && pnpm -r typecheck && pnpm lint && pnpm test` all green locally (137 test files, 2308 tests pass)
- [x] Manual smoke: pre-populate `~/.pax8-test/update-check.json`, run with `PAX8_UPDATE_CHECK_TEST_FORCE=1` → nudge appears on stderr above the `version` output, stdout stays clean
- [x] Manual smoke with `--json`: nudge does NOT appear on stderr (JSON envelope is the only stderr content)
- [ ] CI green
- [ ] Lifecycle audit: nudge prints once per release (verified in test `stamps acknowledgedAt after rendering so the next run stays quiet`)