### PR TITLE
feat(telemetry): attribute credentialed runs to a partner-account group

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,18 +454,21 @@ The CLI also honors two ambient environment variables (no opt-in required) and s
 | `node_version` | always | `process.version` |
 | `os` | always | `process.platform` |
 | `demo_mode` | always | Whether `PAX8_DEMO=1` was set |
+| `credentialed` | always | Boolean — whether any credential source was configured at emit time (never the credentials themselves) |
 | `recs_presented`, `recs_ordered`, `recs_skipped`, `recs_mrr_captured` | `recommendations act` | Aggregate counts only |
 | `order_success`, `order_total_dollars`, `order_mrr_impact`, `order_seats` | `orders create` | Aggregate transaction outcome only |
 
-The anonymous `distinct_id` is `sha256(hostname + ":" + username)` truncated to 16 hex chars — computed locally, never reversible to its inputs.
+**Identity — `distinct_id` and the account group.** The anonymous `distinct_id` is a random UUID (`crypto.randomUUID()`) generated once and persisted at `<config-dir>/telemetry-id`. It is not derived from your hostname, username, or any machine attribute, so it can't be regenerated from an AD/LDAP record. Because it is per-install, the same person on two machines (or in ephemeral CI, where `~/.pax8` doesn't persist) counts as multiple `distinct_id`s.
+
+To make **unique accounts** countable despite that, credentialed runs also attach a PostHog *group* — `account = sha256("pax8-cli:account:v1" + clientId)`, a salted one-way hash of your Pax8 API client ID. It is identical across every machine and CI job for a given partner, so PostHog can report account-level unique counts and retention without touching the anonymous per-install `distinct_id`. The salt is a public domain-separation constant (the CLI is open source), so the group key is a **pseudonym, not an anonymization guarantee**: an operator holding both PostHog access and the list of partner client IDs could recompute it. Uncredentialed and demo runs attach no group.
 
 **Never sent:**
 
-- API client_id, client_secret, OAuth tokens
+- Raw API client_id, client_secret, OAuth tokens (only a salted one-way hash of the client_id, as the account group above)
 - Customer / company / subscription / order IDs
 - Customer or company names
 - Command argument values (only flag *names* — `--company`, never `--company "Acme Corp"`)
-- Partner identifiers, account names, billing data
+- Account names, billing data
 - Stack traces, file paths, environment variables
 - Any PII
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -241,6 +241,21 @@ export function createProgram(): Command {
         // validation throws synchronously.
       }
 
+      // Attribute credentialed runs to a partner-account group so PostHog
+      // reports real account-level unique counts (not one "user" per
+      // ephemeral install). Only a salted hash of the clientId leaves the
+      // machine; the per-install distinct_id is untouched. Gated on
+      // `credentialed` so uncredentialed/demo runs pay no extra read and
+      // stay attributed to the anonymous id only.
+      if (credentialed) {
+        try {
+          const creds = await new CredentialStore().getCredentials();
+          telemetry.setAccount(creds?.clientId ?? null);
+        } catch {
+          telemetry.setAccount(null);
+        }
+      }
+
       // Single canonical event for every command run (#146). Handlers
       // contribute aggregate counters via setTelemetryFields(); they no
       // longer call telemetry.track() directly.

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -503,6 +503,18 @@ async function emitFailureEvent(error: unknown): Promise<void> {
     } catch {
       // Telemetry must never crash the CLI.
     }
