### PR TITLE
fix(confirm): clarify [y/n/c] → [y/n/e] for confirmWithChange

### DIFF
--- a/docs/UX_GUIDE.md
+++ b/docs/UX_GUIDE.md
@@ -257,7 +257,7 @@ Three helpers in `packages/cli/src/lib/confirm.ts`:
 | Helper | Use for |
 |---|---|
 | `confirm(msg, {default})` | Standard `[y/n]` — most writes. |
-| `confirmWithChange(msg, currentValue, {label})` | `[y/n/c]` — lets the user edit a numeric value (e.g. quantity) inline before confirming. |
+| `confirmWithChange(msg, currentValue, {label})` | `[y/n/e]` — `e` opens an inline edit for a numeric value (e.g. quantity) before confirming. The letter is `e` (edit), not `c` — a `c` reads as "cancel" to most partners and inverts the meaning. |
 | `confirmDestructive(msg, keyword)` | User must type an exact keyword. Reserved for cancellations and deletes. |
 
 For **batched writes** where the partner has many similar candidates (e.g. `pax8 recommendations act` walking high-priority recs), use the `prompts` multi-select + single batch confirm rather than N per-item `confirm()` prompts:
@@ -285,7 +285,7 @@ Show the user what they're about to do, in plain English with concrete numbers, 
     Microsoft 365 Business Premium × 25 seats
     $22.00/seat/mo · $550.00/mo · annual billing
 
