### PR TITLE
feat(cli): pax8 explain <term> — built-in glossary (UXR F8)

### DIFF
--- a/packages/cli/src/__tests__/explain.test.ts
+++ b/packages/cli/src/__tests__/explain.test.ts
@@ -1,0 +1,184 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { runCliExpectSuccess, runCliExpectFailure } from "./test-utils.js";
+
+// Force table mode where we assert on the human render. Without this,
+// the subprocess sees a non-TTY stdout and getOutputFormat() falls back
+// to JSON.
+const TABLE = { PAX8_OUTPUT_FORMAT: "table" as const };
+
+describe("pax8 explain", () => {
+  describe("basic lookup", () => {
+    it("renders the canonical entry for a known term (text mode)", async () => {
+      const result = await runCliExpectSuccess(["explain", "seat-gap"], TABLE);
+      expect(result.stdout).toContain("seat gap");
+      expect(result.stdout).toMatch(/cross-product seat mismatch/i);
+      // Metadata block
+      expect(result.stdout).toContain("Category:");
+      expect(result.stdout).toContain("Recommendations");
+      // See also lists cross-sell somewhere
+      expect(result.stdout).toContain("cross-sell");
+    });
+
+    it("emits a --json envelope with the expected fields", async () => {
+      const result = await runCliExpectSuccess(["explain", "seat-gap", "--json"]);
+      const data = JSON.parse(result.stdout);
+      expect(data.term).toBe("seat-gap");
+      expect(data.category).toBe("recommendation");
+      expect(typeof data.short).toBe("string");
+      expect(data.short.length).toBeGreaterThan(0);
+      expect(Array.isArray(data.seeAlso)).toBe(true);
+      expect(data.seeAlso).toContain("cross-sell");
+    });
+
+    it("under a piped (non-TTY) stdout defaults to JSON without --json", async () => {
+      const result = await runCliExpectSuccess(["explain", "seat-gap"]);
+      const data = JSON.parse(result.stdout);
+      expect(data.term).toBe("seat-gap");
+    });
+  });
+
+  describe("normalization and aliases", () => {
+    it("accepts spaces via variadic args (\"opportunity type\")", async () => {
+      const result = await runCliExpectSuccess(
+        ["explain", "opportunity", "type", "--json"],
+      );
+      const data = JSON.parse(result.stdout);
+      expect(data.term).toBe("opportunity-type");
+    });
+
+    it("accepts an alias declared in the glossary (\"mismatched seats\")", async () => {
+      const result = await runCliExpectSuccess(
+        ["explain", "mismatched", "seats", "--json"],
+      );
+      const data = JSON.parse(result.stdout);
+      // "mismatched seats" is an alias for seat-gap.
+      expect(data.term).toBe("seat-gap");
+    });
+
+    it("resolves underscore-style input to the kebab-case canonical", async () => {
+      const result = await runCliExpectSuccess(["explain", "seat_gap", "--json"]);
+      const data = JSON.parse(result.stdout);
+      expect(data.term).toBe("seat-gap");
+    });
+
+    it("is case-insensitive", async () => {
+      const result = await runCliExpectSuccess(["explain", "SEAT-GAP", "--json"]);
+      const data = JSON.parse(result.stdout);
+      expect(data.term).toBe("seat-gap");
+    });
+  });
+
+  describe("--list", () => {
+    it("lists every canonical term in the glossary (JSON)", async () => {
+      const result = await runCliExpectSuccess(["explain", "--list", "--json"]);
+      const data = JSON.parse(result.stdout);
+      expect(Array.isArray(data.terms)).toBe(true);
+      // Pin the v1 size loosely — 15 terms today, may grow in follow-ups.
+      // The tight assertion is that every entry has the required shape.
+      expect(data.terms.length).toBeGreaterThanOrEqual(15);
+      for (const t of data.terms) {
+        expect(typeof t.term).toBe("string");
+        expect(typeof t.category).toBe("string");
+        expect(typeof t.short).toBe("string");
+      }
+      // A few anchor terms must be present
+      const slugs = data.terms.map((t: { term: string }) => t.term);
+      expect(slugs).toContain("seat-gap");
+      expect(slugs).toContain("cross-sell");
+      expect(slugs).toContain("mrr-uplift");
+    });
+
+    it("renders a grouped listing in text mode", async () => {
+      const result = await runCliExpectSuccess(["explain", "--list"], TABLE);
+      expect(result.stdout).toContain("Pax8 CLI glossary");
+      expect(result.stdout).toContain("Recommendations");
+      // At least one representative term from each major category
+      expect(result.stdout).toContain("seat-gap");
+      expect(result.stdout).toContain("billing-term");
+    });
+  });
+
+  describe("term-not-found", () => {
+    it("exits 1 and suggests a nearby term on a typo", async () => {
+      const result = await runCliExpectFailure(
+        ["explain", "xross-sell"],
+        TABLE,
+      );
+      // The nearest-match hint lands on stderr per the CliError envelope.
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/cross-sell/);
+      expect(combined.toLowerCase()).toContain("no glossary entry");
+    });
+
+    it("carries ERROR_TERM_NOT_FOUND in the --json envelope", async () => {
+      const result = await runCliExpectFailure(
+        ["explain", "xross-sell", "--json"],
+      );
+      // The envelope is a JSON object on stderr — same shape as the
+      // company-not-found path pinned in error-codes.test.ts.
+      const start = result.stderr.indexOf("{");
+      expect(start).toBeGreaterThanOrEqual(0);
+      const json = JSON.parse(result.stderr.slice(start));
+      expect(json.code).toBe("ERROR_TERM_NOT_FOUND");
+      // The suggestion appears in causes, not in the (redactor-sanitized)
+      // message.
+      expect(json.causes.join(" ")).toContain("cross-sell");
+    });
+  });
+
+  describe("input validation", () => {
+    it("rejects --list combined with a positional term", async () => {
+      const result = await runCliExpectFailure(
+        ["explain", "--list", "seat-gap"],
+        TABLE,
+      );
+      const combined = result.stdout + result.stderr;
+      expect(combined.toLowerCase()).toContain("mutually exclusive");
+    });
+
+    it("rejects no args and no --list", async () => {
+      const result = await runCliExpectFailure(["explain"], TABLE);
+      const combined = result.stdout + result.stderr;
+      expect(combined.toLowerCase()).toContain("missing term");
+    });
+  });
+
+  describe("help", () => {
+    it("shows the command and its --list flag", async () => {
+      const result = await runCliExpectSuccess(["explain", "--help"]);
+      expect(result.stdout).toContain("explain");
+      expect(result.stdout).toContain("--list");
+    });
+
+    it("is registered on the top-level program", async () => {
+      const result = await runCliExpectSuccess(["--help"]);
+      expect(result.stdout).toContain("explain");
+    });
+  });
+
+  describe("glossary integrity", () => {
+    // Startup-contract asserts that would fire at import time — verified
+    // here by importing the module in-process and checking invariants.
+    it("every seeAlso reference resolves to a canonical entry", async () => {
+      const { GLOSSARY, lookupTerm } = await import("../commands/explain-glossary.js");
+      for (const entry of GLOSSARY) {
+        for (const ref of entry.seeAlso ?? []) {
+          expect(
+            lookupTerm(ref),
+            `${entry.term}.seeAlso includes "${ref}", which has no glossary entry`,
+          ).toBeDefined();
+        }
+      }
+    });
+
+    it("every canonical slug is lowercase kebab-case", async () => {
+      const { GLOSSARY } = await import("../commands/explain-glossary.js");
+      for (const entry of GLOSSARY) {
+        expect(entry.term).toMatch(/^[a-z][a-z0-9-]*$/);
+      }
+    });
+  });
+});

