### PR TITLE
ci(release): pin pnpm + enable HTTP debug so the next 0.1.6 publish is diagnosable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pin pnpm to the version declared in root `packageManager` so the
+      # runtime doesn't drift off the pnpm/action-setup default. The
+      # previous release runs surfaced a `pnpm v10 installation layout /
+      # pnpm v11 expects bins in PNPM_HOME/bin` warning — the runner had
+      # an older pnpm on the image and the action's default target had
+      # moved past it, leaving the publish step running an untested
+      # pnpm/npm combination. Explicit pin keeps the tarball packing +
+      # publish path matched to `pnpm@9.15.4`, which is what maintainers
+      # exercise locally.
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 9.15.4
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -46,6 +57,17 @@ jobs:
       # ships 0.1.0 for `@pax8/cli` and `@pax8/core`. Subsequent pushes do
       # nothing until a "chore: release" PR (opened by the action below
       # when a changeset is present) bumps versions and is merged.
+      #
+      # 0.1.5 publish attempt (2026-07-06/07) failed here with a hard-to-
+      # diagnose `E404 Not Found - PUT https://registry.npmjs.org/@pax8%2fcore`.
+      # Provenance signing (sigstore) succeeded — meaning the OIDC token was
+      # minted correctly and the workflow identity matched the trusted-
+      # publisher pattern — but the actual PUT to the registry got 404,
+      # which npm returns for scoped packages when the effective identity
+      # lacks publish rights. 0.1.5 was ultimately shipped from a
+      # maintainer laptop via `pnpm publish --otp`. Debug logging enabled
+      # below so the next attempt captures the token-exchange response
+      # inline in the workflow log.
       - name: Publish (gate opened in #370)
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
@@ -66,3 +88,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+          # Surface the OIDC token-exchange HTTP round-trip in the log so
+          # future publish failures don't require inspecting a redacted
+          # local debug file. `http` shows request/response codes with the
+          # bearer token redacted; use `verbose` if you need parameter-
+          # level detail (much noisier).
+          NPM_CONFIG_LOGLEVEL: "http"


### PR DESCRIPTION
## Summary

The first-ever CI publish attempt (for `0.1.5`) failed with `E404 Not Found - PUT https://registry.npmjs.org/@pax8%2fcore`. Provenance signing succeeded — sigstore attestation `logIndex=2091156826` shows the workflow identity was correctly recognized — but the follow-up PUT got 404, npm's standard mask for "identity lacks publish rights" on scoped packages. Shipped `0.1.5` via `pnpm publish --otp` from a maintainer laptop.

This PR doesn't claim to fix the root cause; it makes the next attempt **diagnosable**.

## Changes

- **Pin `pnpm/action-setup` to `9.15.4`.** The failing run logged `Detected a pnpm v10 installation layout / pnpm v11 expects bins in PNPM_HOME/bin` — the runner image's baked pnpm was older than the action's default target, leaving publish running an untested pnpm/npm combination. `packageManager` in root `package.json` already says `pnpm@9.15.4`; the pin makes the action match.
- **`NPM_CONFIG_LOGLEVEL=http` on the publish step.** Surfaces the OIDC token-exchange request/response codes inline in the workflow log (bearer redacted). Without this, the only debug artifact was `_logs/*-debug-0.log` on a runner that's already been cleaned up.

## Test plan

- [ ] After merge, the next `chore: release` PR merge will exercise the pinned pnpm and produce a workflow log that shows the exact HTTP flow.
- [ ] If publish succeeds → both problems (version drift + no visibility) collapse into one preventive change.
- [ ] If publish still fails → the HTTP log tells us whether it's (a) trusted-publisher match failure, (b) token returned without publish scope, or (c) something else in pnpm/npm's publish path. Follow-up PR can then target the real cause.

## What this PR is **not**

- Not switching from `pnpm changeset publish` to a bash script over `npm publish` — that's a heavier structural change worth doing only if the diagnostic run confirms it's needed.
- Not touching npm's trusted-publisher config (the user has confirmed `pax8labs/pax8-cli` + `release.yml` are registered as trusted publishers for both `@pax8/cli` and `@pax8/core`).

Refs #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)