-  Place this order? [y/n/c]
+  Place this order? [y/n/e]
 ```
 
 ---

--- a/packages/cli/src/commands/orders/create.ts
+++ b/packages/cli/src/commands/orders/create.ts
@@ -631,7 +631,7 @@ Examples:
       process.stderr.write("\n");
 
       // ── Confirmation ──
-      // Single-line, non-dry-run keeps the existing [y/n/c] flow that lets
+      // Single-line, non-dry-run keeps the existing [y/n/e] flow that lets
       // users edit the quantity inline. Multi-line and dry-run use a simple
       // [y/n] — there's no single quantity to edit in multi-line, and a
       // dry-run wants to lock the input as-is so the validation reflects

--- a/packages/cli/src/lib/confirm.test.ts
+++ b/packages/cli/src/lib/confirm.test.ts
@@ -229,35 +229,50 @@ describe("confirmWithChange", () => {
     expect(result).toBe(5);
   });
 
-  it("prompts for change when 'c' picked, then accepts new value", async () => {
-    // Three sequential prompts: 'c', '7', '' (empty re-confirm = accept).
-    answerQueue.push("c", "7", "");
+  it("prompts for edit when 'e' picked, then accepts new value", async () => {
+    // Three sequential prompts: 'e', '7', '' (empty re-confirm = accept).
+    answerQueue.push("e", "7", "");
     const result = await confirmWithChange("Confirm 5?", 5);
     expect(result).toBe(7);
   });
 
-  it("returns null when 'change' answer is invalid", async () => {
-    answerQueue.push("c", "not-a-number");
+  it("also accepts the full word 'edit' (back-compat shape with 'change')", async () => {
+    answerQueue.push("edit", "9", "");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBe(9);
+  });
+
+  it("returns null when 'edit' answer is invalid", async () => {
+    answerQueue.push("e", "not-a-number");
     const result = await confirmWithChange("Confirm 5?", 5);
     expect(result).toBeNull();
   });
 
   it("returns null when re-confirmation rejects the new value", async () => {
-    answerQueue.push("c", "8", "n");
+    answerQueue.push("e", "8", "n");
     const result = await confirmWithChange("Confirm 5?", 5);
     expect(result).toBeNull();
   });
 
-  it("returns null when 'change' answer is zero or negative", async () => {
-    answerQueue.push("c", "0");
+  it("returns null when 'edit' answer is zero or negative", async () => {
+    answerQueue.push("e", "0");
     const result = await confirmWithChange("Confirm 5?", 5);
     expect(result).toBeNull();
   });
 
-  it("returns the existing value when 'change' answer is empty", async () => {
-    answerQueue.push("c", "");
+  it("returns the existing value when 'edit' answer is empty", async () => {
+    answerQueue.push("e", "");
     const result = await confirmWithChange("Confirm 5?", 5);
     expect(result).toBe(5);
+  });
+
+  // Regression: pre-fix `c` was the edit letter. After this PR `c` is
+  // no longer recognized — treated as "neither yes nor edit" and
+  // returns null (same disposition as `n`). Documents the clean break.
+  it("treats the old 'c' letter as a rejection (no longer entering edit)", async () => {
+    answerQueue.push("c");
+    const result = await confirmWithChange("Confirm 5?", 5);
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/cli/src/lib/confirm.ts
+++ b/packages/cli/src/lib/confirm.ts
@@ -54,9 +54,18 @@ export async function confirm(
 }
 
 /**
- * Confirm with an option to change a numeric value (e.g. quantity).
+ * Confirm with an option to edit a numeric value (e.g. quantity).
  * Returns the confirmed value, or null if cancelled.
- * [y] confirms default, [c] prompts for new value, [n] cancels.
+ *
+ * Prompt is `[y/n/e]` where the letters mean:
+ *   y — accept the current value (also: empty enter = accept)
+ *   n — reject (returns null) — readable as "no" or "cancel"
+ *   e — edit the value, then re-confirm
+ *
+ * The historical letter was `c` (for "change"), which read as "cancel"
+ * to many partners and produced an inverted-intent gotcha (typing what
+ * felt like "abort" actually entered the edit flow). `e` removes the
+ * ambiguity — same shape, clearer meaning.
  */
 export async function confirmWithChange(
   message: string,
@@ -65,10 +74,10 @@ export async function confirmWithChange(
 ): Promise<number | null> {
   if (shouldAutoConfirm()) return currentValue;
 
-  const answer = await prompt(`  ${message} [y/n/c] `);
+  const answer = await prompt(`  ${message} [y/n/e] `);
   const a = answer.toLowerCase();
 
-  if (a === "c" || a === "change") {
+  if (a === "e" || a === "edit") {
     const label = options?.label ?? "Quantity";
     const newAnswer = await prompt(`  ${label}? [${currentValue}] `);
     if (newAnswer === "") return currentValue;


### PR DESCRIPTION
## Summary

The historical `c` for "change" reads as **cancel** to most partners and inverts intent — typing what feels like "abort the order" actually enters the edit flow. Replace with `e` for "edit", which is unambiguous and matches the standard interactive-CLI convention (`git rebase -i`, `vim`, etc).

## Behavioral change

Clean break — `c` is no longer recognized and falls through to the "neither yes nor edit" branch (returns null, same disposition as `n`). v0.x has no muscle-memory contract to preserve, and accepting both letters would perpetuate the ambiguity this PR is fixing.

`e` and the full word `edit` are both accepted.

## Sites updated

- `packages/cli/src/lib/confirm.ts` — prompt label changed to `[y/n/e]`; accepts `e` or `edit`
- `packages/cli/src/lib/confirm.test.ts` — 6 test cases pivoted to `e`, plus **two new regressions**:
  - full-word `edit` alias works
  - old `c` letter returns null (pins the clean-break contract)
- `packages/cli/src/commands/orders/create.ts` — comment reference
- `docs/UX_GUIDE.md` — §7 table entry + the §7 example snippet, with one sentence explaining why the letter changed

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm test packages/cli/src/lib/confirm.test.ts` — 34 pass (was 32)
- [x] `pnpm test packages/cli/src/__tests__/orders.test.ts` — 46 pass (exercises the order-create confirmation flow)
- [x] Manual: `PAX8_DEMO=1 pax8 orders create --company "Acme Corp" --product "Microsoft 365 Business Premium" --quantity 5` — prompt now reads `[y/n/e]`; typing `e` opens the edit, `c` is rejected

## Note on unrelated CI

The `license-consistency.test.ts` flake some PRs are seeing today is caused by stale `.claude/worktrees/...` agent directories on the test machine leaking into the scan. It fires on `main` independently of this PR.