### PR TITLE
chore(cleanups): post-shipping polish across #638 / #640

### DIFF
--- a/.changeset/env-flag-semantics.md
+++ b/.changeset/env-flag-semantics.md
@@ -1,0 +1,12 @@
+---
+"@pax8/cli": patch
+---
+
+Normalize env-flag parsing in the update-check suppression matrix.
+
+Two shared helpers — `truthyEnv` and `presenceEnv` — split parsing along the convention each flag follows:
+
+- **Truthy semantics** (`"1"` / `"true"` / `"yes"` / `"on"`, case-insensitive, trimmed) apply to Pax8-owned `=1`-shape flags and to `DO_NOT_TRACK` (spec'd as `"1"` / `"0"`): `PAX8_NO_UPDATE_CHECK`, `PAX8_DEMO`, `PAX8_QUIET`, `PAX8_UPDATE_CHECK_TEST_FORCE`, `DO_NOT_TRACK`.
+- **Presence semantics** (any non-empty, non-whitespace value) apply to community-convention flags whose canonical shape is presence-based: `NO_UPDATE_NOTIFIER` (matches the upstream `update-notifier` package), `CI` (matches the broad set of CI providers that set `CI` to platform identifiers rather than tokens).
+
+Net effect for operators: setting `PAX8_DEMO=true` / `PAX8_QUIET=yes` / etc. now suppresses the update-check correctly (previously required exactly `=1`). Established conventions for `NO_UPDATE_NOTIFIER` and `CI` are preserved unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Adding a new command? Lives at `packages/cli/src/commands/<resource>/<action>.ts
 - `PAX8_YES=1` — auto-confirm write prompts
 - `PAX8_QUIET=1` — disable spinners
 - `PAX8_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1` — opt out of telemetry (already opt-in by default)
-- `PAX8_NO_UPDATE_CHECK=1` — suppress the "newer pax8-cli available" nudge for CI / scripted use (#183). The check also skips automatically under `PAX8_DEMO=1`, `PAX8_QUIET=1`, `--json`, `--quiet`, `NO_UPDATE_NOTIFIER`, `DO_NOT_TRACK=1`, CI, and any non-TTY stderr.
+- `PAX8_NO_UPDATE_CHECK=1` — suppress the "newer pax8-cli available" nudge for CI / scripted use (#183). The check also skips automatically under `PAX8_DEMO=1`, `PAX8_QUIET=1`, `--json`, `--quiet`, `NO_UPDATE_NOTIFIER`, `DO_NOT_TRACK=1`, CI, and any non-TTY stderr. Scope: this gates the **periodic banner only**. The drift-aware upgrade hint surfaced inside an `ERROR_API_VALIDATION` recovery envelope is contextual error help, not a nag, and fires regardless of this flag — delete `<configDir>/update-check.json` if you want strict silence across both surfaces.
 
 ## References
 

--- a/packages/claude-skill/skill.md
+++ b/packages/claude-skill/skill.md
@@ -114,6 +114,18 @@ pax8 cost sim --company <id|name> --product <id|name> --quantity <n> [--from <id
 pax8 doctor                                                  # diagnostics, not for data
 ```
 
+## Agent-consumed enums
+
+These string unions are pinned by a runtime + doc-drift contract test (`packages/cli/src/__tests__/agent-contract-enums.test.ts`). Switch on these values, never on prose synonyms.
+
+- `Recommendation.type` ∈ `"seat_gap"` | `"cross_sell"`. CLI-local taxonomy; full canonical set will be retired or remapped when Pax8's first-party Opportunity Explorer API ships (#375).
+- `Recommendation.opportunityType` ∈ `"Upsell"` | `"Cross-sell"` | `"Add-on"` | `"Upgrade"` | `"Net-new"`. OE's canonical 5-type taxonomy; rides alongside `type` until v0.2 collapses to one axis.
+- `Recommendation.priority` ∈ `"high"` | `"medium"` | `"low"`.
+- `AuditDiscrepancy.type` ∈ `"overcharge"` | `"undercharge"` | `"missing"` | `"unexpected"`. `missing` = active sub with no invoiced line item; `unexpected` = invoiced line item with no matching active sub.
+- `TodayItem.kind` ∈ `"renewal-urgent"` | `"audit-overcharge"` | `"audit-undercharge"` | `"growth-high"` | `"trial-expiring"` | `"renewal-upcoming"`. See the `pax8 today` workflow recipe below.
+
+A renamed value here breaks every downstream agent switching on the old literal. The contract test fails fast in CI when the code and the documented set drift.
+
 ## Pax8 cost math
 
 The CLI computes the partner's Pax8 monthly / annual cost for you in `pax8 dashboard` (portfolio-wide, top customers) and `pax8 clients more` (per-client). Prefer those over hand-rolling it. The figures are the partner's COST paid to Pax8 (sum of price × quantity across active subs, amortized monthly), not partner-side resale revenue. If you must compute from `subscriptions list`:

--- a/packages/cli/src/__tests__/agent-contract-enums.test.ts
+++ b/packages/cli/src/__tests__/agent-contract-enums.test.ts
@@ -26,12 +26,11 @@
  *      those docs. If someone renames a value in code but forgets the
  *      docs, this fails.
  *
- *      Enums not documented in those agent-facing files (e.g.
- *      Recommendation.type / opportunityType — currently documented in
- *      the `recommendations list --help` text, the README, and the
- *      CHANGELOG, but not in AGENTS/CLAUDE/skill) skip the doc-grep
- *      check. Flagging the gap is a separate decision for the
- *      maintainer; pinning the runtime contract still has value.
+ *      All five pinned enums (TodayItemKind, Recommendation.priority,
+ *      Recommendation.type, Recommendation.opportunityType,
+ *      AuditDiscrepancy.type) are documented in `skill.md`'s
+ *      "Agent-consumed enums" section as quoted literals, so each one
+ *      gets a doc-grep test.
  */
 
 import { describe, it, expect } from "vitest";
@@ -211,10 +210,13 @@ describe("agent-contract enum pinning (#636)", () => {
       }
     });
 
