### PR TITLE
fix(mock): align embedded pricing field with wire schema (partnerBuyRate)

### DIFF
--- a/packages/core/src/mock/demo-data.ts
+++ b/packages/core/src/mock/demo-data.ts
@@ -124,7 +124,7 @@ export interface Product {
 export interface ProductPricing {
   billingTerm: "Monthly" | "Annual";
   commitmentTerm: "Monthly" | "1-Year" | "3-Year";
-  partnerBuyPrice: number;
+  partnerBuyRate: number;
   suggestedRetailPrice: number;
   flatPrice?: number;
   ranges?: { minQuantity: number; maxQuantity: number; unitPrice: number }[];
@@ -576,13 +576,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 18.0,
+        partnerBuyRate: 18.0,
         suggestedRetailPrice: 22.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 16.5,
+        partnerBuyRate: 16.5,
         suggestedRetailPrice: 22.0,
       },
     ],
@@ -599,13 +599,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 5.0,
+        partnerBuyRate: 5.0,
         suggestedRetailPrice: 6.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 4.5,
+        partnerBuyRate: 4.5,
         suggestedRetailPrice: 6.0,
       },
     ],
@@ -622,13 +622,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 32.0,
+        partnerBuyRate: 32.0,
         suggestedRetailPrice: 36.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 29.0,
+        partnerBuyRate: 29.0,
         suggestedRetailPrice: 36.0,
       },
     ],
@@ -645,13 +645,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 52.0,
+        partnerBuyRate: 52.0,
         suggestedRetailPrice: 57.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 48.0,
+        partnerBuyRate: 48.0,
         suggestedRetailPrice: 57.0,
       },
     ],
@@ -668,13 +668,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 3.5,
+        partnerBuyRate: 3.5,
         suggestedRetailPrice: 4.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 3.0,
+        partnerBuyRate: 3.0,
         suggestedRetailPrice: 4.0,
       },
     ],
@@ -691,13 +691,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 7.0,
+        partnerBuyRate: 7.0,
         suggestedRetailPrice: 8.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 6.5,
+        partnerBuyRate: 6.5,
         suggestedRetailPrice: 8.0,
       },
     ],
@@ -714,13 +714,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 2.5,
+        partnerBuyRate: 2.5,
         suggestedRetailPrice: 3.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 2.0,
+        partnerBuyRate: 2.0,
         suggestedRetailPrice: 3.0,
       },
     ],
@@ -737,13 +737,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 5.0,
+        partnerBuyRate: 5.0,
         suggestedRetailPrice: 6.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 4.5,
+        partnerBuyRate: 4.5,
         suggestedRetailPrice: 6.0,
       },
     ],
@@ -760,7 +760,7 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 6.0,
+        partnerBuyRate: 6.0,
         suggestedRetailPrice: 8.5,
       },
     ],
@@ -777,13 +777,13 @@ export const products: Product[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice: 4.0,
+        partnerBuyRate: 4.0,
         suggestedRetailPrice: 6.0,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: 3.5,
+        partnerBuyRate: 3.5,
         suggestedRetailPrice: 6.0,
       },
     ],

--- a/packages/core/src/mock/large-fixture.ts
+++ b/packages/core/src/mock/large-fixture.ts
@@ -266,22 +266,22 @@ function generateProducts(count: number, rng: ReturnType<typeof makeRng>): Produ
     const name = `${vendor} ${kind} ${tier}`;
     const id = rng.uuid("prod", i);
     const sku = `${vendor.toLowerCase().slice(0, 3)}-${kind.toLowerCase().replace(/\s+/g, "")}-${tier.toLowerCase().slice(0, 3)}-${String(i).padStart(4, "0")}`;
