### PR TITLE
feat(auth): persist OAuth access token across invocations (#233)

### DIFF
--- a/.changeset/oauth-token-cache.md
+++ b/.changeset/oauth-token-cache.md
@@ -1,0 +1,21 @@
+---
+"@pax8/cli": patch
+"@pax8/core": patch
+---
+
+Persist the OAuth access token across CLI invocations.
+
+`TokenManager` now hydrates from `<configDir>/.token-cache.json` (mode 0600, O_NOFOLLOW) before hitting `POST /v1/token`, so the typical `pax8 <command>` no longer pays ~100-300ms of auth latency or burns rate-limit budget on every shell. Cache identity is keyed by `sha256(clientId)` + `sha256(apiBaseUrl)` — switching `PAX8_API_BASE` between prod/staging, or running `pax8 auth login` with new creds, automatically invalidates without leaking either value on disk. TTL honors the auth server's `expires_in` (production: 86400s); refresh skew is `max(1s, min(60s, 10% of TTL))`.
+
+Behavioral shifts worth noting for callers and operators:
+
+- **Cross-process token reuse.** Scripts that loop over multiple `pax8` commands now share the token across processes instead of fetching one per invocation. Integrations or tests assuming "one /token mint per call" will observe different behavior.
+- **`Pax8Client` retries once on 401.** On a 401, the cache is cleared and a fresh token is fetched, then the request retries once. Misconfigured-auth cases incur two failed calls before surfacing, but server-side token revocations now recover automatically instead of hanging the CLI for up to 24h.
+- **Stronger `auth logout`.** `CredentialStore.clearCredentials()` now also wipes `<configDir>/.token-cache.json`, so logout invalidates the cached token across any in-flight shells.
+- **`clearToken()` vs `clearCache()`.** `clearToken()` only clears in-memory state; the new `clearCache()` performs the full wipe (memory + disk). Callers that previously assumed `clearToken()` meant "full revocation" should switch to `clearCache()`.
+- **New optional embedder hook.** `TokenManagerLike.clearCache?: () => void` — invoked exactly once by `Pax8Client` on a 401. Embedders that bring their own token manager don't need to implement it; the optional-chaining call is a no-op.
+- **`pax8 doctor`** now reports token-cache file permissions alongside the existing credentials.json check.
+
+The cache file uses the same OS-level hardening as `credentials.json`. No new dependencies. Token TTL is clamped to 24h on the way in (defense-in-depth against a misbehaving auth endpoint).
+
+Closes #233.

--- a/packages/cli/src/__tests__/local-state-writers.test.ts
+++ b/packages/cli/src/__tests__/local-state-writers.test.ts
@@ -74,6 +74,16 @@ const CORE_HOMEDIR_EXCEPTIONS = new Set<string>([
   // Test fixtures legitimately reference homedir() for assertions.
   "packages/core/src/auth/credential-store.test.ts",
   "packages/core/src/config/loader-extended.test.ts",
+  // token-cache-store.ts (#233): production code uses getConfigDir() for
+  // path resolution; the remaining os.homedir() calls are only inside the
+  // Windows ACL check (checkPermissionsWindows) which compares the cache
+  // file path against the user-profile directory — same pattern as
+  // credential-store.ts above.
+  "packages/core/src/auth/token-cache-store.ts",
+  // token-cache-store.test.ts (#233): mkdtemp's inside $HOME so the test
+  // tmpdir satisfies the home-anchored validateConfigDir guard (M-5).
+  // Same pattern as idempotency.test.ts in the CLI tree.
+  "packages/core/src/auth/token-cache-store.test.ts",
 ]);
 
 /**
@@ -93,6 +103,11 @@ const CORE_ALLOWED_RAW_WRITERS = new Set<string>([
   "packages/core/src/config/loader-extended.test.ts",
   "packages/core/src/config/loader.test.ts",
   "packages/core/src/telemetry/telemetry.test.ts",
+  // token-cache-store.test.ts (#233): seeds malformed JSON, wrong-mode,
+  // and ACL-blocker fixtures into a tmpdir to exercise the error paths
+  // (corrupt cache → return null, bad mode → security check fails, etc).
+  // The production write path goes through safeWriteFileSync.
+  "packages/core/src/auth/token-cache-store.test.ts",
 ]);
 
 /**

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { replCmd } from "../lib/confirm.js";
-import { CredentialStore, getConfigDir, getDefaultBaseUrl } from "@pax8/core";
+import { CredentialStore, TokenCacheStore, getConfigDir, getDefaultBaseUrl } from "@pax8/core";
 import {
   getOutputFormat,
   resolveDemoModeAsync,
@@ -318,6 +318,20 @@ async function checkCredentialPermissions(): Promise<CheckResult> {
   };
 }
 
+// #233 — the OAuth access-token cache lives next to credentials.json under
+// the same config dir with the same 0o600 / icacls hardening. Surface the
+// same kind of permission probe here so a loosened-perms cache file gets
+// flagged the same way a loosened credentials file would.
+async function checkTokenCachePermissions(): Promise<CheckResult> {
+  const store = new TokenCacheStore();
+  const result = await store.checkPermissions();
+  return {
+    name: "Token cache file permissions",
+    passed: result.secure,
+    detail: result.detail,
+  };
+}
+
 async function checkTelemetry(): Promise<CheckResult> {
   try {
     const { loadConfig } = await import("@pax8/core");
@@ -418,19 +432,20 @@ Examples:
     }
 
     // Run all checks in parallel for speed
-    const [nodeV, apiBase, configF, authC, credPerms, tokenC, apiCs, cacheC, telC, mcpC] = await Promise.all([
+    const [nodeV, apiBase, configF, authC, credPerms, tokenCachePerms, tokenC, apiCs, cacheC, telC, mcpC] = await Promise.all([
       checkNodeVersion(),
       checkApiBase(),
       checkConfigFile(),
       checkAuth(),
       checkCredentialPermissions(),
+      checkTokenCachePermissions(),
       checkTokenFetch(),
       checkApiHealth(),
       checkCacheDir(),
       checkTelemetry(),
       checkMcp(),
     ]);
-    const checks: CheckResult[] = [nodeV, apiBase, configF, authC, credPerms, tokenC, ...apiCs, cacheC, telC, mcpC];
+    const checks: CheckResult[] = [nodeV, apiBase, configF, authC, credPerms, tokenCachePerms, tokenC, ...apiCs, cacheC, telC, mcpC];
 
     let allPassed = true;
     for (const check of checks) {

--- a/packages/core/src/api/client-extended.test.ts
+++ b/packages/core/src/api/client-extended.test.ts
@@ -221,4 +221,114 @@ describe("Pax8Client — extended coverage", () => {
 
     await expect(client.get("/bad")).rejects.toThrow(ApiError);
   });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // #233 — 401 recovery: clear stale token cache and retry once.
+  // ───────────────────────────────────────────────────────────────────────
+
+  describe("401 cache-clear retry (#233)", () => {
+    function jsonResponse(status: number, body: unknown) {
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? "OK" : "Unauthorized",
+        headers: new Headers(),
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+      };
+    }
+
+    it("clears the token cache and retries once on a 401, then succeeds", async () => {
+      const getToken = vi
+        .fn()
+        .mockResolvedValueOnce("stale-token")
+        .mockResolvedValueOnce("fresh-token");
+      const clearCache = vi.fn();
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(401, { error: "token revoked" }))
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      const client = new Pax8Client({
+        tokenManager: { getToken, clearCache },
+        baseUrl: "https://api.pax8.com/v1",
+        cacheTtlMs: 0,
+      });
+
+      const result = await client.get<{ ok: boolean }>("/companies");
+      expect(result).toEqual({ ok: true });
+      expect(clearCache).toHaveBeenCalledOnce();
+      expect(getToken).toHaveBeenCalledTimes(2);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+      // The retry must carry the fresh Authorization header.
+      const secondCallInit = fetchFn.mock.calls[1][1] as RequestInit;
+      const secondHeaders = secondCallInit.headers as Record<string, string>;
+      expect(secondHeaders.Authorization).toBe("Bearer fresh-token");
+    });
+
+    it("does not retry a second time when the retry also returns 401", async () => {
+      const getToken = vi.fn().mockResolvedValue("any-token");
+      const clearCache = vi.fn();
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValue(jsonResponse(401, { error: "still unauthorized" }));
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      const client = new Pax8Client({
+        tokenManager: { getToken, clearCache },
+        baseUrl: "https://api.pax8.com/v1",
+        cacheTtlMs: 0,
+      });
+
+      await expect(client.get("/companies")).rejects.toThrow(ApiError);
+      // One cache clear + exactly two fetches (initial + single retry).
+      expect(clearCache).toHaveBeenCalledOnce();
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not invoke clearCache when the token manager lacks the hook", async () => {
+      // Older / embedder-provided token managers may not implement
+      // clearCache. The optional-chaining call must not throw and the
+      // retry must still happen.
+      const getToken = vi
+        .fn()
+        .mockResolvedValueOnce("first")
+        .mockResolvedValueOnce("second");
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(401, { error: "revoked" }))
+        .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      const client = new Pax8Client({
+        tokenManager: { getToken },
+        baseUrl: "https://api.pax8.com/v1",
+        cacheTtlMs: 0,
+      });
+
+      await expect(client.get("/x")).resolves.toEqual({ ok: true });
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not enter the retry loop on a 403 (only 401 triggers cache clear)", async () => {
+      // Pin the boundary: 403 (forbidden, not unauthorized) must NOT
+      // clear the token cache — the token is valid, the user just
+      // doesn't have access to this resource.
+      const getToken = vi.fn().mockResolvedValue("token");
+      const clearCache = vi.fn();
+      const fetchFn = vi.fn().mockResolvedValue(jsonResponse(403, { error: "forbidden" }));
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      const client = new Pax8Client({
+        tokenManager: { getToken, clearCache },
+        baseUrl: "https://api.pax8.com/v1",
+        cacheTtlMs: 0,
+      });
+
+      await expect(client.get("/x")).rejects.toThrow(ApiError);
+      expect(clearCache).not.toHaveBeenCalled();
+      expect(fetchFn).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/packages/core/src/api/client-extended.test.ts
+++ b/packages/core/src/api/client-extended.test.ts
@@ -227,12 +227,16 @@ describe("Pax8Client — extended coverage", () => {
   // ───────────────────────────────────────────────────────────────────────
 
   describe("401 cache-clear retry (#233)", () => {
-    function jsonResponse(status: number, body: unknown) {
+    function jsonResponse(
+      status: number,
+      body: unknown,
+      headers: Record<string, string> = {},
+    ) {
       return {
         ok: status >= 200 && status < 300,
         status,
         statusText: status === 200 ? "OK" : "Unauthorized",
-        headers: new Headers(),
+        headers: new Headers(headers),
         json: () => Promise.resolve(body),
         text: () => Promise.resolve(JSON.stringify(body)),
       };
@@ -329,6 +333,45 @@ describe("Pax8Client — extended coverage", () => {
       await expect(client.get("/x")).rejects.toThrow(ApiError);
       expect(clearCache).not.toHaveBeenCalled();
       expect(fetchFn).toHaveBeenCalledOnce();
+    });
+
+    // Regression: PR #649 round-2 bot review caught that a 401 landing on
+    // the final retry slot (after earlier slots are burned by 429s) would
+    // set retriedAfterAuthClear=true, continue the loop, and fall through
+    // to `throw lastError ?? new Error("Unexpected error")` — a code-less
+    // bare Error that violates the "errors carry codes" contract. The
+    // fix (client.ts) gates the 401 retry on `attempt < MAX_RETRIES` so a
+    // terminal 401 falls through to the !response.ok branch and surfaces
+    // as a structured ApiError(401).
+    it("surfaces ApiError(401), not a bare Error, when a 401 lands on the final retry slot", async () => {
+      const getToken = vi.fn().mockResolvedValue("token");
+      const clearCache = vi.fn();
+      // MAX_RETRIES=3 → up to 4 attempts (indices 0..3). Burn the first
+      // three on 429s, then return 401 on the final slot. Retry-After=0
+      // skips the 429 backoff sleep so the test runs instantly.
+      const r429 = jsonResponse(429, { error: "rate limited" }, { "Retry-After": "0" });
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce(r429)
+        .mockResolvedValueOnce(r429)
+        .mockResolvedValueOnce(r429)
+        .mockResolvedValueOnce(jsonResponse(401, { error: "unauthorized" }));
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      const client = new Pax8Client({
+        tokenManager: { getToken, clearCache },
+        baseUrl: "https://api.pax8.com/v1",
+        cacheTtlMs: 0,
+      });
+
+      // The throw MUST be an ApiError (carries status + ERROR_* code),
+      // never a bare Error("Unexpected error"). That's the regression.
+      await expect(client.get("/x")).rejects.toThrow(ApiError);
+      // Cache must NOT be cleared because the terminal-slot guard
+      // short-circuits before the clear-and-retry side effect.
+      expect(clearCache).not.toHaveBeenCalled();
+      // Three 429s + one 401 = 4 fetch calls. No retry beyond the 401.
+      expect(fetchFn).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -547,7 +547,23 @@ export class Pax8Client {
           // Safe for non-idempotent methods (POST /orders, etc.) because a
           // 401 means the server *rejected* the request before processing —
           // same logic as 429. Retry can't produce a duplicate side effect.
-          if (response.status === 401 && !retriedAfterAuthClear) {
+          // The `attempt < MAX_RETRIES` guard prevents a final-slot 401
+          // from setting `retriedAfterAuthClear = true` and `continue`-ing
+          // the loop without ever actually running the retried request:
+          // the next iteration condition fails and we fall through to the
+          // generic `throw lastError ?? new Error("Unexpected error")` at
+          // the bottom, surfacing a code-less Error that violates the
+          // "errors carry codes" contract (CLAUDE.md). Reachable when
+          // earlier attempts were burned by 429s (e.g. 0/1/2 = 429,
+          // attempt 3 = 401). Without the guard the user sees a bare
+          // Error("Unexpected error") instead of a structured
+          // ApiError(401). With the guard, a terminal 401 falls through
+          // to the `!response.ok` branch below and surfaces correctly.
+          if (
+            response.status === 401 &&
+            !retriedAfterAuthClear &&
+            attempt < MAX_RETRIES
+          ) {
             clearTimeout(timeoutId);
             retriedAfterAuthClear = true;
             // Drain the response body so the underlying socket can be reused.

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -9,8 +9,25 @@ import { FileCache } from "../services/cache.js";
 import { validateBaseUrl } from "../security/validate-env.js";
 import { redactDebugBody } from "../security/redact-debug.js";
 
+/**
+ * Minimal interface the client needs from a token manager. Carries an
+ * optional `clearCache()` hook so a 401 response can invalidate any stale
+ * server-side token without coupling `Pax8Client` to the full
+ * `TokenManager` shape (keeps embedders that bring their own token source
+ * free to ignore the cache plumbing).
+ */
+export interface TokenManagerLike {
+  getToken(): Promise<string>;
+  /**
+   * Optional. When defined, called once on a 401 response before the
+   * request is retried — gives the token manager a chance to drop a
+   * server-side-revoked token from memory + disk (#233).
+   */
+  clearCache?(): void;
+}
+
 export interface Pax8ClientOptions {
-  tokenManager: { getToken(): Promise<string> };
+  tokenManager: TokenManagerLike;
   baseUrl?: string;
   timeout?: number;
   debug?: boolean;
@@ -307,7 +324,7 @@ export function buildCacheKey(input: BuildCacheKeyInput): string {
 }
 
 export class Pax8Client {
-  private readonly tokenManager: { getToken(): Promise<string> };
+  private readonly tokenManager: TokenManagerLike;
   private readonly baseUrl: string;
   private readonly apiBaseOverrides: Record<string, string> | undefined;
   private readonly timeout: number;
@@ -476,6 +493,14 @@ export class Pax8Client {
 
     let lastError: Error | undefined;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    // #233: track whether we've already retried after a 401-driven cache
+    // invalidation. The on-disk token cache (TokenManager) lets a stale
+    // token live up to 24 h; a server-side revocation would otherwise hang
+    // the CLI for the rest of that lifetime. On the first 401 we clear the
+    // cached token and retry the request once with a freshly-minted token.
+    // Single retry only — a real 401 (revoked creds, wrong scopes) must
+    // still surface to the caller, not loop forever.
+    let retriedAfterAuthClear = false;
 
     try {
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -507,6 +532,35 @@ export class Pax8Client {
             }
             const retryAfter = parseRetryAfter(response) ?? (attempt + 1);
             await sleep(retryAfter * 1000);
+            continue;
+          }
+
+          // #233 — single-shot retry on 401. The on-disk token cache (see
+          // TokenManager) lets a stale token live up to 24 h; without this
+          // guard a server-side revocation would hang the CLI for the rest
+          // of that lifetime. We clear the cache (memory + disk) and
+          // re-fetch a fresh token, then retry the request *once* with the
+          // new Authorization header. A second 401 is treated as a real
+          // auth failure (revoked creds, wrong scopes) and surfaces to the
+          // caller via the standard !response.ok branch below.
+          //
+          // Safe for non-idempotent methods (POST /orders, etc.) because a
+          // 401 means the server *rejected* the request before processing —
+          // same logic as 429. Retry can't produce a duplicate side effect.
+          if (response.status === 401 && !retriedAfterAuthClear) {
+            clearTimeout(timeoutId);
+            retriedAfterAuthClear = true;
+            // Drain the response body so the underlying socket can be reused.
+            // Ignore parse errors — we don't surface the error body on this
+            // path (the retry might succeed; if it doesn't, the second 401
+            // is handled by the generic !response.ok branch below).
+            await safeJson(response);
+            this.tokenManager.clearCache?.();
+            const freshToken = await this.tokenManager.getToken();
+            headers.Authorization = `Bearer ${freshToken}`;
+            // The retry consumes one of the MAX_RETRIES transient slots.
+            // With MAX_RETRIES=3 that leaves plenty of headroom for a
+            // genuine network blip on the retried request.
             continue;
           }
 

--- a/packages/core/src/auth/credential-store.ts
+++ b/packages/core/src/auth/credential-store.ts
@@ -9,6 +9,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { safeWriteFileSync } from "../security/safe-write.js";
 import { getConfigDir } from "../config/loader.js";
+import { TokenCacheStore } from "./token-cache-store.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -115,7 +116,12 @@ export class CredentialStore {
   }
 
   /**
-   * Removes the credentials file.
+   * Removes the credentials file. Also wipes the on-disk OAuth token cache
+   * (#233) — leaving a stale token paired with cleared credentials would let
+   * a logged-out session keep hitting the API until the token's natural
+   * 24 h expiry. The token-cache clear is best-effort: a permission error
+   * on the cache file must not block the credential removal, since the
+   * credentials themselves are the higher-value secret.
    */
   async clearCredentials(): Promise<void> {
     try {
@@ -125,6 +131,12 @@ export class CredentialStore {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         throw err;
       }
+    }
+    try {
+      new TokenCacheStore().clear();
+    } catch {
+      // Best-effort. The credentials are gone; a leftover token cache will
+      // be invalidated by `clientIdHash` mismatch on the next `auth login`.
     }
   }
 

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -4,3 +4,9 @@
 export { TokenManager } from "./token-manager.js";
 export { CredentialStore } from "./credential-store.js";
 export type { Credentials, PermissionCheckResult } from "./credential-store.js";
+export { TokenCacheStore } from "./token-cache-store.js";
+export type {
+  TokenCacheFile,
+  TokenCacheLookupKey,
+  PermissionCheckResult as TokenCachePermissionCheckResult,
+} from "./token-cache-store.js";

--- a/packages/core/src/auth/token-cache-store.test.ts
+++ b/packages/core/src/auth/token-cache-store.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { TokenCacheStore, computeCacheIdentity } from "./token-cache-store.js";
+
+const CLIENT_ID = "test-client-id";
+const API_BASE = "https://api.pax8.com/v1";
+
+describe("TokenCacheStore (#233)", () => {
+  let dir: string;
+  const originalConfigDir = process.env.PAX8_CONFIG_DIR;
+
+  beforeEach(() => {
+    // Use a homedir-anchored tmpdir so `validateConfigDir` accepts it
+    // without the PAX8_ALLOW_NON_HOME_CONFIG opt-in (matches production
+    // and the credential-store test pattern).
+    dir = mkdtempSync(path.join(os.homedir(), ".pax8-tokencache-test-"));
+    process.env.PAX8_CONFIG_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) delete process.env.PAX8_CONFIG_DIR;
+    else process.env.PAX8_CONFIG_DIR = originalConfigDir;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup.
+    }
+  });
+
+  it("round-trips a saved entry", async () => {
+    const store = new TokenCacheStore();
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    const entry = {
+      accessToken: "tok",
+      expiresAt: Date.now() + 60_000,
+      ttlMs: 86_400_000,
+      ...id,
+    };
+
+    await store.save(entry);
+    const loaded = store.load({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    expect(loaded).toEqual(entry);
+  });
+
+  it("writes the cache file at <configDir>/.token-cache.json with mode 0o600", async () => {
+    // Pin the file path + permissions. The path is part of the public
+    // contract (`pax8 doctor` surfaces the same path) and 0o600 is the
+    // confidentiality guarantee — both must not drift unintentionally.
+    const store = new TokenCacheStore();
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    await store.save({
+      accessToken: "tok",
+      expiresAt: Date.now() + 60_000,
+      ttlMs: 86_400_000,
+      ...id,
+    });
+
+    const expected = path.join(dir, ".token-cache.json");
+    expect(TokenCacheStore.cacheFilePath).toBe(expected);
+    const stat = statSync(expected);
+    if (process.platform !== "win32") {
+      expect(stat.mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("returns null when the cache file is missing", () => {
+    const store = new TokenCacheStore();
+    expect(store.load({ clientId: CLIENT_ID, apiBaseUrl: API_BASE })).toBeNull();
+  });
+
+  it("returns null on a clientIdHash mismatch (credential rotation)", async () => {
+    const store = new TokenCacheStore();
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    await store.save({
+      accessToken: "tok",
+      expiresAt: Date.now() + 60_000,
+      ttlMs: 86_400_000,
+      ...id,
+    });
+
+    // Read back under a different clientId — must be null.
+    expect(store.load({ clientId: "rotated-client", apiBaseUrl: API_BASE })).toBeNull();
+  });
+
+  it("returns null on an apiBaseHash mismatch (prod↔staging switch)", async () => {
+    const store = new TokenCacheStore();
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    await store.save({
+      accessToken: "tok",
+      expiresAt: Date.now() + 60_000,
+      ttlMs: 86_400_000,
+      ...id,
+    });
+
+    expect(
+      store.load({ clientId: CLIENT_ID, apiBaseUrl: "https://api-staging.pax8.com/v1" }),
+    ).toBeNull();
+  });
+
+  it("normalizes trailing slashes on the API base URL when hashing", async () => {
+    // The TokenManager always passes the trailing-slash-stripped form;
+    // pin that the hash helper agrees so a future caller passing the
+    // raw env var doesn't blow up the round-trip.
+    const a = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: "https://api.pax8.com/v1" });
+    const b = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: "https://api.pax8.com/v1/" });
+    const c = computeCacheIdentity({
+      clientId: CLIENT_ID,
+      apiBaseUrl: "https://api.pax8.com/v1///",
+    });
+    expect(a.apiBaseHash).toBe(b.apiBaseHash);
+    expect(a.apiBaseHash).toBe(c.apiBaseHash);
+  });
+
+  it("does not store the raw clientId or apiBase on disk", async () => {
+    const store = new TokenCacheStore();
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    await store.save({
+      accessToken: "tok",
+      expiresAt: Date.now() + 60_000,
+      ttlMs: 86_400_000,
+      ...id,
+    });
+
+    const raw = readFileSync(path.join(dir, ".token-cache.json"), "utf-8");
+    expect(raw).not.toContain(CLIENT_ID);
+    expect(raw).not.toContain(API_BASE);
+    // The hash itself MUST be present, of course.
+    expect(raw).toContain(id.clientIdHash);
+  });
+
+  it("returns null on a corrupt JSON file (treated as cache miss)", () => {
+    writeFileSync(path.join(dir, ".token-cache.json"), "not json{", { mode: 0o600 });
+    const store = new TokenCacheStore();
+    expect(store.load({ clientId: CLIENT_ID, apiBaseUrl: API_BASE })).toBeNull();
+  });
+
+  it("returns null on a structurally-incomplete file (missing fields)", () => {
+    writeFileSync(
+      path.join(dir, ".token-cache.json"),
+      JSON.stringify({ accessToken: "tok" }),
+      { mode: 0o600 },
+    );
+    const store = new TokenCacheStore();
+    expect(store.load({ clientId: CLIENT_ID, apiBaseUrl: API_BASE })).toBeNull();
+  });
+
+  it("clear() removes the cache file and is idempotent", async () => {
+    const store = new TokenCacheStore();
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    await store.save({
+      accessToken: "tok",
+      expiresAt: Date.now() + 60_000,
+      ttlMs: 86_400_000,
+      ...id,
+    });
+
+    store.clear();
+    expect(store.load({ clientId: CLIENT_ID, apiBaseUrl: API_BASE })).toBeNull();
+
+    // Second clear must not throw — ENOENT is swallowed.
+    expect(() => store.clear()).not.toThrow();
+  });
+
+  it("checkPermissions() reports 'no token cache file' when missing", async () => {
+    const store = new TokenCacheStore();
+    const result = await store.checkPermissions();
+    expect(result.secure).toBe(true);
+    expect(result.detail).toContain("No token cache");
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "checkPermissions() reports insecure perms on Unix when group/other can read",
+    async () => {
+      // Bypass safeWriteFileSync (which would write 0o600) so we can
+      // pin a known-insecure mode for the doctor check.
+      const file = path.join(dir, ".token-cache.json");
+      writeFileSync(file, "{}", { mode: 0o644 });
+
+      const store = new TokenCacheStore();
+      const result = await store.checkPermissions();
+      expect(result.secure).toBe(false);
+      expect(result.detail).toContain("group/other have access");
+      expect(result.detail).toContain("chmod 600");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "checkPermissions() reports secure on Unix with mode 0o600",
+    async () => {
+      const store = new TokenCacheStore();
+      const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+      await store.save({
+        accessToken: "tok",
+        expiresAt: Date.now() + 60_000,
+        ttlMs: 86_400_000,
+        ...id,
+      });
+
+      const result = await store.checkPermissions();
+      expect(result.secure).toBe(true);
+      expect(result.detail).toContain("600");
+    },
+  );
+
+  it("save() is best-effort: a failure inside the write path does not throw", async () => {
+    // Point the store at a path that can't be written. We can't easily
+    // force a write failure with the real safeWriteFileSync, but we can
+    // force `mkdirSync` to fail by pointing at an existing regular file.
+    const collidingPath = path.join(dir, "blocking-file");
+    writeFileSync(collidingPath, "blocker", { mode: 0o644 });
+    process.env.PAX8_CONFIG_DIR = collidingPath;
+
+    const store = new TokenCacheStore();
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: API_BASE });
+    await expect(
+      store.save({
+        accessToken: "tok",
+        expiresAt: Date.now() + 60_000,
+        ttlMs: 86_400_000,
+        ...id,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/auth/token-cache-store.ts
+++ b/packages/core/src/auth/token-cache-store.ts
@@ -1,0 +1,328 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Persistent on-disk cache for the OAuth access token (#233).
+ *
+ * Every `pax8 <command>` invocation previously rebuilt a fresh `TokenManager`
+ * and hit `POST /v1/token` on its first API call — ~100-300 ms of pure auth
+ * latency per command, plus one of the 1000 req/min budget burned on auth.
+ * Pax8's own auth docs say: *"You should not need to request a new access
+ * token before every request."* This module persists the access token to
+ * disk (mirroring the `aws-cli` / `gcloud` / `gh` / `stripe-cli` pattern) so
+ * subsequent invocations of the CLI can reuse it until it's near expiry.
+ *
+ * Storage shape:
+ *
+ *   <configDir>/.token-cache.json   (mode 0o600, O_NOFOLLOW symlink-safe)
+ *
+ *   {
+ *     "accessToken": "...",
+ *     "expiresAt":   1715000000000,     // ms-since-epoch
+ *     "clientIdHash": "<sha256 hex>",   // hashed, not raw — auto-invalidates
+ *                                       // when `auth login` rotates clientId
+ *     "apiBaseHash":  "<sha256 hex>"    // hashed too — keeps prod/staging
+ *                                       // caches strictly separated
+ *   }
+ *
+ * Hashing instead of storing the raw `clientId` / `apiBase` means a `pax8
+ * auth login` with new credentials, or a `PAX8_API_BASE` toggle between
+ * prod and staging, automatically invalidates the cache without leaking
+ * the previous identity on disk. The hashes are compared byte-for-byte; a
+ * mismatch on either dimension is treated as "stale cache, refetch."
+ *
+ * No file locking. Concurrent invocations may both hit `/token`; last
+ * write wins on functionally-identical tokens.
+ *
+ * Out of scope here (deferred to v1.x): OS-keychain integration. The
+ * token-cache file uses the same 0o600 + O_NOFOLLOW protections as
+ * `credentials.json` — for a low-value (short-lived, fetchable-from-creds)
+ * token that's a reasonable place to start.
+ */
+
+import * as fs from "node:fs";
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { safeWriteFileSync } from "../security/safe-write.js";
+import { getConfigDir } from "../config/loader.js";
+
+const execFileAsync = promisify(execFile);
+
+const TOKEN_CACHE_FILENAME = ".token-cache.json";
+const isWindows = process.platform === "win32";
+
+/**
+ * On-disk shape of the token cache. All fields required; a partial file is
+ * treated as corrupt and ignored.
+ */
+export interface TokenCacheFile {
+  accessToken: string;
+  /** Absolute expiry timestamp in ms since Unix epoch. */
+  expiresAt: number;
+  /**
+   * Original token lifetime in ms (i.e. `expires_in * 1000` at mint time).
+   * Persisted so the refresh-skew buffer can be computed as `min(60s, 10% of
+   * ttl)` without re-deriving it from `expiresAt` + obtained-at — see
+   * `TokenManager`. Pax8 production returns `expires_in=86400` (so this is
+   * 86_400_000); the field is part of the on-disk shape so the buffer math
+   * stays stable across CLI invocations.
+   */
+  ttlMs: number;
+  /** SHA-256 hex of the clientId the token was minted for. */
+  clientIdHash: string;
+  /** SHA-256 hex of the API base URL the token was minted against. */
+  apiBaseHash: string;
+}
+
+export interface TokenCacheLookupKey {
+  clientId: string;
+  apiBaseUrl: string;
+}
+
+export interface PermissionCheckResult {
+  /** True iff permissions are tight enough to keep the token confidential. */
+  secure: boolean;
+  /** Short human-readable detail string — surfaced by `pax8 doctor`. */
+  detail: string;
+}
+
+function tokenCacheFile(): string {
+  return path.join(getConfigDir(), TOKEN_CACHE_FILENAME);
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Normalize an API base URL before hashing. Strips trailing slashes so a
+ * `PAX8_API_BASE=https://api.pax8.com/v1` and `…/v1/` resolve to the same
+ * cache partition. Mirrors the trailing-slash strip applied by `Pax8Client`
+ * and `getTokenUrl` so the hash key matches whatever the caller passes.
+ */
+function normalizeApiBase(raw: string): string {
+  return raw.replace(/\/+$/, "");
+}
+
+/**
+ * Compute the (clientIdHash, apiBaseHash) tuple for a lookup. Exported so
+ * callers (TokenManager) can attach the same values to the in-memory cache
+ * without recomputing.
+ */
+export function computeCacheIdentity(key: TokenCacheLookupKey): {
+  clientIdHash: string;
+  apiBaseHash: string;
+} {
+  return {
+    clientIdHash: sha256Hex(key.clientId),
+    apiBaseHash: sha256Hex(normalizeApiBase(key.apiBaseUrl)),
+  };
+}
+
+/**
+ * Persistent on-disk store for the OAuth access token.
+ *
+ * Stateless — every method re-resolves the config dir (honors
+ * `PAX8_CONFIG_DIR` set/unset between calls) and opens the file fresh.
+ */
+export class TokenCacheStore {
+  /** Resolved path to the on-disk cache file. */
+  static get cacheFilePath(): string {
+    return tokenCacheFile();
+  }
+
+  /**
+   * Read and validate the on-disk cache. Returns `null` for any failure mode
+   * — file missing, malformed JSON, missing fields, identity mismatch, or
+   * non-fatal I/O errors. The caller treats `null` as "fetch a fresh token."
+   *
+   * Identity matching: a cached entry is only returned when BOTH `clientIdHash`
+   * and `apiBaseHash` match the requested key. A mismatch on either dimension
+   * (rotated credentials, prod↔staging switch) is treated as a stale cache.
+   */
+  load(key: TokenCacheLookupKey): TokenCacheFile | null {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(tokenCacheFile(), "utf-8");
+    } catch {
+      // ENOENT is the common case (first run); EACCES / EISDIR / etc. are
+      // all "treat as no cache" too — failing softly here is the right
+      // call because the caller will refetch and overwrite.
+      return null;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+
+    if (!isTokenCacheFile(parsed)) return null;
+  // Defensive: a corrupt file with `ttlMs <= 0` would short-circuit the
+  // refresh-buffer math; refuse it before returning to the caller.
+  if (parsed.ttlMs <= 0) return null;
+
+    const expected = computeCacheIdentity(key);
+    if (
+      parsed.clientIdHash !== expected.clientIdHash ||
+      parsed.apiBaseHash !== expected.apiBaseHash
+    ) {
+      // Identity mismatch (credentials rotated or API base flipped). Caller
+      // will overwrite on the next save().
+      return null;
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Persist `entry` to disk with mode 0o600 and O_NOFOLLOW symlink protection
+   * (POSIX) / icacls hardening (Windows). The config dir is created if missing.
+   *
+   * Best-effort: write failures are swallowed. Rationale: the in-memory token
+   * is still valid for the current process, and a disk error (full disk,
+   * read-only fs, etc.) shouldn't fail the user's command. The next
+   * invocation will re-fetch a token and try writing again.
+   */
+  async save(entry: TokenCacheFile): Promise<void> {
+    const file = tokenCacheFile();
+    const dir = path.dirname(file);
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      // Permissions on the directory itself are owned by CredentialStore /
+      // safeWriteFileSync — we don't re-chmod here to avoid clobbering a
+      // previously-tightened parent.
+      safeWriteFileSync(file, JSON.stringify(entry));
+      if (isWindows) {
+        await this.secureFileWindows(file);
+      }
+    } catch {
+      // Best-effort. The in-memory token still works for this process.
+    }
+  }
+
+  /**
+   * Remove the on-disk cache. Used on `auth logout`, on 401 recovery, and
+   * by tests. Silent on ENOENT; propagates other errors so the caller can
+   * decide (e.g. logout surfaces a permission failure to the user).
+   */
+  clear(): void {
+    try {
+      fs.unlinkSync(tokenCacheFile());
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") return;
+      throw err;
+    }
+  }
+
+  /**
+   * Inspect the on-disk cache's permissions for `pax8 doctor`. Mirrors
+   * `CredentialStore.checkPermissions` — same shape so the doctor surface
+   * can render the result identically.
+   */
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    const file = tokenCacheFile();
+    try {
+      fs.accessSync(file, fs.constants.F_OK);
+    } catch {
+      return {
+        secure: true,
+        detail: "No token cache file (not yet authenticated)",
+      };
+    }
+    if (isWindows) {
+      return this.checkPermissionsWindows(file);
+    }
+    return this.checkPermissionsUnix(file);
+  }
+
+  private checkPermissionsUnix(file: string): PermissionCheckResult {
+    try {
+      const stat = fs.statSync(file);
+      const perms = stat.mode & 0o777;
+      if (perms === 0o600) {
+        return { secure: true, detail: "Permissions 600 (owner read/write only)" };
+      }
+      const groupOther = perms & 0o077;
+      if (groupOther !== 0) {
+        return {
+          secure: false,
+          detail: `Permissions ${perms.toString(8)} — group/other have access. Run: chmod 600 ${file}`,
+        };
+      }
+      return { secure: true, detail: `Permissions ${perms.toString(8)} (owner-only access)` };
+    } catch (err) {
+      return {
+        secure: false,
+        detail: `Could not stat token cache file: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  private async checkPermissionsWindows(file: string): Promise<PermissionCheckResult> {
+    try {
+      const { stdout } = await execFileAsync("icacls", [file]);
+      const homeDir = os.homedir();
+      const inUserDir = file.toLowerCase().startsWith(homeDir.toLowerCase());
+      if (!inUserDir) {
+        return { secure: false, detail: "Token cache file is outside user home directory" };
+      }
+      const insecurePatterns = ["BUILTIN\\Users", "Everyone", "Authenticated Users"];
+      const hasInsecureAcl = insecurePatterns.some(
+        (pattern) => stdout.includes(pattern) && !stdout.includes(`${pattern}:(DENY)`),
+      );
+      if (hasInsecureAcl) {
+        return {
+          secure: false,
+          detail: `File may be readable by other users. Run: icacls "${file}" /inheritance:r /grant:r "%USERNAME%:F"`,
+        };
+      }
+      return { secure: true, detail: "File ACLs restrict access (Windows)" };
+    } catch {
+      const homeDir = os.homedir();
+      const inUserDir = file.toLowerCase().startsWith(homeDir.toLowerCase());
+      if (inUserDir) {
+        return { secure: true, detail: "In user home directory (could not verify ACLs)" };
+      }
+      return {
+        secure: false,
+        detail: "Token cache file is outside user home directory and ACLs could not be verified",
+      };
+    }
+  }
+
+  private async secureFileWindows(file: string): Promise<void> {
+    try {
+      const username = os.userInfo().username;
+      await execFileAsync("icacls", [file, "/inheritance:r", "/grant:r", `${username}:(F)`]);
+    } catch {
+      // Best-effort. doctor will surface the warning later.
+    }
+  }
+}
+
+/**
+ * Type guard for the on-disk cache shape. Treats any missing or wrong-typed
+ * field as "not a cache file" — the caller falls back to a fresh fetch.
+ */
+function isTokenCacheFile(value: unknown): value is TokenCacheFile {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.accessToken === "string" &&
+    v.accessToken.length > 0 &&
+    typeof v.expiresAt === "number" &&
+    Number.isFinite(v.expiresAt) &&
+    typeof v.ttlMs === "number" &&
+    Number.isFinite(v.ttlMs) &&
+    typeof v.clientIdHash === "string" &&
+    v.clientIdHash.length > 0 &&
+    typeof v.apiBaseHash === "string" &&
+    v.apiBaseHash.length > 0
+  );
+}

--- a/packages/core/src/auth/token-cache-store.ts
+++ b/packages/core/src/auth/token-cache-store.ts
@@ -126,6 +126,14 @@ export function computeCacheIdentity(key: TokenCacheLookupKey): {
   clientIdHash: string;
   apiBaseHash: string;
 } {
+  // Reject a degenerate empty clientId. SHA-256 of the empty string is a
+  // valid hex digest that would silently match any other empty-clientId
+  // session — accidentally sharing a cache key across two callers that
+  // both forgot to plumb credentials. Better to fail loud here than
+  // surface a confusing cross-session token reuse later.
+  if (!key.clientId) {
+    throw new Error("computeCacheIdentity: clientId must be a non-empty string");
+  }
   return {
     clientIdHash: sha256Hex(key.clientId),
     apiBaseHash: sha256Hex(normalizeApiBase(key.apiBaseUrl)),

--- a/packages/core/src/auth/token-cache-store.ts
+++ b/packages/core/src/auth/token-cache-store.ts
@@ -102,9 +102,19 @@ function sha256Hex(input: string): string {
  * `PAX8_API_BASE=https://api.pax8.com/v1` and `…/v1/` resolve to the same
  * cache partition. Mirrors the trailing-slash strip applied by `Pax8Client`
  * and `getTokenUrl` so the hash key matches whatever the caller passes.
+ *
+ * Implementation: char-by-char loop instead of `replace(/\/+$/, "")`.
+ * The regex form is anchored and linear in practice, but CodeQL's static
+ * analysis flags the greedy `+` quantifier as polynomial-regex on
+ * uncontrolled input (js/polynomial-redos). The loop avoids the false
+ * positive without changing semantics — same input → same output.
  */
 function normalizeApiBase(raw: string): string {
-  return raw.replace(/\/+$/, "");
+  let end = raw.length;
+  while (end > 0 && raw.charCodeAt(end - 1) === 47 /* '/' */) {
+    end--;
+  }
+  return raw.slice(0, end);
 }
 
 /**

--- a/packages/core/src/auth/token-manager.test.ts
+++ b/packages/core/src/auth/token-manager.test.ts
@@ -5,13 +5,52 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TokenManager } from "./token-manager.js";
 import { AuthError } from "../api/errors.js";
 import { Pax8SecurityError } from "../security/validate-env.js";
+import {
+  TokenCacheStore,
+  computeCacheIdentity,
+  type TokenCacheFile,
+} from "./token-cache-store.js";
 
 const MOCK_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.mock-token";
 const CLIENT_ID = "test-client-id";
 const CLIENT_SECRET = "test-client-secret";
 
-function createManager() {
-  return new TokenManager({ clientId: CLIENT_ID, clientSecret: CLIENT_SECRET });
+/**
+ * In-memory `TokenCacheStore` stand-in. Lets each test exercise the
+ * TokenManager flow without touching the real filesystem. The pre-#233
+ * tests in this file are about in-memory cache behavior, so we wire a
+ * fresh empty stub for every test — anything that needs to assert on
+ * disk-write semantics is covered in `token-cache-store.test.ts`.
+ */
+class StubCacheStore extends TokenCacheStore {
+  public entry: TokenCacheFile | null = null;
+  public saveCount = 0;
+  public clearCount = 0;
+  override load(key: { clientId: string; apiBaseUrl: string }): TokenCacheFile | null {
+    if (!this.entry) return null;
+    // Mirror the real store's identity-match contract so the manager's
+    // hash-mismatch tests exercise the same code path.
+    const expected = computeCacheIdentity(key);
+    if (
+      this.entry.clientIdHash !== expected.clientIdHash ||
+      this.entry.apiBaseHash !== expected.apiBaseHash
+    ) {
+      return null;
+    }
+    return this.entry;
+  }
+  override async save(entry: TokenCacheFile): Promise<void> {
+    this.entry = entry;
+    this.saveCount++;
+  }
+  override clear(): void {
+    this.entry = null;
+    this.clearCount++;
+  }
+}
+
+function createManager(cacheStore: TokenCacheStore = new StubCacheStore()) {
+  return new TokenManager({ clientId: CLIENT_ID, clientSecret: CLIENT_SECRET, cacheStore });
 }
 
 describe("TokenManager", () => {
@@ -95,26 +134,50 @@ describe("TokenManager", () => {
     expect((error as AuthError).message).toContain("fetch failed");
   });
 
-  it("refreshes token when expired (past 23h)", async () => {
+  it("refreshes token when remaining lifetime drops inside the skew buffer", async () => {
+    // #233 — the refresh buffer is now `min(60s, 10% of ttl)`. For a 24 h
+    // production token that's 60 s. Advance past `24h - 60s + 1s` so the
+    // freshness check trips and the manager refetches.
     fetchSpy
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ access_token: "token-1" }), { status: 200 })
+        new Response(JSON.stringify({ access_token: "token-1", expires_in: 86400 }), { status: 200 })
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ access_token: "token-2" }), { status: 200 })
+        new Response(JSON.stringify({ access_token: "token-2", expires_in: 86400 }), { status: 200 })
       );
 
     const manager = createManager();
     const token1 = await manager.getToken();
     expect(token1).toBe("token-1");
 
-    // Advance time past the 23h refresh threshold
-    const TWENTY_THREE_HOURS = 23 * 60 * 60 * 1000;
-    vi.spyOn(Date, "now").mockReturnValue(Date.now() + TWENTY_THREE_HOURS + 1000);
+    // Twenty-four hours minus 59 seconds elapsed: the token has 59 s left,
+    // which is *inside* the 60 s skew buffer. Manager must refetch.
+    const ALMOST_FULL_TTL = 24 * 60 * 60 * 1000 - 59 * 1000;
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + ALMOST_FULL_TTL);
 
     const token2 = await manager.getToken();
     expect(token2).toBe("token-2");
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT refresh when remaining lifetime exceeds the skew buffer", async () => {
+    // Symmetric to the above: at 23 h elapsed on a 24 h token, we have 1 h
+    // remaining — well outside the 60 s buffer. The old (pre-#233) flat
+    // 1 h buffer would have refreshed here; the new policy must not.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN, expires_in: 86400 }), { status: 200 })
+    );
+
+    const manager = createManager();
+    await manager.getToken();
+
+    const TWENTY_THREE_HOURS = 23 * 60 * 60 * 1000;
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + TWENTY_THREE_HOURS);
+
+    const token2 = await manager.getToken();
+    expect(token2).toBe(MOCK_TOKEN);
+    // Only one fetch — the cache was still fresh.
+    expect(fetchSpy).toHaveBeenCalledOnce();
   });
 
   it("isAuthenticated() returns false initially", () => {
@@ -132,17 +195,19 @@ describe("TokenManager", () => {
     expect(manager.isAuthenticated()).toBe(true);
   });
 
-  it("isAuthenticated() returns false after token expires", async () => {
+  it("isAuthenticated() returns false after token enters the skew buffer", async () => {
+    // #233 — buffer is now 60 s on a 24 h Pax8 token. Advance to inside
+    // the buffer (24h - 59s) and the cache flips to "stale."
     fetchSpy.mockResolvedValueOnce(
-      new Response(JSON.stringify({ access_token: MOCK_TOKEN }), { status: 200 })
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN, expires_in: 86400 }), { status: 200 })
     );
 
     const manager = createManager();
     await manager.getToken();
     expect(manager.isAuthenticated()).toBe(true);
 
-    const TWENTY_THREE_HOURS = 23 * 60 * 60 * 1000;
-    vi.spyOn(Date, "now").mockReturnValue(Date.now() + TWENTY_THREE_HOURS + 1000);
+    const ALMOST_FULL_TTL = 24 * 60 * 60 * 1000 - 59 * 1000;
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + ALMOST_FULL_TTL);
 
     expect(manager.isAuthenticated()).toBe(false);
   });
@@ -313,5 +378,171 @@ describe("TokenManager + PAX8_API_BASE security (#234)", () => {
     } finally {
       writeSpy.mockRestore();
     }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #233 — persistent on-disk token cache
+// ──────────────────────────────────────────────────────────────────────────
+
+describe("TokenManager + on-disk cache (#233)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates the in-memory cache from a fresh-enough disk entry without re-fetching", async () => {
+    const store = new StubCacheStore();
+    const TWELVE_HOURS = 12 * 60 * 60 * 1000;
+    store.entry = {
+      accessToken: "from-disk",
+      expiresAt: Date.now() + TWELVE_HOURS,
+      ttlMs: 24 * 60 * 60 * 1000,
+      // Hash format must match what the manager computes for the test
+      // creds; verify the round-trip explicitly via the helper.
+      clientIdHash: "",
+      apiBaseHash: "",
+    };
+    // Compute the correct hashes via the same helper the manager uses.
+    const id = computeCacheIdentity({ clientId: CLIENT_ID, apiBaseUrl: "https://api.pax8.com/v1" });
+    store.entry.clientIdHash = id.clientIdHash;
+    store.entry.apiBaseHash = id.apiBaseHash;
+
+    const manager = createManager(store);
+    const token = await manager.getToken();
+
+    expect(token).toBe("from-disk");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores a disk entry whose clientIdHash does not match (credential rotation)", async () => {
+    const store = new StubCacheStore();
+    store.entry = {
+      accessToken: "from-disk",
+      expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      ttlMs: 24 * 60 * 60 * 1000,
+      clientIdHash: "not-the-current-hash",
+      apiBaseHash: "not-the-current-hash",
+    };
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: "fresh", expires_in: 86400 }), { status: 200 })
+    );
+
+    const manager = createManager(store);
+    const token = await manager.getToken();
+
+    // Disk entry rejected on identity mismatch; manager refetched.
+    expect(token).toBe("fresh");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("persists a fresh token to the cache store after fetch", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN, expires_in: 86400 }), { status: 200 })
+    );
+
+    const store = new StubCacheStore();
+    const manager = createManager(store);
+    await manager.getToken();
+    // The save call is fire-and-forget inside fetchToken; the stub
+    // updates synchronously inside `save`, so a microtask flush is
+    // enough to observe it.
+    await Promise.resolve();
+
+    expect(store.saveCount).toBe(1);
+    expect(store.entry?.accessToken).toBe(MOCK_TOKEN);
+    expect(store.entry?.ttlMs).toBe(86400 * 1000);
+    // The expiry should land in the future, roughly TTL away.
+    expect(store.entry?.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("falls back to the 24h default when /token omits expires_in", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN }), { status: 200 })
+    );
+
+    const store = new StubCacheStore();
+    const manager = createManager(store);
+    await manager.getToken();
+    await Promise.resolve();
+
+    expect(store.entry?.ttlMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("clearCache() wipes the on-disk entry and forces a refetch", async () => {
+    const store = new StubCacheStore();
+    fetchSpy
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "first", expires_in: 86400 }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "second", expires_in: 86400 }), { status: 200 })
+      );
+
+    const manager = createManager(store);
+    expect(await manager.getToken()).toBe("first");
+    await Promise.resolve();
+    expect(store.entry?.accessToken).toBe("first");
+
+    manager.clearCache();
+    expect(store.clearCount).toBe(1);
+    expect(store.entry).toBeNull();
+
+    // Even though we'd otherwise hit the in-memory cache, `forceRefetch`
+    // forces the network round trip.
+    expect(await manager.getToken()).toBe("second");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("clearCache() does not throw when the disk clear fails", async () => {
+    class ThrowingStore extends TokenCacheStore {
+      override load(): null {
+        return null;
+      }
+      override async save(): Promise<void> {
+        // no-op
+      }
+      override clear(): never {
+        throw new Error("EPERM: simulated");
+      }
+    }
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN, expires_in: 86400 }), { status: 200 })
+    );
+
+    const manager = new TokenManager({
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+      cacheStore: new ThrowingStore(),
+    });
+    await manager.getToken();
+
+    // Must not throw.
+    expect(() => manager.clearCache()).not.toThrow();
+    // In-memory still cleared.
+    expect(manager.isAuthenticated()).toBe(false);
+  });
+
+  it("clearToken() does NOT touch the on-disk cache (back-compat)", async () => {
+    const store = new StubCacheStore();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: MOCK_TOKEN, expires_in: 86400 }), { status: 200 })
+    );
+
+    const manager = createManager(store);
+    await manager.getToken();
+    await Promise.resolve();
+    expect(store.entry).not.toBeNull();
+
+    manager.clearToken();
+    // On-disk untouched.
+    expect(store.clearCount).toBe(0);
+    expect(store.entry).not.toBeNull();
   });
 });