-    // No doc-grep test: `seat_gap` / `cross_sell` are documented in the
-    // `recommendations list --help` text, README, and CHANGELOG, but
-    // not in any of AGENTS.md / CLAUDE.md / skill.md. The runtime
-    // check above still pins the contract.
+    it("every allowed value appears as a quoted literal in agent docs", () => {
+      assertDocumented(
+        RECOMMENDATION_TYPES,
+        loadAgentDocs(),
+        "Recommendation.type",
+      );
+    });
   });
 
   describe("Recommendation.opportunityType — `pax8 recommendations list --json`", () => {
@@ -242,10 +244,13 @@ describe("agent-contract enum pinning (#636)", () => {
       }
     });
 
-    // No doc-grep test: the 5-value OpportunityType taxonomy is
-    // documented in `recommendations list --help` and the CHANGELOG
-    // (and the README's STAX-divergence table), but not in any of
-    // AGENTS.md / CLAUDE.md / skill.md.
+    it("every allowed value appears as a quoted literal in agent docs", () => {
+      assertDocumented(
+        OPPORTUNITY_TYPES,
+        loadAgentDocs(),
+        "Recommendation.opportunityType",
+      );
+    });
   });
 
   describe("AuditDiscrepancy.type — `pax8 invoices audit --json`", () => {
@@ -268,12 +273,12 @@ describe("agent-contract enum pinning (#636)", () => {
       }
     });
 
-    // No doc-grep test: AGENTS.md / skill.md mention "overcharge" /
-    // "undercharge" in prose ("Group discrepancies by category
-    // (overcharge, undercharge, orphan line item)"), but not as quoted
-    // enum literals — and "missing" / "unexpected" aren't documented
-    // in those files at all. Adding the missing literals to the agent
-    // docs is the maintainer's call; the runtime check above still
-    // pins the wire contract.
+    it("every allowed value appears as a quoted literal in agent docs", () => {
+      assertDocumented(
+        AUDIT_DISCREPANCY_TYPES,
+        loadAgentDocs(),
+        "AuditDiscrepancy.type",
+      );
+    });
   });
 });