-    const partnerBuyPrice = Number((5 + rng.next() * 195).toFixed(2));
-    const suggestedRetailPrice = Number((partnerBuyPrice * (1.15 + rng.next() * 0.6)).toFixed(2));
+    const partnerBuyRate = Number((5 + rng.next() * 195).toFixed(2));
+    const suggestedRetailPrice = Number((partnerBuyRate * (1.15 + rng.next() * 0.6)).toFixed(2));
     const pricing: ProductPricing[] = [
       {
         billingTerm: "Monthly",
         commitmentTerm: "Monthly",
-        partnerBuyPrice,
+        partnerBuyRate,
         suggestedRetailPrice,
-        flatPrice: partnerBuyPrice,
+        flatPrice: partnerBuyRate,
       },
       {
         billingTerm: "Annual",
         commitmentTerm: "1-Year",
-        partnerBuyPrice: Number((partnerBuyPrice * 0.9).toFixed(2)),
+        partnerBuyRate: Number((partnerBuyRate * 0.9).toFixed(2)),
         suggestedRetailPrice: Number((suggestedRetailPrice * 0.9).toFixed(2)),
-        flatPrice: Number((partnerBuyPrice * 0.9).toFixed(2)),
+        flatPrice: Number((partnerBuyRate * 0.9).toFixed(2)),
       },
     ];
     result.push({
@@ -313,7 +313,7 @@ function generateSubscriptions(
     const startMs = Date.UTC(2015, 0, 1) + Math.floor(rng.next() * (Date.now() - Date.UTC(2015, 0, 1)));
     const startDate = new Date(startMs).toISOString().split("T")[0];
     const pricing = product.pricing[0];
-    const price = pricing.flatPrice ?? pricing.partnerBuyPrice;
+    const price = pricing.flatPrice ?? pricing.partnerBuyRate;
     const currencyCode = rng.pickWeighted(CURRENCY_WEIGHTS);
     // Commitment-term end date: ~1 year out for committed terms, null for monthly/one-time.
     const hasCommitment = billingTerm === "Annual" || billingTerm === "2-Year" || billingTerm === "3-Year";

--- a/packages/core/src/mock/mock-client.ts
+++ b/packages/core/src/mock/mock-client.ts
@@ -426,7 +426,7 @@ class ProductsResource {
       unitOfMeasurement: product.unitOfMeasurement,
       rates: [
         {
-          partnerBuyRate: p.partnerBuyPrice,
+          partnerBuyRate: p.partnerBuyRate,
           suggestedRetailPrice: p.suggestedRetailPrice,
         },
       ],
@@ -1019,7 +1019,7 @@ class QuotesResource {
     const term = input.billingTerm ?? "Monthly";
     const plan = product?.pricing.find((p) => p.billingTerm === term);
     const unitPrice =
-      typeof input.price === "number" ? input.price : plan?.partnerBuyPrice;
+      typeof input.price === "number" ? input.price : plan?.partnerBuyRate;
     const newId = `li-demo-${Date.now()}`;
     // Round-trip `commitmentTermId` back onto the line as a
     // `commitmentTerm: { id, term }` object, mirroring the real v2 read


### PR DESCRIPTION
## Summary

The demo mock used two different field names for the same partner-cost concept — `partnerBuyPrice` on the embedded product `pricing[]` array, `partnerBuyRate` on `GET /products/{id}/pricing`. The latter matches the wire schema; the former was mock-only drift. A partner or agent reading both surfaces (e.g. `pax8 products list --json` vs `pax8 products show <id> --pricing --json`) saw two keys for the same value — same footgun class as the `orderCommand` / `orderArgs` split fixed in #462.

Rename to the wire-canonical `partnerBuyRate` across three mock files. Pure key rename, no behavior change.

## Scope

Turned out to be larger than #665 estimated (issue said "2 sites in mock-client.ts"). Actual footprint after grep:

- `demo-data.ts` — type definition on `ProductPricing` + 19 hand-curated data instances.
- `large-fixture.ts` — 6 sites in the large-portfolio generator.
- `mock-client.ts` — 2 consumer sites (`getPricing()` mapper on line 429, `createLineItem` price-lookup on line 1022).

Total: 28 line changes, all within `packages/core/src/mock/`.

## Test plan

- [x] `pnpm build` — clean, no type errors from the rename.
- [x] `pnpm test` — 2455 pass, 0 fail. Existing subprocess tests already cover the pricing paths (`mock-client.test.ts:193` asserts `partnerBuyRate` present in `getPricing()` output).
- [x] `grep -rn partnerBuyPrice packages/core/src/ packages/cli/src/` — zero remaining references.

## What this PR is not

- No Zod-schema guard added (the #665 acceptance criteria list it as *optional*). If a follow-up wants belt-and-suspenders drift protection, a runtime schema check at fixture-load time would go in `demo-data.ts` — but the rename alone removes the drift that made a guard necessary.

Closes #665. Refs #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)