--- a/packages/core/src/auth/token-manager.ts
+++ b/packages/core/src/auth/token-manager.ts
@@ -38,7 +38,12 @@ const DEFAULT_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
  * 4.5 minutes of usable cache.
  */
 function refreshBufferForTtl(ttlMs: number): number {
-  return Math.min(60_000, Math.floor(ttlMs * 0.1));
+  // Floor at 1s — a misconfigured auth server returning a 1-9 second
+  // expires_in would otherwise collapse the buffer to 0ms and let
+  // requests race the server clock into avoidable 401 flakes. The
+  // 401-retry path recovers from that, but a 1s buffer is essentially
+  // free defense-in-depth that keeps the proactive-refresh path warm.
+  return Math.max(1000, Math.min(60_000, Math.floor(ttlMs * 0.1)));
 }
 
 interface TokenManagerOptions {
@@ -240,12 +245,16 @@ export class TokenManager {
     }
 
     // Honor `expires_in` from the response (seconds, per OAuth2). Production
-    // returns 86400. A missing / non-numeric / non-positive value falls back
-    // to the 24 h default so we never end up with a token cached at a
-    // negative or zero TTL.
+    // returns 86400 (24h). A missing / non-numeric / non-positive value
+    // falls back to the 24h default so we never end up with a token cached
+    // at a negative or zero TTL. A value > 24h is clamped — defense-in-
+    // depth against a misbehaving or compromised auth endpoint persisting
+    // an unexpectedly long-lived token to disk, where it would survive
+    // 24h+ across CLI invocations.
+    const MAX_TTL_SEC = 24 * 60 * 60; // 86400
     const expiresInSec =
       typeof body.expires_in === "number" && Number.isFinite(body.expires_in) && body.expires_in > 0
-        ? body.expires_in
+        ? Math.min(body.expires_in, MAX_TTL_SEC)
         : DEFAULT_TOKEN_TTL_MS / 1000;
     const ttlMs = expiresInSec * 1000;
     const expiresAt = Date.now() + ttlMs;

--- a/packages/core/src/auth/token-manager.ts
+++ b/packages/core/src/auth/token-manager.ts
@@ -3,41 +3,106 @@
 
 import { AuthError } from "../api/errors.js";
 import { getDefaultBaseUrl } from "../api/client.js";
+import {
+  TokenCacheStore,
+  computeCacheIdentity,
+  type TokenCacheFile,
+} from "./token-cache-store.js";
+
+function getTokenBaseUrl(): string {
+  return getDefaultBaseUrl().replace(/\/+$/, "");
+}
 
 function getTokenUrl(): string {
-  return getDefaultBaseUrl().replace(/\/+$/, "") + "/token";
+  return getTokenBaseUrl() + "/token";
 }
-const TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const REFRESH_BUFFER_MS = 1 * 60 * 60 * 1000; // 1 hour buffer — refresh at 23h
-const REFRESH_AT_MS = TOKEN_TTL_MS - REFRESH_BUFFER_MS;
+
+/**
+ * Fallback TTL applied when the `/token` response is missing `expires_in`.
+ * Pax8's production endpoint returns `expires_in: 86400` (24h); this floor
+ * is what the previous (in-memory-only) cache assumed.
+ */
+const DEFAULT_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Refresh-skew buffer used by the cache freshness check. We refresh the
+ * token early so that a request issued *just* before the wire-side expiry
+ * doesn't race the server's clock — the network round trip plus the API
+ * call could easily land after `expiresAt` if we cut it to zero.
+ *
+ * Old (#233) constant: a flat 1h buffer, regardless of TTL. That inverted
+ * behavior for any TTL under 1h — every call would refresh-on-every-call,
+ * defeating the cache entirely. The new policy: 60 s OR 10 % of the TTL,
+ * whichever is *smaller*. For Pax8's 24 h tokens this is 60 s. For a
+ * hypothetical 5-minute test token it becomes 30 s (10 %), still leaving
+ * 4.5 minutes of usable cache.
+ */
+function refreshBufferForTtl(ttlMs: number): number {
+  return Math.min(60_000, Math.floor(ttlMs * 0.1));
+}
 
 interface TokenManagerOptions {
   clientId: string;
   clientSecret: string;
+  /**
+   * Optional injectable on-disk cache store. Defaults to a fresh
+   * `TokenCacheStore`. Exposed for tests that want to assert on
+   * `save` / `load` / `clear` call shape without touching the
+   * real filesystem.
+   */
+  cacheStore?: TokenCacheStore;
 }
 
 interface CachedToken {
   accessToken: string;
-  obtainedAt: number;
+  /** Absolute expiry in ms since epoch; matches the on-disk shape. */
+  expiresAt: number;
+  /** Original lifetime in ms (i.e. `expires_in * 1000`). Drives the refresh buffer. */
+  ttlMs: number;
 }
 
 export class TokenManager {
   private readonly clientId: string;
   private readonly clientSecret: string;
+  private readonly cacheStore: TokenCacheStore;
   private cachedToken: CachedToken | null = null;
   private pendingRequest: Promise<string> | null = null;
+  /**
+   * If true, the next `getToken()` call skips the in-memory + on-disk caches
+   * and fetches a fresh token. Set by `clearCache()` (e.g. on a 401 from a
+   * downstream API call). Re-armed automatically after a successful refetch.
+   */
+  private forceRefetch = false;
 
   constructor(options: TokenManagerOptions) {
     this.clientId = options.clientId;
     this.clientSecret = options.clientSecret;
+    this.cacheStore = options.cacheStore ?? new TokenCacheStore();
   }
 
   async getToken(): Promise<string> {
-    if (this.cachedToken && !this.isExpired()) {
+    // 1. In-memory fast path.
+    if (!this.forceRefetch && this.cachedToken && !this.isExpired(this.cachedToken)) {
       return this.cachedToken.accessToken;
     }
 
-    // Deduplicate concurrent requests
+    // 2. On-disk cache. Hydrate the in-memory cache from a fresh-enough
+    //    entry so subsequent calls within this process hit path (1).
+    if (!this.forceRefetch) {
+      const fromDisk = this.loadFromDisk();
+      if (fromDisk) {
+        this.cachedToken = {
+          accessToken: fromDisk.accessToken,
+          expiresAt: fromDisk.expiresAt,
+          ttlMs: fromDisk.ttlMs,
+        };
+        return fromDisk.accessToken;
+      }
+    }
+
+    // 3. Network. Deduplicate concurrent requests so parallel callers
+    //    (subscriptions+invoices+orders fired in parallel by `pax8 today`)
+    //    share a single token exchange.
     if (this.pendingRequest) {
       return this.pendingRequest;
     }
@@ -52,18 +117,72 @@ export class TokenManager {
   }
 
   isAuthenticated(): boolean {
-    return this.cachedToken !== null && !this.isExpired();
+    return this.cachedToken !== null && !this.isExpired(this.cachedToken);
   }
 
+  /**
+   * Clear the in-memory cached token. Backwards-compatible alias for the
+   * pre-#233 surface; does NOT touch the on-disk cache. Use `clearCache()`
+   * for the full wipe (in-memory + disk).
+   */
   clearToken(): void {
     this.cachedToken = null;
     this.pendingRequest = null;
   }
 
-  private isExpired(): boolean {
-    if (!this.cachedToken) return true;
-    const elapsed = Date.now() - this.cachedToken.obtainedAt;
-    return elapsed >= REFRESH_AT_MS;
+  /**
+   * Full cache wipe: drop the in-memory entry AND delete the on-disk file.
+   * Called from `Pax8Client` on a 401 response so a server-side token
+   * revocation doesn't hang the CLI for the rest of the TTL, and from
+   * `CredentialStore.clearCredentials` so `pax8 auth logout` doesn't leave
+   * a stale token paired with the wiped credentials.
+   *
+   * The next `getToken()` call after this is guaranteed to re-fetch from
+   * the network — the on-disk file is gone AND `forceRefetch` is set, so
+   * even a concurrent invocation that writes a new cache mid-call won't
+   * shortcut us back to a stale token.
+   */
+  clearCache(): void {
+    this.cachedToken = null;
+    this.pendingRequest = null;
+    this.forceRefetch = true;
+    try {
+      this.cacheStore.clear();
+    } catch {
+      // Best-effort: a permission error on disk shouldn't fail the calling
+      // command. The in-memory clear already happened.
+    }
+  }
+
+  private isExpired(entry: CachedToken): boolean {
+    const remaining = entry.expiresAt - Date.now();
+    if (remaining <= 0) return true;
+    // The buffer is keyed to the token's *original* lifetime (`ttlMs`), not
+    // its remaining time, so the cache stays usable for most of the token's
+    // life and only flips to "refresh me" near the end. For a 24 h Pax8
+    // token: `min(60s, 10% of 24h)` = 60 s. For a hypothetical 5-minute
+    // test token: `min(60s, 30s)` = 30 s.
+    const buffer = refreshBufferForTtl(entry.ttlMs);
+    return remaining <= buffer;
+  }
+
+  private loadFromDisk(): TokenCacheFile | null {
+    const apiBaseUrl = getTokenBaseUrl();
+    const entry = this.cacheStore.load({ clientId: this.clientId, apiBaseUrl });
+    if (!entry) return null;
+    // Apply the same freshness check we use for in-memory entries. A cache
+    // file that's older than the skew buffer is treated as a miss; the
+    // caller will refetch and overwrite.
+    if (
+      this.isExpired({
+        accessToken: entry.accessToken,
+        expiresAt: entry.expiresAt,
+        ttlMs: entry.ttlMs,
+      })
+    ) {
+      return null;
+    }
+    return entry;
   }
 
   private async fetchToken(): Promise<string> {
@@ -120,10 +239,33 @@ export class TokenManager {
       throw new AuthError("Invalid response from Pax8 auth server: missing access_token");
     }
 
-    this.cachedToken = {
+    // Honor `expires_in` from the response (seconds, per OAuth2). Production
+    // returns 86400. A missing / non-numeric / non-positive value falls back
+    // to the 24 h default so we never end up with a token cached at a
+    // negative or zero TTL.
+    const expiresInSec =
+      typeof body.expires_in === "number" && Number.isFinite(body.expires_in) && body.expires_in > 0
+        ? body.expires_in
+        : DEFAULT_TOKEN_TTL_MS / 1000;
+    const ttlMs = expiresInSec * 1000;
+    const expiresAt = Date.now() + ttlMs;
+
+    this.cachedToken = { accessToken, expiresAt, ttlMs };
+    this.forceRefetch = false;
+
+    // Persist asynchronously. We don't await because the in-memory token is
+    // already returnable; the write is purely a hint for the next process.
+    const identity = computeCacheIdentity({
+      clientId: this.clientId,
+      apiBaseUrl: getTokenBaseUrl(),
+    });
+    void this.cacheStore.save({
       accessToken,
-      obtainedAt: Date.now(),
-    };
+      expiresAt,
+      ttlMs,
+      clientIdHash: identity.clientIdHash,
+      apiBaseHash: identity.apiBaseHash,
+    });
 
     return accessToken;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -207,6 +207,8 @@ export type {
 export { TokenManager } from "./auth/token-manager.js";
 export { CredentialStore } from "./auth/credential-store.js";
 export type { Credentials, PermissionCheckResult } from "./auth/credential-store.js";
+export { TokenCacheStore } from "./auth/token-cache-store.js";
+export type { TokenCacheFile, TokenCacheLookupKey } from "./auth/token-cache-store.js";
 
 // ─── Services: computed business logic over the API ─────────────────────────
 


### PR DESCRIPTION
## Summary

Persists the OAuth access token to disk so subsequent `pax8 <command>` invocations don't re-hit `POST /v1/token`. Closes #233.

Today every CLI invocation builds a fresh `TokenManager`, fires `/token` on its first API call, and discards the token at process exit — ~100-300 ms of pure auth latency per command plus one of the 1000 req/min budget burned on auth. Pax8's own auth docs explicitly say partners shouldn't be re-requesting a token per call. This PR mirrors the `aws-cli` / `gcloud` / `gh` / `stripe-cli` pattern by writing the token to `<configDir>/.token-cache.json` with the same 0600 / O_NOFOLLOW / icacls hardening the credentials file gets.

## What's in scope

- New `TokenCacheStore` in `@pax8/core` — uses the existing `safeWriteFileSync` helper, honors `PAX8_CONFIG_DIR`, exported from the public surface.
- Cache shape: `{ accessToken, expiresAt, ttlMs, clientIdHash, apiBaseHash }`. SHA-256 of `clientId` and the (trailing-slash-normalized) API base URL — never raw — so an `auth login` with new creds or a prod↔staging `PAX8_API_BASE` switch auto-invalidates the cache without leaking the prior identity on disk.
- `TokenManager.getToken()` flow: memory → disk hydrate (with hash-match + freshness check) → network. `expires_in` from the response is honored (Pax8 returns 86400, with a 24 h fallback). Cache writes are fire-and-forget and best-effort.
- Refresh-skew buffer is `min(60s, 10% of TTL)` — replaces the previous flat 1 h buffer that inverted (refresh-on-every-call) for any TTL under 1 h.
- `Pax8Client.request` does a single-shot retry on 401: calls `tokenManager.clearCache()` (memory + disk), re-fetches a fresh token, retries the request once. Second 401 surfaces as `ApiError`.
- `CredentialStore.clearCredentials()` also wipes the on-disk token cache so `pax8 auth logout` doesn't leave a stale token paired with cleared credentials.
- `pax8 doctor` adds a new "Token cache file permissions" check mirroring the existing credentials-file probe.

## What's out of scope

- OS-keychain integration (deferred to v1.x).
- Forced-refresh CLI flag.

## Decisions worth a sanity check

- **PAX8_API_BASE in the cache key**: hashed as `apiBaseHash` alongside `clientIdHash`. A partner flipping between prod and staging will get cache misses both ways — intentional, since reusing a prod token against a staging endpoint (or vice-versa) is exactly the bug we want to prevent.
- **401 retry placement**: between the 429 and 5xx handlers in `Pax8Client.request`. Single-shot, gated by a `retriedAfterAuthClear` flag so a genuine 401 (revoked creds, wrong scopes) still surfaces cleanly. Safe for non-idempotent methods because a 401 means the server *rejected* the request before processing — same reasoning as 429.
- **`clearCache()` is a new optional hook** on the `TokenManagerLike` interface — embedders that bring their own token manager don't have to implement it. `Pax8Client` uses optional chaining.
- **`ttlMs` persisted on disk** in addition to `expiresAt`, so the refresh-skew math doesn't have to reconstruct the original lifetime from `obtainedAt` (which we'd otherwise have to persist too).

## Test plan

- [x] `pnpm test` (142 files / 2394 passing)
- [x] `pnpm lint` (no new warnings)
- [x] `npx tsc --noEmit -p packages/core/tsconfig.json` clean
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` clean
- [x] Manual smoke: `PAX8_DEMO=1 node packages/cli/dist/index.js --help` and `pax8 doctor` both behave; new permission check renders in the doctor output.
- [x] New unit tests cover: round-trip persistence, hash-mismatch invalidation (clientId + apiBase), corrupt-file fallback, mode 0600 enforcement on POSIX, `clearCache` (with throwing-store edge case), the 401 retry shape (single-shot, fresh Authorization header on retry), and the 403-doesn't-clear boundary.

## In passing (NOT for this PR)

- `client.test.ts` has a 401-bearing redaction test that I left alone — it still works because the retry consumes both queued mock responses, but it'd be a tiny bit cleaner to use 403 there. Worth a follow-up tidy if anyone else is in that file.