### PR TITLE
fix(cli): UXR Track 1 — recs recovery hint + product-name picker

### DIFF
--- a/packages/cli/src/__tests__/products.test.ts
+++ b/packages/cli/src/__tests__/products.test.ts
@@ -169,6 +169,44 @@ describe("pax8 products", () => {
       expect(data.products).toEqual([]);
       expect(data.page.totalElements).toBe(0);
     });
+
+    // UXR F7 (#653): the human table doesn't expose product IDs, so the
+    // "Try next" picker must not surface a raw ID either — labels use the
+    // product name, and the numeric pick spawns `products show` silently.
+    // (The numbered menu itself only renders under a TTY — see
+    // `promptNextSteps` in lib/next-step.ts — so we assert on the "Try
+    // next:" header and the no-ID contract, not the numbered rows.)
+    it("table mode does not leak product IDs into the next-step affordance", async () => {
+      const result = await runCli(
+        ["products", "search", "microsoft"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined).not.toMatch(
+        /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+      );
+      expect(combined).not.toMatch(/pax8 products show prod-/);
+      expect(combined).toContain("Try next:");
+    });
+
+    // Contract: `--json` output shape is machine-facing and byte-stable —
+    // the human-surface fix above must not perturb it.
+    it("--json output shape is unchanged by the picker refactor", async () => {
+      const result = await runCliExpectSuccess([
+        "products",
+        "search",
+        "microsoft",
+        "--json",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("products");
+      expect(data).toHaveProperty("page");
+      // Every product still carries its id — machine consumers rely on it.
+      for (const p of data.products) {
+        expect(p).toHaveProperty("id");
+        expect(p).toHaveProperty("name");
+      }
+    });
   });
 
   describe("products --help", () => {

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -254,6 +254,21 @@ describe("pax8 recommendations", () => {
       expect(allRecs.length).toBe(defaultRecs.length);
     });
 
+    // UXR F6 (#652): the hidden-count footer used to end at "no orderable
+    // products in catalog yet" with no follow-up command. Participants
+    // treated it as a dead end. The mixed-case footer now surfaces the
+    // same --include-all recovery hint the empty-state branch already
+    // uses. Large-scale demo fixture has hidden recs; the small default
+    // fixture doesn't, so this test flips PAX8_DEMO_SCALE.
+    it("table mode surfaces --include-all when hidden recs are trimmed", async () => {
+      const result = await runCliExpectSuccess(
+        ["recommendations", "list", "--top", "0"],
+        { PAX8_OUTPUT_FORMAT: "table", PAX8_DEMO_SCALE: "large" },
+      );
+      expect(result.stderr).toMatch(/more recommendations? hidden/);
+      expect(result.stderr).toMatch(/--include-all/);
+    });
+
     // #521 footer hint: when the cap fires, table mode must tell the
     // partner that there's more behind the curtain and how to widen it.
     // Forcing table mode via PAX8_OUTPUT_FORMAT because a non-TTY stdout

--- a/packages/cli/src/commands/products/search.ts
+++ b/packages/cli/src/commands/products/search.ts
@@ -109,17 +109,21 @@ Examples:
       if (ctx.outputFormat === "table") {
         process.stderr.write(chalk.dim(`\n  ${matches.length} products\n`));
         if (matches.length > 0) {
-          const first = matches[0] as Record<string, unknown>;
-          // Pickable next step: drill into the top match. `orders create`
-          // needs --company (a value the user has to choose) so it can't be
-          // pickable — surfaced as an affordance pointer below.
-          const steps: NextStep[] = [
-            {
-              key: "1",
-              label: `${chalk.cyan(replCmd(`pax8 products show ${String(first.id)}`))}  ${chalk.dim("view details & pricing")}`,
-              command: ["products", "show", String(first.id)],
-            },
-          ];
+          // UXR F7 (#653): participants couldn't identify the ID to pass to
+          // `pax8 products show` because the table doesn't expose it and the
+          // previous next-step only surfaced the top match's UUID. Now we
+          // pick with product NAME (which is in the table) and let the
+          // command spawn the id silently. Top 5 covers the choice space
+          // without turning into a second table.
+          const pickable = matches.slice(0, 5);
+          const steps: NextStep[] = pickable.map((p, i) => {
+            const rec = p as Record<string, unknown>;
+            return {
+              key: String(i + 1),
+              label: `${chalk.cyan(String(rec.name))}  ${chalk.dim("— view details & pricing")}`,
+              command: ["products", "show", String(rec.id)],
+            };
+          });
           process.stderr.write(chalk.dim("\n  Try next:\n"));
           await promptNextSteps(steps, { renderList: true });
           process.stderr.write(

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -457,7 +457,11 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
       }
 
       if (hiddenCount > 0) {
-        process.stderr.write(chalk.dim(`  ${hiddenCount} more recommendation${hiddenCount > 1 ? "s" : ""} hidden — no orderable products in catalog yet\n`));
+        process.stderr.write(
+          chalk.dim(`  ${hiddenCount} more recommendation${hiddenCount > 1 ? "s" : ""} hidden — no orderable products in catalog yet · run with `) +
+          chalk.cyan("--include-all") +
+          chalk.dim(" to see them\n")
+        );
       }
 
       // Suggest recommendations act


### PR DESCRIPTION
## Summary

Two UXR-driven bug fixes from the 2026-07-02 readout. Full context in the [Notion review](https://app.notion.com/p/3918fa2a9e288124b6d4ed20bdc73cdd) and the tracking issue at #661.

- **Fixes #652** — `recommendations list` hidden-count footer now surfaces `--include-all` as the recovery command instead of terminating on a dead-end message.
- **Fixes #653** — `products search` "Try next" picker labels now use product names (which are in the table) instead of raw UUIDs, and covers the top 5 matches instead of only the top 1. `--json` shape unchanged.

**Note on the third UXR bug (F10 / #654):** the `[y/n/c]` shorthand issue shipped independently in #651 as `[y/n/e]` two days ago (arrived at the same insight without seeing the readout). Closed #654 as resolved-by-#651 rather than layering a competing label change on top.

## Test plan

- [x] `pnpm build && pnpm test` — 2400 pass, 0 fail on the merged tree.
- [x] `pnpm lint` — only pre-existing warnings, 0 new.
- [x] Manual: `PAX8_DEMO=1 PAX8_DEMO_SCALE=large PAX8_OUTPUT_FORMAT=table pax8 recommendations list --top 0` — footer reads `365 more recommendations hidden — no orderable products in catalog yet · run with --include-all to see them`.
- [x] Manual: `PAX8_DEMO=1 PAX8_OUTPUT_FORMAT=table pax8 products search microsoft` — table shows no ID column, no UUIDs appear anywhere, "Try next:" header renders.
- [x] Manual: `PAX8_DEMO=1 pax8 products search microsoft --json | jq '.products[0] | {id, name}'` — JSON envelope unchanged; every product still carries its `id`.
- [x] Unit tests added for each fix (`recommendations.test.ts`, `products.test.ts`).