### PR TITLE
feat(pricing): partner-price labels + null-aware render + margin column (UXR F9)

### DIFF
--- a/.changeset/pricing-clarity.md
+++ b/.changeset/pricing-clarity.md
@@ -1,0 +1,15 @@
+---
+"@pax8/cli": patch
+---
+
+Sharpen pricing surfaces across `subscriptions` and `products show`.
+
+UXR F9 (#657): partners couldn't tell whether the `Price` column showed their partner cost or the customer-facing MSRP, and a missing wire `price` rendered as `$0.00` or the misleading `-$0.00`. Three human-readable output changes ship together — the `--json` shape on all four commands is unchanged.
+
+- **`subscriptions list` / `show` / `update`**: the `Price` column and detail label are now `Partner Price` so the meaning is explicit at a glance.
+- **`subscriptions show` / `update` / `cancel`**: a missing wire `price` (null, undefined, or NaN) renders as a dim em-dash (`—`) instead of `$0.00` / `-$0.00`. A real `0` still renders `$0.00` — the em-dash only stands in for "we don't have a value from the API."
+- **`products show --pricing`**: the table gains a new `Margin` column derived from the first rate entry so partners can compare cost vs MSRP inline.
+
+Scripts and integrations that parse the human table output (labels or column counts) will see these shifts — the ensemble reviewer flagged this on the PR. `--json` is the stable contract and unchanged; steer any automation that keys off row labels toward `--json`.
+
+Closes #657.

--- a/packages/cli/src/commands/products/show.ts
+++ b/packages/cli/src/commands/products/show.ts
@@ -7,7 +7,7 @@ import { buildContext } from "../../lib/context.js";
 import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
-import { formatCurrency } from "../../lib/formatters.js";
+import { formatCurrencyNullable } from "../../lib/formatters.js";
 import { resolveProduct } from "../../lib/resolve-product.js";
 
 export const productsShowCommand = new Command("show")
@@ -79,12 +79,23 @@ Examples:
 
       if (pricing && pricing.length > 0) {
         process.stdout.write(`\n  ${chalk.cyan.bold("Pricing Plans")}\n`);
-        const pricingRows = pricing.map((p) => ({
-          billingTerm: p.billingTerm,
-          commitmentTerm: p.commitmentTerm,
-          partnerBuyRate: p.rates[0]?.partnerBuyRate,
-          suggestedRetailPrice: p.rates[0]?.suggestedRetailPrice,
-        }));
+        const pricingRows = pricing.map((p) => {
+          const partner = p.rates[0]?.partnerBuyRate;
+          const retail = p.rates[0]?.suggestedRetailPrice;
+          // #657 / UXR F9: derive margin client-side. Only meaningful when
+          // both sides are numeric — if either is missing we render `—`.
+          const margin =
+            typeof partner === "number" && typeof retail === "number"
+              ? retail - partner
+              : null;
+          return {
+            billingTerm: p.billingTerm,
+            commitmentTerm: p.commitmentTerm,
+            partnerBuyRate: partner,
+            suggestedRetailPrice: retail,
+            margin,
+          };
+        });
         const pricingColumns = [
           { key: "billingTerm", header: "Billing", width: 10 },
           { key: "commitmentTerm", header: "Commitment", width: 12 },
@@ -92,13 +103,19 @@ Examples:
             key: "partnerBuyRate",
             header: "Partner Price",
             width: 16,
-            format: (v: unknown) => formatCurrency(Number(v)),
+            format: (v: unknown) => formatCurrencyNullable(v as number | null | undefined),
           },
           {
             key: "suggestedRetailPrice",
             header: "Retail Price",
             width: 16,
-            format: (v: unknown) => formatCurrency(Number(v)),
+            format: (v: unknown) => formatCurrencyNullable(v as number | null | undefined),
+          },
+          {
+            key: "margin",
+            header: "Margin",
+            width: 12,
+            format: (v: unknown) => formatCurrencyNullable(v as number | null | undefined),
           },
         ];
         output(pricingRows, { format: "table", columns: pricingColumns });

--- a/packages/cli/src/commands/subscriptions/cancel.ts
+++ b/packages/cli/src/commands/subscriptions/cancel.ts
@@ -9,7 +9,7 @@ import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { CliError, handleCommandError } from "../../lib/errors.js";
 import { confirmDestructive } from "../../lib/confirm.js";
-import { formatCurrency, formatQuantity, calculateMrr } from "../../lib/formatters.js";
+import { formatCurrency, formatCurrencyNullable, formatQuantity, calculateMrr } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { replCmd } from "../../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
@@ -198,7 +198,9 @@ Behavior on committed subscriptions:
             `  ${chalk.bold("Days remaining")}     ${activeCommitment.daysRemaining}\n`,
           );
           process.stdout.write(
-            `  ${chalk.bold("Estimated cost through term end")}   ${formatCurrency(estimatedCost)}\n`,
+            `  ${chalk.bold("Estimated cost through term end")}   ${
+              sub.price == null ? formatCurrencyNullable(null) : formatCurrency(estimatedCost)
+            }\n`,
           );
           process.stdout.write(
             chalk.dim(
@@ -257,7 +259,14 @@ Behavior on committed subscriptions:
             `  ${chalk.bold("Cancel Date")}  ${effectiveCancelDate}${usedSafePath ? chalk.dim(" (commitment term end)") : ""}\n`,
           );
         }
