### PR TITLE
ci(claude-review): skip on dependabot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,9 +23,17 @@ concurrency:
 
 jobs:
   claude-review:
+    # Also skip on dependabot-authored PRs. Dependabot PRs land on
+    # branches in the same repo (so the head.repo.full_name check
+    # above doesn't catch them), but GitHub withholds repo secrets
+    # from dependabot-triggered runs by default. Without this guard
+    # `ANTHROPIC_API_KEY` is empty and the action fails — a red X on
+    # every routine dep bump. Dependabot PRs are formulaic and don't
+    # need AI review anyway.
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Summary

- `claude-code-review.yml` already skips fork PRs (they can't see `ANTHROPIC_API_KEY`), but dependabot pushes to same-repo branches, so it falls through and fails with an empty secret.
- Add `github.actor != 'dependabot[bot]'` to the same-repo guard. Removes the red 1/8 on every open dependabot PR (#673, #672, #671, #669, #668, #642, #641) and every future dep bump.
- Dependabot PRs are formulaic — no signal lost by skipping AI review.

## Test plan

- [ ] Merge, then trigger a dependabot rebase on any of #673/#672/#671/#669/#668 — the `claude-review` job should be `skipped` rather than `failed`.
- [ ] Regular contributor PRs continue to get reviewed (the guard only excludes `dependabot[bot]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)