### PR TITLE
fix(homebrew): drop redundant version stanza from generated formula

### DIFF
--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -49,7 +49,10 @@ async function sha256OfUrl(url) {
  * `std_npm_args` installs the package into `libexec`; we then symlink its
  * bin into Homebrew's `bin`.
  */
-function renderFormula({ version, tarball, sha256 }) {
+// No explicit `version` stanza: Homebrew scans the version from the tarball
+// URL (`cli-<version>.tgz`), and `brew audit --strict` flags a literal
+// `version` line as redundant.
+function renderFormula({ tarball, sha256 }) {
   return `# Copyright 2026 Pax8, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -63,7 +66,6 @@ class Pax8 < Formula
   url "${tarball}"
   sha256 "${sha256}"
   license "Apache-2.0"
-  version "${version}"
 
   depends_on "node"
 
@@ -116,7 +118,7 @@ async function main() {
     throw new Error(`computed sha256 is malformed: ${sha256}`);
   }
 
-  const formula = renderFormula({ version, tarball, sha256 });
+  const formula = renderFormula({ tarball, sha256 });
   writeFileSync(outfile, formula);
   process.stdout.write(
     `Wrote ${outfile}\n  version: ${version}\n  url:     ${tarball}\n  sha256:  ${sha256}\n`,

--- a/packaging/homebrew/pax8.rb
+++ b/packaging/homebrew/pax8.rb
@@ -8,10 +8,9 @@ require "language/node"
 class Pax8 < Formula
   desc "Open-source CLI for MSPs to manage Pax8 cloud marketplace operations"
   homepage "https://github.com/pax8labs/pax8-cli"
-  url "https://registry.npmjs.org/@pax8/cli/-/cli-0.1.6.tgz"
-  sha256 "ffac2858f838387a18e15b0b324a28a92102684813a44cd049e6db481764443d"
+  url "https://registry.npmjs.org/@pax8/cli/-/cli-0.2.0.tgz"
+  sha256 "944eaa0c585d54ddbee8641e0b653a7886de97c81a7176166ce5e474ab62b2ca"
   license "Apache-2.0"
-  version "0.1.6"
 
   depends_on "node"
 


### PR DESCRIPTION
## Summary

While bootstrapping the live `pax8labs/homebrew-tap` (now created and seeded with 0.2.0), `brew audit --strict` flagged two problems in the generated formula, both caused by the explicit `version "x.y.z"` stanza: it's redundant (Homebrew scans the version from the tarball URL) and mis-ordered relative to `sha256`. This drops the stanza from the generator and regenerates the reference `pax8.rb`.

The tap's authoritative copy already has the fix; this prevents the next release's `homebrew.yml` run from reintroducing it. Audit now passes clean:

```
brew audit --strict --formula pax8labs/tap/pax8   # no findings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)