-        process.stdout.write(`  ${chalk.bold("Est. Pax8 Cost Impact")}   ${chalk.red("-" + formatCurrency(mrr))}/mo\n`);
+        // #657: guard against a null upstream `price` — the multiplication
+        // above still returns a numeric `mrr`, but rendering it as `-$0.00`
+        // is worse than surfacing that we don't know.
+        process.stdout.write(
+          `  ${chalk.bold("Est. Pax8 Cost Impact")}   ${
+            sub.price == null ? formatCurrencyNullable(null) : chalk.red("-" + formatCurrency(mrr)) + "/mo"
+          }\n`,
+        );
         process.stdout.write("\n");
       }
 

--- a/packages/cli/src/commands/subscriptions/list.ts
+++ b/packages/cli/src/commands/subscriptions/list.ts
@@ -25,7 +25,7 @@ import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError } from "../../lib/errors.js";
 import {
   formatStatus,
-  formatCurrency,
+  formatCurrencyNullable,
   formatCompanyName,
 } from "../../lib/formatters.js";
 import { resolveCompanyId } from "../../lib/resolve-company.js";
@@ -77,15 +77,20 @@ const columns: Column[] = [
   { key: "billingTerm", header: "Term" },
   {
     key: "price",
-    header: "Price",
+    // #657 / UXR F9: partners couldn't tell whether the `Price` column
+    // meant their cost or the customer's cost. Rename to `Partner Price`
+    // (what the partner pays Pax8) so the semantic is unambiguous at a
+    // glance, matching the label already used in `products show --pricing`.
+    header: "Partner Price",
     // Thread the row's `currencyCode` through `formatCurrency` so the
     // rendered symbol matches the subscription's actual currency (#472).
     // Previously this layered a `" EUR"` suffix on top of a hard-coded
     // `"$"`; now `formatCurrency` handles the unit directly via
-    // `Intl.NumberFormat`.
+    // `Intl.NumberFormat`. #657: use the null-aware helper so a missing
+    // upstream `price` renders as `—` instead of the ambiguous `$0.00`.
     format: (v, row) => {
       const code = String((row as { currencyCode?: string } | undefined)?.currencyCode ?? "USD");
-      return formatCurrency(Number(v), code);
+      return formatCurrencyNullable(v == null ? null : Number(v), code);
     },
   },
 ];

--- a/packages/cli/src/commands/subscriptions/show.ts
+++ b/packages/cli/src/commands/subscriptions/show.ts
@@ -10,6 +10,7 @@ import { handleCommandError } from "../../lib/errors.js";
 import {
   formatStatus,
   formatCurrency,
+  formatCurrencyNullable,
   formatDate,
   formatQuantity,
 } from "../../lib/formatters.js";