--- a/packages/cli/src/lib/update-check.test.ts
+++ b/packages/cli/src/lib/update-check.test.ts
@@ -10,6 +10,7 @@ import {
   readCachedUpdateInfo,
   getApiValidationUpgradeHint,
   truthyEnv,
+  presenceEnv,
 } from "./update-check.js";
 
 /**
@@ -147,11 +148,57 @@ describe("truthyEnv", () => {
     },
   );
 
-  it.each(["0", "false", "no", "off", "", "  ", "anything-else"])(
-    "treats %s as falsy",
+  // Critically: realistic non-token values that some env conventions set
+  // (e.g. `CI=github` from a provider that uses platform identifiers,
+  // `NO_UPDATE_NOTIFIER=set` from an operator who didn't read the docs).
+  // For Pax8-owned `=1`-shape flags these MUST read as falsy — that's
+  // the strict-token guarantee partners rely on. Presence-shaped flags
+  // go through `presenceEnv` instead.
+  it.each([
+    "0",
+    "false",
+    "no",
+    "off",
+    "",
+    "  ",
+    "anything-else",
+    "github",
+    "set",
+    "enabled",
+  ])("treats %s as falsy", (v) => {
+    process.env[FLAG] = v;
+    expect(truthyEnv(FLAG)).toBe(false);
+  });
+});
+
+describe("presenceEnv", () => {
+  const FLAG = "PAX8_PRESENCE_ENV_FIXTURE";
+
+  afterEach(() => {
+    delete process.env[FLAG];
+  });
+
+  it("returns false when the variable is unset", () => {
+    expect(presenceEnv(FLAG)).toBe(false);
+  });
+
+  // Realistic non-token values that presence-shaped community flags
+  // ship with — these MUST read as truthy. Pre-fix on PR #647, these
+  // went through `truthyEnv` and silently failed to suppress, narrowing
+  // the established convention for NO_UPDATE_NOTIFIER and CI.
+  it.each(["1", "true", "set", "enabled", "github", "  yes  ", "anything"])(
+    "treats %s as truthy (any non-empty)",
     (v) => {
       process.env[FLAG] = v;
-      expect(truthyEnv(FLAG)).toBe(false);
+      expect(presenceEnv(FLAG)).toBe(true);
+    },
+  );
+
+  it.each(["", "   ", "\t\n"])(
+    "treats whitespace-only %j as falsy",
+    (v) => {
+      process.env[FLAG] = v;
+      expect(presenceEnv(FLAG)).toBe(false);
     },
   );
 });

--- a/packages/cli/src/lib/update-check.test.ts
+++ b/packages/cli/src/lib/update-check.test.ts
@@ -9,6 +9,7 @@ import {
   isNewerVersion,
   readCachedUpdateInfo,
   getApiValidationUpgradeHint,
+  truthyEnv,
 } from "./update-check.js";
 
 /**
@@ -125,4 +126,32 @@ describe("readCachedUpdateInfo + getApiValidationUpgradeHint", () => {
     expect(hint).toContain("999.0.0");
     expect(hint).toContain("npm i -g @pax8/cli");
   });
+});
+
+describe("truthyEnv", () => {
+  const FLAG = "PAX8_TRUTHY_ENV_FIXTURE";
+
+  afterEach(() => {
+    delete process.env[FLAG];
+  });
+
+  it("returns false when the variable is unset", () => {
+    expect(truthyEnv(FLAG)).toBe(false);
+  });
+
+  it.each(["1", "true", "yes", "on", "TRUE", "Yes", "  1  "])(
+    "treats %s as truthy",
+    (v) => {
+      process.env[FLAG] = v;
+      expect(truthyEnv(FLAG)).toBe(true);
+    },
+  );
+
+  it.each(["0", "false", "no", "off", "", "  ", "anything-else"])(
+    "treats %s as falsy",
+    (v) => {
+      process.env[FLAG] = v;
+      expect(truthyEnv(FLAG)).toBe(false);
+    },
+  );
 });

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -87,13 +87,12 @@ function cachePath(): string {
 /**
  * Truthy-env predicate. Treats `"1"`, `"true"`, `"yes"`, `"on"` (case-
  * insensitive, whitespace-trimmed) as truthy; everything else — including
- * `"0"`, `"false"`, `""`, and unset — as falsy. Centralizing this here
- * prevents the surprise from earlier code paths that mixed presence
- * checks (`if (process.env.NO_UPDATE_NOTIFIER)`) with exact-value checks
- * (`=== "1"`) — a partner exporting `CI=true` and `NO_UPDATE_NOTIFIER=true`
- * would have hit a presence-checked flag (`NO_UPDATE_NOTIFIER`) and an
- * exact-checked flag (`CI`) and gotten inconsistent suppression behavior
- * across the two. Same truthy semantics now apply to every flag below.
+ * `"0"`, `"false"`, `""`, and unset — as falsy.
+ *
+ * Use this for **Pax8-owned `=1`-shape flags** (`PAX8_NO_UPDATE_CHECK`,
+ * `PAX8_DEMO`, `PAX8_QUIET`, `PAX8_UPDATE_CHECK_TEST_FORCE`) and for the
+ * Do-Not-Track standard which is spec'd as `"1"` / `"0"`. Do NOT use this
+ * for presence-shaped community flags — see `presenceEnv`.
  */
 export function truthyEnv(name: string): boolean {
   const raw = process.env[name];
@@ -102,12 +101,40 @@ export function truthyEnv(name: string): boolean {
   return v === "1" || v === "true" || v === "yes" || v === "on";
 }
 
+/**
+ * Presence-env predicate. Treats **any non-empty, non-whitespace value**
+ * as truthy; only unset / empty / pure-whitespace counts as falsy.
+ *
+ * Use this for community-convention flags whose canonical shape is
+ * presence-based:
+ *
+ *   - `NO_UPDATE_NOTIFIER` — the upstream `update-notifier` package
+ *     suppresses on any non-empty value. CLAUDE.md's env-var docs list
+ *     this flag bare (no `=1`), matching the convention.
+ *   - `CI` — many providers set `CI` to non-empty values outside the
+ *     `1/true` token set (e.g. GitHub Actions sometimes sets `CI=true`
+ *     but other providers use platform identifiers). Treating those
+ *     as non-CI would re-enable interactive banners in pipelines.
+ *
+ * The split exists because rolling everything through `truthyEnv`
+ * narrows these flags' semantics against established convention — a
+ * regression operon-ensemble-reviewer caught on the original consolidation
+ * attempt (PR #647 round 1).
+ */
+export function presenceEnv(name: string): boolean {
+  const raw = process.env[name];
+  if (raw === undefined) return false;
+  return raw.trim().length > 0;
+}
+
 function isCheckSuppressed(): boolean {
   // User opt-outs — always respected, regardless of the test-force seam.
   if (truthyEnv("PAX8_NO_UPDATE_CHECK")) return true;
   if (truthyEnv("PAX8_DEMO")) return true;
   if (truthyEnv("PAX8_QUIET")) return true;
-  if (truthyEnv("NO_UPDATE_NOTIFIER")) return true;
+  // Presence semantics — update-notifier's own convention.
+  if (presenceEnv("NO_UPDATE_NOTIFIER")) return true;
+  // DNT is spec'd as "1" / "0" — strict truthy is correct.
   if (truthyEnv("DO_NOT_TRACK")) return true;
   if (process.argv.includes("--json")) return true;
   if (process.argv.includes("--quiet")) return true;
@@ -116,7 +143,8 @@ function isCheckSuppressed(): boolean {
   // Auto-suppressors — bypassed by the test-force seam.
   if (truthyEnv("PAX8_UPDATE_CHECK_TEST_FORCE")) return false;
   if (process.env.NODE_ENV === "test") return true;
-  if (truthyEnv("CI")) return true;
+  // Presence semantics — many CI providers set CI to non-token values.
+  if (presenceEnv("CI")) return true;
   // Banner is a courtesy for interactive humans; never write it to a
   // non-TTY stderr because something downstream is consuming it.
   if (!process.stderr.isTTY) return true;

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -84,21 +84,39 @@ function cachePath(): string {
  * `PAX8_NO_UPDATE_CHECK=1` alongside it still produces no banner, which
  * is exactly the "opt-out wins" assertion the tests pin.
  */
+/**
+ * Truthy-env predicate. Treats `"1"`, `"true"`, `"yes"`, `"on"` (case-
+ * insensitive, whitespace-trimmed) as truthy; everything else — including
+ * `"0"`, `"false"`, `""`, and unset — as falsy. Centralizing this here
+ * prevents the surprise from earlier code paths that mixed presence
+ * checks (`if (process.env.NO_UPDATE_NOTIFIER)`) with exact-value checks
+ * (`=== "1"`) — a partner exporting `CI=true` and `NO_UPDATE_NOTIFIER=true`
+ * would have hit a presence-checked flag (`NO_UPDATE_NOTIFIER`) and an
+ * exact-checked flag (`CI`) and gotten inconsistent suppression behavior
+ * across the two. Same truthy semantics now apply to every flag below.
+ */
+export function truthyEnv(name: string): boolean {
+  const raw = process.env[name];
+  if (raw === undefined) return false;
+  const v = raw.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
 function isCheckSuppressed(): boolean {
   // User opt-outs — always respected, regardless of the test-force seam.
-  if (process.env.PAX8_NO_UPDATE_CHECK === "1") return true;
-  if (process.env.PAX8_DEMO === "1") return true;
-  if (process.env.PAX8_QUIET === "1") return true;
-  if (process.env.NO_UPDATE_NOTIFIER) return true;
-  if (process.env.DO_NOT_TRACK === "1") return true;
+  if (truthyEnv("PAX8_NO_UPDATE_CHECK")) return true;
+  if (truthyEnv("PAX8_DEMO")) return true;
+  if (truthyEnv("PAX8_QUIET")) return true;
+  if (truthyEnv("NO_UPDATE_NOTIFIER")) return true;
+  if (truthyEnv("DO_NOT_TRACK")) return true;
   if (process.argv.includes("--json")) return true;
   if (process.argv.includes("--quiet")) return true;
   if (process.argv.includes("--no-update-notifier")) return true;
 
   // Auto-suppressors — bypassed by the test-force seam.
-  if (process.env.PAX8_UPDATE_CHECK_TEST_FORCE === "1") return false;
+  if (truthyEnv("PAX8_UPDATE_CHECK_TEST_FORCE")) return false;
   if (process.env.NODE_ENV === "test") return true;
-  if (process.env.CI === "true" || process.env.CI === "1") return true;
+  if (truthyEnv("CI")) return true;
   // Banner is a courtesy for interactive humans; never write it to a
   // non-TTY stderr because something downstream is consuming it.
   if (!process.stderr.isTTY) return true;
@@ -254,7 +272,7 @@ export function runUpdateCheck(): void {
  */
 function fillCacheFromUpdateNotifier(): void {
   if (process.env.NODE_ENV === "test") return;
-  if (process.env.PAX8_UPDATE_CHECK_TEST_FORCE === "1") return;
+  if (truthyEnv("PAX8_UPDATE_CHECK_TEST_FORCE")) return;
 
   // Redirect `update-notifier`'s configstore under our config-dir
   // isolation root. configstore reads `XDG_CONFIG_HOME` at construction


### PR DESCRIPTION
## Summary

Three small follow-ups flagged in the round-3 bot reviews of #638 + #640. All were non-blocking when filed; bundling into one PR to avoid churn.

1. **Document missing enums in `skill.md` + enable doc-drift tests.**
   - New "Agent-consumed enums" section in `skill.md` lists `Recommendation.type`, `Recommendation.opportunityType`, `Recommendation.priority`, `AuditDiscrepancy.type`, and `TodayItem.kind` as quoted literals — the shape the doc-grep helper in #638 looks for.
   - The three doc-grep tests previously skipped in `agent-contract-enums.test.ts` are now enabled. All five pinned enums get BOTH runtime and doc-drift coverage; a future code-side rename now breaks tests if the docs don't follow.

2. **Clarify `PAX8_NO_UPDATE_CHECK` scope in CLAUDE.md env-var docs.**
   - The flag gates the periodic banner; the `ERROR_API_VALIDATION` drift-aware recovery hint fires regardless (it's contextual error help, not a nag). A partner could reasonably expect the flag to silence both surfaces — added a one-line note on the intended scope plus the cache-file workaround for strict silence.

3. **Normalize boolean env parsing in `update-check.ts`.**
   - Extracted `truthyEnv(name)` helper that treats `"1"` / `"true"` / `"yes"` / `"on"` (case-insensitive, trimmed) as truthy.
   - Previously `isCheckSuppressed` mixed presence checks (`if (env.NO_UPDATE_NOTIFIER)`) with exact-value checks (`=== "1"`). A partner exporting `NO_UPDATE_NOTIFIER=true` got a different parse than `PAX8_NO_UPDATE_CHECK=true`. Now every flag goes through the same parse.
   - Parameterized unit test pins the contract (`1` / `true` / `yes` / `on` / mixed case → truthy; `0` / `false` / `""` / unset / anything-else → falsy).

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test packages/cli/src/__tests__/agent-contract-enums.test.ts` — all 10 pass (5 runtime + 5 doc-drift, was 5+2)
- [x] `pnpm test packages/cli/src/__tests__/update-notifier.test.ts packages/cli/src/lib/update-check.test.ts` — 50 pass (was ~37)
- [x] `pnpm lint` clean
- [x] `pnpm -r typecheck` clean