### PR TITLE
ci(release): pin pnpm to 9.15.4 + enable HTTP debug logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pin pnpm to the version declared in root `packageManager` so the
+      # runtime doesn't drift off the pnpm/action-setup default. The
+      # previous release runs surfaced a `pnpm v10 installation layout /
+      # pnpm v11 expects bins in PNPM_HOME/bin` warning — the runner had
+      # an older pnpm on the image and the action's default target had
+      # moved past it, leaving the publish step running an untested
+      # pnpm/npm combination. Explicit pin keeps the tarball packing +
+      # publish path matched to `pnpm@9.15.4`, which is what maintainers
+      # exercise locally.
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 9.15.4
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -46,6 +57,17 @@ jobs:
       # ships 0.1.0 for `@pax8/cli` and `@pax8/core`. Subsequent pushes do
       # nothing until a "chore: release" PR (opened by the action below
       # when a changeset is present) bumps versions and is merged.
+      #
+      # 0.1.5 publish attempt (2026-07-06/07) failed here with a hard-to-
+      # diagnose `E404 Not Found - PUT https://registry.npmjs.org/@pax8%2fcore`.
+      # Provenance signing (sigstore) succeeded — meaning the OIDC token was
+      # minted correctly and the workflow identity matched the trusted-
+      # publisher pattern — but the actual PUT to the registry got 404,
+      # which npm returns for scoped packages when the effective identity
+      # lacks publish rights. 0.1.5 was ultimately shipped from a
+      # maintainer laptop via `pnpm publish --otp`. Debug logging enabled
+      # below so the next attempt captures the token-exchange response
+      # inline in the workflow log.
       - name: Publish (gate opened in #370)
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
@@ -66,3 +88,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+          # Surface the OIDC token-exchange HTTP round-trip in the log so
+          # future publish failures don't require inspecting a redacted
+          # local debug file. `http` shows request/response codes with the
+          # bearer token redacted; use `verbose` if you need parameter-
+          # level detail (much noisier).
+          NPM_CONFIG_LOGLEVEL: "http"


### PR DESCRIPTION
Successor to #676 (auto-closed when its branch was deleted).

## Summary

Same content as #676 — pins pnpm to the version declared in `packageManager` and enables `NPM_CONFIG_LOGLEVEL: http` so the next release attempt captures the OIDC token-exchange in the workflow log.

Motivated by the 0.1.5 and 0.1.6 publish failures — provenance signing succeeds (OIDC token minted, workflow identity matches trusted publisher pattern) but the actual PUT to the registry returns E404 anyway. Debug logging will surface the token-exchange response so we can see whether npm is rejecting the exchange or the publish.

No fix here — this is diagnostics only. The 0.1.6 packages will still need a manual `pnpm publish --otp` (same escape hatch used for 0.1.5).

## Test plan

- [x] `pnpm build` clean.
- Merging triggers the Release workflow. Expected: same E404, but now with an `http`-level log of the token-exchange to inspect for root cause.