@@ -86,16 +87,23 @@ provisioning detail.`
       // case stays unchanged; non-USD partners get e.g. `$1,234.56 EUR`.
       // Surfaced in #273 (fixes #6).
       const currencyCode = (sub as { currencyCode?: string }).currencyCode ?? "USD";
-      const priceFormatted = currencyCode === "USD"
-        ? formatCurrency(sub.price ?? 0)
-        : `${formatCurrency(sub.price ?? 0)} ${currencyCode}`;
+      // #657 / UXR F9: use the null-aware helper so a missing `price`
+      // renders as `—` instead of the ambiguous `$0.00`. Label renamed
+      // to `Partner Price` to match the wire semantic (what the partner
+      // pays Pax8) and the `products show --pricing` column.
+      const priceFormatted =
+        sub.price == null
+          ? formatCurrencyNullable(null)
+          : currencyCode === "USD"
+            ? formatCurrency(sub.price)
+            : `${formatCurrency(sub.price)} ${currencyCode}`;
       const fields: [string, string][] = [
         ["ID", sub.id],
         ["Company", sub.companyName ?? sub.companyId],
         ["Product", sub.productName ?? ""],
         ["Quantity", formatQuantity(sub.quantity)],
         ["Status", formatStatus(sub.status)],
-        ["Price", priceFormatted],
+        ["Partner Price", priceFormatted],
         ["Billing Term", sub.billingTerm ?? ""],
         ["Start Date", formatDate(sub.startDate)],
         // #385: read canonical `createdAt`. Legacy `createdDate` is still

--- a/packages/cli/src/commands/subscriptions/update.ts
+++ b/packages/cli/src/commands/subscriptions/update.ts
@@ -8,7 +8,7 @@ import { output } from "../../lib/output.js";
 import { createSpinner } from "../../lib/spinner.js";
 import { handleCommandError, CliError, extractErrorDetail } from "../../lib/errors.js";
 import { confirmWithChange, replCmd } from "../../lib/confirm.js";
-import { formatQuantity, formatCurrency, formatStatus } from "../../lib/formatters.js";
+import { formatQuantity, formatCurrencyNullable, formatStatus } from "../../lib/formatters.js";
 import { invalidateCacheAfterWrite } from "../../lib/invalidate-cache.js";
 import { markWriteInFlight } from "../../lib/signals.js";
 import { ApiError, BillingTermSchema, ERROR_API_VALIDATION, ERROR_INVALID_INPUT } from "@pax8/core";
@@ -250,7 +250,11 @@ across vendors, so the CLI provides the guard.`,
       process.stdout.write(`  ${chalk.dim("Status:".padEnd(18))}${formatStatus(updated.status)}\n`);
       process.stdout.write(`  ${chalk.dim("Quantity:".padEnd(18))}${formatQuantity(updated.quantity)}\n`);
       process.stdout.write(`  ${chalk.dim("Billing Term:".padEnd(18))}${updated.billingTerm}\n`);
-      process.stdout.write(`  ${chalk.dim("Price:".padEnd(18))}${formatCurrency(updated.price ?? 0)}\n`);
+      // #657 / UXR F9: relabel to disambiguate from customer-side price,
+      // and render missing data as `—` rather than `$0.00`.
+      process.stdout.write(
+        `  ${chalk.dim("Partner Price:".padEnd(18))}${formatCurrencyNullable(updated.price ?? null)}\n`,
+      );
       process.stdout.write("\n");
     } catch (error) {
       // Wrap opaque API rejections (post-confirm) with a generic

--- a/packages/cli/src/lib/formatters.test.ts
+++ b/packages/cli/src/lib/formatters.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   formatTimeAgo,
   formatCurrency,
+  formatCurrencyNullable,
   formatQuantity,
   formatStatus,
   formatCompanyName,
@@ -125,6 +126,39 @@ describe("formatCurrency", () => {
     expect(result).toContain("42.50");
     // Could be "-€42.50" or "(€42.50)" depending on ICU defaults; both
     // contain '-' or '(' — just assert the magnitude renders correctly.
+  });
+});
+
+// #657 / UXR F9: `?? 0` fallbacks used to misrender missing prices as
+// `$0.00`, indistinguishable from a genuine zero. `formatCurrencyNullable`
+// draws that distinction — null/undefined/NaN render as a dim em-dash;
+// real zeros still render as `$0.00`.
+describe("formatCurrencyNullable", () => {
+  it("returns a dim em-dash for null", () => {
+    // chalk wraps the em-dash in ANSI dim codes; a substring match keeps
+    // the assertion robust to the exact escape sequence.
+    expect(formatCurrencyNullable(null)).toContain("—");
+  });
+
+  it("returns a dim em-dash for undefined", () => {
+    expect(formatCurrencyNullable(undefined)).toContain("—");
+  });
+
+  it("returns a dim em-dash for NaN", () => {
+    expect(formatCurrencyNullable(NaN)).toContain("—");
+  });
+
+  it("still renders a real zero as $0.00", () => {
+    expect(formatCurrencyNullable(0)).toBe("$0.00");
+  });
+
+  it("formats a real amount the same as formatCurrency", () => {
+    expect(formatCurrencyNullable(1234.56)).toBe(formatCurrency(1234.56));
+  });
+
+  it("honors the currencyCode parameter", () => {
+    const result = formatCurrencyNullable(42.5, "EUR");
+    expect(result).toContain("42.50");
   });
 });
 