+    // Attribute failed credentialed runs to the partner-account group too, so
+    // account-level unique counts and retention aren't skewed by failures.
+    // Only the salted clientId hash leaves the machine; see index.ts success
+    // path and Telemetry.setAccount().
+    if (credentialed) {
+      try {
+        const creds = await new CredentialStore().getCredentials();
+        telemetry.setAccount(creds?.clientId ?? null);
+      } catch {
+        telemetry.setAccount(null);
+      }
+    }
     telemetry.track({
       event: "command_executed",
       command: active?.command ?? "unknown",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -303,6 +303,7 @@ export {
   Telemetry,
   getTelemetry,
   TELEMETRY_NOTICE,
+  accountGroupKey,
 } from "./telemetry/telemetry.js";
 export type { TelemetryEvent } from "./telemetry/telemetry.js";
 

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -7,12 +7,14 @@ import * as fs from "node:fs/promises";
 import * as fsSync from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { createHash } from "node:crypto";
 import {
   Telemetry,
   resetTelemetry,
   bucketDollars,
   bucketSeats,
   bucketLineCount,
+  accountGroupKey,
   type TelemetryEvent,
 } from "./telemetry.js";
 import { ERROR_COMPANY_NOT_FOUND } from "../errors/codes.js";
@@ -525,5 +527,109 @@ describe("PostHog write-token (source-file shape guard)", () => {
     // insight or alert in the shared portfolio project that filters on
     // `app = "pax8-cli"`. The test is here to make that breakage loud.
     expect(match![1]).toBe("pax8-cli");
+  });
+
+  // ── Account grouping (real unique-user counts) ──────────────────────────
+
+  it("accountGroupKey is a stable, salted sha256 hex — not the raw clientId", () => {
+    const clientId = "abc-123-partner";
+    const key = accountGroupKey(clientId);
+
+    // 64 hex chars = sha256 digest.
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    // Deterministic: same input → same key, across machines and CI (this is
+    // what unifies a partner into one PostHog account).
+    expect(accountGroupKey(clientId)).toBe(key);
+    // Distinct partners → distinct keys.
+    expect(accountGroupKey("different-partner")).not.toBe(key);
+    // The raw clientId never appears in the digest.
+    expect(key).not.toContain(clientId);
+    // Salted, not a bare sha256(clientId): the digest must differ from an
+    // un-salted hash so it can't be trivially correlated against another
+    // system's sha256(clientId).
+    const bare = createHash("sha256").update(clientId).digest("hex");
+    expect(key).not.toBe(bare);
+  });
+
+  it("flush attaches the account group + calls groupIdentify when credentialed", async () => {
+    const t = new Telemetry();
+    (t as any).enabled = true;
+    (t as any).storageDir = makeTmpDir();
+
+    const captures: Array<{ groups?: Record<string, string> }> = [];
+    const groupIdentifies: Array<{ groupType: string; groupKey: string }> = [];
+    (t as any).posthog = {
+      capture: (payload: { groups?: Record<string, string> }) => captures.push(payload),
+      groupIdentify: (payload: { groupType: string; groupKey: string }) =>
+        groupIdentifies.push(payload),
+      flush: async () => {},
+      shutdown: async () => {},
+    };
+
+    t.setAccount("partner-xyz");
+    t.track(makeEvent());
+    await t.flush();
+
+    const expectedKey = accountGroupKey("partner-xyz");
+    expect(groupIdentifies).toEqual([{ groupType: "account", groupKey: expectedKey }]);
+    expect(captures).toHaveLength(1);
+    expect(captures[0].groups).toEqual({ account: expectedKey });
+
+    await fs.rm((t as any).storageDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("flush omits the account group for uncredentialed / demo runs", async () => {
+    const t = new Telemetry();
+    (t as any).enabled = true;
+    (t as any).storageDir = makeTmpDir();
+
+    const captures: Array<{ groups?: Record<string, string> }> = [];
+    let groupIdentifyCalled = false;
+    (t as any).posthog = {
+      capture: (payload: { groups?: Record<string, string> }) => captures.push(payload),
+      groupIdentify: () => {
+        groupIdentifyCalled = true;
+      },
+      flush: async () => {},
+      shutdown: async () => {},
+    };
+
+    // No setAccount() call at all — and an explicit null clear — must both
+    // leave the run attributed to the anonymous distinct_id only.
+    t.setAccount(null);
+    t.track(makeEvent());
+    await t.flush();
+
+    expect(groupIdentifyCalled).toBe(false);
+    expect(captures).toHaveLength(1);
+    expect(captures[0].groups).toBeUndefined();
+
+    await fs.rm((t as any).storageDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("setAccount does not alter the per-install distinct_id (M-2 anonymity)", async () => {
+    const t = new Telemetry();
+    (t as any).enabled = true;
+    (t as any).storageDir = makeTmpDir();
+
+    const captures: Array<{ distinctId: string }> = [];
+    (t as any).posthog = {
+      capture: (payload: { distinctId: string }) => captures.push(payload),
+      groupIdentify: () => {},
+      flush: async () => {},
+      shutdown: async () => {},
+    };
+
+    const anonId = (t as any).anonymousId as string;
+    t.setAccount("partner-xyz");
+    t.track(makeEvent());
+    await t.flush();
+
+    // distinct_id stays the random per-install UUID; the partner is carried
+    // only in the group, never promoted to the distinct_id.
+    expect(captures[0].distinctId).toBe(anonId);
+    expect(captures[0].distinctId).not.toBe(accountGroupKey("partner-xyz"));
+
+    await fs.rm((t as any).storageDir, { recursive: true, force: true }).catch(() => {});
   });
 });

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -25,6 +25,41 @@ const POSTHOG_HOST = "https://us.i.posthog.com";
 // insight or alert in PostHog that filters on `app = "pax8-cli"`.
 const APP_NAME = "pax8-cli";
 
+// Domain-separation salt for the partner-account group key (see
+// {@link accountGroupKey}). This is NOT a secret — the CLI is open source, so
+// anyone reading this repo can see it. Its only job is to keep the account
+// key from being a bare sha256(clientId) that an unrelated system could
+// trivially recompute and correlate against. The account group key is
+// therefore a *pseudonym*, not an anonymization guarantee: an internal
+// operator holding BOTH PostHog access AND the list of partner OAuth client
+// IDs could still reverse it by recomputing this hash. That is the same
+// residual risk the M-2 review flagged for derivable IDs (see
+// getAnonymousId()); genuine de-anonymization resistance would require a
+// server-side salt we do not have. Bump the version suffix only if you ever
+// need to rotate the key space (it re-partitions every account in PostHog).
+const ACCOUNT_KEY_SALT = "pax8-cli:account:v1";
+
+/**
+ * Stable, salted pseudonym for a partner's OAuth `clientId`, used as the
+ * PostHog *group* key (groupType `account`).
+ *
+ * Because it is derived purely from the clientId + a fixed salt, it is
+ * identical across every machine and CI job a given partner runs on. That is
+ * exactly what lets PostHog collapse a partner's runs into a single "account"
+ * and report real account-level unique counts and retention — independent of
+ * the per-install `distinct_id`, which (by design, post-M-2) is a random UUID
+ * and thus over-counts unique *users* whenever `~/.pax8` does not persist
+ * (ephemeral CI, `npx`, fresh containers).
+ *
+ * The raw clientId is never stored or transmitted — only this digest.
+ */
+export function accountGroupKey(clientId: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(ACCOUNT_KEY_SALT + clientId)
+    .digest("hex");
+}
+
 export interface TelemetryEvent {
   event: "command_executed";
   command: string;
@@ -126,6 +161,8 @@ export const TELEMETRY_NOTICE = `
     Command names and flags used (never values or arguments)
     Success/failure and duration
     OS and Node.js version
+    A salted, one-way hash of your Pax8 API client ID, used only to
+      count unique accounts (never the raw ID, never a name)
 
   What we never collect:
     Company names, IDs, or subscription data
@@ -189,6 +226,7 @@ export class Telemetry {
   private storageDir: string;
   private posthog: PostHog | null = null;
   private anonymousId: string;
+  private accountKey: string | null = null;
 
   constructor() {
     this.storageDir = path.join(getConfigDir(), "telemetry");
@@ -257,6 +295,23 @@ export class Telemetry {
     this.buffer.push(event);
   }
 
+  /**
+   * Associate subsequent events with a partner-account group so PostHog can
+   * report account-level unique counts and retention (see
+   * {@link accountGroupKey}). Pass the raw OAuth `clientId` from the active
+   * credential source; only its salted hash is retained. Passing
+   * null/undefined/empty clears the association (e.g. an unauthenticated or
+   * demo run), which correctly leaves that run attributed to the anonymous
+   * per-install distinct_id only.
+   *
+   * Idempotent and cheap; last value wins. Never throws — a bad clientId just
+   * results in a hash. Wiring lives in the CLI (the two canonical emit sites)
+   * so `@pax8/core` telemetry stays decoupled from `CredentialStore`.
+   */
+  setAccount(clientId: string | null | undefined): void {
+    this.accountKey = clientId ? accountGroupKey(clientId) : null;
+  }
+
   async flush(): Promise<void> {
     if (this.buffer.length === 0) return;
 
@@ -286,10 +341,18 @@ export class Telemetry {
     // operator can still audit their own machine's usage.
     try {
       const ph = this.getPostHog();
+      // Register the partner-account group once (if credentialed this run) so
+      // PostHog can report account-level unique counts + retention. The
+      // per-install `distinct_id` stays the random UUID; `groups.account`
+      // unifies a partner across machines and ephemeral CI.
+      if (this.accountKey) {
+        ph.groupIdentify({ groupType: "account", groupKey: this.accountKey });
+      }
       for (const event of events) {
         ph.capture({
           distinctId: this.anonymousId,
           event: event.event,
+          ...(this.accountKey && { groups: { account: this.accountKey } }),
           properties: {
             app: APP_NAME,
             command: event.command,


### PR DESCRIPTION
## Problem

PostHog "unique users" was running ~1:1 with command executions, making it useless for counting real users.

The PostHog-side diagnosis (add `identify()` with a hashed email) didn't fit this codebase:

- **A stable per-install ID already exists.** `getAnonymousId()` mints a random UUID once and persists it to `<config-dir>/telemetry-id`. So `identify()` wouldn't change counts on a normal machine.
- **There is no user email.** Auth is OAuth **client-credentials** — the only stable identity available is the partner's `clientId`.

The real cause: that per-install UUID only survives where `~/.pax8` persists. In ephemeral CI, `npx`, and fresh containers, each run mints a fresh UUID → one "user" per execution.

## Fix

On **credentialed** runs, attach a PostHog **group**:

```
account = sha256("pax8-cli:account:v1" + clientId)
```

via `groupIdentify({ groupType: "account" })` and a per-event `groups: { account }`. Because the key is derived purely from `clientId` + a fixed salt, it's identical across every machine and CI job for a given partner → PostHog reports real **account-level** unique counts and retention.

The per-install `distinct_id` is **untouched** (stays the random UUID), so the M-2 anonymity posture for the distinct_id is preserved. Uncredentialed and demo runs attach no group.

## Privacy tradeoff (disclosed)

The salt is a **public** domain-separation constant (the CLI is open source), so the account key is a **pseudonym, not an anonymization guarantee** — an operator holding both PostHog access and the partner clientId list could recompute it. This is documented in `TELEMETRY_NOTICE` and the README. Raw `clientId` is still never sent.

## Also in this PR

- Fixes a **stale README claim** that `distinct_id` is `sha256(hostname+username)` — that was replaced by the random UUID in the M-2 change.
- Updates the README "Never sent" list to disclose the salted `clientId` hash, and adds the `credentialed` property row.

## Testing

- 4 new unit tests (salt/determinism/no-raw-id, group attach + `groupIdentify`, group omitted when uncredentialed, `distinct_id` unchanged).
- Full suite green: **2484 passed**. `tsc --noEmit` clean on core + cli. Lint clean (only pre-existing warnings).

## Follow-up (not in this PR)

The salt is `pax8-cli`-scoped, so the same partner is a distinct account in `pax8-cli` vs `pax8-cta`. Portfolio-wide account unification would require both CLIs to share the salt — separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)