### PR TITLE
ci(release): upgrade npm to >=11.5.1 so OIDC trusted publishing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,17 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # npm OIDC trusted publishing requires npm >= 11.5.1. Node 22 bundles
+      # npm 10.x, which never attempts the OIDC token exchange — the publish
+      # PUT goes out carrying only setup-node's literal placeholder token,
+      # and the registry answers with its existence-masking E404. This was
+      # the actual cause of every CI publish failure since 0.1.5 (see #685's
+      # run log: "using npm trusted publishing" followed by E404, with no
+      # token-exchange round-trip despite loglevel=http). Upgrading npm in
+      # place keeps the build/test runtime on Node 22.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5.1 && npm --version
+
       # Publish gate opened 2026-06-04 (closes #370). Pushing to main now
       # invokes `pnpm changeset publish`, which publishes whichever package
       # versions in main exceed what's on the registry. The first publish
@@ -59,15 +70,17 @@ jobs:
       # when a changeset is present) bumps versions and is merged.
       #
       # 0.1.5 publish attempt (2026-07-06/07) failed here with a hard-to-
-      # diagnose `E404 Not Found - PUT https://registry.npmjs.org/@pax8%2fcore`.
-      # Provenance signing (sigstore) succeeded — meaning the OIDC token was
-      # minted correctly and the workflow identity matched the trusted-
-      # publisher pattern — but the actual PUT to the registry got 404,
-      # which npm returns for scoped packages when the effective identity
-      # lacks publish rights. 0.1.5 was ultimately shipped from a
-      # maintainer laptop via `pnpm publish --otp`. Debug logging enabled
-      # below so the next attempt captures the token-exchange response
-      # inline in the workflow log.
+      # diagnose `E404 Not Found - PUT https://registry.npmjs.org/@pax8%2fcore`,
+      # and 0.1.6/0.2.0 failed the same way; all three were shipped from a
+      # maintainer laptop via `pnpm publish --otp`. Root cause (found
+      # 2026-07-24 via the debug logging below): the bundled npm 10.x
+      # predates trusted-publishing support, so the OIDC exchange never ran —
+      # see the "Upgrade npm" step above. (The earlier theory that sigstore
+      # success proved the token exchange worked was wrong: provenance
+      # signing consumes the Actions OIDC token directly and is independent
+      # of the registry token exchange.) Side effect of the manual publishes:
+      # no git tags or GitHub Releases for 0.1.5/0.1.6/0.2.0, since the
+      # changesets action only tags when its own publish step succeeds.
       - name: Publish (gate opened in #370)
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
       # moved past it, leaving the publish step running an untested
       # pnpm/npm combination. Explicit pin keeps the tarball packing +
       # publish path matched to `pnpm@9.15.4`, which is what maintainers
-      # exercise locally.
+      # exercise locally. (One deliberate divergence from local setups: the
+      # "Upgrade npm" step below swaps in npm 11 for the registry PUT, which
+      # laptops don't run — CI needs it for OIDC; laptops use `--otp`.)
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 9.15.4
@@ -55,12 +57,27 @@ jobs:
       # npm 10.x, which never attempts the OIDC token exchange — the publish
       # PUT goes out carrying only setup-node's literal placeholder token,
       # and the registry answers with its existence-masking E404. This was
-      # the actual cause of every CI publish failure since 0.1.5 (see #685's
-      # run log: "using npm trusted publishing" followed by E404, with no
-      # token-exchange round-trip despite loglevel=http). Upgrading npm in
+      # the actual cause of every CI publish failure since 0.1.5. Evidence
+      # in #685's run log: changesets/action prints "using npm trusted
+      # publishing" (its own OIDC detection), then npm 10's PUT 404s with no
+      # token-exchange round-trip despite loglevel=http. Upgrading npm in
       # place keeps the build/test runtime on Node 22.
+      #
+      # Exact-pinned (not `^`) to match this workflow's H-4 supply-chain
+      # posture — a floating range would install whatever npm publishes,
+      # unreviewed, into the job that holds `id-token: write`. Dependabot
+      # does NOT manage versions inside `run:` scripts; bump manually and
+      # note npm 11's engine floor (^20.17.0 || >=22.9.0).
+      #
+      # Caveat for future debugging: npm 11's oidc() is never-throw — if the
+      # exchange is skipped (id-token permission lost, or the trusted-
+      # publisher registration no longer matches after e.g. a workflow file
+      # rename), it logs only at silly/verbose (invisible at loglevel=http),
+      # silently falls back to the placeholder token, and reproduces the
+      # same masked E404. If that error returns, check the auth layer first
+      # and re-run with NPM_CONFIG_LOGLEVEL=verbose.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@^11.5.1 && npm --version
+        run: npm install -g npm@11.18.0 && npm --version
 
       # Publish gate opened 2026-06-04 (closes #370). Pushing to main now
       # invokes `pnpm changeset publish`, which publishes whichever package
@@ -79,8 +96,10 @@ jobs:
       # success proved the token exchange worked was wrong: provenance
       # signing consumes the Actions OIDC token directly and is independent
       # of the registry token exchange.) Side effect of the manual publishes:
-      # no git tags or GitHub Releases for 0.1.5/0.1.6/0.2.0, since the
-      # changesets action only tags when its own publish step succeeds.
+      # the changesets action only tags/creates GitHub Releases when its own
+      # publish step succeeds, so 0.1.5/0.1.6/0.2.0 got neither. The tags
+      # were backfilled manually on 2026-07-24; the GitHub Releases for
+      # those three versions are still missing.
       - name: Publish (gate opened in #370)
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ On merge to `main`, the release workflow opens (or updates) a `chore: release` P
 
 ### Maintainer note: npm trusted publishing
 
-The release workflow publishes via [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — no `NPM_TOKEN` secret. For this to work, the `@pax8` scope must have the `pax8labs/pax8-cli` repository and the `Release` workflow registered as a trusted publisher at <https://www.npmjs.com/settings/pax8/packages> for every package the workflow publishes (`@pax8/cli`, `@pax8/core`). The workflow already declares `permissions.id-token: write` and `setup-node`'s `registry-url`; once the npm side is configured, `npm publish` exchanges the OIDC token for an ephemeral publish token automatically.
+The release workflow publishes via [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — no `NPM_TOKEN` secret. For this to work, the `@pax8` scope must have the `pax8labs/pax8-cli` repository and the `Release` workflow registered as a trusted publisher at <https://www.npmjs.com/settings/pax8/packages> for every package the workflow publishes (`@pax8/cli`, `@pax8/core`). The workflow already declares `permissions.id-token: write` and `setup-node`'s `registry-url`; once the npm side is configured, `npm publish` exchanges the OIDC token for an ephemeral publish token automatically. One more hard prerequisite: the npm CLI doing the publish must be **>= 11.5.1** — older npm (including the 10.x bundled with Node 22) has no trusted-publishing code at all and silently falls back to whatever token is configured, which surfaces as a masked `E404` on the PUT. The release workflow upgrades npm explicitly for this reason; keep that step if you copy this setup to another repo.
 
 ## Security Reports
 


### PR DESCRIPTION
## Summary

Every CI publish since 0.1.5 (#677, #685) failed with `E404 Not Found - PUT https://registry.npmjs.org/@pax8%2fcli`, forcing manual laptop publishes — which also skip the git tags and GitHub Releases the changesets action would create, leaving `@pax8/cli@0.1.5/0.1.6/0.2.0` untagged and the tag-triggered Homebrew workflow (#683) unable to ever fire.

**Root cause** (from #685's run log, with the #681 debug logging active): npm OIDC trusted publishing requires **npm >= 11.5.1**, but the workflow's Node 22 bundles npm 10.9.8. npm 10 never attempts the token exchange, so the PUT carried only setup-node's placeholder token and got the registry's existence-masking 404. **Publish chain** (verified in comments below): `changeset publish` spawns `pnpm publish`, and pnpm 9 packs the tarball (rewriting `workspace:*`) then delegates the registry PUT to the **system npm** — so upgrading the PATH npm is exactly the load-bearing change.

This also corrects the earlier misdiagnosis in the workflow comments: sigstore provenance succeeding proved nothing about the registry token exchange — provenance signing consumes the Actions OIDC token directly.

## Change

- Add an `npm install -g npm@^11.5.1` step before publish (keeps build/test on the pinned Node 22 runtime rather than jumping to Node 24)
- Rewrite the stale 0.1.5 failure comment with the confirmed root cause

## Verification

The real proof is the next `chore: release` merge publishing from CI with tags + GitHub Release created. Precondition to double-check on npmjs.com: both `@pax8/cli` and `@pax8/core` have this repo + `Release` workflow registered as trusted publisher.

## Follow-ups (not this PR)

1. Backfill tags for 0.1.5/0.1.6/0.2.0 at their release commits
2. Homebrew tap bootstrap per `packaging/homebrew/README.md` (do before pushing tags, since a `@pax8/cli@*` tag push fires the tap workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)