--- a/packages/cli/src/lib/formatters.ts
+++ b/packages/cli/src/lib/formatters.ts
@@ -63,6 +63,25 @@ export function formatCurrency(amount: number, currencyCode: string = "USD"): st
   }
 }
 
+/**
+ * Null-safe wrapper around `formatCurrency`. Callers that receive an
+ * optional price from the wire should use this rather than `?? 0`,
+ * which silently misrenders \"missing data\" as \"\$0.00\" — the confusion
+ * UXR F9 / #657 flagged.
+ *
+ * When the amount is null / undefined / NaN, returns a dim em-dash so
+ * a missing value is visually distinguishable from a real zero.
+ * When the amount is a real number (including 0), formats it the same
+ * way `formatCurrency` does.
+ */
+export function formatCurrencyNullable(
+  amount: number | null | undefined,
+  currencyCode: string = "USD",
+): string {
+  if (amount == null || Number.isNaN(amount)) return chalk.dim("—");
+  return formatCurrency(amount, currencyCode);
+}
+
 export function formatQuantity(n: number): string {
   return `${n} seat${n !== 1 ? "s" : ""}`;
 }


### PR DESCRIPTION
## Summary

Fourth wave of the [2026-07-02 UXR readout](https://app.notion.com/p/3918fa2a9e288124b6d4ed20bdc73cdd). UXR finding F9: participants saw `$0` pricing values in CLI output and couldn't tell whether that was partner cost, customer cost, markup, or missing data.

Closes #657. Follow-up (mock naming cleanup) filed as #665. Tracking: #661.

## Audit-refined scope

The [pricing API audit](https://github.com/pax8labs/pax8-cli/issues/657#issuecomment-4870648744) confirmed:

- `GET /products/{id}/pricing` is the only endpoint that separately exposes `partnerBuyRate` + `suggestedRetailPrice`.
- **`pax8 products show --pricing` already ships that split** — no change needed there.
- Every other price surface (`Subscription.price`, `InvoiceItem.price`) is single-valued. The `$0` complaint traced to ambiguous labels + `?? 0` fallbacks, not to missing wire data.

Reframed from the plan's ~1–3 days down to ~3 hours of coding.

## What ships

**`lib/formatters.ts` — new `formatCurrencyNullable(amount, currencyCode)`.** Returns a dim `—` for null / undefined / NaN; formats real values (including a genuine zero) the same way `formatCurrency` does. Colocated tests.

**Subscription surfaces (`subscriptions list / show / cancel / update`)** — three coordinated edits:
- Rename ambiguous `Price` label to `Partner Price` (what the partner pays Pax8), matching the label already used in `products show --pricing`.
- Replace `sub.price ?? 0` display fallbacks with the null-aware helper — a missing upstream `price` now renders as `—` instead of the misleading `$0.00`.
- `subscriptions cancel` guards `Est. Pax8 Cost Impact` at the display site so a null price doesn't produce `-$0.00/mo`.

**`products show --pricing`** — add a computed `Margin` column (`retail − partner`), rendering with the null-aware helper. `--json` shape unchanged; margin is a display-only derivation.

## Test plan

- [x] `pnpm build && pnpm test` — 2403 pass, 0 fail.
- [x] `pnpm lint` — no new warnings (3 pre-existing on main).
- [x] Manual: `PAX8_DEMO=1 pax8 subscriptions list --size 3` — header reads `Partner Price`.
- [x] Manual: `PAX8_DEMO=1 pax8 subscriptions show sub-summit-m365bp-001` — field label reads `Partner Price:`.
- [x] Manual: `PAX8_DEMO=1 pax8 products show prod-m365-biz-prem-0001 --pricing` — table renders `Billing | Commitment | Partner Price | Retail Price | Margin` with M365 showing `$18.00 | $22.00 | $4.00` and `$16.50 | $22.00 | $5.50` for Monthly/Annual.
- [x] Manual: `PAX8_DEMO=1 pax8 subscriptions list --json` — `price` field still present with unchanged semantic.
- [x] 6 new formatCurrencyNullable unit tests pin the null/undefined/NaN → dim-em-dash contract and the "real zero still renders as `$0.00`" invariant.

## Related

- Depends on nothing; touches different files than #662, #663, and #664.
- Follow-up #665 for the demo-mock `partnerBuyPrice` vs API `partnerBuyRate` naming inconsistency (surfaced by the audit).