### PR TITLE
feat(recs): pax8 recommendations email <n> with mailto handoff (UXR F3)

### DIFF
--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -543,6 +543,137 @@ describe("pax8 recommendations", () => {
         expect(result.stdout).toContain("recommendations why");
       });
     });
+
+    // UXR F3 (#658): `pax8 recommendations email <n>` drafts a customer-
+    // ready email from the cached recommendation. The CLI must NOT send —
+    // it emits either a `mailto:` URL, structured JSON, or a human-readable
+    // draft. Same cache-based drill-in as `recommendations why`.
+    describe("recommendations email", () => {
+      let tmpConfigDir: string;
+
+      beforeEach(async () => {
+        tmpConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-recs-email-"));
+      });
+
+      afterEach(async () => {
+        await fs.rm(tmpConfigDir, { recursive: true, force: true });
+      });
+
+      it("default text output shows subject + body + mailto hand-off hint", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const result = await runCliExpectSuccess(
+          ["recommendations", "email", "1"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        expect(result.stdout).toContain("Subject:");
+        expect(result.stdout).toMatch(/Hi\s+\w/);
+        // Next-step hints on stderr point at both --open and --mailto.
+        expect(result.stderr).toContain("--open");
+        expect(result.stderr).toContain("--mailto");
+        // The raw mailto: URL is surfaced for copy-paste.
+        expect(result.stderr).toContain("mailto:");
+      });
+
+      it("--mailto prints the URL and nothing else on stdout", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const result = await runCliExpectSuccess(
+          ["recommendations", "email", "1", "--mailto"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        expect(result.stdout.trim().startsWith("mailto:")).toBe(true);
+        // Single-line — pipeable to `open`, `pbcopy`, etc.
+        expect(result.stdout.trim().split("\n").length).toBe(1);
+      });
+
+      it("--to <email> populates the mailto URL", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const result = await runCliExpectSuccess(
+          ["recommendations", "email", "1", "--to", "alice@example.com", "--mailto"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        // encodeURIComponent turns @ into %40, so both spellings are
+        // acceptable. Match either form.
+        expect(result.stdout).toMatch(/^mailto:alice(@|%40)example\.com\?/);
+      });
+
+      it("--json envelope carries draft.subject / body / mailto / reason", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const result = await runCliExpectSuccess(
+          ["recommendations", "email", "1", "--json"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        const data = JSON.parse(result.stdout);
+        expect(data.draft).toBeDefined();
+        expect(typeof data.draft.subject).toBe("string");
+        expect(typeof data.draft.body).toBe("string");
+        expect(typeof data.draft.mailto).toBe("string");
+        expect(data.draft.mailto.startsWith("mailto:")).toBe(true);
+        expect(typeof data.draft.reason).toBe("string");
+        expect(Array.isArray(data.draft.product_summary)).toBe(true);
+      });
+
+      it("percent-encodes special characters in subject and body", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const result = await runCliExpectSuccess(
+          ["recommendations", "email", "1", "--mailto"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        const url = result.stdout.trim();
+        // Newlines in the body must be percent-encoded so the mailto: URL
+        // survives a click across every mail client.
+        expect(url).toContain("%0A");
+        // Raw newlines and unencoded ampersands would break mailto handoff.
+        expect(url).not.toMatch(/\n/);
+      });
+
+      it("out-of-range index exits 1 with ERROR_RECOMMENDATION_NOT_FOUND", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const result = await runCliExpectFailure(
+          ["recommendations", "email", "999", "--json"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        const start = result.stderr.indexOf("{");
+        expect(start).toBeGreaterThanOrEqual(0);
+        const json = JSON.parse(result.stderr.slice(start));
+        expect(json.code).toBe("ERROR_RECOMMENDATION_NOT_FOUND");
+      });
+
+      it("missing cache exits 1 with a hint to run `recommendations list` first", async () => {
+        const result = await runCliExpectFailure(
+          ["recommendations", "email", "1"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const combined = result.stdout + result.stderr;
+        expect(combined).toContain("No cached recommendations");
+        expect(combined).toContain("recommendations list");
+      });
+
+      it("--help shows the command and its flags", async () => {
+        const result = await runCliExpectSuccess(["recommendations", "email", "--help"]);
+        expect(result.stdout).toContain("email");
+        expect(result.stdout).toContain("--mailto");
+        expect(result.stdout).toContain("--open");
+        expect(result.stdout).toContain("--to");
+      });
+    });
   });
 
   describe("recommendations upsell", () => {

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -387,6 +387,126 @@ describe("pax8 recommendations", () => {
     });
   });
 
+  // UXR F5 (#655): the recommendations table now carries a "Rationale"
+  // column and every rec ships a `rationaleSnippet` in --json output.
+  // `pax8 recommendations why <n>` reads the cached pending-actions.json
+  // and drills into a specific rec without hitting the API.
+  describe("recommendations rationale (#655)", () => {
+    it("every --json rec carries a non-empty rationaleSnippet", async () => {
+      const result = await runCliExpectSuccess([
+        "recommendations", "list", "--json", "--top", "0",
+      ]);
+      const data = JSON.parse(result.stdout);
+      expect(data.recommendations.length).toBeGreaterThan(0);
+      for (const rec of data.recommendations) {
+        expect(typeof rec.rationaleSnippet).toBe("string");
+        expect(rec.rationaleSnippet.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("table-mode list renders a Rationale column", async () => {
+      const result = await runCliExpectSuccess(
+        ["recommendations", "list", "--top", "5"],
+        { PAX8_OUTPUT_FORMAT: "table" },
+      );
+      // The column header appears once in the ASCII table row.
+      expect(result.stdout).toContain("Rationale");
+      // At least one seat-gap snippet ("N/M …") lands in the table.
+      expect(result.stdout).toMatch(/\d+\/\d+ /);
+    });
+
+    describe("recommendations why", () => {
+      let tmpConfigDir: string;
+
+      beforeEach(async () => {
+        tmpConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "pax8-recs-why-"));
+      });
+
+      afterEach(async () => {
+        await fs.rm(tmpConfigDir, { recursive: true, force: true });
+      });
+
+      it("drills into a recommendation after `list` populates the cache", async () => {
+        const listResult = await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        expect(listResult.exitCode).toBe(0);
+        // pending-actions.json exists and includes the new rationale fields.
+        const cache = JSON.parse(
+          await fs.readFile(path.join(tmpConfigDir, "pending-actions.json"), "utf-8"),
+        );
+        expect(Array.isArray(cache)).toBe(true);
+        expect(cache.length).toBeGreaterThan(0);
+        for (const entry of cache) {
+          expect(entry.rec).toHaveProperty("reason");
+          expect(entry.rec).toHaveProperty("rationaleSnippet");
+          expect(typeof entry.rec.reason).toBe("string");
+        }
+
+        const whyResult = await runCliExpectSuccess(
+          ["recommendations", "why", "1"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        expect(whyResult.stdout).toContain("Recommendation #1");
+        expect(whyResult.stdout).toContain("Why this recommendation");
+        expect(whyResult.stdout).toContain("Why it ranks here");
+        // Cross-links to `pax8 explain` for terminology drill-in.
+        expect(whyResult.stdout).toContain("pax8 explain");
+      });
+
+      it("--json envelope carries reason, rationaleSnippet, seeAlso", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const whyResult = await runCliExpectSuccess(
+          ["recommendations", "why", "1", "--json"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        const data = JSON.parse(whyResult.stdout);
+        expect(data.index).toBe(1);
+        expect(typeof data.reason).toBe("string");
+        expect(typeof data.rationaleSnippet).toBe("string");
+        expect(Array.isArray(data.seeAlso)).toBe(true);
+        expect(data.seeAlso.length).toBeGreaterThan(0);
+      });
+
+      it("out-of-range index exits 1 with ERROR_RECOMMENDATION_NOT_FOUND", async () => {
+        await runCli(
+          ["recommendations", "list", "--top", "3"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const result = await runCliExpectFailure(
+          ["recommendations", "why", "999", "--json"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        const start = result.stderr.indexOf("{");
+        expect(start).toBeGreaterThanOrEqual(0);
+        const json = JSON.parse(result.stderr.slice(start));
+        expect(json.code).toBe("ERROR_RECOMMENDATION_NOT_FOUND");
+      });
+
+      it("missing cache exits 1 with a hint to run `recommendations list` first", async () => {
+        // No prior `list` invocation — the cache file doesn't exist in
+        // tmpConfigDir, so `why` must fail loudly with recovery guidance.
+        const result = await runCliExpectFailure(
+          ["recommendations", "why", "1"],
+          { PAX8_CONFIG_DIR: tmpConfigDir, PAX8_OUTPUT_FORMAT: "table" },
+        );
+        const combined = result.stdout + result.stderr;
+        expect(combined).toContain("No cached recommendations");
+        expect(combined).toContain("recommendations list");
+      });
+
+      it("--help shows the command and an example", async () => {
+        const result = await runCliExpectSuccess(["recommendations", "why", "--help"]);
+        expect(result.stdout).toContain("why");
+        expect(result.stdout).toContain("recommendations why");
+      });
+    });
+  });
+
   describe("recommendations upsell", () => {
     it("returns the upsell cohort as JSON by default", async () => {
       const result = await runCliExpectSuccess([

--- a/packages/cli/src/__tests__/recommendations.test.ts
+++ b/packages/cli/src/__tests__/recommendations.test.ts
@@ -499,6 +499,44 @@ describe("pax8 recommendations", () => {
         expect(combined).toContain("recommendations list");
       });
 
+      it("corrupt cache exits 1 with ERROR_RECOMMENDATION_NOT_FOUND and a rewrite hint", async () => {
+        // Write malformed JSON to the cache file to simulate a
+        // truncated / partially written pending-actions.json.
+        await fs.writeFile(
+          path.join(tmpConfigDir, "pending-actions.json"),
+          "{not-json,",
+          "utf-8",
+        );
+        const result = await runCliExpectFailure(
+          ["recommendations", "why", "1", "--json"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        const start = result.stderr.indexOf("{");
+        expect(start).toBeGreaterThanOrEqual(0);
+        const json = JSON.parse(result.stderr.slice(start));
+        expect(json.code).toBe("ERROR_RECOMMENDATION_NOT_FOUND");
+        expect(json.recoverySteps.join(" ")).toContain("recommendations list");
+      });
+
+      it("cache with wrong top-level shape exits 1 with a rewrite hint", async () => {
+        // The reader expects an array of {key, rec} entries. A JSON
+        // object at the top level (an older format, or a stray write)
+        // must fail with the same recovery path.
+        await fs.writeFile(
+          path.join(tmpConfigDir, "pending-actions.json"),
+          JSON.stringify({ wrong: "shape" }),
+          "utf-8",
+        );
+        const result = await runCliExpectFailure(
+          ["recommendations", "why", "1", "--json"],
+          { PAX8_CONFIG_DIR: tmpConfigDir },
+        );
+        const start = result.stderr.indexOf("{");
+        const json = JSON.parse(result.stderr.slice(start));
+        expect(json.code).toBe("ERROR_RECOMMENDATION_NOT_FOUND");
+        expect(json.recoverySteps.join(" ")).toContain("recommendations list");
+      });
+
       it("--help shows the command and an example", async () => {
         const result = await runCliExpectSuccess(["recommendations", "why", "--help"]);
         expect(result.stdout).toContain("why");

--- a/packages/cli/src/commands/recommendations/email.ts
+++ b/packages/cli/src/commands/recommendations/email.ts
@@ -1,0 +1,295 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { ERROR_INVALID_INPUT, ERROR_RECOMMENDATION_NOT_FOUND } from "@pax8/core";
+import { getOutputFormat } from "../../lib/context.js";
+import { CliError, handleCommandError } from "../../lib/errors.js";
+import { formatCurrency } from "../../lib/formatters.js";
+import { replCmd } from "../../lib/confirm.js";
+import { openUrl } from "../../lib/open-url.js";
+import { loadCache, type CachedRec } from "./why.js";
+
+/**
+ * `pax8 recommendations email <n>` — draft a customer-ready email from
+ * the specified recommendation and hand off to the partner's mail
+ * client via a `mailto:` URL. #658 / UXR F3.
+ *
+ * Design constraint: the CLI must NOT send. It emits a draft (JSON
+ * envelope, mailto: URL, or system-opener hand-off) — the partner or
+ * their mail client is the sender-of-record. Matches the safety
+ * contract in `packages/claude-skill/skill.md`.
+ */
+
+interface Draft {
+  to: string | null;
+  subject: string;
+  body: string;
+  mailto: string;
+  rationaleSnippet: string | null;
+  reason: string | null;
+  productSummary: string[];
+  estimatedMrrUplift: number | null;
+  companyName: string;
+}
+
+export const recommendationsEmailCommand = new Command("email")
+  .description(
+    "Draft a customer-ready email for a specific recommendation and hand off to your default mail client",
+  )
+  .argument("<n>", "The `#` from the recommendations table")
+  .option(
+    "--to <email>",
+    "Populate the To: field on the mailto URL. When omitted, the mail client prompts.",
+  )
+  .option(
+    "--mailto",
+    "Print only the mailto: URL (pipeable to `open`, `pbcopy`, `xclip`, etc.)",
+  )
+  .option(
+    "--open",
+    "Fire the OS-native URL opener (macOS `open`, Linux `xdg-open`, Windows `start`) to launch the mail client with the draft pre-populated",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 recommendations email 1
+  pax8 recommendations email 1 --to alice@example.com
+  pax8 recommendations email 1 --mailto | pbcopy
+  pax8 recommendations email 1 --open
+  pax8 recommendations email 1 --json
+
+Reads the cached output of the last \`pax8 recommendations list\` — run
+that first if you get a "no cached recommendations" error.
+
+The CLI never sends the email — it hands the drafted subject + body to
+your default mail client (via a mailto: URL). You review and send.`,
+  )
+  .action(
+    async (
+      nRaw: string,
+      options: { to?: string; mailto?: boolean; open?: boolean },
+      command,
+    ) => {
+      try {
+        const globalOpts = command.optsWithGlobals();
+        const format = getOutputFormat(globalOpts);
+        const wantJson = format === "json";
+        const wantQuiet = format === "quiet";
+
+        const n = parseInt(nRaw, 10);
+        if (Number.isNaN(n) || n <= 0) {
+          throw new CliError(
+            `\`${nRaw}\` is not a valid recommendation index.`,
+            [
+              `Expected a positive integer matching the \`#\` column in \`pax8 recommendations list\`.`,
+            ],
+            [
+              `Run \`${replCmd("pax8 recommendations list")}\` to see the current numbering.`,
+            ],
+            undefined,
+            ERROR_INVALID_INPUT,
+          );
+        }
+
+        const cache = loadCache();
+        const entry = cache.find((e) => e.key === String(n));
+        if (!entry) {
+          throw new CliError(
+            `No recommendation #${n} in the last \`pax8 recommendations list\`.`,
+            [
+              `Cached results contain ${cache.length} recommendation${cache.length === 1 ? "" : "s"} — valid indexes are 1..${cache.length}.`,
+            ],
+            [
+              `Re-run \`${replCmd("pax8 recommendations list")}\` if the portfolio has changed.`,
+              `Or pick a different index (1..${cache.length}).`,
+            ],
+            undefined,
+            ERROR_RECOMMENDATION_NOT_FOUND,
+          );
+        }
+
+        const draft = buildDraft(entry.rec, options.to);
+
+        if (options.open) {
+          // Print the URL first so it's visible even if the opener silently
+          // fails (headless SSH, missing xdg-open, no default handler, etc.).
+          // Same affordance pattern as `auth/login.ts` and `report-bug.ts`.
+          process.stderr.write(chalk.dim(`  Opening: ${draft.mailto}\n`));
+          const opened = await openUrl(draft.mailto);
+          if (!opened) {
+            process.stderr.write(
+              chalk.yellow(
+                `  Couldn't launch a mail client. Copy the URL above into your browser or mail app.\n`,
+              ),
+            );
+          }
+          return;
+        }
+
+        if (options.mailto) {
+          // Stdout-only single-line URL — safe to pipe to `open`, `pbcopy`,
+          // `xclip`, `wl-copy`, `clip.exe`, etc.
+          process.stdout.write(draft.mailto + "\n");
+          return;
+        }
+
+        renderDraft(draft, { wantJson, wantQuiet });
+      } catch (error) {
+        await handleCommandError(error, undefined, "Failed to draft email");
+      }
+    },
+  );
+
+// ─── Draft builder ─────────────────────────────────────────────────────────
+
+function buildDraft(rec: CachedRec, to: string | undefined): Draft {
+  const kind: "seat_gap" | "cross_sell" =
+    rec.type === "seat_gap" ? "seat_gap" : "cross_sell";
+  const primaryProduct = rec.suggestedProducts?.[0] ?? "the recommended product";
+  const upliftLabel =
+    rec.estimatedMrrUplift != null
+      ? `${formatCurrency(rec.estimatedMrrUplift)}/mo`
+      : null;
+
+  const subject =
+    kind === "seat_gap"
+      ? `Bridging your ${primaryProduct} coverage gap`
+      : `A gap worth addressing in ${rec.companyName}'s stack`;
+
+  const bodyLines: string[] =
+    kind === "seat_gap"
+      ? seatGapBody(rec, primaryProduct, upliftLabel)
+      : crossSellBody(rec, primaryProduct, upliftLabel);
+
+  const body = bodyLines.join("\n");
+
+  // mailto: URL. Per RFC 6068 we percent-encode subject and body via
+  // encodeURIComponent, then swap `+` back to `%20` because some mail
+  // clients (notably older Outlook installs) treat `+` as a literal.
+  const encode = (s: string): string =>
+    encodeURIComponent(s).replace(/\+/g, "%20");
+  const params = [
+    `subject=${encode(subject)}`,
+    `body=${encode(body)}`,
+  ];
+  const mailto = `mailto:${to ? encodeURIComponent(to) : ""}?${params.join("&")}`;
+
+  return {
+    to: to ?? null,
+    subject,
+    body,
+    mailto,
+    rationaleSnippet: rec.rationaleSnippet ?? null,
+    reason: rec.reason ?? null,
+    productSummary: rec.suggestedProducts ?? [],
+    estimatedMrrUplift: rec.estimatedMrrUplift ?? null,
+    companyName: rec.companyName,
+  };
+}
+
+function seatGapBody(
+  rec: CachedRec,
+  primaryProduct: string,
+  upliftLabel: string | null,
+): string[] {
+  const anchor = rec.rationaleSnippet ?? "a cross-product seat mismatch";
+  const reasonLine =
+    rec.reason ??
+    `${primaryProduct} coverage is behind the rest of the stack, leaving some users unprotected.`;
+  const seats = rec.targetSeats != null ? `${rec.targetSeats} more seats` : "additional seats";
+  const priceClause = upliftLabel
+    ? `and cost about ${upliftLabel} more`
+    : "";
+
+  return [
+    `Hi ${rec.companyName},`,
+    "",
+    `Reviewing your Pax8 stack today, I noticed ${anchor} — for context, ${reasonLine}`,
+    "",
+    `Adding ${seats} of ${primaryProduct} would close the gap ${priceClause}, keeping every user covered under the same policy.`,
+    "",
+    `Happy to walk through this together — reply and we'll set a time.`,
+    "",
+    `<partner name>`,
+  ];
+}
+
+function crossSellBody(
+  rec: CachedRec,
+  primaryProduct: string,
+  upliftLabel: string | null,
+): string[] {
+  const reasonLine =
+    rec.reason ??
+    `there's a gap in the stack worth closing.`;
+  const priceClause = upliftLabel
+    ? `estimated added cost around ${upliftLabel}.`
+    : "impact varies by seat count — happy to price it for you.";
+
+  return [
+    `Hi ${rec.companyName},`,
+    "",
+    `Auditing your subscriptions today, one gap stood out: ${reasonLine}`,
+    "",
+    `${primaryProduct} would close it — ${priceClause} It ties in cleanly with what you already run, and the switch is minimal-touch.`,
+    "",
+    `Happy to walk through this — reply and we'll set a time.`,
+    "",
+    `<partner name>`,
+  ];
+}
+
+// ─── Renderer (default text + --json paths) ────────────────────────────────
+
+function renderDraft(
+  draft: Draft,
+  { wantJson, wantQuiet }: { wantJson: boolean; wantQuiet: boolean },
+): void {
+  if (wantQuiet) return;
+
+  if (wantJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          draft: {
+            to: draft.to,
+            subject: draft.subject,
+            body: draft.body,
+            mailto: draft.mailto,
+            rationaleSnippet: draft.rationaleSnippet,
+            reason: draft.reason,
+            product_summary: draft.productSummary,
+            estimatedMrrUplift: draft.estimatedMrrUplift,
+            companyName: draft.companyName,
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  // Human text mode: show the drafted subject + body so partners can
+  // copy manually, and surface the mailto URL as a next-step hint.
+  process.stdout.write("\n" + chalk.bold("Subject: ") + draft.subject + "\n\n");
+  process.stdout.write(draft.body + "\n\n");
+
+  process.stderr.write(
+    chalk.dim("Hand off to your mail client:\n") +
+      chalk.dim("  · Open now:    ") +
+      chalk.cyan(replCmd("pax8 recommendations email <n> --open")) +
+      "\n" +
+      chalk.dim("  · Copy URL:    ") +
+      chalk.cyan(replCmd("pax8 recommendations email <n> --mailto") + " | pbcopy") +
+      "\n" +
+      chalk.dim("  · Populate To: add ") +
+      chalk.cyan("--to alice@example.com") +
+      "\n\n",
+  );
+  process.stderr.write(chalk.dim("Or copy the mailto URL directly:\n"));
+  process.stderr.write("  " + chalk.cyan(draft.mailto) + "\n\n");
+}

--- a/packages/cli/src/commands/recommendations/filter.test.ts
+++ b/packages/cli/src/commands/recommendations/filter.test.ts
@@ -13,6 +13,7 @@ function makeRec(overrides: Partial<Recommendation> = {}): Recommendation {
     priority: "high",
     title: "Add Microsoft Defender for Endpoint",
     reason: "No endpoint protection detected",
+    rationaleSnippet: "no endpoint protection",
     suggestedProducts: ["Microsoft Defender for Endpoint P2"],
     orderCommand: null,
     productAvailable: true,

--- a/packages/cli/src/commands/recommendations/index.ts
+++ b/packages/cli/src/commands/recommendations/index.ts
@@ -5,6 +5,7 @@ import { Command } from "commander";
 import { recommendationsListCommand } from "./list.js";
 import { recommendationsActCommand } from "./act.js";
 import { recommendationsUpsellCommand } from "./upsell.js";
+import { recommendationsWhyCommand } from "./why.js";
 
 export function registerRecommendationsCommands(program: Command): void {
   const recommendations = new Command("recommendations")
@@ -14,6 +15,7 @@ export function registerRecommendationsCommands(program: Command): void {
   recommendations.addCommand(recommendationsListCommand);
   recommendations.addCommand(recommendationsActCommand);
   recommendations.addCommand(recommendationsUpsellCommand);
+  recommendations.addCommand(recommendationsWhyCommand);
 
   program.addCommand(recommendations);
 }

--- a/packages/cli/src/commands/recommendations/index.ts
+++ b/packages/cli/src/commands/recommendations/index.ts
@@ -6,6 +6,7 @@ import { recommendationsListCommand } from "./list.js";
 import { recommendationsActCommand } from "./act.js";
 import { recommendationsUpsellCommand } from "./upsell.js";
 import { recommendationsWhyCommand } from "./why.js";
+import { recommendationsEmailCommand } from "./email.js";
 
 export function registerRecommendationsCommands(program: Command): void {
   const recommendations = new Command("recommendations")
@@ -16,6 +17,7 @@ export function registerRecommendationsCommands(program: Command): void {
   recommendations.addCommand(recommendationsActCommand);
   recommendations.addCommand(recommendationsUpsellCommand);
   recommendations.addCommand(recommendationsWhyCommand);
+  recommendations.addCommand(recommendationsEmailCommand);
 
   program.addCommand(recommendations);
 }

--- a/packages/cli/src/commands/recommendations/list.ts
+++ b/packages/cli/src/commands/recommendations/list.ts
@@ -56,6 +56,9 @@ const columns: Column[] = [
   },
   { key: "type", header: "Type", format: (v) => String(v) === "seat_gap" ? "Seat Gap" : "Cross-sell" },
   { key: "title", header: "Recommendation" },
+  // #655 / UXR F5: at-a-glance "why" between the recommendation title and
+  // the uplift. Engine populates it; we just render.
+  { key: "rationaleSnippet", header: "Rationale", format: (v) => chalk.dim(String(v)) },
   {
     key: "estimatedMrrUplift",
     header: "Pax8 Cost+",
@@ -491,6 +494,15 @@ Note: Numbers shown are Pax8 cost — what Pax8 charges you. For partner revenue
                 orderCommand: r.orderCommand,
                 suggestedProducts: r.suggestedProducts,
                 targetSeats: r.targetSeats,
+                // #655 / UXR F5: persist rationale so `recommendations why <n>`
+                // can drill in without re-running the engine.
+                type: r.type,
+                priority: r.priority,
+                opportunityType: r.opportunityType,
+                reason: r.reason,
+                rationaleSnippet: r.rationaleSnippet,
+                estimatedMrrUplift: r.estimatedMrrUplift,
+                productAvailable: r.productAvailable,
               },
             })),
           ),

--- a/packages/cli/src/commands/recommendations/why.ts
+++ b/packages/cli/src/commands/recommendations/why.ts
@@ -66,8 +66,38 @@ function loadCache(): CachedEntry[] {
       ERROR_RECOMMENDATION_NOT_FOUND,
     );
   }
-  const raw = readFileSync(file, "utf8");
-  return JSON.parse(raw) as CachedEntry[];
+  // TOCTOU window between existsSync and readFileSync, plus the file
+  // is self-produced but not guaranteed well-formed on disk (partial
+  // write, corrupted JSON, stale format). Convert every failure mode
+  // into the same structured recovery hint so we don't leak a raw
+  // SyntaxError / ENOENT past the CliError envelope.
+  let parsed: unknown;
+  try {
+    const raw = readFileSync(file, "utf8");
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new CliError(
+      `Cached recommendations at \`${file}\` are unreadable or corrupted.`,
+      [err instanceof Error ? err.message : String(err)],
+      [
+        `Re-run \`${replCmd("pax8 recommendations list")}\` to rewrite the cache, then re-run this command.`,
+      ],
+      undefined,
+      ERROR_RECOMMENDATION_NOT_FOUND,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new CliError(
+      `Cached recommendations at \`${file}\` are in an unexpected format.`,
+      [`Expected a JSON array; got \`${typeof parsed}\`.`],
+      [
+        `Re-run \`${replCmd("pax8 recommendations list")}\` to rewrite the cache.`,
+      ],
+      undefined,
+      ERROR_RECOMMENDATION_NOT_FOUND,
+    );
+  }
+  return parsed as CachedEntry[];
 }
 
 export const recommendationsWhyCommand = new Command("why")

--- a/packages/cli/src/commands/recommendations/why.ts
+++ b/packages/cli/src/commands/recommendations/why.ts
@@ -1,0 +1,232 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { ERROR_INVALID_INPUT, ERROR_RECOMMENDATION_NOT_FOUND, getConfigDir } from "@pax8/core";
+import { getOutputFormat } from "../../lib/context.js";
+import { CliError, handleCommandError } from "../../lib/errors.js";
+import { formatCurrency } from "../../lib/formatters.js";
+import { replCmd } from "../../lib/confirm.js";
+
+/**
+ * `pax8 recommendations why <n>` — expanded rationale for a specific
+ * recommendation. #655 / UXR F5.
+ *
+ * Reads the `pending-actions.json` cache written by `recommendations
+ * list`. No API call — everything the drill-down needs was persisted
+ * there. If the user hasn't run `list` yet (no cache), or the index
+ * is out of range, we throw `ERROR_RECOMMENDATION_NOT_FOUND` with a
+ * clear recovery hint.
+ */
+
+interface CachedRec {
+  companyId: string;
+  companyName: string;
+  title: string;
+  orderArgs: string[] | null;
+  orderCommand: string | null;
+  suggestedProducts: string[];
+  targetSeats: number | null;
+  // #655 additions: everything the drill-down surfaces beyond title.
+  type?: "cross_sell" | "seat_gap";
+  priority?: "high" | "medium" | "low";
+  opportunityType?: string;
+  reason?: string;
+  rationaleSnippet?: string;
+  estimatedMrrUplift?: number | null;
+  productAvailable?: boolean;
+}
+
+interface CachedEntry {
+  key: string;
+  rec: CachedRec;
+}
+
+// Which glossary terms each rec type wants to point at. Kept minimal;
+// the drill-down output shows them as `pax8 explain <term>` hints so
+// partners can jump to the definition without leaving the workflow.
+const SEE_ALSO_BY_TYPE: Record<"seat_gap" | "cross_sell", string[]> = {
+  seat_gap: ["seat-gap", "mrr-uplift", "opportunity-type"],
+  cross_sell: ["cross-sell", "mrr-uplift", "opportunity-type"],
+};
+
+function loadCache(): CachedEntry[] {
+  const file = join(getConfigDir(), "pending-actions.json");
+  if (!existsSync(file)) {
+    throw new CliError(
+      `No cached recommendations found.`,
+      [`The drill-down reads the last \`pax8 recommendations list\` invocation's output from \`${file}\`.`],
+      [
+        `Run \`${replCmd("pax8 recommendations list")}\` first, then re-run this command.`,
+      ],
+      undefined,
+      ERROR_RECOMMENDATION_NOT_FOUND,
+    );
+  }
+  const raw = readFileSync(file, "utf8");
+  return JSON.parse(raw) as CachedEntry[];
+}
+
+export const recommendationsWhyCommand = new Command("why")
+  .description("Explain a specific recommendation from the last `recommendations list`")
+  .argument("<n>", "The `#` from the recommendations table")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  pax8 recommendations why 1
+  pax8 recommendations why 3 --json
+
+Reads the cached output of the last \`pax8 recommendations list\` — run
+that first if you get a "no cached recommendations" error.`
+  )
+  .action(async (nRaw: string, _options, command) => {
+    try {
+      const globalOpts = command.optsWithGlobals();
+      const format = getOutputFormat(globalOpts);
+      const wantJson = format === "json";
+      const wantQuiet = format === "quiet";
+
+      const n = parseInt(nRaw, 10);
+      if (Number.isNaN(n) || n <= 0) {
+        throw new CliError(
+          `\`${nRaw}\` is not a valid recommendation index.`,
+          [`Expected a positive integer matching the \`#\` column in \`pax8 recommendations list\`.`],
+          [`Run \`${replCmd("pax8 recommendations list")}\` to see the current numbering.`],
+          undefined,
+          ERROR_INVALID_INPUT,
+        );
+      }
+
+      const cache = loadCache();
+      const entry = cache.find((e) => e.key === String(n));
+      if (!entry) {
+        throw new CliError(
+          `No recommendation #${n} in the last \`pax8 recommendations list\`.`,
+          [`Cached results contain ${cache.length} recommendation${cache.length === 1 ? "" : "s"} — valid indexes are 1..${cache.length}.`],
+          [
+            `Re-run \`${replCmd("pax8 recommendations list")}\` if the portfolio has changed.`,
+            `Or pick a different index (1..${cache.length}).`,
+          ],
+          undefined,
+          ERROR_RECOMMENDATION_NOT_FOUND,
+        );
+      }
+
+      renderWhy(entry, { wantJson, wantQuiet });
+    } catch (error) {
+      await handleCommandError(error, undefined, "Failed to explain recommendation");
+    }
+  });
+
+// ─── Renderer ──────────────────────────────────────────────────────────────
+
+function renderWhy(
+  entry: CachedEntry,
+  { wantJson, wantQuiet }: { wantJson: boolean; wantQuiet: boolean },
+): void {
+  if (wantQuiet) return;
+
+  const { rec } = entry;
+  const seeAlso =
+    rec.type && SEE_ALSO_BY_TYPE[rec.type] ? SEE_ALSO_BY_TYPE[rec.type] : ["mrr-uplift", "opportunity-type"];
+
+  if (wantJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          index: parseInt(entry.key, 10),
+          companyId: rec.companyId,
+          companyName: rec.companyName,
+          type: rec.type ?? null,
+          opportunityType: rec.opportunityType ?? null,
+          priority: rec.priority ?? null,
+          title: rec.title,
+          reason: rec.reason ?? null,
+          rationaleSnippet: rec.rationaleSnippet ?? null,
+          estimatedMrrUplift: rec.estimatedMrrUplift ?? null,
+          productAvailable: rec.productAvailable ?? null,
+          targetSeats: rec.targetSeats,
+          orderArgs: rec.orderArgs,
+          seeAlso,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  const typeLabel = rec.type === "seat_gap" ? "Seat Gap" : rec.type === "cross_sell" ? "Cross-sell" : "Recommendation";
+  const priorityChip =
+    rec.priority === "high"
+      ? chalk.red.bold("HIGH")
+      : rec.priority === "medium"
+        ? chalk.yellow("MED")
+        : rec.priority === "low"
+          ? chalk.dim("LOW")
+          : "";
+  const upliftChip =
+    rec.estimatedMrrUplift != null
+      ? chalk.green(`+${formatCurrency(rec.estimatedMrrUplift)}/mo Pax8 cost`)
+      : "";
+
+  process.stdout.write("\n" + chalk.bold(`Recommendation #${entry.key}`) + "\n");
+  const headerBits = [chalk.cyan(rec.companyName), typeLabel, priorityChip, upliftChip].filter((s) => s.length > 0);
+  process.stdout.write("  " + headerBits.join(chalk.dim(" · ")) + "\n\n");
+  process.stdout.write("  " + rec.title + "\n\n");
+
+  if (rec.reason) {
+    process.stdout.write(chalk.bold("Why this recommendation") + "\n");
+    process.stdout.write("  " + wrap(rec.reason, 74) + "\n\n");
+  }
+
+  // Sort narrative — a global property, not per-rec, but the drill-down is
+  // the natural place to answer "why is this one first?" too.
+  process.stdout.write(chalk.bold("Why it ranks here") + "\n");
+  process.stdout.write(
+    "  " +
+      wrap(
+        "Sorted by estimated monthly Pax8 cost uplift, descending. Priority (high, medium, low) is the tiebreaker — but a $5k/mo medium still ranks above a $500/mo high on the primary sort.",
+        74,
+      ) +
+      "\n\n",
+  );
+
+  const facts: string[] = [];
+  if (rec.productAvailable != null) {
+    facts.push(`Orderable now: ${rec.productAvailable ? chalk.green("yes") : chalk.dim("no")}`);
+  }
+  if (rec.targetSeats != null) facts.push(`Target seats: ${rec.targetSeats}`);
+  if (facts.length > 0) {
+    process.stdout.write("  " + facts.join(chalk.dim("  ·  ")) + "\n\n");
+  }
+
+  process.stdout.write(chalk.dim("See also:  ") + seeAlso.map((s) => chalk.cyan(replCmd(`pax8 explain ${s}`))).join(chalk.dim("    ")) + "\n");
+  process.stdout.write(chalk.dim("To act:    ") + chalk.cyan(replCmd("pax8 recommendations act")) + "\n\n");
+}
+
+/**
+ * Simple word-wrap for the "Why" paragraphs. Two-space indent is applied
+ * by the caller; this function just splits on whitespace to `width` chars.
+ */
+function wrap(text: string, width: number): string {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current += " " + word;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current.length > 0) lines.push(current);
+  return lines.join("\n  ");
+}

--- a/packages/cli/src/commands/recommendations/why.ts
+++ b/packages/cli/src/commands/recommendations/why.ts
@@ -40,10 +40,12 @@ interface CachedRec {
   productAvailable?: boolean;
 }
 
-interface CachedEntry {
+export interface CachedEntry {
   key: string;
   rec: CachedRec;
 }
+
+export type { CachedRec };
 
 // Which glossary terms each rec type wants to point at. Kept minimal;
 // the drill-down output shows them as `pax8 explain <term>` hints so
@@ -53,7 +55,7 @@ const SEE_ALSO_BY_TYPE: Record<"seat_gap" | "cross_sell", string[]> = {
   cross_sell: ["cross-sell", "mrr-uplift", "opportunity-type"],
 };
 
-function loadCache(): CachedEntry[] {
+export function loadCache(): CachedEntry[] {
   const file = join(getConfigDir(), "pending-actions.json");
   if (!existsSync(file)) {
     throw new CliError(

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -33,6 +33,13 @@ export const ERROR_QUOTE_LINE_ITEM_NOT_FOUND = "ERROR_QUOTE_LINE_ITEM_NOT_FOUND"
  * real failures.
  */
 export const ERROR_CANCELLED = "ERROR_CANCELLED";
+/**
+ * `pax8 recommendations why <n>` was passed an index that isn't in the
+ * cached results of the last `recommendations list` invocation — either
+ * out-of-range, or the cache file doesn't exist. Recovery hint tells the
+ * user to run `recommendations list` first.
+ */
+export const ERROR_RECOMMENDATION_NOT_FOUND = "ERROR_RECOMMENDATION_NOT_FOUND";
 
 /**
  * Union of all known Pax8 CLI error codes. Use this for exhaustive switch
@@ -52,4 +59,5 @@ export type Pax8ErrorCode =
   | typeof ERROR_NOT_FOUND
   | typeof ERROR_INTERNAL
   | typeof ERROR_QUOTE_LINE_ITEM_NOT_FOUND
-  | typeof ERROR_CANCELLED;
+  | typeof ERROR_CANCELLED
+  | typeof ERROR_RECOMMENDATION_NOT_FOUND;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ export {
   ERROR_INTERNAL,
   ERROR_QUOTE_LINE_ITEM_NOT_FOUND,
   ERROR_CANCELLED,
+  ERROR_RECOMMENDATION_NOT_FOUND,
 } from "./errors/codes.js";
 export type { Pax8ErrorCode } from "./errors/codes.js";
 

--- a/packages/core/src/services/recommendations.test.ts
+++ b/packages/core/src/services/recommendations.test.ts
@@ -230,6 +230,55 @@ describe("getRecommendations", () => {
     expect(report.recommendations.some((r) => r.opportunityType === "Upsell")).toBe(true);
   });
 
+  // #655 / UXR F5: every rec carries a short "at-a-glance why" for the
+  // `Rationale` column in `recommendations list`. Customer-specific
+  // quantitative anchor for seat gaps (a ratio), categorical form for
+  // cross-sell rules and zero-active-subs.
+  it("populates rationaleSnippet on every recommendation across all emit paths", () => {
+    const subs = [
+      makeSub({ companyId: "c1", companyName: "Has Productivity", quantity: 100, price: 22 }),
+      makeSub({
+        companyId: "c1", companyName: "Has Productivity",
+        productId: "p2", productName: "Microsoft 365 Business Basic [New Commerce Experience]",
+        quantity: 20, price: 6,
+      }),
+    ];
+    const companies = [
+      { id: "c1", name: "Has Productivity" },
+      { id: "c2", name: "Ghost Co" },
+    ];
+    const report = getRecommendations(subs, undefined, companies);
+
+    // Every rec has a non-empty snippet that fits the table budget.
+    for (const rec of report.recommendations) {
+      expect(rec.rationaleSnippet).toBeTruthy();
+      expect(rec.rationaleSnippet.length).toBeLessThanOrEqual(40);
+    }
+
+    // Seat-gap snippets are a quantity ratio ("20/100 productivity").
+    const seatGaps = report.recommendations.filter((r) => r.type === "seat_gap");
+    expect(seatGaps.length).toBeGreaterThan(0);
+    for (const rec of seatGaps) {
+      expect(rec.rationaleSnippet).toMatch(/^\d+\/\d+ /);
+    }
+
+    // Cross-sell rule snippets are categorical ("no backup", "no security", …).
+    const crossSells = report.recommendations.filter(
+      (r) => r.type === "cross_sell" && r.companyId === "c1",
+    );
+    expect(crossSells.length).toBeGreaterThan(0);
+    for (const rec of crossSells) {
+      expect(rec.rationaleSnippet).toMatch(/^no /);
+    }
+
+    // Zero-active-subs path uses the fixed "no active subs" snippet.
+    const zeroSub = report.recommendations.find(
+      (r) => r.companyId === "c2" && r.title.includes("No active subscriptions"),
+    );
+    expect(zeroSub).toBeDefined();
+    expect(zeroSub!.rationaleSnippet).toBe("no active subs");
+  });
+
   // orderCommand is the agent's handle on a recommendation — CLAUDE.md and
   // skill.md document "extract orderCommand from --json and run it." That
   // makes the agent the unintentional executor of any value we interpolate

--- a/packages/core/src/services/recommendations.ts
+++ b/packages/core/src/services/recommendations.ts
@@ -174,6 +174,22 @@ export const ALL_CATEGORIES: ProductCategory[] = [
   "cloud_infrastructure",
 ];
 
+/**
+ * Short human labels for each product category, used to build the
+ * `rationaleSnippet` on every Recommendation. Kept intentionally short
+ * (≤ ~20 chars) so the snippet fits in the `recommendations list`
+ * table column between the title and the uplift. #655 / UXR F5.
+ */
+const CATEGORY_SHORT_LABEL: Record<ProductCategory, string> = {
+  productivity: "productivity",
+  email: "email",
+  security: "security",
+  endpoint_protection: "endpoint protection",
+  identity: "identity/MFA",
+  backup: "backup",
+  cloud_infrastructure: "cloud",
+};
+
 export function categorizeProduct(productName: string): ProductCategory[] {
   const categories: ProductCategory[] = [];
   for (const rule of CATEGORY_RULES) {
@@ -366,6 +382,15 @@ export interface Recommendation {
   priority: "high" | "medium" | "low";
   title: string;
   reason: string;
+  /**
+   * Short "at-a-glance why" — customer-specific quantitative anchor when
+   * available (e.g. `"30/150 backup"`), categorical when not
+   * (e.g. `"no backup"`, `"no active subs"`). Kept ≤ ~20 chars so it
+   * fits in the `recommendations list` table between the title and the
+   * uplift column. #655 / UXR F5. See also the full `reason` above for
+   * the paragraph-length explanation surfaced by `recommendations why`.
+   */
+  rationaleSnippet: string;
   suggestedProducts: string[];
   /**
    * The exact CLI command to execute this recommendation.
@@ -724,6 +749,7 @@ export function getRecommendations(
           priority: effectivePriority,
           title,
           reason: rule.reason,
+          rationaleSnippet: `no ${CATEGORY_SHORT_LABEL[rule.butMissing]}`,
           suggestedProducts: [resolvedProductName, ...rule.suggestedProducts.slice(1)],
           orderCommand,
           orderArgs,
@@ -772,6 +798,7 @@ export function getRecommendations(
         // heuristic is cross-product mismatch coverage. See #298.
         title: `${gap.missingSeats} mismatched seats: ${gap.gapProduct} (${gap.gapQuantity}/${gap.baseQuantity})`,
         reason: `${gap.baseProduct} covers ${gap.baseQuantity} seats but ${gap.gapProduct} only covers ${gap.gapQuantity}. ${gap.missingSeats} seats are unprotected.`,
+        rationaleSnippet: `${gap.gapQuantity}/${gap.baseQuantity} ${CATEGORY_SHORT_LABEL[gap.category]}`,
         suggestedProducts: [gap.gapProduct],
         orderCommand,
         orderArgs,
@@ -805,6 +832,7 @@ export function getRecommendations(
           priority: "high",
           title: `No active subscriptions for ${company.name}`,
           reason: "This customer has no active subscriptions. Consider reaching out to discuss their needs.",
+          rationaleSnippet: "no active subs",
           suggestedProducts: [],
           orderCommand: null,
           orderArgs: null,


### PR DESCRIPTION
## Summary

Track 3 of the [2026-07-02 UXR readout](https://app.notion.com/p/3918fa2a9e288124b6d4ed20bdc73cdd). Participants described a repeated workflow: export recs → paste into Copilot → generate a customer email. Josh: *"why don't we just generate the email?"*

Design constraint (from #658): **the CLI must not send.** Emit as data — draft JSON, a `mailto:` URL, or fire the OS-native opener with the draft pre-populated in the partner's default mail client. Same safety contract as `packages/claude-skill/skill.md`.

Closes #658. Also closes #659 as no-code-changes-needed — see the [audit comment](https://github.com/pax8labs/pax8-cli/issues/659#issuecomment-4871128029) for the per-command envelope matrix.

Tracking: #661.

> **Base branch note:** this PR targets `feat/uxr-recommendations-why` (#664) rather than `main` because it reuses the exported `loadCache()` + extended `pending-actions.json` shape from that branch. Once #664 merges, retarget this to `main`. If you prefer to merge in the reverse order, this PR still applies cleanly on main once #664 is in.

## Surface

```
pax8 recommendations email 1                                # text draft + mailto hint
pax8 recommendations email 1 --json                         # structured envelope
pax8 recommendations email 1 --mailto                       # single-line URL, pipeable
pax8 recommendations email 1 --to alice@example.com --mailto
pax8 recommendations email 1 --open                         # spawn OS-native opener
```

Template selection reads the cached `type` field:
- **seat_gap** → "Bridging your `<product>` coverage gap" — pulls `rationaleSnippet`, `targetSeats`, `estimatedMrrUplift`.
- **cross_sell** → "A gap worth addressing in `<company>`'s stack" — pulls `reason` and the primary suggested product.

Both end with a literal `<partner name>` placeholder. Plumbing operator identity through is a follow-up.

## Sample text output

```
Subject: Bridging your M365 onboarding & migration (one-time) coverage gap

Hi Coastline Legal Group,

Reviewing your Pax8 stack today, I noticed 1/40 productivity — for context,
Microsoft 365 E3 [New Commerce Experience] covers 40 seats but M365
onboarding & migration (one-time) only covers 1. 39 seats are unprotected.

Adding 39 more seats of M365 onboarding & migration (one-time) would close
the gap and cost about $195,000.00/mo more, keeping every user covered
under the same policy.

Happy to walk through this together — reply and we'll set a time.

<partner name>

Hand off to your mail client:
  · Open now:    pax8 recommendations email <n> --open
  · Copy URL:    pax8 recommendations email <n> --mailto | pbcopy
  · Populate To: add --to alice@example.com
```

## What ships

- `packages/cli/src/commands/recommendations/email.ts` (new) — command builder, template selection, mailto builder, three output surfaces (text / JSON / bare URL) plus `--open`.
- `packages/cli/src/commands/recommendations/why.ts` — small change: export `loadCache()` and the `CachedRec` / `CachedEntry` types so `email.ts` can reuse them. No behavior change.
- `packages/cli/src/commands/recommendations/index.ts` — one-line `.addCommand(recommendationsEmailCommand)`.
- 8 subprocess tests colocated in the existing `recommendations.test.ts`.

Reuses:
- `loadCache()` from `why.ts` (#664) — same `pending-actions.json` contract.
- `openUrl()` from `packages/cli/src/lib/open-url.ts` — the cross-platform system-opener helper.
- Affordance pattern from `auth/login.ts` / `report-bug.ts`: print URL first, then call opener, so the URL is visible even if the opener fails.
- `formatCurrency` for the uplift in the body.

## Reviewer asks

- **Wording review** on the two template variants (`seatGapBody` + `crossSellBody` in `email.ts`) — `needs-sme-review` label applied. Please red-pencil anything you'd say differently to a partner.
- The `<partner name>` placeholder is v1 — no `whoami` path in the current API surface. Follow-up ticket if we want to plumb it through partner profile.
- The mailto URL is ~800 chars for a full seat-gap draft; well under Outlook's 2048 cap and every other major client. If a longer template ever pushes past 2000 chars we may need to shorten or offer a `--body-file` variant.

## Test plan

- [x] `pnpm build && pnpm test` — 2413 pass, 0 fail. Adds 8 subprocess tests.
- [x] `pnpm lint` — no new warnings (3 pre-existing on `main`).
- [x] Manual: `PAX8_DEMO=1 pax8 recommendations list --top 3` then `email 1` — renders subject + body + mailto URL + hand-off hints.
- [x] Manual: `PAX8_DEMO=1 pax8 recommendations email 1 --json | jq '.draft.mailto'` — starts with `mailto:`.
- [x] Manual: `PAX8_DEMO=1 pax8 recommendations email 1 --mailto` — single-line URL, pipeable.
- [x] Manual: `PAX8_DEMO=1 pax8 recommendations email 1 --to alice@example.com --mailto` — URL starts with `mailto:alice%40example.com?`.
- [x] Manual: `PAX8_DEMO=1 pax8 recommendations email 999` — exits 1 with recovery hint.
- [x] Manual: fresh state, `pax8 recommendations email 1` — exits 1 with "run `recommendations list` first" hint.
- [x] Verified body newlines are percent-encoded (`%0A`) in the mailto URL.

## Companion audit (closes #659)

The [export shape audit](https://github.com/pax8labs/pax8-cli/issues/659#issuecomment-4871128029) posted on #659 found no gaps. Every recommendation-adjacent command already ships stable envelopes and CSV support. Two "custom" shapes (`invoices audit`, `report renewals`) are aggregation reports whose semantics don't fit a paginated list — leaving them as-is is correct. #659 is closed.