--- a/packages/cli/src/__tests__/explain.test.ts
+++ b/packages/cli/src/__tests__/explain.test.ts
@@ -113,6 +113,19 @@ describe("pax8 explain", () => {
       expect(combined.toLowerCase()).toContain("no glossary entry");
     });
 
+    it("strips terminal control chars before echoing the unknown term", async () => {
+      // \x1b[31m is a red-ANSI sequence. If the sanitizer misses it, the
+      // stderr banner colors leak past the quoted value.
+      const result = await runCliExpectFailure(
+        ["explain", "\x1b[31mnope\x1b[0m"],
+        TABLE,
+      );
+      expect(result.stderr).not.toContain("\x1b[31m");
+      // The letters themselves (post-strip) should still surface so the
+      // user sees what they typed.
+      expect(result.stderr).toMatch(/nope/);
+    });
+
     it("carries ERROR_TERM_NOT_FOUND in the --json envelope", async () => {
       const result = await runCliExpectFailure(
         ["explain", "xross-sell", "--json"],

--- a/packages/cli/src/commands/explain-glossary.ts
+++ b/packages/cli/src/commands/explain-glossary.ts
@@ -1,0 +1,263 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Static glossary backing `pax8 explain <term>` (#656 — UXR F8).
+ *
+ * The v1 term list is drawn from wording that already appears in
+ * user-facing CLI output (table headers, --json field names, help
+ * blocks). Terms that are internal-only or purely aspirational stay
+ * out — they can join in follow-ups once someone encounters them.
+ * SME copy review lands via the `needs-sme-review` label on #656.
+ *
+ * **Append-only in spirit, but not enforced.** New entries welcome;
+ * removing or renaming a canonical `term` is a breaking change for
+ * scripts that do `pax8 explain <slug> --json`, so treat it like a
+ * public API change.
+ */
+
+export type GlossaryCategory =
+  | "recommendation"
+  | "subscription"
+  | "billing"
+  | "product"
+  | "operational";
+
+export interface GlossaryEntry {
+  /** Canonical kebab-case slug. Lowercase, hyphen-separated. */
+  term: string;
+  /**
+   * Alternate forms that resolve to this entry. Aliases are matched
+   * after the same normalization the lookup applies to user input
+   * (lowercase, `_` → `-`, whitespace → `-`).
+   */
+  aliases?: readonly string[];
+  category: GlossaryCategory;
+  /** One sentence. Always shown. */
+  short: string;
+  /**
+   * Additional context (1–3 sentences). Shown in the default text
+   * layout below `short`. Optional — some terms don't need it.
+   */
+  detail?: string;
+  /** Other canonical slugs the reader may want to look up next. */
+  seeAlso?: readonly string[];
+  /**
+   * Short human hint at where this term shows up in the CLI.
+   * Not a URL — reads like a breadcrumb.
+   */
+  reference?: string;
+}
+
+export const GLOSSARY: readonly GlossaryEntry[] = [
+  {
+    term: "seat-gap",
+    aliases: ["seat gap", "seatgap", "seat_gap", "mismatched-seats", "mismatched seats"],
+    category: "recommendation",
+    short:
+      "A cross-product seat mismatch surfaced as a recommendation — e.g. 100 email seats but only 30 backup seats.",
+    detail:
+      "The CLI's own heuristic, not the same as Pax8's canonical Seat Utilization metric (which measures assigned-vs-purchased seats within a single product). Seat gaps typically map to an Upsell opportunity on the OE five-type taxonomy.",
+    seeAlso: ["cross-sell", "opportunity-type", "recommendation"],
+    reference: "pax8 recommendations list",
+  },
+  {
+    term: "cross-sell",
+    aliases: ["cross_sell", "crosssell"],
+    category: "recommendation",
+    short:
+      "A recommendation to add a product category the customer doesn't have yet.",
+    detail:
+      "In the recommendations JSON, `type: \"cross_sell\"` on an active-sub customer maps to Opportunity Explorer's Cross-sell; on a zero-sub customer it maps to Net-new (carried on `opportunityType`).",
+    seeAlso: ["opportunity-type", "recommendation", "upsell"],
+    reference: "pax8 recommendations list --json",
+  },
+  {
+    term: "upsell",
+    category: "recommendation",
+    short:
+      "An opportunity to expand what the customer already has — more seats or a higher tier of the same product.",
+    detail:
+      "One of the five Pax8 Opportunity Explorer types on `opportunityType`. In the CLI it's most commonly surfaced through seat-gap recommendations.",
+    seeAlso: ["seat-gap", "opportunity-type", "cross-sell"],
+    reference: "pax8 recommendations list --json",
+  },
+  {
+    term: "add-on",
+    aliases: ["addon", "add_on"],
+    category: "recommendation",
+    short:
+      "A product designed to attach to an existing subscription — e.g. Defender for Microsoft 365.",
+    detail:
+      "One of the five OE opportunity types on `opportunityType`. Add-ons are still recommendations, just with a stronger prerequisite than pure cross-sell.",
+    seeAlso: ["opportunity-type", "cross-sell"],
+    reference: "pax8 recommendations list --json",
+  },
+  {
+    term: "opportunity-type",
+    aliases: ["opportunitytype", "opportunity type"],
+    category: "recommendation",
+    short:
+      "Pax8 Opportunity Explorer's five-value taxonomy: Upsell, Cross-sell, Add-on, Upgrade, Net-new.",
+    detail:
+      "Carried on the `opportunityType` field in `recommendations list --json`. The legacy `type` field (`cross_sell` | `seat_gap`) collapses two motions onto `cross_sell` for v0.x — see `recommendations list --help` for the mapping.",
+    seeAlso: ["cross-sell", "upsell", "add-on", "seat-gap"],
+    reference: "pax8 recommendations list --help",
+  },
+  {
+    term: "mrr-uplift",
+    aliases: ["mrr", "estimated-mrr-uplift", "estimatedmrruplift", "pax8-cost-plus", "pax8 cost+"],
+    category: "recommendation",
+    short:
+      "Estimated monthly Pax8-cost increase if a recommendation is executed.",
+    detail:
+      "Shown as the `Pax8 Cost+` column in `recommendations list` and as `estimatedMrrUplift` in JSON. It's the sort key — recommendations are ranked by uplift descending, with priority breaking ties. Note this is added Pax8 cost (what the partner pays Pax8), not partner-side resale revenue.",
+    seeAlso: ["pax8-cost", "priority", "recommendation"],
+    reference: "pax8 recommendations list",
+  },
+  {
+    term: "pax8-cost",
+    aliases: ["pax8 cost", "partner-cost", "partner cost", "partner-buy-rate"],
+    category: "billing",
+    short:
+      "The partner's cost paid to Pax8 for a subscription — not partner-side resale revenue.",
+    detail:
+      "Aggregated in `dashboard`, `report subscriptions`, and per-customer via `clients more`. The dashboard's `monthlyCost.amount` / `annualCost.amount` are portfolio-wide sums of this value.",
+    seeAlso: ["mrr-uplift", "billing-term"],
+    reference: "pax8 dashboard",
+  },
+  {
+    term: "orderable",
+    category: "recommendation",
+    short:
+      "A recommendation is orderable when the recommended product is in the partner's catalog and can be added via `orders create`.",
+    detail:
+      "Recommendations flagged as not orderable are hidden from the table by default. Use `--include-all` to see them — the underlying gap is real, but the fulfillment path isn't.",
+    seeAlso: ["catalog", "recommendation"],
+    reference: "pax8 recommendations list --include-all",
+  },
+  {
+    term: "commitment-term",
+    aliases: ["commitment", "commitmentterm"],
+    category: "subscription",
+    short:
+      "How long the customer is contractually locked into a subscription — Monthly, Annual, 2-Year, or 3-Year.",
+    detail:
+      "Distinct from billing term. A subscription can commit for a year but bill monthly. The commitment governs early-cancellation policy.",
+    seeAlso: ["billing-term"],
+    reference: "pax8 subscriptions cancel / update",
+  },
+  {
+    term: "billing-term",
+    aliases: ["billingterm"],
+    category: "subscription",
+    short:
+      "How often the customer is invoiced — typically Monthly or Annual.",
+    detail:
+      "Frequently confused with commitment term. Billing term is invoice cadence; commitment term is contractual lock-in.",
+    seeAlso: ["commitment-term"],
+    reference: "pax8 subscriptions list --json",
+  },
+  {
+    term: "priority",
+    category: "recommendation",
+    short:
+      "Heuristic ranking on recommendations: high, medium, or low.",
+    detail:
+      "Rendered as `HIGH`, `MED`, `LOW` in the recommendations table. Used as a tiebreaker when two recommendations have identical `estimatedMrrUplift` — a $5k/mo medium still outranks a $500/mo high on the primary sort.",
+    seeAlso: ["mrr-uplift", "recommendation"],
+    reference: "pax8 recommendations list",
+  },
+  {
+    term: "catalog",
+    category: "product",
+    short:
+      "The set of products the partner is authorized to sell via Pax8.",
+    detail:
+      "A recommendation may target a product outside the partner's catalog — those show as `hidden` in `recommendations list` unless `--include-all` is passed. Ask your Pax8 rep to enable a category to unblock those recs.",
+    seeAlso: ["orderable"],
+    reference: "pax8 products list",
+  },
+  {
+    term: "demo-mode",
+    aliases: ["demo", "pax8-demo", "pax8_demo"],
+    category: "operational",
+    short:
+      "Set `PAX8_DEMO=1` to run every command against a synthetic fixture instead of the real API.",
+    detail:
+      "Two scales: the default (~12 companies, dozens of subscriptions) suits screenshots and golden-path checks; `PAX8_DEMO_SCALE=large` swaps in a 1,000-company / 5,000-subscription fixture for scale testing.",
+    seeAlso: [],
+    reference: "PAX8_DEMO=1 pax8 <any-command>",
+  },
+  {
+    term: "idempotency-key",
+    aliases: ["idempotencykey", "idempotency"],
+    category: "operational",
+    short:
+      "A UUID passed to every write command so a retry can't duplicate the write.",
+    detail:
+      "The CLI auto-generates one if `--idempotency-key <uuid>` is omitted. On SIGINT during an in-flight write, the key is logged with `(cancelled)` so you can safely retry with the same key.",
+    seeAlso: [],
+    reference: "pax8 orders create --idempotency-key <uuid>",
+  },
+  {
+    term: "recommendation",
+    aliases: ["rec", "recs"],
+    category: "recommendation",
+    short:
+      "A computed suggestion to add or expand a subscription, produced by `pax8 recommendations list`.",
+    detail:
+      "Every recommendation carries a type (`seat_gap` or `cross_sell`), an opportunity type (Upsell / Cross-sell / Add-on / Upgrade / Net-new), a priority (high/medium/low), and an estimated MRR uplift used as the primary sort key.",
+    seeAlso: ["seat-gap", "cross-sell", "opportunity-type", "mrr-uplift", "priority", "orderable"],
+    reference: "pax8 recommendations list",
+  },
+] as const;
+
+// ─── Lookup index ───────────────────────────────────────────────────────────
+
+const NORMALIZE_RE = /[\s_]+/g;
+
+/**
+ * Normalize user input to the canonical kebab-case form we index by.
+ * Lowercases, collapses whitespace and underscores to a single `-`,
+ * and trims edge hyphens. Idempotent.
+ */
+export function normalizeTerm(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(NORMALIZE_RE, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const INDEX = ((): Map<string, GlossaryEntry> => {
+  const m = new Map<string, GlossaryEntry>();
+  for (const entry of GLOSSARY) {
+    m.set(entry.term, entry);
+    for (const alias of entry.aliases ?? []) {
+      const key = normalizeTerm(alias);
+      // A collision here means two glossary entries claim the same
+      // alias — deterministic authoring bug, worth failing loud so
+      // the startup contract test catches it.
+      if (m.has(key) && m.get(key) !== entry) {
+        throw new Error(
+          `explain-glossary: alias "${alias}" (normalized "${key}") collides across "${
+            m.get(key)!.term
+          }" and "${entry.term}"`,
+        );
+      }
+      m.set(key, entry);
+    }
+  }
+  return m;
+})();
+
+/** Look up a term (canonical slug or any alias). Returns `undefined` on miss. */
+export function lookupTerm(input: string): GlossaryEntry | undefined {
+  return INDEX.get(normalizeTerm(input));
+}
+
+/** All canonical slugs, alphabetized. Used by `--list` and by suggest(). */
+export function allCanonicalTerms(): string[] {
+  return GLOSSARY.map((e) => e.term).sort();
+}

--- a/packages/cli/src/commands/explain.ts
+++ b/packages/cli/src/commands/explain.ts
@@ -110,8 +110,12 @@ Aliases and normalization:
           normalizeTerm(rawInput),
           allCanonicalTerms(),
         );
+        // Strip C0/C1 control chars so an input carrying ANSI escapes
+        // can't repaint the surrounding error banner. redactString() only
+        // scrubs PII patterns, not terminal control bytes.
+        const safeInput = rawInput.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
         throw new CliError(
-          `No glossary entry for "${rawInput}".`,
+          `No glossary entry for "${safeInput}".`,
           suggestions.length > 0
             ? [`Nearest matches: ${suggestions.join(", ")}.`]
             : [],

--- a/packages/cli/src/commands/explain.ts
+++ b/packages/cli/src/commands/explain.ts
@@ -1,0 +1,225 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  ERROR_INVALID_INPUT,
+  ERROR_TERM_NOT_FOUND,
+} from "@pax8/core";
+import { getOutputFormat } from "../lib/context.js";
+import { CliError, handleCommandError } from "../lib/errors.js";
+import { suggest } from "../lib/fuzzy.js";
+import {
+  GLOSSARY,
+  type GlossaryCategory,
+  type GlossaryEntry,
+  allCanonicalTerms,
+  lookupTerm,
+  normalizeTerm,
+} from "./explain-glossary.js";
+
+/**
+ * `pax8 explain <term>` — built-in glossary. #656 / UXR F8.
+ *
+ * Fully local: no API, no auth, no config. We read the output format
+ * off `--json` directly via `getOutputFormat` and skip `buildContext`
+ * entirely so that (a) there's no token refresh on a docs command and
+ * (b) the demo-mode banner doesn't fire on something that has no data
+ * to demo.
+ */
+
+const CATEGORY_ORDER: readonly GlossaryCategory[] = [
+  "recommendation",
+  "subscription",
+  "billing",
+  "product",
+  "operational",
+];
+
+const CATEGORY_LABEL: Record<GlossaryCategory, string> = {
+  recommendation: "Recommendations",
+  subscription: "Subscriptions",
+  billing: "Billing",
+  product: "Products",
+  operational: "Operational",
+};
+
+export const explainCommand = new Command("explain")
+  .description("Explain a Pax8 CLI or marketplace term")
+  .argument("[term...]", "Term to explain — joined with spaces if multi-word")
+  .option("--list", "List all known terms, grouped by category")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 explain seat-gap
+  pax8 explain "opportunity type"
+  pax8 explain seat_gap --json
+  pax8 explain --list
+  pax8 explain --list --json
+
+Aliases and normalization:
+  Space, underscore, and case are all normalized. \`seat gap\`, \`SEAT_GAP\`,
+  and \`seat-gap\` all resolve to the same entry.`
+  )
+  .action(async (termArgs: string[], options: { list?: boolean }, command) => {
+    try {
+      const globalOpts = command.optsWithGlobals();
+      const format = getOutputFormat(globalOpts);
+      const wantJson = format === "json";
+      const wantQuiet = format === "quiet";
+
+      // --list and a positional term are a nonsense combo — reject explicitly
+      // rather than silently ignoring one. Same reasoning as most CLIs
+      // enforce mutex flag/arg pairs.
+      if (options.list && termArgs.length > 0) {
+        throw new CliError(
+          `\`--list\` and a term argument are mutually exclusive.`,
+          [`You passed both: --list and \`${termArgs.join(" ")}\`.`],
+          [`Use \`pax8 explain --list\` to see every known term, or \`pax8 explain ${termArgs[0]}\` to look up one term.`],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      if (options.list) {
+        renderList({ wantJson, wantQuiet });
+        return;
+      }
+
+      if (termArgs.length === 0) {
+        throw new CliError(
+          `Missing term to explain.`,
+          [],
+          [
+            `Try \`pax8 explain seat-gap\` — or \`pax8 explain --list\` to browse every term.`,
+          ],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      // Variadic args let partners type `pax8 explain MRR uplift` without
+      // shell-quoting the space. Join, then normalize.
+      const rawInput = termArgs.join(" ");
+      const entry = lookupTerm(rawInput);
+
+      if (!entry) {
+        const suggestions = suggest(
+          normalizeTerm(rawInput),
+          allCanonicalTerms(),
+        );
+        throw new CliError(
+          `No glossary entry for "${rawInput}".`,
+          suggestions.length > 0
+            ? [`Nearest matches: ${suggestions.join(", ")}.`]
+            : [],
+          suggestions.length > 0
+            ? [
+                `Try \`pax8 explain ${suggestions[0]}\`, or run \`pax8 explain --list\` to browse every term.`,
+              ]
+            : [
+                `Run \`pax8 explain --list\` to browse every term.`,
+              ],
+          undefined,
+          ERROR_TERM_NOT_FOUND,
+        );
+      }
+
+      renderEntry(entry, { wantJson, wantQuiet });
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to explain term");
+    }
+  });
+
+// ─── Renderers ─────────────────────────────────────────────────────────────
+
+function renderEntry(
+  entry: GlossaryEntry,
+  { wantJson, wantQuiet }: { wantJson: boolean; wantQuiet: boolean },
+): void {
+  if (wantQuiet) return;
+
+  if (wantJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          term: entry.term,
+          category: entry.category,
+          short: entry.short,
+          detail: entry.detail ?? null,
+          seeAlso: entry.seeAlso ?? [],
+          reference: entry.reference ?? null,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  // Text: title, blank line, indented short/detail, then a metadata block.
+  process.stdout.write("\n" + chalk.bold(entry.term.replace(/-/g, " ")) + "\n\n");
+  process.stdout.write("  " + entry.short + "\n");
+  if (entry.detail) {
+    process.stdout.write("\n  " + entry.detail + "\n");
+  }
+
+  const metaLines: string[] = [];
+  metaLines.push(`  ${chalk.dim("Category:")}   ${CATEGORY_LABEL[entry.category]}`);
+  if (entry.reference) {
+    metaLines.push(`  ${chalk.dim("Referenced:")} ${chalk.cyan(entry.reference)}`);
+  }
+  if (entry.seeAlso && entry.seeAlso.length > 0) {
+    metaLines.push(
+      `  ${chalk.dim("See also:")}   ${entry.seeAlso.map((s) => chalk.cyan(s)).join(", ")}`,
+    );
+  }
+  process.stdout.write("\n" + metaLines.join("\n") + "\n\n");
+}
+
+function renderList({
+  wantJson,
+  wantQuiet,
+}: {
+  wantJson: boolean;
+  wantQuiet: boolean;
+}): void {
+  if (wantQuiet) return;
+
+  if (wantJson) {
+    const rows = [...GLOSSARY]
+      .sort((a, b) => a.term.localeCompare(b.term))
+      .map((e) => ({
+        term: e.term,
+        category: e.category,
+        short: e.short,
+      }));
+    process.stdout.write(JSON.stringify({ terms: rows }, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write("\n" + chalk.bold("Pax8 CLI glossary") + "\n");
+  process.stdout.write(
+    chalk.dim(`  ${GLOSSARY.length} terms · run `) +
+      chalk.cyan("pax8 explain <term>") +
+      chalk.dim(` for a full entry.\n\n`),
+  );
+
+  for (const category of CATEGORY_ORDER) {
+    const entries = GLOSSARY.filter((e) => e.category === category);
+    if (entries.length === 0) continue;
+    entries.sort((a, b) => a.term.localeCompare(b.term));
+    process.stdout.write("  " + chalk.bold(CATEGORY_LABEL[category]) + "\n");
+    // Column-align term slugs so definitions line up. The longest term in
+    // the v1 set is `opportunity-type` (16 chars); leave room for growth.
+    const width = Math.max(...entries.map((e) => e.term.length));
+    for (const e of entries) {
+      process.stdout.write(
+        `    ${chalk.cyan(e.term.padEnd(width))}  ${chalk.dim(e.short)}\n`,
+      );
+    }
+    process.stdout.write("\n");
+  }
+}

--- a/packages/cli/src/commands/explain.ts
+++ b/packages/cli/src/commands/explain.ts
@@ -112,7 +112,11 @@ Aliases and normalization:
         );
         // Strip C0/C1 control chars so an input carrying ANSI escapes
         // can't repaint the surrounding error banner. redactString() only
-        // scrubs PII patterns, not terminal control bytes.
+        // scrubs PII patterns, not terminal control bytes. The regex
+        // matches literal control chars by definition — that's the
+        // whole point — so the `no-control-regex` rule is disabled
+        // for this line only.
+        // eslint-disable-next-line no-control-regex
         const safeInput = rawInput.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
         throw new CliError(
           `No glossary entry for "${safeInput}".`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ import { doctorCommand } from "./commands/doctor.js";
 import { completionsCommand } from "./commands/completions.js";
 import { versionCommand } from "./commands/version.js";
 import { initCommand } from "./commands/init.js";
+import { explainCommand } from "./commands/explain.js";
 import { reportBugCommand } from "./commands/report-bug.js";
 import { handleCommandError, flushTelemetryBeforeExit } from "./lib/errors.js";
 import { installSigintHandler } from "./lib/signals.js";
@@ -120,6 +121,7 @@ export function createProgram(): Command {
   program.addCommand(todayCommand);
   program.addCommand(initCommand);
   program.addCommand(doctorCommand);
+  program.addCommand(explainCommand);
   program.addCommand(completionsCommand);
   program.addCommand(versionCommand);
   program.addCommand(reportBugCommand());

--- a/packages/cli/src/lib/fuzzy.test.ts
+++ b/packages/cli/src/lib/fuzzy.test.ts
@@ -1,0 +1,90 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { levenshtein, suggest } from "./fuzzy.js";
+
+describe("levenshtein", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshtein("", "")).toBe(0);
+    expect(levenshtein("abc", "abc")).toBe(0);
+  });
+
+  it("returns the length of the non-empty string when one is empty", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abcd", "")).toBe(4);
+  });
+
+  it("counts a single insertion", () => {
+    expect(levenshtein("abc", "abcd")).toBe(1);
+    expect(levenshtein("abc", "abxc")).toBe(1);
+  });
+
+  it("counts a single deletion", () => {
+    expect(levenshtein("abcd", "abc")).toBe(1);
+    expect(levenshtein("abxc", "abc")).toBe(1);
+  });
+
+  it("counts a single substitution", () => {
+    expect(levenshtein("abc", "aXc")).toBe(1);
+  });
+
+  it("is case-sensitive at the function level", () => {
+    expect(levenshtein("abc", "ABC")).toBe(3);
+  });
+
+  it("computes the classic kitten/sitting distance = 3", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+});
+
+describe("suggest", () => {
+  const CANDIDATES = [
+    "seat-gap",
+    "cross-sell",
+    "upsell",
+    "add-on",
+    "opportunity-type",
+    "mrr-uplift",
+    "orderable",
+    "commitment-term",
+    "billing-term",
+    "priority",
+  ];
+
+  it("returns close matches, sorted by distance", () => {
+    // 'xross-sell' → 'cross-sell' is the obvious neighbor (distance 1).
+    // 'add-on' at distance 8+ is outside the default threshold.
+    expect(suggest("xross-sell", CANDIDATES)).toEqual(["cross-sell"]);
+  });
+
+  it("returns empty when nothing is close enough", () => {
+    expect(suggest("zzzzzzzzz", CANDIDATES)).toEqual([]);
+  });
+
+  it("respects the max cap", () => {
+    // Very high threshold to force many matches, then cap at 2.
+    const result = suggest("seat", CANDIDATES, { max: 2, threshold: 10 });
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+
+  it("orders ties alphabetically for stable output", () => {
+    // Two candidates at the same distance from the needle should be
+    // ordered lexicographically. `foo-a` and `foo-b` are both distance
+    // 1 from `foo`.
+    const tied = suggest("foo", ["foo-b", "foo-a"], { threshold: 3 });
+    expect(tied).toEqual(["foo-a", "foo-b"]);
+  });
+
+  it("lower-cases before comparing so typos in the wrong case still match", () => {
+    expect(suggest("Cross-Sell", CANDIDATES, { threshold: 0 })).toEqual([
+      "cross-sell",
+    ]);
+  });
+
+  it("tighter default threshold on short inputs prevents spam", () => {
+    // Default threshold for "cs" (length 2) is floor(2*0.4)=0. Nothing
+    // should match a 2-char input with zero distance.
+    expect(suggest("cs", CANDIDATES)).toEqual([]);
+  });
+});

--- a/packages/cli/src/lib/fuzzy.ts
+++ b/packages/cli/src/lib/fuzzy.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Small pure-function fuzzy match helpers. First introduced for
+ * `pax8 explain <term>` (#656) so partners get did-you-mean suggestions
+ * on unknown glossary terms. Kept generic so other commands can call
+ * `suggest()` for their own unknown-input paths.
+ */
+
+/**
+ * Iterative two-row Levenshtein edit distance. Case-sensitive; the caller
+ * lower-cases inputs when case shouldn't matter. Returns the number of
+ * single-character insertions, deletions, or substitutions between `a`
+ * and `b`.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Two-row DP: `prev` is the previous row of the edit matrix, `curr`
+  // fills as we iterate. We don't need the full matrix — only the last
+  // row — so this is O(min(a.length, b.length)) space.
+  const prev = new Array<number>(b.length + 1);
+  const curr = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        curr[j - 1] + 1,       // insertion
+        prev[j] + 1,           // deletion
+        prev[j - 1] + cost,    // substitution
+      );
+    }
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+
+  return prev[b.length];
+}
+
+export interface SuggestOptions {
+  /** Max suggestions returned. Default 3. */
+  max?: number;
+  /**
+   * Maximum edit distance allowed. Default `min(3, floor(input.length * 0.4))`
+   * — tighter for short inputs so a 3-character typo doesn't match every
+   * 3-character candidate.
+   */
+  threshold?: number;
+}
+
+/**
+ * Return up to `opts.max` candidates whose lower-cased edit distance to
+ * `input` is ≤ `opts.threshold`. Sorted by ascending distance, ties broken
+ * alphabetically for stable output.
+ */
+export function suggest(
+  input: string,
+  candidates: readonly string[],
+  opts?: SuggestOptions,
+): string[] {
+  const max = opts?.max ?? 3;
+  const threshold = opts?.threshold ?? Math.min(3, Math.floor(input.length * 0.4));
+  const needle = input.toLowerCase();
+
+  const scored: Array<{ candidate: string; distance: number }> = [];
+  for (const c of candidates) {
+    const d = levenshtein(needle, c.toLowerCase());
+    if (d <= threshold) scored.push({ candidate: c, distance: d });
+  }
+
+  scored.sort((a, b) => {
+    if (a.distance !== b.distance) return a.distance - b.distance;
+    return a.candidate.localeCompare(b.candidate);
+  });
+
+  return scored.slice(0, max).map((s) => s.candidate);
+}

--- a/packages/cli/src/lib/fuzzy.ts
+++ b/packages/cli/src/lib/fuzzy.ts
@@ -57,6 +57,10 @@ export interface SuggestOptions {
  * Return up to `opts.max` candidates whose lower-cased edit distance to
  * `input` is ≤ `opts.threshold`. Sorted by ascending distance, ties broken
  * alphabetically for stable output.
+ *
+ * Intended for small candidate sets — the auto-threshold and tie-breaking
+ * rules are an implicit contract, treat as internal/unstable when tuning
+ * matters.
  */
 export function suggest(
   input: string,
@@ -69,6 +73,9 @@ export function suggest(
 
   const scored: Array<{ candidate: string; distance: number }> = [];
   for (const c of candidates) {
+    // Length-band cheap reject: a length delta > threshold forces at
+    // least that many insertions/deletions, so distance > threshold too.
+    if (Math.abs(c.length - needle.length) > threshold) continue;
     const d = levenshtein(needle, c.toLowerCase());
     if (d <= threshold) scored.push({ candidate: c, distance: d });
   }

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -33,6 +33,13 @@ export const ERROR_QUOTE_LINE_ITEM_NOT_FOUND = "ERROR_QUOTE_LINE_ITEM_NOT_FOUND"
  * real failures.
  */
 export const ERROR_CANCELLED = "ERROR_CANCELLED";
+/**
+ * `pax8 explain <term>` was passed a term that is not in the built-in
+ * glossary. The error envelope carries the original input and up to
+ * three fuzzy-matched suggestions so agents can either retry with the
+ * suggested slug or escalate.
+ */
+export const ERROR_TERM_NOT_FOUND = "ERROR_TERM_NOT_FOUND";
 
 /**
  * Union of all known Pax8 CLI error codes. Use this for exhaustive switch
@@ -52,4 +59,5 @@ export type Pax8ErrorCode =
   | typeof ERROR_NOT_FOUND
   | typeof ERROR_INTERNAL
   | typeof ERROR_QUOTE_LINE_ITEM_NOT_FOUND
-  | typeof ERROR_CANCELLED;
+  | typeof ERROR_CANCELLED
+  | typeof ERROR_TERM_NOT_FOUND;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ export {
   ERROR_INTERNAL,
   ERROR_QUOTE_LINE_ITEM_NOT_FOUND,
   ERROR_CANCELLED,
+  ERROR_TERM_NOT_FOUND,
 } from "./errors/codes.js";
 export type { Pax8ErrorCode } from "./errors/codes.js";
 


### PR DESCRIPTION
## Summary

Second Track of the [2026-07-02 UXR readout](https://app.notion.com/p/3918fa2a9e288124b6d4ed20bdc73cdd) — the explainability track. Adds `pax8 explain <term>` and `pax8 explain --list`, backed by a 15-entry glossary of Pax8 CLI and marketplace terms. UXR finding F8: partners left the workflow to look up terms like "seat gap" and "MRR uplift" because the CLI didn't tell them what those meant.

Closes #656. Tracking: #661.

## What ships

- New standalone command at `packages/cli/src/commands/explain.ts`. Fully local (no API, no auth, no config) — skips `buildContext` entirely so there's no token refresh or demo-mode banner on a docs command.
- Static glossary at `packages/cli/src/commands/explain-glossary.ts` with 15 v1 terms drawn from wording already in user-facing CLI output. Every alias resolves via a startup index; duplicate aliases fail loud at import time. **Wording is a draft** — `needs-sme-review` label captures the SME review requirement.
- Reusable fuzzy matcher at `packages/cli/src/lib/fuzzy.ts` — iterative two-row Levenshtein + `suggest()` helper. First fuzzy utility in the repo; future did-you-mean paths can call it too.
- New `ERROR_TERM_NOT_FOUND` machine-readable code (append-only per `codes.ts`).
- Both text and `--json` output surfaces. `--list --json` returns `{ terms: [...] }` for agent consumption.

## Surface examples

```
$ pax8 explain seat-gap
seat gap
  A cross-product seat mismatch surfaced as a recommendation — e.g. …
  Category:    Recommendations
  Referenced:  pax8 recommendations list
  See also:    cross-sell, opportunity-type, recommendation

$ pax8 explain "opportunity type" --json
{ "term": "opportunity-type", "category": "recommendation", ... }

$ pax8 explain xross-sell
✗ Failed to explain term
  No glossary entry for "xross-sell".
  Causes: Nearest matches: cross-sell.
  Recovery: Try `pax8 explain cross-sell`, or run `pax8 explain --list`.

$ pax8 explain --list
Pax8 CLI glossary — 15 terms
  Recommendations
    add-on            A product designed to attach to an existing subscription…
    cross-sell        A recommendation to add a product category the customer…
    ...
```

## v1 term list (15 entries)

Recommendation: seat-gap, cross-sell, upsell, add-on, opportunity-type, mrr-uplift, orderable, priority, recommendation. Subscription: commitment-term, billing-term. Billing: pax8-cost. Product: catalog. Operational: demo-mode, idempotency-key.

## Test plan

- [x] `pnpm build && pnpm test` — 2427 pass, 0 fail. Adds 17 subprocess tests + 13 fuzzy unit tests.
- [x] `pnpm lint` — no new warnings (3 pre-existing on main).
- [x] Manual: `PAX8_DEMO=1 pax8 explain seat-gap` — renders.
- [x] Manual: `PAX8_DEMO=1 pax8 explain "opportunity type"` — resolves via space→hyphen normalize.
- [x] Manual: `PAX8_DEMO=1 pax8 explain xross-sell` — stderr suggests `cross-sell`, exit 1.
- [x] Manual: `PAX8_DEMO=1 pax8 explain seat-gap --json | jq .term` → `"seat-gap"`.
- [x] Manual: `PAX8_DEMO=1 pax8 explain --list` — reads clean.
- [x] `pax8 --help` lists `explain`; `pax8 explain --help` shows examples.

## Reviewer asks

- **Wording review** on the 15 short/detail strings in `explain-glossary.ts` — the `needs-sme-review` label is applied. Please red-pencil anything you'd say differently to a partner.
- The v1 term set intentionally trims speculative entries (MCP server, telemetry, held). Follow-ups can add terms once someone actually hits them.