### PR TITLE
feat: add PSA reconciliation audit scaffold

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@pax8/core": "workspace:*",
+    "@pax8/psa": "workspace:*",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.5",
     "commander": "^12.1.0",

--- a/packages/cli/src/__tests__/invoices.test.ts
+++ b/packages/cli/src/__tests__/invoices.test.ts
@@ -115,12 +115,7 @@ describe("pax8 invoices", () => {
     });
 
     it("--with-actions adds nextActions to { invoices, page } envelope", async () => {
-      const result = await runCliExpectSuccess([
-        "invoices",
-        "list",
-        "--json",
-        "--with-actions",
-      ]);
+      const result = await runCliExpectSuccess(["invoices", "list", "--json", "--with-actions"]);
       const data = JSON.parse(result.stdout);
       expect(data).toHaveProperty("invoices");
       expect(data).toHaveProperty("page");
@@ -157,11 +152,7 @@ describe("pax8 invoices", () => {
 
   describe("invoices items", () => {
     it("lists invoice items in demo mode", async () => {
-      const result = await runCliExpectSuccess([
-        "invoices",
-        "items",
-        "--json",
-      ]);
+      const result = await runCliExpectSuccess(["invoices", "items", "--json"]);
       // #483: JSON envelope is { items, page }.
       const data = JSON.parse(result.stdout);
       expect(data).toHaveProperty("items");
@@ -207,27 +198,50 @@ describe("pax8 invoices", () => {
       expect(result.stderr).not.toMatch(/page limit|results may be incomplete/);
     });
 
-    it("produces audit report in JSON", async () => {
-      const result = await runCliExpectSuccess([
-        "invoices",
-        "audit",
-        "--json",
-      ]);
+    it("produces audit report in JSON without PSA fields by default", async () => {
+      const result = await runCliExpectSuccess(["invoices", "audit", "--json"]);
       const data = JSON.parse(result.stdout);
       expect(data).toHaveProperty("discrepancies");
       expect(data).toHaveProperty("totalOvercharge");
       expect(data).toHaveProperty("totalUndercharge");
       expect(data).toHaveProperty("netImpact");
       expect(data).toHaveProperty("itemsAudited");
+      expect(data).not.toHaveProperty("psaSummary");
       expect(data.discrepancies.length).toBeGreaterThan(0);
+      expect(data.discrepancies[0]).not.toHaveProperty("psa");
     });
 
-    it("each discrepancy has required fields", async () => {
+    it("extends audit JSON additively when --psa is supplied", async () => {
       const result = await runCliExpectSuccess([
         "invoices",
         "audit",
+        "--psa",
+        "connectwise",
         "--json",
       ]);
+      const data = JSON.parse(result.stdout);
+      expect(data).toHaveProperty("discrepancies");
+      expect(data).toHaveProperty("psaSummary");
+      expect(data.psaSummary).toMatchObject({
+        provider: "connectwise",
+        counts: expect.objectContaining({
+          propagated: expect.any(Number),
+          costOnly: expect.any(Number),
+          psaDrift: expect.any(Number),
+          unmapped: expect.any(Number),
+        }),
+        unmappedDollarImpact: expect.objectContaining({ currency: "USD" }),
+        customerImpactTotal: expect.objectContaining({ currency: "USD" }),
+      });
+      expect(data.discrepancies.length).toBeGreaterThan(0);
+      expect(data.discrepancies[0]).toHaveProperty("psa");
+      expect(data.discrepancies[0].psa).toMatchObject({
+        status: expect.stringMatching(/^(propagated|cost-only|psa-drift|unmapped)$/),
+      });
+    });
+
+    it("each discrepancy has required fields", async () => {
+      const result = await runCliExpectSuccess(["invoices", "audit", "--json"]);
       const data = JSON.parse(result.stdout);
       const disc = data.discrepancies[0];
       expect(disc).toHaveProperty("companyName");
@@ -316,11 +330,7 @@ describe("pax8 invoices", () => {
     // #389: every spec-backed filter must appear in --help. Pre-#389 the CLI
     // didn't surface --from / --to / --sort at all.
     it("list --help advertises every #389 filter and sort flag", async () => {
-      const result = await runCliExpectSuccess([
-        "invoices",
-        "list",
-        "--help",
-      ]);
+      const result = await runCliExpectSuccess(["invoices", "list", "--help"]);
       const flat = result.stdout.replace(/\s+/g, " ");
       // Date range
       expect(flat).toContain("--from");
@@ -346,22 +356,11 @@ describe("pax8 invoices", () => {
     // only 4 of the 6 documented values (`Nothing Due` and `Credited` were
     // missing).
     it("list --status help advertises every documented API enum value (#250)", async () => {
-      const result = await runCliExpectSuccess([
-        "invoices",
-        "list",
-        "--help",
-      ]);
+      const result = await runCliExpectSuccess(["invoices", "list", "--help"]);
       // Commander wraps long option descriptions across lines on narrow
       // terminals, so collapse whitespace before matching multi-word values.
       const flat = result.stdout.replace(/\s+/g, " ");
-      const DOCUMENTED_STATUSES = [
-        "Unpaid",
-        "Paid",
-        "Void",
-        "Carried",
-        "Nothing Due",
-        "Credited",
-      ];
+      const DOCUMENTED_STATUSES = ["Unpaid", "Paid", "Void", "Carried", "Nothing Due", "Credited"];
       for (const status of DOCUMENTED_STATUSES) {
         expect(flat).toContain(status);
       }

--- a/packages/cli/src/commands/invoices/audit.ts
+++ b/packages/cli/src/commands/invoices/audit.ts
@@ -15,11 +15,13 @@ import { replCmd } from "../../lib/confirm.js";
 import { promptNextSteps, type NextStep } from "../../lib/next-step.js";
 import { validateMonth } from "../../lib/validate.js";
 import { collectSubsWithSpinner } from "../../lib/subs-stream.js";
+import { classifyAuditDiscrepanciesWithPsa, resolvePsaProviderName } from "../../lib/psa.js";
 
 export const invoicesAuditCommand = new Command("audit")
   .description("Audit invoices against active subscriptions")
   .option("--month <YYYY-MM>", "Filter by month (YYYY-MM)")
   .option("--company <id|name>", "Filter by company ID or name")
+  .option("--psa [provider]", "Join discrepancies to PSA agreement data (connectwise)")
   .addHelpText(
     "after",
     `
@@ -27,6 +29,7 @@ Examples:
   pax8 invoices audit
   pax8 invoices audit --month 2026-03
   pax8 invoices audit --company "Summit Healthcare"
+  pax8 invoices audit --psa connectwise --json
   pax8 invoices audit --json
 
 Note: this audit compares the partner's invoiced charges against their
@@ -148,6 +151,20 @@ JSON output (--json):
         }),
       }));
 
+      const psaProviderName = resolvePsaProviderName(options.psa);
+      let outputDiscrepancies: Array<(typeof stampedDiscrepancies)[number] & { psa?: unknown }> = stampedDiscrepancies;
+      let psaSummary: unknown;
+      if (psaProviderName) {
+        try {
+          const psaResult = await classifyAuditDiscrepanciesWithPsa(ctx, psaProviderName, stampedDiscrepancies);
+          outputDiscrepancies = psaResult.discrepancies as Array<(typeof stampedDiscrepancies)[number] & { psa?: unknown }>;
+          psaSummary = psaResult.psaSummary;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          process.stderr.write(`${chalk.yellow("⚠")} PSA join failed; base invoice audit is still valid. ${message}\n`);
+        }
+      }
+
       // JSON output
       if (ctx.outputFormat === "json") {
         const nextActions = stampedDiscrepancies
@@ -158,7 +175,7 @@ JSON output (--json):
           }));
         process.stdout.write(
           JSON.stringify(
-            { ...report, discrepancies: stampedDiscrepancies, nextActions },
+            { ...report, discrepancies: outputDiscrepancies, ...(psaSummary ? { psaSummary } : {}), nextActions },
             null,
             2,
           ) + "\n",
@@ -204,7 +221,7 @@ JSON output (--json):
       // "type 3 to dispute discrepancy #3"). Keeps the existing single-id
       // form in the `[…]` brackets so partners who copy-paste the id by
       // hand can still locate it.
-      stampedDiscrepancies.forEach((d, i) => {
+      outputDiscrepancies.forEach((d, i) => {
         const idx = i + 1;
         process.stdout.write(
           `  ${chalk.bold(`${idx}.`)} ${chalk.bold(d.companyName)} — ${d.productName}  ${chalk.dim(`[${d.discrepancyId}]`)}\n`
@@ -219,6 +236,11 @@ JSON output (--json):
         process.stdout.write(
           `     Invoiced: ${formatQuantity(d.invoicedQuantity)}    Active: ${formatQuantity(d.activeQuantity)}    Δ ${deltaSign}${d.delta} (${impactLabel})\n`
         );
+        if ("psa" in d && d.psa) {
+          const psa = d.psa as { status: string; customerImpact?: { amount: number; currency: string } | null };
+          const impact = psa.customerImpact ? `, customer impact ${formatCurrency(psa.customerImpact.amount)}` : "";
+          process.stdout.write(`     PSA: ${psa.status}${impact}\n`);
+        }
         process.stdout.write("\n");
       });
 
@@ -237,6 +259,12 @@ JSON output (--json):
       process.stdout.write(
         `  ${chalk.bold("Net impact:")}   ${formatCurrency(report.netImpact)}\n`
       );
+      if (psaSummary) {
+        const summary = psaSummary as { coveragePercent: number; customerImpactTotal: { amount: number }; unmappedDollarImpact: { amount: number } };
+        process.stdout.write(
+          `  ${chalk.bold("PSA coverage:")} ${summary.coveragePercent}%    Customer impact: ${formatCurrency(summary.customerImpactTotal.amount)}    Unmapped: ${formatCurrency(summary.unmappedDollarImpact.amount)}\n`
+        );
+      }
       process.stdout.write("\n");
 
       // Closed-loop hint: every discrepancy becomes a pickable dispute
@@ -245,7 +273,7 @@ JSON output (--json):
       // filtering by month) carried through automatically.
       if (stampedDiscrepancies.length > 0) {
         const monthArgs = options.month ? ["--month", options.month] : [];
-        const steps: NextStep[] = stampedDiscrepancies.map((d, i) => {
+        const steps: NextStep[] = outputDiscrepancies.map((d, i) => {
           const command = ["invoices", "dispute", "--discrepancy", d.discrepancyId, ...monthArgs];
           return {
             key: String(i + 1),

--- a/packages/cli/src/commands/psa/index.ts
+++ b/packages/cli/src/commands/psa/index.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "commander";
+import chalk from "chalk";
+import { buildContext } from "../../lib/context.js";
+import { buildPsaProvider, describeConnectWiseCredentialHelp, getPsaMappingsPath, loadPsaMappings, resolvePsaProviderName } from "../../lib/psa.js";
+
+export const psaCommand = new Command("psa")
+  .description("Manage read-only PSA reconciliation setup")
+  .addCommand(
+    new Command("test")
+      .description("Verify PSA credentials/connectivity")
+      .option("--provider <provider>", "PSA provider", "connectwise")
+      .action(async (options, command) => {
+        const ctx = await buildContext(command.optsWithGlobals());
+        const providerName = resolvePsaProviderName(options.provider) ?? "connectwise";
+        const provider = buildPsaProvider(ctx, providerName, []);
+        await provider.testConnection();
+        process.stdout.write(`${chalk.green("✓")} ${providerName} PSA credentials look usable\n`);
+      }),
+  )
+  .addCommand(
+    new Command("map")
+      .description("Show local PSA mapping file status")
+      .action(async () => {
+        const mappings = await loadPsaMappings();
+        process.stdout.write(`Mapping file: ${getPsaMappingsPath()}\n`);
+        process.stdout.write(`Mappings: ${mappings.mappings.length}\n`);
+        if (mappings.mappings.length === 0) {
+          process.stdout.write(`\nAdd mappings to classify invoice discrepancies. ConnectWise env vars:\n`);
+          for (const name of describeConnectWiseCredentialHelp()) process.stdout.write(`  ${name}\n`);
+        }
+      }),
+  );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { registerContactsCommands } from "./commands/contacts/index.js";
 import { registerQuotesCommands } from "./commands/quotes/index.js";
 import { registerCostCommands } from "./commands/cost/index.js";
 import { registerReportCommands } from "./commands/report/index.js";
+import { psaCommand } from "./commands/psa/index.js";
 import { dashboardCommand } from "./commands/dashboard.js";
 import { todayCommand } from "./commands/today.js";
 import { doctorCommand } from "./commands/doctor.js";
@@ -118,6 +119,7 @@ export function createProgram(): Command {
   registerQuotesCommands(program);
   registerCostCommands(program);
   registerReportCommands(program);
+  program.addCommand(psaCommand);
   program.addCommand(dashboardCommand);
   program.addCommand(todayCommand);
   program.addCommand(initCommand);

--- a/packages/cli/src/lib/psa.test.ts
+++ b/packages/cli/src/lib/psa.test.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveConnectWiseCredentials, resolvePsaProviderName } from "./psa.js";
+import type { CommandContext } from "./context.js";
+
+const ENV_KEYS = [
+  "PAX8_PSA_CONNECTWISE_BASE_URL",
+  "PAX8_PSA_CONNECTWISE_COMPANY_ID",
+  "PAX8_PSA_CONNECTWISE_PUBLIC_KEY",
+  "PAX8_PSA_CONNECTWISE_PRIVATE_KEY",
+  "PAX8_PSA_CONNECTWISE_CLIENT_ID",
+] as const;
+
+function ctx(config: CommandContext["config"]): CommandContext {
+  return { config } as CommandContext;
+}
+
+describe("PSA CLI helpers", () => {
+  afterEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  it("defaults --psa to connectwise and lists supported providers on errors", () => {
+    expect(resolvePsaProviderName(undefined)).toBeUndefined();
+    expect(resolvePsaProviderName(true)).toBe("connectwise");
+    expect(resolvePsaProviderName("connectwise")).toBe("connectwise");
+    expect(() => resolvePsaProviderName("autotask")).toThrow(/Supported providers: connectwise/);
+  });
+
+  it("lets ConnectWise environment variables override persisted config", () => {
+    process.env.PAX8_PSA_CONNECTWISE_BASE_URL = "https://env.example.test";
+    process.env.PAX8_PSA_CONNECTWISE_PRIVATE_KEY = "env-private";
+
+    expect(
+      resolveConnectWiseCredentials(
+        ctx({
+          psa: {
+            connectwise: {
+              baseUrl: "https://config.example.test",
+              companyId: "config-company",
+              publicKey: "config-public",
+              privateKey: "config-private",
+              clientId: "config-client",
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      baseUrl: "https://env.example.test",
+      companyId: "config-company",
+      publicKey: "config-public",
+      privateKey: "env-private",
+      clientId: "config-client",
+    });
+  });
+
+  it("does not require PSA config when no PSA provider is used", () => {
+    expect(resolveConnectWiseCredentials(ctx({}))).toEqual({
+      baseUrl: undefined,
+      companyId: undefined,
+      publicKey: undefined,
+      privateKey: undefined,
+      clientId: undefined,
+    });
+  });
+});

--- a/packages/cli/src/lib/psa.ts
+++ b/packages/cli/src/lib/psa.ts
@@ -1,0 +1,98 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  classifyWithPsa,
+  ConnectWiseProvider,
+  createEmptyMappings,
+  DemoConnectWiseProvider,
+  type PsaClassifiableDiscrepancy,
+  type PsaMappingsFile,
+  type PsaProvider,
+  type PsaProviderName,
+  requiredConnectWiseCredentialNames,
+} from "@pax8/psa";
+import { getConfigDir } from "@pax8/core";
+import type { CommandContext } from "./context.js";
+
+export const PSA_MAPPINGS_FILE = "psa-mappings.json";
+
+export function resolvePsaProviderName(input: string | true | undefined): PsaProviderName | undefined {
+  if (input === undefined) return undefined;
+  if (input === true || input === "connectwise") return "connectwise";
+  throw new Error(`Unsupported PSA provider: ${input}`);
+}
+
+export function getPsaMappingsPath(): string {
+  return path.join(getConfigDir(), PSA_MAPPINGS_FILE);
+}
+
+export async function loadPsaMappings(): Promise<PsaMappingsFile> {
+  try {
+    const raw = await fs.readFile(getPsaMappingsPath(), "utf8");
+    const parsed = JSON.parse(raw) as PsaMappingsFile;
+    if (parsed.version === "1.0" && Array.isArray(parsed.mappings)) return parsed;
+  } catch {
+    // Missing or invalid mappings should not break a read-only audit; unmapped
+    // output is the useful setup worklist.
+  }
+  return createEmptyMappings();
+}
+
+export async function savePsaMappings(mappings: PsaMappingsFile): Promise<void> {
+  const file = getPsaMappingsPath();
+  await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+  await fs.writeFile(file, JSON.stringify(mappings, null, 2) + "\n", { mode: 0o600 });
+}
+
+export function buildPsaProvider(ctx: CommandContext, providerName: PsaProviderName, discrepancies: PsaClassifiableDiscrepancy[]): PsaProvider {
+  if (providerName !== "connectwise") throw new Error(`Unsupported PSA provider: ${providerName}`);
+  if (ctx.isDemo) {
+    return new DemoConnectWiseProvider(
+      discrepancies.slice(0, 3).map((d, i) => ({
+        agreementId: `demo-agreement-${i + 1}`,
+        additionRef: `demo-addition-${i + 1}`,
+        quantity: i === 0 ? d.invoicedQuantity : i === 1 ? d.activeQuantity : d.activeQuantity + d.invoicedQuantity + 7,
+        unitPrice: Math.abs(d.dollarImpact / (d.delta || 1)) || 1,
+        currency: "USD",
+      })),
+    );
+  }
+
+  const cfg = ctx.config.psa?.connectwise;
+  return new ConnectWiseProvider({
+    baseUrl: process.env.PAX8_PSA_CONNECTWISE_BASE_URL ?? cfg?.baseUrl,
+    companyId: process.env.PAX8_PSA_CONNECTWISE_COMPANY_ID ?? cfg?.companyId,
+    publicKey: process.env.PAX8_PSA_CONNECTWISE_PUBLIC_KEY ?? cfg?.publicKey,
+    privateKey: process.env.PAX8_PSA_CONNECTWISE_PRIVATE_KEY ?? cfg?.privateKey,
+    clientId: process.env.PAX8_PSA_CONNECTWISE_CLIENT_ID ?? cfg?.clientId,
+  });
+}
+
+export function buildDemoMappings(discrepancies: PsaClassifiableDiscrepancy[]): PsaMappingsFile {
+  return {
+    version: "1.0",
+    mappings: discrepancies.slice(0, 3).map((d, i) => ({
+      pax8CompanyId: d.companyId,
+      pax8ProductName: d.productName,
+      agreementId: `demo-agreement-${i + 1}`,
+      additionRef: `demo-addition-${i + 1}`,
+    })),
+  };
+}
+
+export async function classifyAuditDiscrepanciesWithPsa(
+  ctx: CommandContext,
+  providerName: PsaProviderName,
+  discrepancies: PsaClassifiableDiscrepancy[],
+): Promise<Awaited<ReturnType<typeof classifyWithPsa>>> {
+  const mappings = ctx.isDemo ? buildDemoMappings(discrepancies) : await loadPsaMappings();
+  const provider = buildPsaProvider(ctx, providerName, discrepancies);
+  return classifyWithPsa(provider, discrepancies, mappings, { currency: "USD" });
+}
+
+export function describeConnectWiseCredentialHelp(): string[] {
+  return requiredConnectWiseCredentialNames().map((name) => `PAX8_PSA_CONNECTWISE_${name.replace(/[A-Z]/g, (c) => `_${c}`).toUpperCase()}`);
+}

--- a/packages/cli/src/lib/psa.ts
+++ b/packages/cli/src/lib/psa.ts
@@ -19,10 +19,12 @@ import type { CommandContext } from "./context.js";
 
 export const PSA_MAPPINGS_FILE = "psa-mappings.json";
 
-export function resolvePsaProviderName(input: string | true | undefined): PsaProviderName | undefined {
+export function resolvePsaProviderName(
+  input: string | true | undefined,
+): PsaProviderName | undefined {
   if (input === undefined) return undefined;
   if (input === true || input === "connectwise") return "connectwise";
-  throw new Error(`Unsupported PSA provider: ${input}`);
+  throw new Error(`Unsupported PSA provider: ${input}. Supported providers: connectwise`);
 }
 
 export function getPsaMappingsPath(): string {
@@ -47,28 +49,51 @@ export async function savePsaMappings(mappings: PsaMappingsFile): Promise<void> 
   await fs.writeFile(file, JSON.stringify(mappings, null, 2) + "\n", { mode: 0o600 });
 }
 
-export function buildPsaProvider(ctx: CommandContext, providerName: PsaProviderName, discrepancies: PsaClassifiableDiscrepancy[]): PsaProvider {
+export function buildPsaProvider(
+  ctx: CommandContext,
+  providerName: PsaProviderName,
+  discrepancies: PsaClassifiableDiscrepancy[],
+): PsaProvider {
   if (providerName !== "connectwise") throw new Error(`Unsupported PSA provider: ${providerName}`);
   if (ctx.isDemo) {
     return new DemoConnectWiseProvider(
       discrepancies.slice(0, 3).map((d, i) => ({
         agreementId: `demo-agreement-${i + 1}`,
         additionRef: `demo-addition-${i + 1}`,
-        quantity: i === 0 ? d.invoicedQuantity : i === 1 ? d.activeQuantity : d.activeQuantity + d.invoicedQuantity + 7,
+        quantity:
+          i === 0
+            ? d.invoicedQuantity
+            : i === 1
+              ? d.activeQuantity
+              : d.activeQuantity + d.invoicedQuantity + 7,
         unitPrice: Math.abs(d.dollarImpact / (d.delta || 1)) || 1,
         currency: "USD",
       })),
     );
   }
 
+  return new ConnectWiseProvider(resolveConnectWiseCredentials(ctx));
+}
+
+export function resolveConnectWiseCredentials(ctx: CommandContext): {
+  baseUrl?: string;
+  companyId?: string;
+  publicKey?: string;
+  privateKey?: string;
+  clientId?: string;
+} {
   const cfg = ctx.config.psa?.connectwise;
-  return new ConnectWiseProvider({
+  // Environment variables intentionally win over persisted config so CI,
+  // one-off runs, and secret managers can override `~/.pax8/config.json`
+  // without mutating local state. Missing PSA config is fine for every
+  // non-PSA command; credentials are validated only when a PSA provider is used.
+  return {
     baseUrl: process.env.PAX8_PSA_CONNECTWISE_BASE_URL ?? cfg?.baseUrl,
     companyId: process.env.PAX8_PSA_CONNECTWISE_COMPANY_ID ?? cfg?.companyId,
     publicKey: process.env.PAX8_PSA_CONNECTWISE_PUBLIC_KEY ?? cfg?.publicKey,
     privateKey: process.env.PAX8_PSA_CONNECTWISE_PRIVATE_KEY ?? cfg?.privateKey,
     clientId: process.env.PAX8_PSA_CONNECTWISE_CLIENT_ID ?? cfg?.clientId,
-  });
+  };
 }
 
 export function buildDemoMappings(discrepancies: PsaClassifiableDiscrepancy[]): PsaMappingsFile {
@@ -94,5 +119,7 @@ export async function classifyAuditDiscrepanciesWithPsa(
 }
 
 export function describeConnectWiseCredentialHelp(): string[] {
-  return requiredConnectWiseCredentialNames().map((name) => `PAX8_PSA_CONNECTWISE_${name.replace(/[A-Z]/g, (c) => `_${c}`).toUpperCase()}`);
+  return requiredConnectWiseCredentialNames().map(
+    (name) => `PAX8_PSA_CONNECTWISE_${name.replace(/[A-Z]/g, (c) => `_${c}`).toUpperCase()}`,
+  );
 }

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -29,6 +29,19 @@ export const ConfigSchema = z.object({
       enabled: z.boolean().default(false),
     })
     .default({}),
+  psa: z
+    .object({
+      connectwise: z
+        .object({
+          baseUrl: z.string().optional(),
+          companyId: z.string().optional(),
+          publicKey: z.string().optional(),
+          privateKey: z.string().optional(),
+          clientId: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/packages/psa/README.md
+++ b/packages/psa/README.md
@@ -1,0 +1,23 @@
+# @pax8/psa
+
+Read-only PSA reconciliation helpers for the Pax8 CLI.
+
+This package is an integration scaffold for `pax8 invoices audit --psa connectwise`. It defines the provider interface, local mapping shape, demo provider, and classification/summary logic used by the CLI. Live ConnectWise fetching is intentionally not implemented yet; `ConnectWiseProvider.getAddition()` validates credentials and then throws until the live read-only API adapter is wired in.
+
+## Safety contract
+
+- Read-only only: no PSA write commands or mutation helpers live here.
+- Local-only mappings: Pax8 company/product IDs are joined to PSA agreement/addition refs through the local mappings file used by the CLI.
+- Missing mappings are surfaced as `unmapped` with dollar impact instead of being silently skipped.
+
+## ConnectWise credentials
+
+The CLI reads ConnectWise credentials from persisted config and environment variables. Environment variables win so CI, secret managers, and one-off runs can override local config without editing `~/.pax8/config.json`:
+
+- `PAX8_PSA_CONNECTWISE_BASE_URL`
+- `PAX8_PSA_CONNECTWISE_COMPANY_ID`
+- `PAX8_PSA_CONNECTWISE_PUBLIC_KEY`
+- `PAX8_PSA_CONNECTWISE_PRIVATE_KEY`
+- `PAX8_PSA_CONNECTWISE_CLIENT_ID`
+
+Non-PSA commands do not require this config. Credentials are validated only when a PSA provider is selected.

--- a/packages/psa/package.json
+++ b/packages/psa/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@pax8/psa",
+  "version": "0.1.0",
+  "description": "Read-only PSA reconciliation helpers for Pax8 CLI",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean --sourcemap"
+  },
+  "dependencies": {
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/psa/src/index.test.ts
+++ b/packages/psa/src/index.test.ts
@@ -1,0 +1,182 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+  classifyWithPsa,
+  DemoConnectWiseProvider,
+  findMapping,
+  type PsaClassifiableDiscrepancy,
+  type PsaMappingsFile,
+} from "./index.js";
+
+function discrepancy(
+  overrides: Partial<PsaClassifiableDiscrepancy> = {},
+): PsaClassifiableDiscrepancy {
+  return {
+    companyId: "company-1",
+    companyName: "Summit Healthcare",
+    productName: "Microsoft 365 Business Premium",
+    invoicedQuantity: 12,
+    activeQuantity: 10,
+    delta: 2,
+    dollarImpact: 40,
+    ...overrides,
+  };
+}
+
+const mappings: PsaMappingsFile = {
+  version: "1.0",
+  mappings: [
+    {
+      pax8CompanyId: "company-1",
+      pax8ProductName: "Microsoft 365 Business Premium",
+      agreementId: "agreement-1",
+      additionRef: "addition-propagated",
+    },
+    {
+      pax8CompanyId: "company-2",
+      pax8ProductName: "Azure Plan",
+      agreementId: "agreement-2",
+      additionRef: "addition-cost-only",
+    },
+    {
+      pax8CompanyId: "company-3",
+      pax8ProductName: "Defender",
+      agreementId: "agreement-3",
+      additionRef: "addition-drift",
+    },
+    {
+      pax8CompanyId: "company-4",
+      pax8ProductName: "Backup",
+      agreementId: "agreement-4",
+      additionRef: "addition-missing",
+    },
+  ],
+};
+
+describe("PSA reconciliation helpers", () => {
+  it("matches mappings case-insensitively and trims product names", () => {
+    expect(
+      findMapping(
+        mappings,
+        discrepancy({ companyId: "COMPANY-1", productName: "  microsoft 365 business premium " }),
+      ),
+    ).toMatchObject({ agreementId: "agreement-1", additionRef: "addition-propagated" });
+  });
+
+  it("classifies propagated, cost-only, psa-drift, and unmapped discrepancies", async () => {
+    const discrepancies = [
+      discrepancy({
+        companyId: "company-1",
+        productName: "Microsoft 365 Business Premium",
+        invoicedQuantity: 12,
+        activeQuantity: 10,
+        delta: 2,
+        dollarImpact: 40,
+      }),
+      discrepancy({
+        companyId: "company-2",
+        productName: "Azure Plan",
+        invoicedQuantity: 8,
+        activeQuantity: 6,
+        delta: 2,
+        dollarImpact: 60,
+      }),
+      discrepancy({
+        companyId: "company-3",
+        productName: "Defender",
+        invoicedQuantity: 20,
+        activeQuantity: 15,
+        delta: 5,
+        dollarImpact: 125,
+      }),
+      discrepancy({
+        companyId: "company-4",
+        productName: "Backup",
+        invoicedQuantity: 5,
+        activeQuantity: 3,
+        delta: 2,
+        dollarImpact: 30,
+      }),
+      discrepancy({
+        companyId: "company-5",
+        productName: "Unmapped",
+        invoicedQuantity: 7,
+        activeQuantity: 4,
+        delta: 3,
+        dollarImpact: -90,
+      }),
+    ];
+    const provider = new DemoConnectWiseProvider([
+      {
+        agreementId: "agreement-1",
+        additionRef: "addition-propagated",
+        quantity: 12,
+        unitPrice: 20,
+        currency: "USD",
+      },
+      {
+        agreementId: "agreement-2",
+        additionRef: "addition-cost-only",
+        quantity: 6,
+        unitPrice: 30,
+        currency: "USD",
+      },
+      {
+        agreementId: "agreement-3",
+        additionRef: "addition-drift",
+        quantity: 99,
+        unitPrice: 25,
+        currency: "USD",
+      },
+    ]);
+
+    const result = await classifyWithPsa(provider, discrepancies, mappings, {
+      asOf: new Date("2026-03-31T00:00:00.000Z"),
+      currency: "USD",
+    });
+
+    expect(result.discrepancies.map((d) => d.psa.status)).toEqual([
+      "propagated",
+      "cost-only",
+      "psa-drift",
+      "unmapped",
+      "unmapped",
+    ]);
+    expect(result.psaSummary).toMatchObject({
+      provider: "connectwise",
+      asOf: "2026-03-31T00:00:00.000Z",
+      coveragePercent: 60,
+      counts: { propagated: 1, costOnly: 1, psaDrift: 1, unmapped: 2 },
+      unmappedDollarImpact: { amount: 120, currency: "USD" },
+      customerImpactTotal: { amount: 165, currency: "USD" },
+    });
+    expect(result.discrepancies[3].psa).toMatchObject({
+      status: "unmapped",
+      agreementId: "agreement-4",
+      additionRef: "addition-missing",
+      customerImpact: null,
+    });
+  });
+
+  it("reports full coverage for an empty discrepancy set", async () => {
+    const result = await classifyWithPsa(
+      new DemoConnectWiseProvider(),
+      [],
+      { version: "1.0", mappings: [] },
+      {
+        asOf: new Date("2026-03-31T00:00:00.000Z"),
+      },
+    );
+
+    expect(result.discrepancies).toEqual([]);
+    expect(result.psaSummary.coveragePercent).toBe(100);
+    expect(result.psaSummary.counts).toEqual({
+      propagated: 0,
+      costOnly: 0,
+      psaDrift: 0,
+      unmapped: 0,
+    });
+  });
+});

--- a/packages/psa/src/index.ts
+++ b/packages/psa/src/index.ts
@@ -1,0 +1,211 @@
+// Copyright 2026 Pax8, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export type PsaProviderName = "connectwise";
+
+export type PsaClassificationStatus = "propagated" | "cost-only" | "psa-drift" | "unmapped";
+
+export interface PsaMoney {
+  amount: number;
+  currency: string;
+}
+
+export interface PsaMapping {
+  pax8CompanyId: string;
+  pax8ProductName: string;
+  agreementId: string;
+  additionRef: string;
+}
+
+export interface PsaMappingsFile {
+  version: "1.0";
+  mappings: PsaMapping[];
+}
+
+export interface PsaAgreementAddition {
+  agreementId: string;
+  additionRef: string;
+  quantity: number;
+  unitPrice?: number;
+  currency?: string;
+  effectiveStart?: string;
+  effectiveEnd?: string;
+}
+
+export interface PsaProvider {
+  readonly name: PsaProviderName;
+  testConnection(): Promise<void>;
+  getAddition(mapping: PsaMapping, asOf: Date): Promise<PsaAgreementAddition | null>;
+}
+
+export interface PsaClassifiableDiscrepancy {
+  companyId: string;
+  companyName: string;
+  productName: string;
+  invoicedQuantity: number;
+  activeQuantity: number;
+  delta: number;
+  dollarImpact: number;
+}
+
+export interface PsaClassification {
+  status: PsaClassificationStatus;
+  customerImpact: PsaMoney | null;
+  agreementId: string | null;
+  additionRef: string | null;
+}
+
+export interface PsaSummary {
+  provider: PsaProviderName;
+  asOf: string;
+  coveragePercent: number;
+  counts: {
+    propagated: number;
+    costOnly: number;
+    psaDrift: number;
+    unmapped: number;
+  };
+  unmappedDollarImpact: PsaMoney;
+  customerImpactTotal: PsaMoney;
+}
+
+function mappingKey(companyId: string, productName: string): string {
+  return `${companyId.toLowerCase()}\u0000${productName.trim().toLowerCase()}`;
+}
+
+export function createEmptyMappings(): PsaMappingsFile {
+  return { version: "1.0", mappings: [] };
+}
+
+export function findMapping(mappings: PsaMappingsFile, discrepancy: PsaClassifiableDiscrepancy): PsaMapping | undefined {
+  const wanted = mappingKey(discrepancy.companyId, discrepancy.productName);
+  return mappings.mappings.find((m) => mappingKey(m.pax8CompanyId, m.pax8ProductName) === wanted);
+}
+
+export class DemoConnectWiseProvider implements PsaProvider {
+  readonly name = "connectwise" as const;
+  private readonly additions = new Map<string, PsaAgreementAddition>();
+
+  constructor(additions: PsaAgreementAddition[] = []) {
+    for (const addition of additions) {
+      this.additions.set(addition.additionRef, addition);
+    }
+  }
+
+  async testConnection(): Promise<void> {
+    return;
+  }
+
+  async getAddition(mapping: PsaMapping): Promise<PsaAgreementAddition | null> {
+    return this.additions.get(mapping.additionRef) ?? null;
+  }
+}
+
+export class ConnectWiseProvider implements PsaProvider {
+  readonly name = "connectwise" as const;
+
+  constructor(
+    private readonly credentials: {
+      baseUrl?: string;
+      companyId?: string;
+      publicKey?: string;
+      privateKey?: string;
+      clientId?: string;
+    },
+  ) {}
+
+  async testConnection(): Promise<void> {
+    const missing = requiredConnectWiseCredentialNames().filter((name) => !this.credentials[name]);
+    if (missing.length > 0) {
+      throw new Error(`Missing ConnectWise PSA credentials: ${missing.join(", ")}`);
+    }
+  }
+
+  async getAddition(): Promise<PsaAgreementAddition | null> {
+    await this.testConnection();
+    throw new Error("ConnectWise Manage live fetch is not implemented yet; use PAX8_DEMO=1 or local mappings with demo fixtures");
+  }
+}
+
+export function requiredConnectWiseCredentialNames(): Array<"baseUrl" | "companyId" | "publicKey" | "privateKey" | "clientId"> {
+  return ["baseUrl", "companyId", "publicKey", "privateKey", "clientId"];
+}
+
+export async function classifyWithPsa(
+  provider: PsaProvider,
+  discrepancies: PsaClassifiableDiscrepancy[],
+  mappings: PsaMappingsFile,
+  options: { asOf?: Date; currency?: string } = {},
+): Promise<{ discrepancies: Array<PsaClassifiableDiscrepancy & { psa: PsaClassification }>; psaSummary: PsaSummary }> {
+  const asOf = options.asOf ?? new Date();
+  const currency = options.currency ?? "USD";
+  const counts = { propagated: 0, costOnly: 0, psaDrift: 0, unmapped: 0 };
+  let unmappedDollarImpact = 0;
+  let customerImpactTotal = 0;
+
+  const classified = [] as Array<PsaClassifiableDiscrepancy & { psa: PsaClassification }>;
+
+  for (const discrepancy of discrepancies) {
+    const mapping = findMapping(mappings, discrepancy);
+    if (!mapping) {
+      counts.unmapped += 1;
+      unmappedDollarImpact += Math.abs(discrepancy.dollarImpact);
+      classified.push({
+        ...discrepancy,
+        psa: { status: "unmapped", customerImpact: null, agreementId: null, additionRef: null },
+      });
+      continue;
+    }
+
+    const addition = await provider.getAddition(mapping, asOf);
+    if (!addition) {
+      counts.unmapped += 1;
+      unmappedDollarImpact += Math.abs(discrepancy.dollarImpact);
+      classified.push({
+        ...discrepancy,
+        psa: { status: "unmapped", customerImpact: null, agreementId: mapping.agreementId, additionRef: mapping.additionRef },
+      });
+      continue;
+    }
+
+    const psaCurrency = addition.currency ?? currency;
+    const unitPrice = addition.unitPrice ?? Math.abs(discrepancy.dollarImpact / (discrepancy.delta || 1));
+    const customerImpact = Math.abs(discrepancy.delta) * unitPrice;
+    let status: PsaClassificationStatus;
+    if (addition.quantity === discrepancy.invoicedQuantity) {
+      status = "propagated";
+      counts.propagated += 1;
+      customerImpactTotal += customerImpact;
+    } else if (addition.quantity === discrepancy.activeQuantity) {
+      status = "cost-only";
+      counts.costOnly += 1;
+    } else {
+      status = "psa-drift";
+      counts.psaDrift += 1;
+      customerImpactTotal += customerImpact;
+    }
+
+    classified.push({
+      ...discrepancy,
+      psa: {
+        status,
+        customerImpact: { amount: customerImpact, currency: psaCurrency },
+        agreementId: addition.agreementId,
+        additionRef: addition.additionRef,
+      },
+    });
+  }
+
+  const mapped = discrepancies.length - counts.unmapped;
+  return {
+    discrepancies: classified,
+    psaSummary: {
+      provider: provider.name,
+      asOf: asOf.toISOString(),
+      coveragePercent: discrepancies.length === 0 ? 100 : Math.round((mapped / discrepancies.length) * 100),
+      counts,
+      unmappedDollarImpact: { amount: unmappedDollarImpact, currency },
+      customerImpactTotal: { amount: customerImpactTotal, currency },
+    },
+  };
+}

--- a/packages/psa/tsconfig.json
+++ b/packages/psa/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@pax8/core':
         specifier: workspace:*
         version: link:../core
+      '@pax8/psa':
+        specifier: workspace:*
+        version: link:../psa
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -124,6 +127,19 @@ importers:
         version: 25.9.3
       tsup:
         specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
+  packages/psa:
+    dependencies:
+      zod:
+        specifier: ^4.1.13
+        version: 4.4.3
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.5.0
@@ -2070,6 +2086,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
@@ -3878,3 +3897,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary

Starts the PSA reconciliation surface for #687 with a ConnectWise-first scaffold:

- adds a new `@pax8/psa` package with provider interfaces and ConnectWise/demo provider plumbing
- wires `pax8 psa test` and `pax8 psa map` command surfaces
- adds `--psa <provider>` handling to invoice audit so PSA classification can be layered onto the existing audit flow
- extends config schema for PSA provider credentials and local mapping state
- keeps the PSA path read-only/local-only; no new write surfaces

This is intentionally a first slice/scaffold, not a claim that the full month-end-close acceptance bar is complete yet. The next hard parts are period-aware quantity semantics, richer mapping bootstrap UX, and demo/test coverage across all four classification states.

## Verification

- `pnpm --filter @pax8/psa --filter @pax8/cli build`
- `pnpm vitest run packages/cli/src/__tests__/invoices.test.ts packages/cli/src/__tests__/auth.test.ts` — 46 passing

Closes #687? Not yet — draft implementation toward #687.
